### PR TITLE
Add cover support to Freedompro

### DIFF
--- a/homeassistant/components/freedompro/__init__.py
+++ b/homeassistant/components/freedompro/__init__.py
@@ -14,7 +14,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["binary_sensor", "light", "lock", "sensor", "switch"]
+PLATFORMS = ["binary_sensor", "cover", "light", "lock", "sensor", "switch"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):

--- a/homeassistant/components/freedompro/cover.py
+++ b/homeassistant/components/freedompro/cover.py
@@ -1,0 +1,113 @@
+"""Support for Freedompro cover."""
+import json
+
+from pyfreedompro import put_state
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    DEVICE_CLASS_BLIND,
+    DEVICE_CLASS_DOOR,
+    DEVICE_CLASS_GARAGE,
+    DEVICE_CLASS_GATE,
+    DEVICE_CLASS_WINDOW,
+    SUPPORT_SET_POSITION,
+    CoverEntity,
+)
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import callback
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Freedompro cover."""
+    api_key = entry.data[CONF_API_KEY]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        Device(hass, api_key, device, coordinator)
+        for device in coordinator.data
+        if device["type"] == "windowCovering"
+        or device["type"] == "gate"
+        or device["type"] == "garageDoor"
+        or device["type"] == "door"
+        or device["type"] == "window"
+    )
+
+
+class Device(CoordinatorEntity, CoverEntity):
+    """Representation of an Freedompro cover."""
+
+    def __init__(self, hass, api_key, device, coordinator):
+        """Initialize the Freedompro cover."""
+        super().__init__(coordinator)
+        self._hass = hass
+        self._session = aiohttp_client.async_get_clientsession(self._hass)
+        self._api_key = api_key
+        self._attr_name = device["name"]
+        self._attr_unique_id = device["uid"]
+        self._type = device["type"]
+        self._characteristics = device["characteristics"]
+        self._attr_device_info = {
+            "name": self._attr_name,
+            "identifiers": {
+                (DOMAIN, self._attr_unique_id),
+            },
+            "model": self._type,
+            "manufacturer": "Freedompro",
+        }
+        self._attr_current_cover_position = 0
+        self._attr_is_closed = True
+        self._attr_supported_features = SUPPORT_SET_POSITION
+        self._attr_device_class = (
+            DEVICE_CLASS_GATE
+            if self._type == "gate"
+            else DEVICE_CLASS_GARAGE
+            if self._type == "garageDoor"
+            else DEVICE_CLASS_DOOR
+            if self._type == "door"
+            else DEVICE_CLASS_WINDOW
+            if self._type == "window"
+            else DEVICE_CLASS_BLIND
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        device = next(
+            (
+                device
+                for device in self.coordinator.data
+                if device["uid"] == self._attr_unique_id
+            ),
+            None,
+        )
+        if device is not None and "state" in device:
+            state = device["state"]
+            if "position" in state:
+                self._attr_current_cover_position = state["position"]
+                if self._attr_current_cover_position == 0:
+                    self._attr_is_closed = True
+                else:
+                    self._attr_is_closed = False
+        super()._handle_coordinator_update()
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self._handle_coordinator_update()
+
+    async def async_set_cover_position(self, **kwargs):
+        """Async function to set position to cover."""
+        payload = {}
+        if ATTR_POSITION in kwargs:
+            payload["position"] = kwargs[ATTR_POSITION]
+        payload = json.dumps(payload)
+        await put_state(
+            self._session,
+            self._api_key,
+            self._attr_unique_id,
+            payload,
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/freedompro/cover.py
+++ b/homeassistant/components/freedompro/cover.py
@@ -10,6 +10,8 @@ from homeassistant.components.cover import (
     DEVICE_CLASS_GARAGE,
     DEVICE_CLASS_GATE,
     DEVICE_CLASS_WINDOW,
+    SUPPORT_CLOSE,
+    SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
     CoverEntity,
 )
@@ -48,25 +50,24 @@ class Device(CoordinatorEntity, CoverEntity):
     def __init__(self, hass, api_key, device, coordinator):
         """Initialize the Freedompro cover."""
         super().__init__(coordinator)
-        self._hass = hass
-        self._session = aiohttp_client.async_get_clientsession(self._hass)
+        self._session = aiohttp_client.async_get_clientsession(hass)
         self._api_key = api_key
         self._attr_name = device["name"]
         self._attr_unique_id = device["uid"]
-        self._type = device["type"]
-        self._characteristics = device["characteristics"]
         self._attr_device_info = {
             "name": self.name,
             "identifiers": {
                 (DOMAIN, self.unique_id),
             },
-            "model": self._type,
+            "model": device["type"],
             "manufacturer": "Freedompro",
         }
         self._attr_current_cover_position = 0
         self._attr_is_closed = True
-        self._attr_supported_features = SUPPORT_SET_POSITION
-        self._attr_device_class = DEVICE_CLASS_MAP[self._type]
+        self._attr_supported_features = (
+            SUPPORT_CLOSE | SUPPORT_OPEN | SUPPORT_SET_POSITION
+        )
+        self._attr_device_class = DEVICE_CLASS_MAP[device["type"]]
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -96,11 +97,11 @@ class Device(CoordinatorEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        await self.async_set_cover_position(ATTR_POSITION=100)
+        await self.async_set_cover_position(position=100)
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        await self.async_set_cover_position(ATTR_POSITION=0)
+        await self.async_set_cover_position(position=0)
 
     async def async_set_cover_position(self, **kwargs):
         """Async function to set position to cover."""

--- a/tests/components/freedompro/test_cover.py
+++ b/tests/components/freedompro/test_cover.py
@@ -7,6 +7,8 @@ import pytest
 from homeassistant.components.cover import ATTR_POSITION, DOMAIN as COVER_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
     STATE_CLOSED,
     STATE_OPEN,
@@ -110,6 +112,88 @@ async def test_cover_set_position(
             blocking=True,
         )
     mock_put_state.assert_called_once_with(ANY, ANY, ANY, '{"position": 33}')
+
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OPEN
+
+
+@pytest.mark.parametrize(
+    "entity_id, uid, name, model",
+    [
+        (
+            "cover.blind",
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS",
+            "blind",
+            "windowCovering",
+        )
+    ],
+)
+async def test_cover_close(
+    hass, init_integration, entity_id: str, uid: str, name: str, model: str
+):
+    """Test close cover."""
+    init_integration
+    registry = er.async_get(hass)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OPEN
+    assert state.attributes.get("friendly_name") == name
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == uid
+
+    with patch("homeassistant.components.freedompro.cover.put_state") as mock_put_state:
+        assert await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+    mock_put_state.assert_called_once_with(ANY, ANY, ANY, '{"position": 0}')
+
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OPEN
+
+
+@pytest.mark.parametrize(
+    "entity_id, uid, name, model",
+    [
+        (
+            "cover.blind",
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS",
+            "blind",
+            "windowCovering",
+        )
+    ],
+)
+async def test_cover_open(
+    hass, init_integration, entity_id: str, uid: str, name: str, model: str
+):
+    """Test open cover."""
+    init_integration
+    registry = er.async_get(hass)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OPEN
+    assert state.attributes.get("friendly_name") == name
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == uid
+
+    with patch("homeassistant.components.freedompro.cover.put_state") as mock_put_state:
+        assert await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+    mock_put_state.assert_called_once_with(ANY, ANY, ANY, '{"position": 100}')
 
     await hass.async_block_till_done()
     state = hass.states.get(entity_id)

--- a/tests/components/freedompro/test_cover.py
+++ b/tests/components/freedompro/test_cover.py
@@ -1,57 +1,116 @@
 """Tests for the Freedompro cover."""
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    DOMAIN as COVER_DOMAIN,
+from datetime import timedelta
+from unittest.mock import ANY, patch
+
+import pytest
+
+from homeassistant.components.cover import ATTR_POSITION, DOMAIN as COVER_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
     SERVICE_SET_COVER_POSITION,
+    STATE_CLOSED,
+    STATE_OPEN,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_CLOSED
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util.dt import utcnow
+
+from tests.common import async_fire_time_changed
+from tests.components.freedompro.const import DEVICES_STATE
 
 
-async def test_cover_get_state(hass, init_integration):
+@pytest.mark.parametrize(
+    "entity_id, uid, name, model",
+    [
+        (
+            "cover.blind",
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS",
+            "blind",
+            "windowCovering",
+        )
+    ],
+)
+async def test_cover_get_state(
+    hass, init_integration, entity_id: str, uid: str, name: str, model: str
+):
     """Test states of the cover."""
     init_integration
     registry = er.async_get(hass)
+    registry_device = dr.async_get(hass)
 
-    entity_id = "cover.bedroom_window_covering"
+    device = registry_device.async_get_device({("freedompro", uid)})
+    assert device is not None
+    assert device.identifiers == {("freedompro", uid)}
+    assert device.manufacturer == "Freedompro"
+    assert device.name == name
+    assert device.model == model
+
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_CLOSED
-    assert state.attributes.get("friendly_name") == "Bedroom window covering"
+    assert state.attributes.get("friendly_name") == name
 
     entry = registry.async_get(entity_id)
     assert entry
-    assert (
-        entry.unique_id
-        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS"
-    )
+    assert entry.unique_id == uid
+
+    get_states_response = list(DEVICES_STATE)
+    for state_response in get_states_response:
+        if state_response["uid"] == uid:
+            state_response["state"]["position"] = 100
+    with patch(
+        "homeassistant.components.freedompro.get_states",
+        return_value=get_states_response,
+    ):
+        async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
+        await hass.async_block_till_done()
+
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.attributes.get("friendly_name") == name
+
+        entry = registry.async_get(entity_id)
+        assert entry
+        assert entry.unique_id == uid
+
+        assert state.state == STATE_OPEN
 
 
-async def test_cover_set_position(hass, init_integration):
-    """Test set on of the cover."""
+@pytest.mark.parametrize(
+    "entity_id, uid, name, model",
+    [
+        (
+            "cover.blind",
+            "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS",
+            "blind",
+            "windowCovering",
+        )
+    ],
+)
+async def test_cover_set_position(
+    hass, init_integration, entity_id: str, uid: str, name: str, model: str
+):
+    """Test set position of the cover."""
     init_integration
     registry = er.async_get(hass)
 
-    entity_id = "cover.bedroom_window_covering"
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_CLOSED
-    assert state.attributes.get("friendly_name") == "Bedroom window covering"
+    assert state.state == STATE_OPEN
+    assert state.attributes.get("friendly_name") == name
 
     entry = registry.async_get(entity_id)
     assert entry
-    assert (
-        entry.unique_id
-        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS"
-    )
+    assert entry.unique_id == uid
 
-    await hass.services.async_call(
-        COVER_DOMAIN,
-        SERVICE_SET_COVER_POSITION,
-        {ATTR_ENTITY_ID: [entity_id], ATTR_POSITION: 33},
-        blocking=True,
-    )
+    with patch("homeassistant.components.freedompro.cover.put_state") as mock_put_state:
+        assert await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_SET_COVER_POSITION,
+            {ATTR_ENTITY_ID: [entity_id], ATTR_POSITION: 33},
+            blocking=True,
+        )
+    mock_put_state.assert_called_once_with(ANY, ANY, ANY, '{"position": 33}')
 
+    await hass.async_block_till_done()
     state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == STATE_OPEN

--- a/tests/components/freedompro/test_cover.py
+++ b/tests/components/freedompro/test_cover.py
@@ -1,0 +1,57 @@
+"""Tests for the Freedompro cover."""
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_SET_COVER_POSITION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_CLOSED
+from homeassistant.helpers import entity_registry as er
+
+
+async def test_cover_get_state(hass, init_integration):
+    """Test states of the cover."""
+    init_integration
+    registry = er.async_get(hass)
+
+    entity_id = "cover.bedroom_window_covering"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_CLOSED
+    assert state.attributes.get("friendly_name") == "Bedroom window covering"
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert (
+        entry.unique_id
+        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS"
+    )
+
+
+async def test_cover_set_position(hass, init_integration):
+    """Test set on of the cover."""
+    init_integration
+    registry = er.async_get(hass)
+
+    entity_id = "cover.bedroom_window_covering"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_CLOSED
+    assert state.attributes.get("friendly_name") == "Bedroom window covering"
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert (
+        entry.unique_id
+        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*3XSSVIJWK-65HILWTC4WINQK46SP4OEZRCNO25VGWAS"
+    )
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {ATTR_ENTITY_ID: [entity_id], ATTR_POSITION: 33},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_CLOSED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

Add cover support to Freedompro

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18517

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
