### PR TITLE
Add fan support to Freedompro

### DIFF
--- a/homeassistant/components/freedompro/__init__.py
+++ b/homeassistant/components/freedompro/__init__.py
@@ -14,7 +14,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["binary_sensor", "cover", "light", "lock", "sensor", "switch"]
+PLATFORMS = ["binary_sensor", "cover", "fan", "light", "lock", "sensor", "switch"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):

--- a/homeassistant/components/freedompro/fan.py
+++ b/homeassistant/components/freedompro/fan.py
@@ -1,0 +1,99 @@
+"""Support for Freedompro fan."""
+import json
+
+from pyfreedompro import put_state
+
+from homeassistant.components.fan import FanEntity
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import callback
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Freedompro fan."""
+    api_key = entry.data[CONF_API_KEY]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        Device(hass, api_key, device, coordinator)
+        for device in coordinator.data
+        if device["type"] == "fan"
+    )
+
+
+class Device(CoordinatorEntity, FanEntity):
+    """Representation of an Freedompro fan."""
+
+    def __init__(self, hass, api_key, device, coordinator):
+        """Initialize the Freedompro fan."""
+        super().__init__(coordinator)
+        self._hass = hass
+        self._session = aiohttp_client.async_get_clientsession(self._hass)
+        self._api_key = api_key
+        self._attr_name = device["name"]
+        self._attr_unique_id = device["uid"]
+        self._type = device["type"]
+        self._characteristics = device["characteristics"]
+        self._attr_device_info = {
+            "name": self._attr_name,
+            "identifiers": {
+                (DOMAIN, self._attr_unique_id),
+            },
+            "model": self._type,
+            "manufacturer": "Freedompro",
+        }
+        self._attr_is_on = False
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        device = next(
+            (
+                device
+                for device in self.coordinator.data
+                if device["uid"] == self._attr_unique_id
+            ),
+            None,
+        )
+        if device is not None and "state" in device:
+            state = device["state"]
+            if "on" in state:
+                self._attr_is_on = state["on"]
+        super()._handle_coordinator_update()
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self._handle_coordinator_update()
+
+    async def async_turn_on(
+        self,
+        speed,
+        percentage,
+        preset_mode,
+        **kwargs,
+    ):
+        """Async function to set on to fan."""
+        payload = {"on": True}
+        payload = json.dumps(payload)
+        await put_state(
+            self._session,
+            self._api_key,
+            self._attr_unique_id,
+            payload,
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        """Async function to set off to fan."""
+        payload = {"on": False}
+        payload = json.dumps(payload)
+        await put_state(
+            self._session,
+            self._api_key,
+            self._attr_unique_id,
+            payload,
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/freedompro/fan.py
+++ b/homeassistant/components/freedompro/fan.py
@@ -42,8 +42,6 @@ class FreedomproFan(CoordinatorEntity, FanEntity):
             "model": device["type"],
             "manufacturer": "Freedompro",
         }
-        if "rotationSpeed" in device["characteristics"]:
-            self._attr_supported_features = SUPPORT_SET_SPEED
         self._attr_is_on = False
         self._attr_percentage = 0
 
@@ -61,7 +59,7 @@ class FreedomproFan(CoordinatorEntity, FanEntity):
     def supported_features(self):
         """Flag supported features."""
         if "rotationSpeed" in self._characteristics:
-            return self._attr_supported_features
+            return SUPPORT_SET_SPEED
         return 0
 
     @callback

--- a/homeassistant/components/freedompro/fan.py
+++ b/homeassistant/components/freedompro/fan.py
@@ -69,11 +69,7 @@ class Device(CoordinatorEntity, FanEntity):
         self._handle_coordinator_update()
 
     async def async_turn_on(
-        self,
-        speed,
-        percentage,
-        preset_mode,
-        **kwargs,
+        self, speed=None, percentage=None, preset_mode=None, **kwargs
     ):
         """Async function to set on to fan."""
         payload = {"on": True}

--- a/homeassistant/components/freedompro/fan.py
+++ b/homeassistant/components/freedompro/fan.py
@@ -115,8 +115,8 @@ class FreedomproFan(CoordinatorEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int):
         """Set the speed percentage of the fan."""
-        rotationSpeed = {"rotationSpeed": percentage}
-        payload = json.dumps(rotationSpeed)
+        rotation_speed = {"rotationSpeed": percentage}
+        payload = json.dumps(rotation_speed)
         await put_state(
             self._session,
             self._api_key,

--- a/homeassistant/components/freedompro/fan.py
+++ b/homeassistant/components/freedompro/fan.py
@@ -29,21 +29,25 @@ class FreedomproFan(CoordinatorEntity, FanEntity):
     def __init__(self, hass, api_key, device, coordinator):
         """Initialize the Freedompro fan."""
         super().__init__(coordinator)
-        self._hass = hass
-        self._session = aiohttp_client.async_get_clientsession(self._hass)
+        self._session = aiohttp_client.async_get_clientsession(hass)
         self._api_key = api_key
         self._attr_name = device["name"]
         self._attr_unique_id = device["uid"]
-        self._type = device["type"]
         self._characteristics = device["characteristics"]
         self._attr_device_info = {
             "name": self.name,
             "identifiers": {
                 (DOMAIN, self.unique_id),
             },
-            "model": self._type,
+            "model": device["type"],
             "manufacturer": "Freedompro",
         }
+        self._attr_is_on = False
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is on."""
+        return self._attr_is_on
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/tests/components/freedompro/test_fan.py
+++ b/tests/components/freedompro/test_fan.py
@@ -1,0 +1,83 @@
+"""Tests for the Freedompro fan."""
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN, SERVICE_TURN_ON
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, STATE_OFF
+from homeassistant.helpers import entity_registry as er
+
+
+async def test_fan_get_state(hass, init_integration):
+    """Test states of the fan."""
+    init_integration
+    registry = er.async_get(hass)
+
+    entity_id = "fan.bedroom_fan"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get("friendly_name") == "Bedroom fan"
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert (
+        entry.unique_id
+        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
+    )
+
+
+async def test_fan_set_on(hass, init_integration):
+    """Test set on of the fan."""
+    init_integration
+    registry = er.async_get(hass)
+
+    entity_id = "fan.bedroom_fan"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get("friendly_name") == "Bedroom fan"
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert (
+        entry.unique_id
+        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
+    )
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: [entity_id]},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+
+
+async def test_fan_set_off(hass, init_integration):
+    """Test set off of the fan."""
+    init_integration
+    registry = er.async_get(hass)
+
+    entity_id = "fan.bedroom_fan"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get("friendly_name") == "Bedroom fan"
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert (
+        entry.unique_id
+        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
+    )
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: [entity_id]},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF

--- a/tests/components/freedompro/test_fan.py
+++ b/tests/components/freedompro/test_fan.py
@@ -1,83 +1,116 @@
 """Tests for the Freedompro fan."""
+from datetime import timedelta
+from unittest.mock import ANY, patch
+
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN, SERVICE_TURN_ON
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, STATE_OFF
-from homeassistant.helpers import entity_registry as er
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, STATE_OFF, STATE_ON
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util.dt import utcnow
+
+from tests.common import async_fire_time_changed
+from tests.components.freedompro.const import DEVICES_STATE
+
+uid = "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
 
 
 async def test_fan_get_state(hass, init_integration):
     """Test states of the fan."""
     init_integration
     registry = er.async_get(hass)
+    registry_device = dr.async_get(hass)
 
-    entity_id = "fan.bedroom_fan"
+    device = registry_device.async_get_device({("freedompro", uid)})
+    assert device is not None
+    assert device.identifiers == {("freedompro", uid)}
+    assert device.manufacturer == "Freedompro"
+    assert device.name == "bedroom"
+    assert device.model == "fan"
+
+    entity_id = "fan.bedroom"
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_OFF
-    assert state.attributes.get("friendly_name") == "Bedroom fan"
+    assert state.attributes.get("friendly_name") == "bedroom"
 
     entry = registry.async_get(entity_id)
     assert entry
-    assert (
-        entry.unique_id
-        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
-    )
+    assert entry.unique_id == uid
 
+    get_states_response = list(DEVICES_STATE)
+    for state_response in get_states_response:
+        if state_response["uid"] == uid:
+            state_response["state"]["on"] = True
+    with patch(
+        "homeassistant.components.freedompro.get_states",
+        return_value=get_states_response,
+    ):
+        async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
+        await hass.async_block_till_done()
 
-async def test_fan_set_on(hass, init_integration):
-    """Test set on of the fan."""
-    init_integration
-    registry = er.async_get(hass)
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.attributes.get("friendly_name") == "bedroom"
 
-    entity_id = "fan.bedroom_fan"
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF
-    assert state.attributes.get("friendly_name") == "Bedroom fan"
+        entry = registry.async_get(entity_id)
+        assert entry
+        assert entry.unique_id == uid
 
-    entry = registry.async_get(entity_id)
-    assert entry
-    assert (
-        entry.unique_id
-        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
-    )
-
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: [entity_id]},
-        blocking=True,
-    )
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF
+        assert state.state == STATE_ON
 
 
 async def test_fan_set_off(hass, init_integration):
-    """Test set off of the fan."""
+    """Test turn off the fan."""
     init_integration
     registry = er.async_get(hass)
 
-    entity_id = "fan.bedroom_fan"
+    entity_id = "fan.bedroom"
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OFF
-    assert state.attributes.get("friendly_name") == "Bedroom fan"
+    assert state.state == STATE_ON
+    assert state.attributes.get("friendly_name") == "bedroom"
 
     entry = registry.async_get(entity_id)
     assert entry
-    assert (
-        entry.unique_id
-        == "3WRRJR6RCZQZSND8VP0YTO3YXCSOFPKBMW8T51TU-LQ*ILYH1E3DWZOVMNEUIMDYMNLOW-LFRQFDPWWJOVHVDOS"
-    )
+    assert entry.unique_id == uid
 
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: [entity_id]},
-        blocking=True,
-    )
+    with patch("homeassistant.components.freedompro.fan.put_state") as mock_put_state:
+        assert await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+    mock_put_state.assert_called_once_with(ANY, ANY, ANY, '{"on": false}')
 
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+
+async def test_fan_set_on(hass, init_integration):
+    """Test turn on the fan."""
+    init_integration
+    registry = er.async_get(hass)
+
+    entity_id = "fan.bedroom"
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OFF
+    assert state.state == STATE_ON
+    assert state.attributes.get("friendly_name") == "bedroom"
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == uid
+
+    with patch("homeassistant.components.freedompro.fan.put_state") as mock_put_state:
+        assert await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+    mock_put_state.assert_called_once_with(ANY, ANY, ANY, '{"on": true}')
+
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

Add fan support Freedompro

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18518

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
