### PR TITLE
Fix homebridge devices becoming unavailable frequently

### DIFF
--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==0.4.2"],
+  "requirements": ["aiohomekit==0.4.3"],
   "zeroconf": ["_hap._tcp.local."],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k", "@bdraco"],

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -44,7 +44,7 @@ SIMPLE_SENSOR = {
         "unit": TEMP_CELSIUS,
         # This sensor is only for temperature characteristics that are not part
         # of a temperature sensor service.
-        "probe": lambda char: char.service.type != ServicesTypes.TEMPERATURE_SENSOR,
+        "probe": lambda char: char.service.type != ServicesTypes.get_uuid(ServicesTypes.TEMPERATURE_SENSOR),
     },
 }
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -44,7 +44,8 @@ SIMPLE_SENSOR = {
         "unit": TEMP_CELSIUS,
         # This sensor is only for temperature characteristics that are not part
         # of a temperature sensor service.
-        "probe": lambda char: char.service.type != ServicesTypes.get_uuid(ServicesTypes.TEMPERATURE_SENSOR),
+        "probe": lambda char: char.service.type
+        != ServicesTypes.get_uuid(ServicesTypes.TEMPERATURE_SENSOR),
     },
 }
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -175,7 +175,7 @@ aioguardian==1.0.4
 aioharmony==0.2.7
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.4.2
+aiohomekit==0.4.3
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -112,7 +112,7 @@ aioguardian==1.0.4
 aioharmony==0.2.7
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.4.2
+aiohomekit==0.4.3
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -86,6 +86,16 @@ async def test_temperature_sensor_read_state(hass, utcnow):
     assert state.attributes["device_class"] == DEVICE_CLASS_TEMPERATURE
 
 
+async def test_temperature_sensor_not_added_twice(hass, utcnow):
+    """A standalone temperature sensor should not get a characteristic AND a service entity."""
+    helper = await setup_test_component(
+        hass, create_temperature_sensor_service, suffix="temperature"
+    )
+
+    for state in hass.states.async_all():
+        assert state.entity_id == helper.entity_id
+
+
 async def test_humidity_sensor_read_state(hass, utcnow):
     """Test reading the state of a HomeKit humidity sensor accessory."""
     helper = await setup_test_component(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A change in the latest release meant duplicate keys were getting sent to the devices (within a single request) to ask for the same temperature value. Homebridge cannot handle that, causing frequent connection drops. aiohomekit 0.4.3 has a single change, to filter out duplicates. There is a test upstream for this case.

Additionally I realised that there was a secondary bug which could actually cause 2 entities for the same sensor because I was comparising a non-normalised and a normalised service type UUID. The PR includes a test for this case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/52680
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
