### PR TITLE
Add this variable for use by automation and script templates

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -445,15 +445,19 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             trigger_context,
             self._trace_config,
         ) as automation_trace:
+            this = None
+            state = self.hass.states.get(self.entity_id)
+            if state:
+                this = state.as_dict()
+            variables = {"this": this, **(run_variables or {})}
             if self._variables:
                 try:
-                    variables = self._variables.async_render(self.hass, run_variables)
+                    variables = self._variables.async_render(self.hass, variables)
                 except template.TemplateError as err:
                     self._logger.error("Error rendering variables: %s", err)
                     automation_trace.set_error(err)
                     return
-            else:
-                variables = run_variables
+
             # Prepare tracing the automation
             automation_trace.set_trace(trace_get())
 
@@ -569,11 +573,18 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         def log_cb(level, msg, **kwargs):
             self._logger.log(level, "%s %s", msg, self.name, **kwargs)
 
-        variables = None
+        this = None
+        self.async_write_ha_state()
+        state = self.hass.states.get(self.entity_id)
+        if state:
+            this = state.as_dict()
+        variables = {"this": this}
         if self._trigger_variables:
             try:
                 variables = self._trigger_variables.async_render(
-                    self.hass, None, limited=True
+                    self.hass,
+                    variables,
+                    limited=True,
                 )
             except template.TemplateError as err:
                 self._logger.error("Error rendering trigger variables: %s", err)

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -401,7 +401,12 @@ class ScriptEntity(ToggleEntity):
             # Prepare tracing the execution of the script's sequence
             script_trace.set_trace(trace_get())
             with trace_path("sequence"):
-                return await self.script.async_run(variables, context)
+                this = None
+                state = self.hass.states.get(self.entity_id)
+                if state:
+                    this = state.as_dict()
+                script_vars = {"this": this, **(variables or {})}
+                return await self.script.async_run(script_vars, context)
 
     async def async_turn_off(self, **kwargs):
         """Stop running the script.

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1184,6 +1184,7 @@ async def test_automation_variables(hass, caplog):
                     "variables": {
                         "test_var": "defined_in_config",
                         "event_type": "{{ trigger.event.event_type }}",
+                        "this_variables": "{{this.entity_id}}",
                     },
                     "trigger": {"platform": "event", "event_type": "test_event"},
                     "action": {
@@ -1191,6 +1192,8 @@ async def test_automation_variables(hass, caplog):
                         "data": {
                             "value": "{{ test_var }}",
                             "event_type": "{{ event_type }}",
+                            "this_template": "{{this.entity_id}}",
+                            "this_variables": "{{this_variables}}",
                         },
                     },
                 },
@@ -1224,6 +1227,11 @@ async def test_automation_variables(hass, caplog):
     assert len(calls) == 1
     assert calls[0].data["value"] == "defined_in_config"
     assert calls[0].data["event_type"] == "test_event"
+    # Verify this available to all templates
+    assert calls[0].data.get("this_template") == "automation.automation_0"
+    # Verify this available during variables rendering
+    assert calls[0].data.get("this_variables") == "automation.automation_0"
+    assert "Error rendering variables" not in caplog.text
 
     hass.bus.async_fire("test_event_2")
     await hass.async_block_till_done()
@@ -1276,6 +1284,7 @@ async def test_automation_trigger_variables(hass, caplog):
                     },
                     "trigger_variables": {
                         "test_var": "defined_in_config",
+                        "this_trigger_variables": "{{this.entity_id}}",
                     },
                     "trigger": {"platform": "event", "event_type": "test_event_2"},
                     "action": {
@@ -1283,6 +1292,8 @@ async def test_automation_trigger_variables(hass, caplog):
                         "data": {
                             "value": "{{ test_var }}",
                             "event_type": "{{ event_type }}",
+                            "this_template": "{{this.entity_id}}",
+                            "this_trigger_variables": "{{this_trigger_variables}}",
                         },
                     },
                 },
@@ -1300,7 +1311,10 @@ async def test_automation_trigger_variables(hass, caplog):
     assert len(calls) == 2
     assert calls[1].data["value"] == "overridden_in_config"
     assert calls[1].data["event_type"] == "test_event_2"
-
+    # Verify this available to all templates
+    assert calls[1].data.get("this_template") == "automation.automation_1"
+    # Verify this available during trigger variables rendering
+    assert calls[1].data.get("this_trigger_variables") == "automation.automation_1"
     assert "Error rendering variables" not in caplog.text
 
 
@@ -1330,6 +1344,35 @@ async def test_automation_bad_trigger_variables(hass, caplog):
 
     await hass.async_block_till_done()
     assert len(calls) == 0
+
+
+async def test_automation_this_var_always(hass, caplog):
+    """Test automation always has reference to this, even with no variable or trigger variables configured."""
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "action": {
+                        "service": "test.automation",
+                        "data": {
+                            "this_template": "{{this.entity_id}}",
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    # Verify this available to all templates
+    assert calls[0].data.get("this_template") == "automation.automation_0"
+    assert "Error rendering variables" not in caplog.text
 
 
 async def test_blueprint_automation(hass, calls):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a "this" variable to be used in templates for automation and scripts.
In automation "this" contains the states of the automation entity when rendering automation variables and trigger variables.
In script "this" contains the states of the script entity when rendering the script variables.

Note: This replaces #52556

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [18505](https://github.com/home-assistant/home-assistant.io/pull/18505)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing 

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
