### PR TITLE
Upgrade pymazda to 0.2.0

### DIFF
--- a/homeassistant/components/mazda/__init__.py
+++ b/homeassistant/components/mazda/__init__.py
@@ -50,7 +50,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     region = entry.data[CONF_REGION]
 
     websession = aiohttp_client.async_get_clientsession(hass)
-    mazda_client = MazdaAPI(email, password, region, websession)
+    mazda_client = MazdaAPI(
+        email, password, region, websession=websession, use_cached_vehicle_list=True
+    )
 
     try:
         await mazda_client.validate_credentials()
@@ -166,7 +168,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER,
         name=DOMAIN,
         update_method=async_update_data,
-        update_interval=timedelta(seconds=60),
+        update_interval=timedelta(seconds=180),
     )
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/mazda/manifest.json
+++ b/homeassistant/components/mazda/manifest.json
@@ -3,7 +3,7 @@
   "name": "Mazda Connected Services",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/mazda",
-  "requirements": ["pymazda==0.1.6"],
+  "requirements": ["pymazda==0.2.0"],
   "codeowners": ["@bdr99"],
   "quality_scale": "platinum",
   "iot_class": "cloud_polling"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1570,7 +1570,7 @@ pymailgunner==1.4
 pymata-express==1.19
 
 # homeassistant.components.mazda
-pymazda==0.1.6
+pymazda==0.2.0
 
 # homeassistant.components.mediaroom
 pymediaroom==0.6.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -887,7 +887,7 @@ pymailgunner==1.4
 pymata-express==1.19
 
 # homeassistant.components.mazda
-pymazda==0.1.6
+pymazda==0.2.0
 
 # homeassistant.components.melcloud
 pymelcloud==2.5.3

--- a/tests/components/mazda/test_init.py
+++ b/tests/components/mazda/test_init.py
@@ -97,7 +97,7 @@ async def test_update_auth_failure(hass: HomeAssistant):
         "homeassistant.components.mazda.MazdaAPI.get_vehicles",
         side_effect=MazdaAuthenticationException("Login failed"),
     ):
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=61))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=181))
         await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()
@@ -136,7 +136,7 @@ async def test_update_general_failure(hass: HomeAssistant):
         "homeassistant.components.mazda.MazdaAPI.get_vehicles",
         side_effect=Exception("Unknown exception"),
     ):
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=61))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=181))
         await hass.async_block_till_done()
 
     entity = hass.states.get("sensor.my_mazda3_fuel_remaining_percentage")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upgrade the pymazda client library to 0.2.0 to fix the Mazda integration. This change adds an HTTP header which was previously not required by the Mazda API, but is now required. Also enables caching and changes the update interval from 1 minute to 3 minutes, to avoid rate limiting issues which arose at the same time as the new header validation.

It would be great if we could get this into an upcoming patch release, since the integration is currently completely broken. The fix has been validated by several people here: https://github.com/bdr99/pymazda/issues/11

Changes from 0.1.6 to 0.2.0: https://github.com/bdr99/pymazda/compare/0.1.6...0.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: Fixes #51920
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
