### PR TITLE
Bump python-fireservicerota to 0.0.42

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -354,10 +354,6 @@ omit =
     homeassistant/components/garages_amsterdam/__init__.py
     homeassistant/components/garages_amsterdam/binary_sensor.py
     homeassistant/components/garages_amsterdam/sensor.py
-    homeassistant/components/garmin_connect/__init__.py
-    homeassistant/components/garmin_connect/const.py
-    homeassistant/components/garmin_connect/sensor.py
-    homeassistant/components/garmin_connect/alarm_util.py
     homeassistant/components/gc100/*
     homeassistant/components/geniushub/*
     homeassistant/components/github/sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -354,6 +354,10 @@ omit =
     homeassistant/components/garages_amsterdam/__init__.py
     homeassistant/components/garages_amsterdam/binary_sensor.py
     homeassistant/components/garages_amsterdam/sensor.py
+    homeassistant/components/garmin_connect/__init__.py
+    homeassistant/components/garmin_connect/const.py
+    homeassistant/components/garmin_connect/sensor.py
+    homeassistant/components/garmin_connect/alarm_util.py
     homeassistant/components/gc100/*
     homeassistant/components/geniushub/*
     homeassistant/components/github/sensor.py

--- a/homeassistant/components/fireservicerota/manifest.json
+++ b/homeassistant/components/fireservicerota/manifest.json
@@ -3,7 +3,7 @@
   "name": "FireServiceRota",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/fireservicerota",
-  "requirements": ["pyfireservicerota==0.0.40"],
+  "requirements": ["pyfireservicerota==0.0.41"],
   "codeowners": ["@cyberjunky"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/fireservicerota/manifest.json
+++ b/homeassistant/components/fireservicerota/manifest.json
@@ -3,7 +3,7 @@
   "name": "FireServiceRota",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/fireservicerota",
-  "requirements": ["pyfireservicerota==0.0.41"],
+  "requirements": ["pyfireservicerota==0.0.42"],
   "codeowners": ["@cyberjunky"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1422,7 +1422,7 @@ pyezviz==0.1.8.9
 pyfido==2.1.1
 
 # homeassistant.components.fireservicerota
-pyfireservicerota==0.0.40
+pyfireservicerota==0.0.41
 
 # homeassistant.components.flexit
 pyflexit==0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1422,7 +1422,7 @@ pyezviz==0.1.8.9
 pyfido==2.1.1
 
 # homeassistant.components.fireservicerota
-pyfireservicerota==0.0.41
+pyfireservicerota==0.0.42
 
 # homeassistant.components.flexit
 pyflexit==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -357,9 +357,6 @@ gTTS==2.2.3
 # homeassistant.components.garages_amsterdam
 garages-amsterdam==2.1.1
 
-# homeassistant.components.garmin_connect
-garminconnect_ha==0.1.6
-
 # homeassistant.components.geo_json_events
 # homeassistant.components.usgs_earthquakes_feed
 geojson_client==0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -790,7 +790,7 @@ pyezviz==0.1.8.9
 pyfido==2.1.1
 
 # homeassistant.components.fireservicerota
-pyfireservicerota==0.0.41
+pyfireservicerota==0.0.42
 
 # homeassistant.components.flume
 pyflume==0.5.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -790,7 +790,7 @@ pyezviz==0.1.8.9
 pyfido==2.1.1
 
 # homeassistant.components.fireservicerota
-pyfireservicerota==0.0.40
+pyfireservicerota==0.0.41
 
 # homeassistant.components.flume
 pyflume==0.5.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -357,6 +357,9 @@ gTTS==2.2.3
 # homeassistant.components.garages_amsterdam
 garages-amsterdam==2.1.1
 
+# homeassistant.components.garmin_connect
+garminconnect_ha==0.1.6
+
 # homeassistant.components.geo_json_events
 # homeassistant.components.usgs_earthquakes_feed
 geojson_client==0.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump python-fireservicerota to 0.0.42 to make it compatible with latest websocket-client version 1.1.0

https://github.com/cyberjunky/python-fireservicerota/compare/0.0.40...0.0.42


This fixes these errors:
error from callback <bound method FireServiceRotaIncidents.__on_open of <pyfireservicerota.FireServiceRotaIncidents object at 0xffff6f9a5f40>>: __on_open() takes 1 positional argument but 2 were given
error from callback <bound method FireServiceRotaIncidents.__on_message of <pyfireservicerota.FireServiceRotaIncidents object at 0xffff6f9a5f40>>: __on_message() takes 2 positional arguments but 3 were given
error from callback <bound method FireServiceRotaIncidents.__on_error of <pyfireservicerota.FireServiceRotaIncidents object at 0xffff6f9a5f40>>: __on_error() takes 2 positional arguments but 3 were given
error from callback <bound method FireServiceRotaIncidents.__on_close of <pyfireservicerota.FireServiceRotaIncidents object at 0xffff6f9a5f40>>: __on_close() takes 1 positional argument but 4 were given

Occurring in Home Assistant 2021.7.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
