### PR TITLE
Bump pyatv to 0.8.1

### DIFF
--- a/homeassistant/components/apple_tv/manifest.json
+++ b/homeassistant/components/apple_tv/manifest.json
@@ -3,7 +3,7 @@
   "name": "Apple TV",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/apple_tv",
-  "requirements": ["pyatv==0.7.7"],
+  "requirements": ["pyatv==0.8.1"],
   "zeroconf": ["_mediaremotetv._tcp.local.", "_touch-able._tcp.local."],
   "after_dependencies": ["discovery"],
   "codeowners": ["@postlund"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1317,7 +1317,7 @@ pyatmo==5.2.0
 pyatome==0.1.1
 
 # homeassistant.components.apple_tv
-pyatv==0.7.7
+pyatv==0.8.1
 
 # homeassistant.components.bbox
 pybbox==0.0.5-alpha

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -742,7 +742,7 @@ pyatag==0.3.5.3
 pyatmo==5.2.0
 
 # homeassistant.components.apple_tv
-pyatv==0.7.7
+pyatv==0.8.1
 
 # homeassistant.components.blackbird
 pyblackbird==0.5

--- a/tests/components/apple_tv/conftest.py
+++ b/tests/components/apple_tv/conftest.py
@@ -2,7 +2,8 @@
 
 from unittest.mock import patch
 
-from pyatv import conf, net
+from pyatv import conf
+from pyatv.support.http import create_session
 import pytest
 
 from .common import MockPairingHandler, create_conf
@@ -39,7 +40,7 @@ def pairing():
 
         async def _pair(config, protocol, loop, session=None, **kwargs):
             handler = MockPairingHandler(
-                await net.create_session(session), config.get_service(protocol)
+                await create_session(session), config.get_service(protocol)
             )
             handler.always_fail = mock_pair.always_fail
             return handler

--- a/tests/components/apple_tv/conftest.py
+++ b/tests/components/apple_tv/conftest.py
@@ -122,11 +122,7 @@ def dmap_device_with_credentials(mock_scan):
 
 
 @pytest.fixture
-def airplay_device(mock_scan):
+def device_with_no_services(mock_scan):
     """Mock pyatv.scan."""
-    mock_scan.result.append(
-        create_conf(
-            "127.0.0.1", "AirPlay Device", conf.AirPlayService("airplayid", port=7777)
-        )
-    )
+    mock_scan.result.append(create_conf("127.0.0.1", "Invalid Device"))
     yield mock_scan

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -236,15 +236,15 @@ async def test_user_adds_existing_device(hass, mrp_device):
     assert result2["errors"] == {"base": "already_configured"}
 
 
-async def test_user_adds_unusable_device(hass, airplay_device):
-    """Test that it is not possible to add pure AirPlay device."""
+async def test_user_adds_unusable_device(hass, device_with_no_services):
+    """Test that it is not possible to add device with no services."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {"device_input": "AirPlay Device"},
+        {"device_input": "Invalid Device"},
     )
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "no_usable_service"}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump pyatv to 0.8.1 to improve connection handling when connectivity is interrupted.

https://github.com/postlund/pyatv/compare/v0.7.7...v0.8.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #49019
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
