### PR TITLE
Add template option to entity_id for state and numeric_state triggers

### DIFF
--- a/homeassistant/components/homeassistant/triggers/numeric_state.py
+++ b/homeassistant/components/homeassistant/triggers/numeric_state.py
@@ -20,6 +20,8 @@ from homeassistant.helpers.event import (
     async_track_state_change_event,
 )
 
+from .util import validate_entities_or_template_of_entities
+
 # mypy: allow-incomplete-defs, allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs
 
@@ -47,7 +49,7 @@ TRIGGER_SCHEMA = vol.All(
     cv.TRIGGER_BASE_SCHEMA.extend(
         {
             vol.Required(CONF_PLATFORM): "numeric_state",
-            vol.Required(CONF_ENTITY_ID): cv.entity_ids,
+            vol.Required(CONF_ENTITY_ID): validate_entities_or_template_of_entities,
             vol.Optional(CONF_BELOW): cv.NUMERIC_STATE_THRESHOLD_SCHEMA,
             vol.Optional(CONF_ABOVE): cv.NUMERIC_STATE_THRESHOLD_SCHEMA,
             vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
@@ -66,7 +68,7 @@ async def async_attach_trigger(
     hass, config, action, automation_info, *, platform_type="numeric_state"
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
-    entity_ids = config.get(CONF_ENTITY_ID)
+    entity_id = config.get(CONF_ENTITY_ID)
     below = config.get(CONF_BELOW)
     above = config.get(CONF_ABOVE)
     time_delta = config.get(CONF_FOR)
@@ -81,6 +83,7 @@ async def async_attach_trigger(
     trigger_data = automation_info["trigger_data"]
     _variables = automation_info["variables"] or {}
 
+    entity_ids = validate_entities_or_template_of_entities(entity_id, hass, _variables)
     if value_template is not None:
         value_template.hass = hass
 

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -18,10 +18,13 @@ from homeassistant.helpers.event import (
     process_state_match,
 )
 
+from .util import validate_entities_or_template_of_entities
+
 # mypy: allow-incomplete-defs, allow-untyped-calls, allow-untyped-defs
 # mypy: no-check-untyped-defs
 
 _LOGGER = logging.getLogger(__name__)
+
 
 CONF_ENTITY_ID = "entity_id"
 CONF_FROM = "from"
@@ -30,7 +33,7 @@ CONF_TO = "to"
 BASE_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): "state",
-        vol.Required(CONF_ENTITY_ID): cv.entity_ids,
+        vol.Required(CONF_ENTITY_ID): validate_entities_or_template_of_entities,
         vol.Optional(CONF_FOR): cv.positive_time_period_template,
         vol.Optional(CONF_ATTRIBUTE): cv.match_all,
     }
@@ -89,6 +92,8 @@ async def async_attach_trigger(
 
     trigger_data = automation_info["trigger_data"]
     _variables = automation_info["variables"] or {}
+
+    entity_ids = validate_entities_or_template_of_entities(entity_id, hass, _variables)
 
     @callback
     def state_automation_listener(event: Event):
@@ -192,7 +197,7 @@ async def async_attach_trigger(
             entity_ids=entity,
         )
 
-    unsub = async_track_state_change_event(hass, entity_id, state_automation_listener)
+    unsub = async_track_state_change_event(hass, entity_ids, state_automation_listener)
 
     @callback
     def async_remove():

--- a/homeassistant/components/homeassistant/triggers/util.py
+++ b/homeassistant/components/homeassistant/triggers/util.py
@@ -1,0 +1,34 @@
+"""Utility functions for triggers."""
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import exceptions
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, template
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def validate_entities_or_template_of_entities(
+    value: Any, hass: HomeAssistant = None, variables: Any = None
+):
+    """Return List of Entity IDs, directly configured or from a template."""
+    if value is None:
+        raise vol.Invalid("Entity IDs can not be None")
+    if isinstance(value, str):
+        if value.startswith("{"):
+            value = cv.template(value)
+    if isinstance(value, template.Template):
+        if hass:
+            try:
+                value.hass = hass
+                value = value.async_render(variables, limited=True)
+                return cv.entity_ids(value)
+            except (exceptions.TemplateError, vol.Invalid, TypeError):
+                _LOGGER.error("Invalid Template! Must return list of entities")
+                return []
+        else:
+            return value
+    return cv.entity_ids(value)

--- a/tests/components/homeassistant/triggers/test_util.py
+++ b/tests/components/homeassistant/triggers/test_util.py
@@ -1,0 +1,41 @@
+"""The test for trigger util."""
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.homeassistant.triggers.util import (
+    validate_entities_or_template_of_entities,
+)
+from homeassistant.helpers import template
+
+
+def test_validate_entity_or_template_of_entities():
+    """Test Template or entity ID validation."""
+    schema = vol.Schema(validate_entities_or_template_of_entities)
+
+    options = (
+        None,
+        "invalid_entity",
+        "sensor.light,sensor_invalid",
+        ["invalid_entity"],
+        ["sensor.light", "sensor_invalid"],
+        ["sensor.light,sensor_invalid"],
+        "sensor.light,{{more}}",
+        "{{get_ids}",
+    )
+    for value in options:
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    options = (
+        [],
+        ["sensor.light"],
+        "sensor.light",
+        "{{get_ids}}",
+        "{{get_ids}},sensor.light",
+    )
+    for value in options:
+        schema(value)
+
+    assert schema("sensor.LIGHT, light.kitchen ") == ["sensor.light", "light.kitchen"]
+    assert isinstance(schema("{{get_ids}}"), template.Template)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the option to use a template for the entity_id property of State and Numeric State triggers.
This allows a blueprint to use the result of a selector to specify the entities for a trigger. 
Example blueprint is as follows:
```
blueprint:
  name: Test State Entity ID Template
  description: Demonstrate using a selector to select multiple entities for a State Trigger
  domain: automation
  source_url: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/blueprints/test.yaml
  input:
    entities:
      name: Trigger Entities
      selector:
        target:
          entity:
            domain: switch

trigger_variables:
  entities: !input entities

trigger:
  platform: state
  id: StateTemplate
  entity_id: "{{entities.entity_id}}"
action:
  - service: logbook.log
    data:
      name: Triggered
      message: "Trigger:{{trigger}}"

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [18506](https://github.com/home-assistant/home-assistant.io/pull/18506)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
