### PR TITLE
Improve testing of option flow in Coinbase

### DIFF
--- a/tests/components/coinbase/const.py
+++ b/tests/components/coinbase/const.py
@@ -10,13 +10,6 @@ BAD_EXCHANGE_RATE = "ETH"
 
 MOCK_ACCOUNTS_RESPONSE = [
     {
-        "balance": {"amount": "13.38", "currency": GOOD_CURRENCY_3},
-        "currency": GOOD_CURRENCY_3,
-        "id": "ABCDEF",
-        "name": "BTC Wallet",
-        "native_balance": {"amount": "15.02", "currency": GOOD_CURRENCY_2},
-    },
-    {
         "balance": {"amount": "0.00001", "currency": GOOD_CURRENCY},
         "currency": GOOD_CURRENCY,
         "id": "123456789",

--- a/tests/components/coinbase/test_config_flow.py
+++ b/tests/components/coinbase/test_config_flow.py
@@ -19,14 +19,7 @@ from .common import (
     mock_get_exchange_rates,
     mocked_get_accounts,
 )
-from .const import (
-    BAD_CURRENCY,
-    BAD_EXCHANGE_RATE,
-    GOOD_CURRENCY,
-    GOOD_CURRENCY_2,
-    GOOD_EXCHNAGE_RATE,
-    GOOD_EXCHNAGE_RATE_2,
-)
+from .const import BAD_CURRENCY, BAD_EXCHANGE_RATE, GOOD_CURRENCY, GOOD_EXCHNAGE_RATE
 
 from tests.common import MockConfigEntry
 
@@ -144,19 +137,8 @@ async def test_form_catch_all_exception(hass):
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_option_good_account_currency(hass):
+async def test_option_form(hass):
     """Test we handle a good wallet currency option."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="abcde12345",
-        title="Test User",
-        data={CONF_API_KEY: "123456", CONF_API_TOKEN: "AbCDeF"},
-        options={
-            CONF_CURRENCIES: [GOOD_CURRENCY_2],
-            CONF_EXCHANGE_RATES: [],
-        },
-    )
-    config_entry.add_to_hass(hass)
 
     with patch(
         "coinbase.wallet.client.Client.get_current_user",
@@ -166,8 +148,11 @@ async def test_option_good_account_currency(hass):
     ), patch(
         "coinbase.wallet.client.Client.get_exchange_rates",
         return_value=mock_get_exchange_rates(),
-    ):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    ), patch(
+        "homeassistant.components.coinbase.update_listener"
+    ) as mock_update_listener:
+
+        config_entry = await init_mock_coinbase(hass)
         await hass.async_block_till_done()
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -175,10 +160,12 @@ async def test_option_good_account_currency(hass):
             result["flow_id"],
             user_input={
                 CONF_CURRENCIES: [GOOD_CURRENCY],
-                CONF_EXCHANGE_RATES: [],
+                CONF_EXCHANGE_RATES: [GOOD_EXCHNAGE_RATE],
             },
         )
-    assert result2["type"] == "create_entry"
+        assert result2["type"] == "create_entry"
+        await hass.async_block_till_done()
+        assert len(mock_update_listener.mock_calls) == 1
 
 
 async def test_form_bad_account_currency(hass):
@@ -205,43 +192,6 @@ async def test_form_bad_account_currency(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "currency_unavaliable"}
-
-
-async def test_option_good_exchange_rate(hass):
-    """Test we handle a good exchange rate option."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="abcde12345",
-        title="Test User",
-        data={CONF_API_KEY: "123456", CONF_API_TOKEN: "AbCDeF"},
-        options={
-            CONF_CURRENCIES: [],
-            CONF_EXCHANGE_RATES: [GOOD_EXCHNAGE_RATE_2],
-        },
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "coinbase.wallet.client.Client.get_current_user",
-        return_value=mock_get_current_user(),
-    ), patch(
-        "coinbase.wallet.client.Client.get_accounts", new=mocked_get_accounts
-    ), patch(
-        "coinbase.wallet.client.Client.get_exchange_rates",
-        return_value=mock_get_exchange_rates(),
-    ):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        await hass.async_block_till_done()
-        result2 = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_CURRENCIES: [],
-                CONF_EXCHANGE_RATES: [GOOD_EXCHNAGE_RATE],
-            },
-        )
-    assert result2["type"] == "create_entry"
 
 
 async def test_form_bad_exchange_rate(hass):

--- a/tests/components/coinbase/test_init.py
+++ b/tests/components/coinbase/test_init.py
@@ -22,7 +22,6 @@ from .common import (
 from .const import (
     GOOD_CURRENCY,
     GOOD_CURRENCY_2,
-    GOOD_CURRENCY_3,
     GOOD_EXCHNAGE_RATE,
     GOOD_EXCHNAGE_RATE_2,
 )
@@ -103,7 +102,7 @@ async def test_option_updates(hass: HomeAssistant):
         await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
-                CONF_CURRENCIES: [GOOD_CURRENCY, GOOD_CURRENCY_3],
+                CONF_CURRENCIES: [GOOD_CURRENCY, GOOD_CURRENCY_2],
                 CONF_EXCHANGE_RATES: [GOOD_EXCHNAGE_RATE, GOOD_EXCHNAGE_RATE_2],
             },
         )
@@ -126,7 +125,7 @@ async def test_option_updates(hass: HomeAssistant):
             if "xe" in entity.unique_id
         ]
 
-        assert currencies == [GOOD_CURRENCY, GOOD_CURRENCY_3]
+        assert currencies == [GOOD_CURRENCY, GOOD_CURRENCY_2]
         assert rates == [GOOD_EXCHNAGE_RATE, GOOD_EXCHNAGE_RATE_2]
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)

--- a/tests/components/coinbase/test_init.py
+++ b/tests/components/coinbase/test_init.py
@@ -9,6 +9,8 @@ from homeassistant.components.coinbase.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry
 from homeassistant.setup import async_setup_component
 
 from .common import (
@@ -20,6 +22,7 @@ from .common import (
 from .const import (
     GOOD_CURRENCY,
     GOOD_CURRENCY_2,
+    GOOD_CURRENCY_3,
     GOOD_EXCHNAGE_RATE,
     GOOD_EXCHNAGE_RATE_2,
 )
@@ -78,3 +81,81 @@ async def test_unload_entry(hass):
 
     assert entry.state == config_entries.ConfigEntryState.NOT_LOADED
     assert not hass.data.get(DOMAIN)
+
+
+async def test_option_updates(hass: HomeAssistant):
+    """Test handling option updates."""
+
+    with patch(
+        "coinbase.wallet.client.Client.get_current_user",
+        return_value=mock_get_current_user(),
+    ), patch(
+        "coinbase.wallet.client.Client.get_accounts", new=mocked_get_accounts
+    ), patch(
+        "coinbase.wallet.client.Client.get_exchange_rates",
+        return_value=mock_get_exchange_rates(),
+    ):
+        config_entry = await init_mock_coinbase(hass)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        await hass.async_block_till_done()
+        await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_CURRENCIES: [GOOD_CURRENCY, GOOD_CURRENCY_3],
+                CONF_EXCHANGE_RATES: [GOOD_EXCHNAGE_RATE, GOOD_EXCHNAGE_RATE_2],
+            },
+        )
+        await hass.async_block_till_done()
+
+        registry = entity_registry.async_get(hass)
+        entities = entity_registry.async_entries_for_config_entry(
+            registry, config_entry.entry_id
+        )
+        assert len(entities) == 4
+        currencies = [
+            entity.unique_id.split("-")[-1]
+            for entity in entities
+            if "wallet" in entity.unique_id
+        ]
+
+        rates = [
+            entity.unique_id.split("-")[-1]
+            for entity in entities
+            if "xe" in entity.unique_id
+        ]
+
+        assert currencies == [GOOD_CURRENCY, GOOD_CURRENCY_3]
+        assert rates == [GOOD_EXCHNAGE_RATE, GOOD_EXCHNAGE_RATE_2]
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        await hass.async_block_till_done()
+        await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_CURRENCIES: [GOOD_CURRENCY],
+                CONF_EXCHANGE_RATES: [GOOD_EXCHNAGE_RATE],
+            },
+        )
+        await hass.async_block_till_done()
+
+        registry = entity_registry.async_get(hass)
+        entities = entity_registry.async_entries_for_config_entry(
+            registry, config_entry.entry_id
+        )
+        assert len(entities) == 2
+        currencies = [
+            entity.unique_id.split("-")[-1]
+            for entity in entities
+            if "wallet" in entity.unique_id
+        ]
+
+        rates = [
+            entity.unique_id.split("-")[-1]
+            for entity in entities
+            if "xe" in entity.unique_id
+        ]
+
+        assert currencies == [GOOD_CURRENCY]
+        assert rates == [GOOD_EXCHNAGE_RATE]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improves testing of changes to config options. Moves testing of valid wallet currency AND valid exchange rate into a single test and explicitly checks the handling of creating/removing entities after an update via the option flow. Also resolves a race condition in the releasing of a patch that was causing some tests to use the Coinbase endpoint rather than the mock after test was complete.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
