### PR TITLE
Prefer using XY over HS when supported by deCONZ lights

### DIFF
--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -26,6 +26,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.util.color import color_hs_to_xy
 
 from .const import (
     COVER_TYPES,
@@ -189,8 +190,11 @@ class DeconzBaseLight(DeconzDevice, LightEntity):
             data["ct"] = kwargs[ATTR_COLOR_TEMP]
 
         if ATTR_HS_COLOR in kwargs:
-            data["hue"] = int(kwargs[ATTR_HS_COLOR][0] / 360 * 65535)
-            data["sat"] = int(kwargs[ATTR_HS_COLOR][1] / 100 * 255)
+            if COLOR_MODE_XY in self._attr_supported_color_modes:
+                data["xy"] = color_hs_to_xy(*kwargs[ATTR_HS_COLOR])
+            else:
+                data["hue"] = int(kwargs[ATTR_HS_COLOR][0] / 360 * 65535)
+                data["sat"] = int(kwargs[ATTR_HS_COLOR][1] / 100 * 255)
 
         if ATTR_XY_COLOR in kwargs:
             data["xy"] = kwargs[ATTR_XY_COLOR]

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -371,6 +371,34 @@ async def test_light_state_change(hass, aioclient_mock, mock_deconz_websocket):
 @pytest.mark.parametrize(
     "input,expected",
     [
+        (  # Turn on light with hue and sat
+            {
+                "light_on": True,
+                "service": SERVICE_TURN_ON,
+                "call": {
+                    ATTR_ENTITY_ID: "light.hue_go",
+                    ATTR_HS_COLOR: (20, 30),
+                },
+            },
+            {
+                "on": True,
+                "xy": (0.411, 0.351),
+            },
+        ),
+        (  # Turn on light with XY color
+            {
+                "light_on": True,
+                "service": SERVICE_TURN_ON,
+                "call": {
+                    ATTR_ENTITY_ID: "light.hue_go",
+                    ATTR_XY_COLOR: (0.411, 0.351),
+                },
+            },
+            {
+                "on": True,
+                "xy": (0.411, 0.351),
+            },
+        ),
         (  # Turn on light with short color loop
             {
                 "light_on": False,
@@ -811,9 +839,8 @@ async def test_groups(hass, aioclient_mock, input, expected):
                 },
             },
             {
-                "hue": 45510,
                 "on": True,
-                "sat": 127,
+                "xy": (0.235, 0.164),
             },
         ),
         (  # Turn on group with short color loop
@@ -827,9 +854,8 @@ async def test_groups(hass, aioclient_mock, input, expected):
                 },
             },
             {
-                "hue": 45510,
                 "on": True,
-                "sat": 127,
+                "xy": (0.235, 0.164),
             },
         ),
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some lights wrongfully report that they support HS color mode. This change translates HS to XY in case XY is supported.
This will be fixed in deCONZ down the line with a proper color capability attribute

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52665
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
