### PR TITLE
Change kef entity unique_id

### DIFF
--- a/homeassistant/components/kef/manifest.json
+++ b/homeassistant/components/kef/manifest.json
@@ -3,6 +3,6 @@
   "name": "KEF",
   "documentation": "https://www.home-assistant.io/integrations/kef",
   "codeowners": ["@basnijholt"],
-  "requirements": ["aiokef==0.2.16", "getmac==0.8.2"],
+  "requirements": ["aiokef==0.2.16"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/kef/media_player.py
+++ b/homeassistant/components/kef/media_player.py
@@ -1,13 +1,10 @@
 """Platform for the KEF Wireless Speakers."""
 
 from datetime import timedelta
-from functools import partial
-import ipaddress
 import logging
 
 from aiokef import AsyncKefSpeaker
 from aiokef.aiokef import DSP_OPTION_MAPPING
-from getmac import get_mac_address
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -85,16 +82,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def get_ip_mode(host):
-    """Get the 'mode' used to retrieve the MAC address."""
-    try:
-        if ipaddress.ip_address(host).version == 6:
-            return "ip6"
-        return "ip"
-    except ValueError:
-        return "hostname"
-
-
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the KEF platform."""
     if DOMAIN not in hass.data:
@@ -121,10 +108,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         sources,
     )
 
-    mode = get_ip_mode(host)
-    mac = await hass.async_add_executor_job(partial(get_mac_address, **{mode: host}))
-    unique_id = f"kef-{mac}" if mac is not None else None
-
     media_player = KefMediaPlayer(
         name,
         host,
@@ -137,7 +120,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         sources,
         speaker_type,
         loop=hass.loop,
-        unique_id=unique_id,
+        unique_id=f"kef-{host}",
     )
 
     if host in hass.data[DOMAIN]:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -670,7 +670,6 @@ georss_ign_sismologia_client==0.3
 # homeassistant.components.qld_bushfire
 georss_qld_bushfire_alert_client==0.5
 
-# homeassistant.components.kef
 # homeassistant.components.minecraft_server
 # homeassistant.components.nmap_tracker
 getmac==0.8.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -376,7 +376,6 @@ georss_ign_sismologia_client==0.3
 # homeassistant.components.qld_bushfire
 georss_qld_bushfire_alert_client==0.5
 
-# homeassistant.components.kef
 # homeassistant.components.minecraft_server
 # homeassistant.components.nmap_tracker
 getmac==0.8.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Will create a new entity because we use a different `unique_id`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The MAC address isn't available when the speaker is offline, which results in two different entities, one with a `unique_id` set to the MAC address and the other set to None.

Now we use the IP of the speaker as `unique_id`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47678
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
