### PR TITLE
Correct set_temperature in modbus climate

### DIFF
--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -165,8 +165,8 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
         """Set new target temperature."""
         if ATTR_TEMPERATURE not in kwargs:
             return
-        target_temperature = int(
-            (kwargs.get(ATTR_TEMPERATURE) - self._offset) / self._scale
+        target_temperature = (
+            float(kwargs.get(ATTR_TEMPERATURE) - self._offset) / self._scale
         )
         if self._data_type in [
             DATA_TYPE_INT16,
@@ -177,8 +177,6 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
             DATA_TYPE_UINT64,
         ]:
             target_temperature = int(target_temperature)
-        else:
-            target_temperature = float(target_temperature)
         byte_array = struct.pack(self._structure, target_temperature)
         raw_regs = [byte_array[i : i + 2] for i in range(0, len(byte_array), 2)]
         registers = self._swap_registers(raw_regs)

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -177,9 +177,10 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
             DATA_TYPE_UINT64,
         ]:
             target_temperature = int(target_temperature)
-        bytes = struct.pack(self._structure, target_temperature)
+        as_bytes = struct.pack(self._structure, target_temperature)
         raw_regs = [
-            int.from_bytes(bytes[i : i + 2], "big") for i in range(0, len(bytes), 2)
+            int.from_bytes(as_bytes[i : i + 2], "big")
+            for i in range(0, len(as_bytes), 2)
         ]
         registers = self._swap_registers(raw_regs)
         result = await self._hub.async_pymodbus_call(

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -177,8 +177,10 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
             DATA_TYPE_UINT64,
         ]:
             target_temperature = int(target_temperature)
-        byte_array = struct.pack(self._structure, target_temperature)
-        raw_regs = [byte_array[i : i + 2] for i in range(0, len(byte_array), 2)]
+        bytes = struct.pack(self._structure, target_temperature)
+        raw_regs = [
+            int.from_bytes(bytes[i : i + 2], "big") for i in range(0, len(bytes), 2)
+        ]
         registers = self._swap_registers(raw_regs)
         result = await self._hub.async_pymodbus_call(
             self._slave,

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -166,8 +166,8 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
         if ATTR_TEMPERATURE not in kwargs:
             return
         target_temperature = (
-            float(kwargs.get(ATTR_TEMPERATURE) - self._offset) / self._scale
-        )
+            float(kwargs.get(ATTR_TEMPERATURE)) - self._offset
+        ) / self._scale
         if self._data_type in [
             DATA_TYPE_INT16,
             DATA_TYPE_INT32,

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -3,7 +3,15 @@ import pytest
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.climate.const import HVAC_MODE_AUTO
-from homeassistant.components.modbus.const import CONF_CLIMATES, CONF_TARGET_TEMP
+from homeassistant.components.modbus.const import (
+    CONF_CLIMATES,
+    CONF_DATA_TYPE,
+    CONF_TARGET_TEMP,
+    DATA_TYPE_FLOAT32,
+    DATA_TYPE_FLOAT64,
+    DATA_TYPE_INT16,
+    DATA_TYPE_INT32,
+)
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_ADDRESS,
@@ -108,6 +116,46 @@ async def test_service_climate_update(hass, mock_pymodbus):
         "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
     )
     assert hass.states.get(ENTITY_ID).state == "auto"
+
+
+@pytest.mark.parametrize(
+    "data_type, temperature, result",
+    [
+        (DATA_TYPE_INT16, 35, [0x00]),
+        (DATA_TYPE_INT32, 36, [0x00, 0x00]),
+        (DATA_TYPE_FLOAT32, 37.5, [0x00, 0x00]),
+        (DATA_TYPE_FLOAT64, "39", [0x00, 0x00, 0x00, 0x00]),
+    ],
+)
+async def test_service_climate_set_temperature(
+    hass, data_type, temperature, result, mock_pymodbus
+):
+    """Run test for service homeassistant.update_entity."""
+    config = {
+        CONF_CLIMATES: [
+            {
+                CONF_NAME: CLIMATE_NAME,
+                CONF_TARGET_TEMP: 117,
+                CONF_ADDRESS: 117,
+                CONF_SLAVE: 10,
+                CONF_DATA_TYPE: data_type,
+            }
+        ]
+    }
+    mock_pymodbus.read_holding_registers.return_value = ReadResult(result)
+    await prepare_service_update(
+        hass,
+        config,
+    )
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        "set_temperature",
+        {
+            "entity_id": ENTITY_ID,
+            ATTR_TEMPERATURE: temperature,
+        },
+        blocking=True,
+    )
 
 
 test_value = State(ENTITY_ID, 35)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
set_temperature now allow int/float as parameter, and implement the swap parameter (if we need to swap in order to read, we need the same swap to write the correct value).

It uses (as it already did) write_registers, so the incoming value is converted to a number of registers, which are written.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
fixes #52875
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
