### PR TITLE
Add OUIs for legacy samsungtv

### DIFF
--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -18,7 +18,10 @@
   "dhcp": [
     {
       "hostname": "tizen*"
-    }
+    },
+    {"macaddress": "8CC8CD*"},
+    {"macaddress": "606BBD*"},
+    {"macaddress": "F47B5E*"}
   ],
   "codeowners": [
     "@escoand",

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -21,7 +21,8 @@
     },
     {"macaddress": "8CC8CD*"},
     {"macaddress": "606BBD*"},
-    {"macaddress": "F47B5E*"}
+    {"macaddress": "F47B5E*"},
+    {"macaddress": "4844F7*"}
   ],
   "codeowners": [
     "@escoand",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -176,6 +176,18 @@ DHCP = [
         "hostname": "tizen*"
     },
     {
+        "domain": "samsungtv",
+        "macaddress": "8CC8CD*"
+    },
+    {
+        "domain": "samsungtv",
+        "macaddress": "606BBD*"
+    },
+    {
+        "domain": "samsungtv",
+        "macaddress": "F47B5E*"
+    },
+    {
         "domain": "screenlogic",
         "hostname": "pentair: *",
         "macaddress": "00C033*"

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -188,6 +188,10 @@ DHCP = [
         "macaddress": "F47B5E*"
     },
     {
+        "domain": "samsungtv",
+        "macaddress": "4844F7*"
+    },
+    {
         "domain": "screenlogic",
         "hostname": "pentair: *",
         "macaddress": "00C033*"

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1052,7 +1052,7 @@ async def test_update_legacy_missing_mac_from_dhcp(hass, remote: Mock):
 
 
 async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(hass, remote: Mock):
-    """Test missing mac added."""
+    """Test missing mac added when there is no unique id."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_LEGACY_ENTRY,

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -87,6 +87,7 @@ MOCK_SSDP_DATA_WRONGMODEL = {
     ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172df",
 }
 MOCK_DHCP_DATA = {IP_ADDRESS: "fake_host", MAC_ADDRESS: "aa:bb:cc:dd:ee:ff"}
+EXISTING_IP = "192.168.40.221"
 MOCK_ZEROCONF_DATA = {
     CONF_HOST: "fake_host",
     CONF_PORT: 1234,
@@ -100,7 +101,13 @@ MOCK_ZEROCONF_DATA = {
 MOCK_OLD_ENTRY = {
     CONF_HOST: "fake_host",
     CONF_ID: "0d1cef00-00dc-1000-9c80-4844f7b172de_old",
-    CONF_IP_ADDRESS: "fake_ip_old",
+    CONF_IP_ADDRESS: EXISTING_IP,
+    CONF_METHOD: "legacy",
+    CONF_PORT: None,
+}
+MOCK_LEGACY_ENTRY = {
+    CONF_HOST: EXISTING_IP,
+    CONF_ID: "0d1cef00-00dc-1000-9c80-4844f7b172de_old",
     CONF_METHOD: "legacy",
     CONF_PORT: None,
 }
@@ -885,7 +892,7 @@ async def test_update_old_entry(hass: HomeAssistant, remote: Mock):
         assert len(config_entries_domain) == 1
         assert entry is config_entries_domain[0]
         assert entry.data[CONF_ID] == "0d1cef00-00dc-1000-9c80-4844f7b172de_old"
-        assert entry.data[CONF_IP_ADDRESS] == "fake_ip_old"
+        assert entry.data[CONF_IP_ADDRESS] == EXISTING_IP
         assert not entry.unique_id
 
         assert await async_setup_component(hass, DOMAIN, {}) is True
@@ -1016,6 +1023,35 @@ async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
     assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
+async def test_update_legacy_missing_mac_from_dhcp(hass, remote: Mock):
+    """Test missing mac added."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_LEGACY_ENTRY,
+        unique_id="0d1cef00-00dc-1000-9c80-4844f7b172de",
+    )
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.samsungtv.async_setup",
+        return_value=True,
+    ) as mock_setup, patch(
+        "homeassistant.components.samsungtv.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data={IP_ADDRESS: EXISTING_IP, MAC_ADDRESS: "aa:bb:cc:dd:ee:ff"},
+        )
+        await hass.async_block_till_done()
+        assert len(mock_setup.mock_calls) == 1
+        assert len(mock_setup_entry.mock_calls) == 1
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
+
+
 async def test_form_reauth_legacy(hass, remote: Mock):
     """Test reauthenticate legacy."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY)
@@ -1086,9 +1122,6 @@ async def test_form_reauth_websocket_cannot_connect(hass, remotews: Mock):
         )
         await hass.async_block_till_done()
 
-    import pprint
-
-    pprint.pprint(result2)
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": RESULT_AUTH_MISSING}
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes #51553

There are likely a few more OUIs, but since Samsung has so much address space, I'm only added ones that are verified to be used for legacy TVs. If additional ones are reported in the future, they should be simple enough to add.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
