### PR TITLE
Change behavior of Z-Wave JS services

### DIFF
--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -89,7 +89,7 @@ def async_get_node_from_device_id(
     device_entry = dev_reg.async_get(device_id)
 
     if not device_entry:
-        raise ValueError("Device ID is not valid")
+        raise ValueError(f"Device ID {device_id} is not valid")
 
     # Use device config entry ID's to validate that this is a valid zwave_js device
     # and to get the client
@@ -107,7 +107,9 @@ def async_get_node_from_device_id(
         None,
     )
     if config_entry_id is None or config_entry_id not in hass.data[DOMAIN]:
-        raise ValueError("Device is not from an existing zwave_js config entry")
+        raise ValueError(
+            f"Device {device_id} is not from an existing zwave_js config entry"
+        )
 
     client = hass.data[DOMAIN][config_entry_id][DATA_CLIENT]
 
@@ -125,7 +127,7 @@ def async_get_node_from_device_id(
     node_id = int(identifier[1]) if identifier is not None else None
 
     if node_id is None or node_id not in client.driver.controller.nodes:
-        raise ValueError("Device node can't be found")
+        raise ValueError(f"Node for device {device_id} can't be found")
 
     return client.driver.controller.nodes[node_id]
 

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -34,8 +34,9 @@ def parameter_name_does_not_need_bitmask(
     val: dict[str, int | str | list[str]]
 ) -> dict[str, int | str | list[str]]:
     """Validate that if a parameter name is provided, bitmask is not as well."""
-    if isinstance(val[const.ATTR_CONFIG_PARAMETER], str) and (
-        val.get(const.ATTR_CONFIG_PARAMETER_BITMASK)
+    if (
+        isinstance(val[const.ATTR_CONFIG_PARAMETER], str)
+        and const.ATTR_CONFIG_PARAMETER_BITMASK in val
     ):
         raise vol.Invalid(
             "Don't include a bitmask when a parameter name is specified",
@@ -94,25 +95,26 @@ class ZWaveServices:
         def get_nodes_from_service_data(val: dict[str, Any]) -> dict[str, Any]:
             """Get nodes set from service data."""
             nodes: set[ZwaveNode] = set()
-            try:
-                if ATTR_ENTITY_ID in val:
-                    nodes |= {
+            for entity_id in val.get(ATTR_ENTITY_ID, []):
+                try:
+                    nodes.add(
                         async_get_node_from_entity_id(
                             self._hass, entity_id, self._ent_reg, self._dev_reg
                         )
-                        for entity_id in val[ATTR_ENTITY_ID]
-                    }
-                    val.pop(ATTR_ENTITY_ID)
-                if ATTR_DEVICE_ID in val:
-                    nodes |= {
+                    )
+                except ValueError as err:
+                    const.LOGGER.warning(err.args[0])
+            val.pop(ATTR_ENTITY_ID, None)
+            for device_id in val.get(ATTR_DEVICE_ID, []):
+                try:
+                    nodes.add(
                         async_get_node_from_device_id(
                             self._hass, device_id, self._dev_reg
                         )
-                        for device_id in val[ATTR_DEVICE_ID]
-                    }
-                    val.pop(ATTR_DEVICE_ID)
-            except ValueError as err:
-                raise vol.Invalid(err.args[0]) from err
+                    )
+                except ValueError as err:
+                    const.LOGGER.warning(err.args[0])
+            val.pop(ATTR_DEVICE_ID, None)
 
             val[const.ATTR_NODES] = nodes
             return val
@@ -124,20 +126,14 @@ class ZWaveServices:
             broadcast: bool = val[const.ATTR_BROADCAST]
 
             # User must specify a node if they are attempting a broadcast and have more
-            # than one zwave-js network. We know it's a broadcast if the nodes list is
-            # empty because of schema validation.
+            # than one zwave-js network.
             if (
-                not nodes
+                broadcast
+                and not nodes
                 and len(self._hass.config_entries.async_entries(const.DOMAIN)) > 1
             ):
                 raise vol.Invalid(
                     "You must include at least one entity or device in the service call"
-                )
-
-            # When multicasting, user must specify at least two nodes
-            if not broadcast and len(nodes) < 2:
-                raise vol.Invalid(
-                    "To set a value on a single node, use the zwave_js.set_value service"
                 )
 
             first_node = next((node for node in nodes), None)
@@ -412,6 +408,14 @@ class ZWaveServices:
         """Set a value via multicast to multiple nodes."""
         nodes = service.data[const.ATTR_NODES]
         broadcast: bool = service.data[const.ATTR_BROADCAST]
+
+        if not broadcast and len(nodes) == 1:
+            const.LOGGER.warning(
+                "Passing the service call to the zwave_js.set_value service since "
+                "only one node was targeted"
+            )
+            await self.async_set_value(service)
+            return
 
         value = {
             "commandClass": service.data[const.ATTR_COMMAND_CLASS],

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -409,8 +409,8 @@ class ZWaveServices:
 
         if not broadcast and len(nodes) == 1:
             const.LOGGER.warning(
-                "Passing the service call to the zwave_js.set_value service since "
-                "only one node was targeted"
+                "Passing the zwave_js.multicast_set_value service call to the "
+                "zwave_js.set_value service since only one node was targeted"
             )
             await self.async_set_value(service)
             return

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -95,7 +95,7 @@ class ZWaveServices:
         def get_nodes_from_service_data(val: dict[str, Any]) -> dict[str, Any]:
             """Get nodes set from service data."""
             nodes: set[ZwaveNode] = set()
-            for entity_id in val.get(ATTR_ENTITY_ID, []):
+            for entity_id in val.pop(ATTR_ENTITY_ID, []):
                 try:
                     nodes.add(
                         async_get_node_from_entity_id(
@@ -104,8 +104,7 @@ class ZWaveServices:
                     )
                 except ValueError as err:
                     const.LOGGER.warning(err.args[0])
-            val.pop(ATTR_ENTITY_ID, None)
-            for device_id in val.get(ATTR_DEVICE_ID, []):
+            for device_id in val.pop(ATTR_DEVICE_ID, []):
                 try:
                     nodes.add(
                         async_get_node_from_device_id(
@@ -114,7 +113,6 @@ class ZWaveServices:
                     )
                 except ValueError as err:
                     const.LOGGER.warning(err.args[0])
-            val.pop(ATTR_DEVICE_ID, None)
 
             val[const.ATTR_NODES] = nodes
             return val


### PR DESCRIPTION
## Proposed change
A couple of behavior changes:
1. Calls to `zwave_js.multicast_set_value` will no longer raise when a single node is provided, it will log a warning and pass the call to `zwave_js.set_value`
2. Previously if any invalid entity or device ID was provided in a service call will fail. Now we just filter them out and log a warning 
3. Fixed a bug with one of the custom validators that would not raise on falsey values, specifically 0

Items 1 and 2 came from a discussion in #devs_zwave as they seemed like useful improvements. Item 3 I noticed while I was making these changes. I'd say 1 and 3 should definitely be kept, but I would understand if we do not want to do 2.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/52898
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
