### PR TITLE
Update homekit to use network integration

### DIFF
--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -9,7 +9,7 @@
     "base36==0.1.1",
     "PyTurboJPEG==1.5.0"
   ],
-  "dependencies": ["http", "camera", "ffmpeg"],
+  "dependencies": ["http", "camera", "ffmpeg", "network"],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@bdraco"],
   "zeroconf": ["_homekit._tcp.local."],

--- a/homeassistant/components/homekit/type_cameras.py
+++ b/homeassistant/components/homekit/type_cameras.py
@@ -18,7 +18,6 @@ from homeassistant.helpers.event import (
     async_track_state_change_event,
     async_track_time_interval,
 )
-from homeassistant.util import get_local_ip
 
 from .accessories import TYPES, HomeAccessory
 from .const import (
@@ -181,7 +180,7 @@ class Camera(HomeAccessory, PyhapCamera):
             ]
         }
 
-        stream_address = config.get(CONF_STREAM_ADDRESS, get_local_ip())
+        stream_address = config.get(CONF_STREAM_ADDRESS, driver.state.address)
 
         options = {
             "video": video_options,

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -156,7 +156,9 @@ async def test_setup_min(hass, mock_zeroconf):
     )
     entry.add_to_hass(hass)
 
-    with patch(f"{PATH_HOMEKIT}.HomeKit") as mock_homekit:
+    with patch(f"{PATH_HOMEKIT}.HomeKit") as mock_homekit, patch(
+        "homeassistant.components.network.async_get_source_ip", return_value="1.2.3.4"
+    ):
         mock_homekit.return_value = homekit = Mock()
         type(homekit).async_start = AsyncMock()
         assert await hass.config_entries.async_setup(entry.entry_id)
@@ -166,7 +168,7 @@ async def test_setup_min(hass, mock_zeroconf):
         hass,
         BRIDGE_NAME,
         DEFAULT_PORT,
-        None,
+        "1.2.3.4",
         ANY,
         ANY,
         {},
@@ -249,7 +251,7 @@ async def test_homekit_setup(hass, hk_driver, mock_zeroconf):
         hass,
         BRIDGE_NAME,
         DEFAULT_PORT,
-        None,
+        IP_ADDRESS,
         True,
         {},
         {},
@@ -262,10 +264,7 @@ async def test_homekit_setup(hass, hk_driver, mock_zeroconf):
     hass.states.async_set("light.demo", "on")
     hass.states.async_set("light.demo2", "on")
     zeroconf_mock = MagicMock()
-    with patch(
-        f"{PATH_HOMEKIT}.HomeDriver", return_value=hk_driver
-    ) as mock_driver, patch("homeassistant.util.get_local_ip") as mock_ip:
-        mock_ip.return_value = IP_ADDRESS
+    with patch(f"{PATH_HOMEKIT}.HomeDriver", return_value=hk_driver) as mock_driver:
         await hass.async_add_executor_job(homekit.setup, zeroconf_mock)
 
     path = get_persist_fullpath_for_entry_id(hass, entry.entry_id)
@@ -842,7 +841,9 @@ async def test_yaml_updates_update_config_entry_for_name(hass, mock_zeroconf):
     )
     entry.add_to_hass(hass)
 
-    with patch(f"{PATH_HOMEKIT}.HomeKit") as mock_homekit:
+    with patch(f"{PATH_HOMEKIT}.HomeKit") as mock_homekit, patch(
+        "homeassistant.components.network.async_get_source_ip", return_value="1.2.3.4"
+    ):
         mock_homekit.return_value = homekit = Mock()
         type(homekit).async_start = AsyncMock()
         assert await async_setup_component(
@@ -854,7 +855,7 @@ async def test_yaml_updates_update_config_entry_for_name(hass, mock_zeroconf):
         hass,
         BRIDGE_NAME,
         12345,
-        None,
+        "1.2.3.4",
         ANY,
         ANY,
         {},
@@ -1109,7 +1110,9 @@ async def test_reload(hass, mock_zeroconf):
     )
     entry.add_to_hass(hass)
 
-    with patch(f"{PATH_HOMEKIT}.HomeKit") as mock_homekit:
+    with patch(f"{PATH_HOMEKIT}.HomeKit") as mock_homekit, patch(
+        "homeassistant.components.network.async_get_source_ip", return_value="1.2.3.4"
+    ):
         mock_homekit.return_value = homekit = Mock()
         assert await async_setup_component(
             hass, "homekit", {"homekit": {CONF_NAME: "reloadable", CONF_PORT: 12345}}
@@ -1120,7 +1123,7 @@ async def test_reload(hass, mock_zeroconf):
         hass,
         "reloadable",
         12345,
-        None,
+        "1.2.3.4",
         ANY,
         False,
         {},
@@ -1142,6 +1145,8 @@ async def test_reload(hass, mock_zeroconf):
         f"{PATH_HOMEKIT}.get_accessory"
     ), patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
+    ), patch(
+        "homeassistant.components.network.async_get_source_ip", return_value="1.2.3.4"
     ):
         mock_homekit2.return_value = homekit = Mock()
         await hass.services.async_call(
@@ -1156,7 +1161,7 @@ async def test_reload(hass, mock_zeroconf):
         hass,
         "reloadable",
         45678,
-        None,
+        "1.2.3.4",
         ANY,
         False,
         {},


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
    
 - network.async_get_source_ip is now used to make a more
   educated decision on the source ip address for mdns
   and the accessory server.

~~Requires https://github.com/home-assistant/core/pull/52901~~

Fixes #52860

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52860
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
