### PR TITLE
Add last reset and state class to rainforest eagle

### DIFF
--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -1,4 +1,7 @@
 """Support for the Rainforest Eagle-200 energy monitor."""
+from __future__ import annotations
+
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
@@ -7,7 +10,12 @@ from requests.exceptions import ConnectionError as ConnectError, HTTPError, Time
 from uEagle import Eagle as LegacyReader
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
+from homeassistant.components.sensor import (
+    DEVICE_CLASS_ENERGY,
+    PLATFORM_SCHEMA,
+    STATE_CLASS_MEASUREMENT,
+    SensorEntity,
+)
 from homeassistant.const import (
     CONF_IP_ADDRESS,
     DEVICE_CLASS_POWER,
@@ -24,19 +32,43 @@ _LOGGER = logging.getLogger(__name__)
 
 MIN_SCAN_INTERVAL = timedelta(seconds=30)
 
+
+@dataclass
+class SensorType:
+    """Rainforest sensor type."""
+
+    name: str
+    unit_of_measurement: str
+    device_class: str | None = None
+    state_class: str | None = None
+    last_reset: int | None = None
+
+
 SENSORS = {
-    "instantanous_demand": ("Eagle-200 Meter Power Demand", POWER_KILO_WATT),
-    "summation_delivered": (
-        "Eagle-200 Total Meter Energy Delivered",
-        ENERGY_KILO_WATT_HOUR,
+    "instantanous_demand": SensorType(
+        name="Eagle-200 Meter Power Demand",
+        unit_of_measurement=POWER_KILO_WATT,
+        device_class=DEVICE_CLASS_POWER,
     ),
-    "summation_received": (
-        "Eagle-200 Total Meter Energy Received",
-        ENERGY_KILO_WATT_HOUR,
+    "summation_delivered": SensorType(
+        name="Eagle-200 Total Meter Energy Delivered",
+        unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        device_class=DEVICE_CLASS_ENERGY,
+        state_class=STATE_CLASS_MEASUREMENT,
+        last_reset=0,
     ),
-    "summation_total": (
-        "Eagle-200 Net Meter Energy (Delivered minus Received)",
-        ENERGY_KILO_WATT_HOUR,
+    "summation_received": SensorType(
+        name="Eagle-200 Total Meter Energy Received",
+        unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        device_class=DEVICE_CLASS_ENERGY,
+        state_class=STATE_CLASS_MEASUREMENT,
+        last_reset=0,
+    ),
+    "summation_total": SensorType(
+        name="Eagle-200 Net Meter Energy (Delivered minus Received)",
+        unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        device_class=DEVICE_CLASS_ENERGY,
+        state_class=STATE_CLASS_MEASUREMENT,
     ),
 }
 
@@ -86,56 +118,28 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     eagle_data = EagleData(eagle_reader)
     eagle_data.update()
-    monitored_conditions = list(SENSORS)
-    sensors = []
-    for condition in monitored_conditions:
-        sensors.append(
-            EagleSensor(
-                eagle_data, condition, SENSORS[condition][0], SENSORS[condition][1]
-            )
-        )
 
-    add_entities(sensors)
+    add_entities([EagleSensor(eagle_data, condition) for condition in SENSORS])
 
 
 class EagleSensor(SensorEntity):
     """Implementation of the Rainforest Eagle-200 sensor."""
 
-    def __init__(self, eagle_data, sensor_type, name, unit):
+    def __init__(self, eagle_data, sensor_type):
         """Initialize the sensor."""
         self.eagle_data = eagle_data
         self._type = sensor_type
-        self._name = name
-        self._unit_of_measurement = unit
-        self._state = None
-
-    @property
-    def device_class(self):
-        """Return the power device class for the instantanous_demand sensor."""
-        if self._type == "instantanous_demand":
-            return DEVICE_CLASS_POWER
-
-        return None
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return self._unit_of_measurement
+        sensor_info = SENSORS[sensor_type]
+        self._attr_name = sensor_info.name
+        self._attr_unit_of_measurement = sensor_info.unit_of_measurement
+        self._attr_device_class = sensor_info.device_class
+        self._attr_state_class = sensor_info.state_class
+        self._attr_last_reset = sensor_info.last_reset
 
     def update(self):
         """Get the energy information from the Rainforest Eagle."""
         self.eagle_data.update()
-        self._state = self.eagle_data.get_state(self._type)
+        self._attr_state = self.eagle_data.get_state(self._type)
 
 
 class EagleData:

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 from eagle200_reader import EagleReader
@@ -22,7 +22,7 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
 )
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import Throttle
+from homeassistant.util import Throttle, dt
 
 CONF_CLOUD_ID = "cloud_id"
 CONF_INSTALL_CODE = "install_code"
@@ -41,7 +41,7 @@ class SensorType:
     unit_of_measurement: str
     device_class: str | None = None
     state_class: str | None = None
-    last_reset: int | None = None
+    last_reset: datetime | None = None
 
 
 SENSORS = {
@@ -55,14 +55,14 @@ SENSORS = {
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_MEASUREMENT,
-        last_reset=0,
+        last_reset=dt.utc_from_timestamp(0),
     ),
     "summation_received": SensorType(
         name="Eagle-200 Total Meter Energy Received",
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_MEASUREMENT,
-        last_reset=0,
+        last_reset=dt.utc_from_timestamp(0),
     ),
     "summation_total": SensorType(
         name="Eagle-200 Net Meter Energy (Delivered minus Received)",
@@ -119,7 +119,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     eagle_data = EagleData(eagle_reader)
     eagle_data.update()
 
-    add_entities([EagleSensor(eagle_data, condition) for condition in SENSORS])
+    add_entities(EagleSensor(eagle_data, condition) for condition in SENSORS)
 
 
 class EagleSensor(SensorEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds device class, state class and last_reset to the powereagle integration so it is able to be used with the upcoming energy integration.

@mjg59 I saw on Twitter that you just got an Eagle 200. Would you be able to test this PR?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
