### PR TITLE
Rewrite mocking in devolo Home Control tests

### DIFF
--- a/tests/components/devolo_home_control/mocks.py
+++ b/tests/components/devolo_home_control/mocks.py
@@ -1,7 +1,10 @@
 """Mocks for tests."""
 
+from typing import Any
 from unittest.mock import MagicMock
 
+from devolo_home_control_api.devices.zwave import Zwave
+from devolo_home_control_api.homecontrol import HomeControl
 from devolo_home_control_api.publisher.publisher import Publisher
 
 
@@ -22,70 +25,85 @@ class SettingsMock:
     zone = "Test"
 
 
-class DeviceMock:
+class DeviceMock(Zwave):
     """devolo Home Control device mock."""
 
-    available = True
-    brand = "devolo"
-    name = "Test Device"
-    uid = "Test"
-    settings_property = {"general_device_settings": SettingsMock()}
-
-    def is_online(self):
-        """Mock online state of the device."""
-        return DeviceMock.available
+    def __init__(self) -> None:
+        """Initialize the mock."""
+        self.status = 0
+        self.brand = "devolo"
+        self.name = "Test Device"
+        self.uid = "Test"
+        self.settings_property = {"general_device_settings": SettingsMock()}
 
 
 class BinarySensorMock(DeviceMock):
     """devolo Home Control binary sensor device mock."""
 
-    binary_sensor_property = {"Test": BinarySensorPropertyMock()}
+    def __init__(self) -> None:
+        """Initialize the mock."""
+        super().__init__()
+        self.binary_sensor_property = {"Test": BinarySensorPropertyMock()}
 
 
 class RemoteControlMock(DeviceMock):
     """devolo Home Control remote control device mock."""
 
-    remote_control_property = {"Test": BinarySensorPropertyMock()}
+    def __init__(self) -> None:
+        """Initialize the mock."""
+        super().__init__()
+        self.remote_control_property = {"Test": BinarySensorPropertyMock()}
 
 
 class DisabledBinarySensorMock(DeviceMock):
     """devolo Home Control disabled binary sensor device mock."""
 
-    binary_sensor_property = {"devolo.WarningBinaryFI:Test": BinarySensorPropertyMock()}
+    def __init__(self) -> None:
+        """Initialize the mock."""
+        super().__init__()
+        self.binary_sensor_property = {
+            "devolo.WarningBinaryFI:Test": BinarySensorPropertyMock()
+        }
 
 
-class HomeControlMock:
+class HomeControlMock(HomeControl):
     """devolo Home Control gateway mock."""
 
-    binary_sensor_devices = []
-    binary_switch_devices = []
-    multi_level_sensor_devices = []
-    multi_level_switch_devices = []
-    devices = {}
-    publisher = MagicMock()
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the mock."""
+        self.devices = {}
+        self.publisher = MagicMock()
 
-    def websocket_disconnect(self):
+    def websocket_disconnect(self, event: str):
         """Mock disconnect of the websocket."""
-        pass
 
 
 class HomeControlMockBinarySensor(HomeControlMock):
     """devolo Home Control gateway mock with binary sensor device."""
 
-    binary_sensor_devices = [BinarySensorMock()]
-    devices = {"Test": BinarySensorMock()}
-    publisher = Publisher(devices.keys())
-    publisher.unregister = MagicMock()
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the mock."""
+        super().__init__()
+        self.devices = {"Test": BinarySensorMock()}
+        self.publisher = Publisher(self.devices.keys())
+        self.publisher.unregister = MagicMock()
 
 
 class HomeControlMockRemoteControl(HomeControlMock):
     """devolo Home Control gateway mock with remote control device."""
 
-    devices = {"Test": RemoteControlMock()}
-    publisher = Publisher(devices.keys())
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the mock."""
+        super().__init__()
+        self.devices = {"Test": RemoteControlMock()}
+        self.publisher = Publisher(self.devices.keys())
+        self.publisher.unregister = MagicMock()
 
 
 class HomeControlMockDisabledBinarySensor(HomeControlMock):
     """devolo Home Control gateway mock with disabled device."""
 
-    binary_sensor_devices = [DisabledBinarySensorMock()]
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the mock."""
+        super().__init__()
+        self.devices = {"Test": DisabledBinarySensorMock()}

--- a/tests/components/devolo_home_control/mocks.py
+++ b/tests/components/devolo_home_control/mocks.py
@@ -5,24 +5,34 @@ from unittest.mock import MagicMock
 
 from devolo_home_control_api.devices.zwave import Zwave
 from devolo_home_control_api.homecontrol import HomeControl
+from devolo_home_control_api.properties.binary_sensor_property import (
+    BinarySensorProperty,
+)
+from devolo_home_control_api.properties.settings_property import SettingsProperty
 from devolo_home_control_api.publisher.publisher import Publisher
 
 
-class BinarySensorPropertyMock:
+class BinarySensorPropertyMock(BinarySensorProperty):
     """devolo Home Control binary sensor mock."""
 
-    element_uid = "Test"
-    key_count = 1
-    sensor_type = "door"
-    sub_type = ""
-    state = False
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the mock."""
+        self._logger = MagicMock()
+        self.element_uid = "Test"
+        self.key_count = 1
+        self.sensor_type = "door"
+        self.sub_type = ""
+        self.state = False
 
 
-class SettingsMock:
+class SettingsMock(SettingsProperty):
     """devolo Home Control settings mock."""
 
-    name = "Test"
-    zone = "Test"
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the mock."""
+        self._logger = MagicMock()
+        self.name = "Test"
+        self.zone = "Test"
 
 
 class DeviceMock(Zwave):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #49843 @MartinHjelmare requested to rewrite the mocks used in the tests. His proposal was to use the library to spec the mocks and to instantiate the mocks for better control. ~~I kept the old approach for what we call device property as those data as static during the tests and I found it lightweight.~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
