### PR TITLE
Increase polling interval to prevent reaching daily limit

### DIFF
--- a/homeassistant/components/home_plus_control/__init__.py
+++ b/homeassistant/components/home_plus_control/__init__.py
@@ -133,7 +133,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         name="home_plus_control_module",
         update_method=async_update_data,
         # Polling interval. Will only be polled if there are subscribers.
-        update_interval=timedelta(seconds=60),
+        update_interval=timedelta(seconds=300),
     )
     hass_entry_data[DATA_COORDINATOR] = coordinator
 

--- a/tests/components/home_plus_control/test_switch.py
+++ b/tests/components/home_plus_control/test_switch.py
@@ -146,7 +146,7 @@ async def test_plant_topology_reduction_change(
         return_value=mock_modules,
     ) as mock_check:
         async_fire_time_changed(
-            hass, dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=100)
+            hass, dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=400)
         )
         await hass.async_block_till_done()
     assert len(mock_check.mock_calls) == 1
@@ -208,7 +208,7 @@ async def test_plant_topology_increase_change(
         return_value=mock_modules,
     ) as mock_check:
         async_fire_time_changed(
-            hass, dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=100)
+            hass, dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=400)
         )
         await hass.async_block_till_done()
     assert len(mock_check.mock_calls) == 1
@@ -268,7 +268,7 @@ async def test_module_status_unavailable(hass, mock_config_entry, mock_modules):
         return_value=mock_modules,
     ) as mock_check:
         async_fire_time_changed(
-            hass, dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=100)
+            hass, dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=400)
         )
         await hass.async_block_till_done()
     assert len(mock_check.mock_calls) == 1
@@ -339,7 +339,7 @@ async def test_module_status_available(
         return_value=mock_modules,
     ) as mock_check:
         async_fire_time_changed(
-            hass, dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=100)
+            hass, dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=400)
         )
         await hass.async_block_till_done()
     assert len(mock_check.mock_calls) == 1
@@ -443,7 +443,7 @@ async def test_update_with_api_error(
         side_effect=HomePlusControlApiError,
     ) as mock_check:
         async_fire_time_changed(
-            hass, dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=100)
+            hass, dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=400)
         )
         await hass.async_block_till_done()
     assert len(mock_check.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

none 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Increase polling interval to prevent reaching daily api usage limit. See here for reference: https://developer.legrand.com/forums/topic/home-control-user-plant-empty/

Setting it to 5mins makes 288 regular polls a day, which leaves more than 200 updates triggered by actions on entities for instance. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
