### PR TITLE
Handle all WeMo ensure_long_press_virtual_device exceptions

### DIFF
--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -84,7 +84,7 @@ async def async_register_device(
         # Temporarily handling all exceptions for #52996 & pywemo/pywemo/issues/276
         # Replace this with `except: PyWeMoException` after upstream has been fixed.
         except Exception:  # pylint: disable=broad-except
-            _LOGGER.warning(
+            _LOGGER.exception(
                 "Failed to enable long press support for device: %s", wemo.name
             )
             device.supports_long_press = False

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -1,7 +1,7 @@
 """Home Assistant wrapper for a pyWeMo device."""
 import logging
 
-from pywemo import PyWeMoException, WeMoDevice
+from pywemo import WeMoDevice
 from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
 
 from homeassistant.config_entries import ConfigEntry
@@ -81,7 +81,9 @@ async def async_register_device(
     if device.supports_long_press:
         try:
             await hass.async_add_executor_job(wemo.ensure_long_press_virtual_device)
-        except PyWeMoException:
+        # Temporarily handling all exceptions for #52996 & pywemo/pywemo/issues/276
+        # Replace this with `except: PyWeMoException` after upstream has been fixed.
+        except:  # noqa: E722  pylint: disable=bare-except
             _LOGGER.warning(
                 "Failed to enable long press support for device: %s", wemo.name
             )

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -83,7 +83,7 @@ async def async_register_device(
             await hass.async_add_executor_job(wemo.ensure_long_press_virtual_device)
         # Temporarily handling all exceptions for #52996 & pywemo/pywemo/issues/276
         # Replace this with `except: PyWeMoException` after upstream has been fixed.
-        except:  # noqa: E722  pylint: disable=bare-except
+        except Exception:  # pylint: disable=broad-except
             _LOGGER.warning(
                 "Failed to enable long press support for device: %s", wemo.name
             )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

There are a few issues filed for the wemo component breaking due to the long-press feature. It appears there are a few variants of the database that enables this feature that were unknown prior to now. These variants cause the database parsing logic in pyWeMo to break unexpectedly.

This PR is meant as a stop-gap. I'd like to fix the database parsing code upstream in pywemo, but that will take time to understand and develop. I'd rather not leave the wemo component broken while I investigate as that leaves Home Assistant users in a broken state and puts unnecessary time pressure on myself to make a proper fix. Rather than rush toward an upstream fix, this PR uses a broad-except to handle any more unexpected database variants. Once the fixes are in place upstream I'll revert this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52996
- This PR is related to issue: https://github.com/pywemo/pywemo/issues/276

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
