### PR TITLE
Drop support for fan speeds and support reverse

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -141,6 +141,7 @@ COMMAND_MEDIA_SEEK_RELATIVE = f"{PREFIX_COMMANDS}mediaSeekRelative"
 COMMAND_MEDIA_SEEK_TO_POSITION = f"{PREFIX_COMMANDS}mediaSeekToPosition"
 COMMAND_MEDIA_SHUFFLE = f"{PREFIX_COMMANDS}mediaShuffle"
 COMMAND_MEDIA_STOP = f"{PREFIX_COMMANDS}mediaStop"
+COMMAND_REVERSE = f"{PREFIX_COMMANDS}Reverse"
 COMMAND_SET_HUMIDITY = f"{PREFIX_COMMANDS}SetHumidity"
 COMMAND_SELECT_CHANNEL = f"{PREFIX_COMMANDS}selectChannel"
 
@@ -1253,14 +1254,7 @@ class FanSpeedTrait(_Trait):
     """
 
     name = TRAIT_FANSPEED
-    commands = [COMMAND_FANSPEED]
-
-    speed_synonyms = {
-        fan.SPEED_OFF: ["stop", "off"],
-        fan.SPEED_LOW: ["slow", "low", "slowest", "lowest"],
-        fan.SPEED_MEDIUM: ["medium", "mid", "middle"],
-        fan.SPEED_HIGH: ["high", "max", "fast", "highest", "fastest", "maximum"],
-    }
+    commands = [COMMAND_FANSPEED, COMMAND_REVERSE]
 
     @staticmethod
     def supported(domain, features, device_class, _):
@@ -1275,23 +1269,21 @@ class FanSpeedTrait(_Trait):
         """Return speed point and modes attributes for a sync request."""
         domain = self.state.domain
         speeds = []
-        reversible = False
+        result = {}
 
         if domain == fan.DOMAIN:
-            # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
-            modes = self.state.attributes.get(fan.ATTR_SPEED_LIST, [])
-            for mode in modes:
-                speed = {
-                    "speed_name": mode,
-                    "speed_values": [
-                        {"speed_synonym": self.speed_synonyms.get(mode), "lang": "en"}
-                    ],
-                }
-                speeds.append(speed)
             reversible = bool(
                 self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
                 & fan.SUPPORT_DIRECTION
             )
+
+            result.update(
+                {
+                    "reversible": reversible,
+                    "supportsFanSpeedPercent": True,
+                }
+            )
+
         elif domain == climate.DOMAIN:
             modes = self.state.attributes.get(climate.ATTR_FAN_MODES, [])
             for mode in modes:
@@ -1301,32 +1293,32 @@ class FanSpeedTrait(_Trait):
                 }
                 speeds.append(speed)
 
-        return {
-            "availableFanSpeeds": {"speeds": speeds, "ordered": True},
-            "reversible": reversible,
-            "supportsFanSpeedPercent": True,
-        }
+            result.update(
+                {
+                    "reversible": False,
+                    "availableFanSpeeds": {"speeds": speeds, "ordered": True},
+                }
+            )
+
+        return result
 
     def query_attributes(self):
         """Return speed point and modes query attributes."""
+
         attrs = self.state.attributes
         domain = self.state.domain
         response = {}
         if domain == climate.DOMAIN:
-            speed = attrs.get(climate.ATTR_FAN_MODE)
-            if speed is not None:
-                response["currentFanSpeedSetting"] = speed
+            speed = attrs.get(climate.ATTR_FAN_MODE) or "off"
+            response["currentFanSpeedSetting"] = speed
+
         if domain == fan.DOMAIN:
-            speed = attrs.get(fan.ATTR_SPEED)
             percent = attrs.get(fan.ATTR_PERCENTAGE) or 0
-            if speed is not None:
-                response["on"] = speed != fan.SPEED_OFF
-                response["currentFanSpeedSetting"] = speed
-            if percent is not None:
-                response["currentFanSpeedPercent"] = percent
+            response["currentFanSpeedPercent"] = percent
+
         return response
 
-    async def execute(self, command, data, params, challenge):
+    async def execute_fanspeed(self, data, params):
         """Execute an SetFanSpeed command."""
         domain = self.state.domain
         if domain == climate.DOMAIN:
@@ -1340,24 +1332,42 @@ class FanSpeedTrait(_Trait):
                 blocking=True,
                 context=data.context,
             )
-        if domain == fan.DOMAIN:
-            service_params = {
-                ATTR_ENTITY_ID: self.state.entity_id,
-            }
-            if "fanSpeedPercent" in params:
-                service = fan.SERVICE_SET_PERCENTAGE
-                service_params[fan.ATTR_PERCENTAGE] = params["fanSpeedPercent"]
-            else:
-                service = fan.SERVICE_SET_SPEED
-                service_params[fan.ATTR_SPEED] = params["fanSpeed"]
 
+        if domain == fan.DOMAIN:
             await self.hass.services.async_call(
                 fan.DOMAIN,
-                service,
-                service_params,
+                fan.SERVICE_SET_PERCENTAGE,
+                {
+                    ATTR_ENTITY_ID: self.state.entity_id,
+                    fan.ATTR_PERCENTAGE: params["fanSpeedPercent"],
+                },
                 blocking=True,
                 context=data.context,
             )
+
+    async def execute_reverse(self, data, params):
+        """Execute a Reverse command."""
+        domain = self.state.domain
+        if domain == fan.DOMAIN:
+            if self.state.attributes.get(fan.ATTR_DIRECTION) == fan.DIRECTION_FORWARD:
+                direction = fan.DIRECTION_REVERSE
+            else:
+                direction = fan.DIRECTION_FORWARD
+
+            await self.hass.services.async_call(
+                fan.DOMAIN,
+                fan.SERVICE_SET_DIRECTION,
+                {ATTR_ENTITY_ID: self.state.entity_id, fan.ATTR_DIRECTION: direction},
+                blocking=True,
+                context=data.context,
+            )
+
+    async def execute(self, command, data, params, challenge):
+        """Execute a smart home command."""
+        if command == COMMAND_FANSPEED:
+            await self.execute_fanspeed(data, params)
+        elif command == COMMAND_REVERSE:
+            await self.execute_reverse(data, params)
 
 
 @register_trait

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1422,13 +1422,6 @@ async def test_fan_speed(hass):
             "fan.living_room_fan",
             fan.SPEED_HIGH,
             attributes={
-                "speed_list": [
-                    fan.SPEED_OFF,
-                    fan.SPEED_LOW,
-                    fan.SPEED_MEDIUM,
-                    fan.SPEED_HIGH,
-                ],
-                "speed": "low",
                 "percentage": 33,
                 "percentage_step": 1.0,
             },
@@ -1437,63 +1430,13 @@ async def test_fan_speed(hass):
     )
 
     assert trt.sync_attributes() == {
-        "availableFanSpeeds": {
-            "ordered": True,
-            "speeds": [
-                {
-                    "speed_name": "off",
-                    "speed_values": [{"speed_synonym": ["stop", "off"], "lang": "en"}],
-                },
-                {
-                    "speed_name": "low",
-                    "speed_values": [
-                        {
-                            "speed_synonym": ["slow", "low", "slowest", "lowest"],
-                            "lang": "en",
-                        }
-                    ],
-                },
-                {
-                    "speed_name": "medium",
-                    "speed_values": [
-                        {"speed_synonym": ["medium", "mid", "middle"], "lang": "en"}
-                    ],
-                },
-                {
-                    "speed_name": "high",
-                    "speed_values": [
-                        {
-                            "speed_synonym": [
-                                "high",
-                                "max",
-                                "fast",
-                                "highest",
-                                "fastest",
-                                "maximum",
-                            ],
-                            "lang": "en",
-                        }
-                    ],
-                },
-            ],
-        },
         "reversible": False,
         "supportsFanSpeedPercent": True,
     }
 
     assert trt.query_attributes() == {
-        "currentFanSpeedSetting": "low",
-        "on": True,
         "currentFanSpeedPercent": 33,
     }
-
-    assert trt.can_execute(trait.COMMAND_FANSPEED, params={"fanSpeed": "medium"})
-
-    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_SET_SPEED)
-    await trt.execute(trait.COMMAND_FANSPEED, BASIC_DATA, {"fanSpeed": "medium"}, {})
-
-    assert len(calls) == 1
-    assert calls[0].data == {"entity_id": "fan.living_room_fan", "speed": "medium"}
 
     assert trt.can_execute(trait.COMMAND_FANSPEED, params={"fanSpeedPercent": 10})
 
@@ -1502,6 +1445,53 @@ async def test_fan_speed(hass):
 
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage": 10}
+
+
+@pytest.mark.parametrize(
+    "direction_state,direction_call",
+    [
+        (fan.DIRECTION_FORWARD, fan.DIRECTION_REVERSE),
+        (fan.DIRECTION_REVERSE, fan.DIRECTION_FORWARD),
+        (None, fan.DIRECTION_FORWARD),
+    ],
+)
+async def test_fan_reverse(hass, direction_state, direction_call):
+    """Test FanSpeed trait speed control support for fan domain."""
+
+    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_SET_DIRECTION)
+
+    trt = trait.FanSpeedTrait(
+        hass,
+        State(
+            "fan.living_room_fan",
+            fan.SPEED_HIGH,
+            attributes={
+                "percentage": 33,
+                "percentage_step": 1.0,
+                "direction": direction_state,
+                "supported_features": fan.SUPPORT_DIRECTION,
+            },
+        ),
+        BASIC_CONFIG,
+    )
+
+    assert trt.sync_attributes() == {
+        "reversible": True,
+        "supportsFanSpeedPercent": True,
+    }
+
+    assert trt.query_attributes() == {
+        "currentFanSpeedPercent": 33,
+    }
+
+    assert trt.can_execute(trait.COMMAND_REVERSE, params={})
+    await trt.execute(trait.COMMAND_REVERSE, BASIC_DATA, {}, {})
+
+    assert len(calls) == 1
+    assert calls[0].data == {
+        "entity_id": "fan.living_room_fan",
+        "direction": direction_call,
+    }
 
 
 async def test_climate_fan_speed(hass):
@@ -1547,7 +1537,6 @@ async def test_climate_fan_speed(hass):
             ],
         },
         "reversible": False,
-        "supportsFanSpeedPercent": True,
     }
 
     assert trt.query_attributes() == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
 - Requires resync of google assysten devices since we no longer expose fan speeds. Ask your google device to "Sync my devices" or trigger update via google_assistant.request_sync service.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change will drop support for the legacy fan speeds. The google docs is a bit unclear as to if it is a supported state to have both fanspeeds and percentages. So let's only support percentages since we have issue's where google still call the legacy services.

Also add support for fan reversion service that we claimed to support, but really didn't.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is realted to: #52637

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
