### PR TITLE
Execute scripts from HomeKit

### DIFF
--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -55,7 +55,7 @@ VALVE_TYPE = {
 }
 
 
-ACTIVATE_ONLY_SWITCH_DOMAINS = {"automation", "scene", "script"}
+ACTIVATE_ONLY_SWITCH_DOMAINS = {"scene", "script"}
 
 
 @TYPES.register("Outlet")

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -135,8 +135,6 @@ class Switch(HomeAccessory):
         if self._domain == "script":
             service = self._object_id
             params = {}
-        elif self._domain == "automation":
-            service = "trigger"
         else:
             service = SERVICE_TURN_ON if value else SERVICE_TURN_OFF
 

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -130,13 +130,16 @@ class Switch(HomeAccessory):
         if self.activate_only and not value:
             _LOGGER.debug("%s: Ignoring turn_off call", self.entity_id)
             return
+
         params = {ATTR_ENTITY_ID: self.entity_id}
         if self._domain == "script":
-            service = f"script.{self._object_id}"
+            service = self._object_id
+            params = {}
         elif self._domain == "automation":
-            service = "automation.trigger"
+            service = "trigger"
         else:
             service = SERVICE_TURN_ON if value else SERVICE_TURN_OFF
+
         self.async_call_service(self._domain, service, params)
 
         if self.activate_only:

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -55,6 +55,9 @@ VALVE_TYPE = {
 }
 
 
+ACTIVATE_ONLY_SWITCH_DOMAINS = {"automation", "scene", "script"}
+
+
 @TYPES.register("Outlet")
 class Outlet(HomeAccessory):
     """Generate an Outlet accessory."""
@@ -98,7 +101,7 @@ class Switch(HomeAccessory):
     def __init__(self, *args):
         """Initialize a Switch accessory object."""
         super().__init__(*args, category=CATEGORY_SWITCH)
-        self._domain = split_entity_id(self.entity_id)[0]
+        self._domain, self._object_id = split_entity_id(self.entity_id)
         state = self.hass.states.get(self.entity_id)
 
         self.activate_only = self.is_activate(self.hass.states.get(self.entity_id))
@@ -113,9 +116,7 @@ class Switch(HomeAccessory):
 
     def is_activate(self, state):
         """Check if entity is activate only."""
-        if self._domain == "scene":
-            return True
-        return False
+        return self._domain in ACTIVATE_ONLY_SWITCH_DOMAINS
 
     def reset_switch(self, *args):
         """Reset switch to emulate activate click."""
@@ -130,7 +131,12 @@ class Switch(HomeAccessory):
             _LOGGER.debug("%s: Ignoring turn_off call", self.entity_id)
             return
         params = {ATTR_ENTITY_ID: self.entity_id}
-        service = SERVICE_TURN_ON if value else SERVICE_TURN_OFF
+        if self._domain == "script":
+            service = f"script.{self._object_id}"
+        elif self._domain == "automation":
+            service = "automation.trigger"
+        else:
+            service = SERVICE_TURN_ON if value else SERVICE_TURN_OFF
         self.async_call_service(self._domain, service, params)
 
         if self.activate_only:

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -81,6 +81,7 @@ async def test_outlet_set_state(hass, hk_driver, events):
 @pytest.mark.parametrize(
     "entity_id, attrs",
     [
+        ("automation.test", {}),
         ("input_boolean.test", {}),
         ("remote.test", {}),
         ("switch.test", {}),
@@ -315,44 +316,6 @@ async def test_reset_switch(hass, hk_driver, events):
     assert acc.char_on.value is False
 
     call_turn_on = async_mock_service(hass, domain, "turn_on")
-    call_turn_off = async_mock_service(hass, domain, "turn_off")
-
-    await hass.async_add_executor_job(acc.char_on.client_update_value, True)
-    await hass.async_block_till_done()
-    assert acc.char_on.value is True
-    assert call_turn_on
-    assert call_turn_on[0].data[ATTR_ENTITY_ID] == entity_id
-    assert len(events) == 1
-    assert events[-1].data[ATTR_VALUE] is None
-
-    future = dt_util.utcnow() + timedelta(seconds=1)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
-    assert acc.char_on.value is False
-    assert len(events) == 1
-    assert not call_turn_off
-
-    await hass.async_add_executor_job(acc.char_on.client_update_value, False)
-    await hass.async_block_till_done()
-    assert acc.char_on.value is False
-    assert len(events) == 1
-
-
-async def test_automation_switch(hass, hk_driver, events):
-    """Test if automation switch accessory is reset correctly."""
-    domain = "automation"
-    entity_id = "automation.test"
-
-    hass.states.async_set(entity_id, None)
-    await hass.async_block_till_done()
-    acc = Switch(hass, hk_driver, "Switch", entity_id, 2, None)
-    await acc.run()
-    await hass.async_block_till_done()
-
-    assert acc.activate_only is True
-    assert acc.char_on.value is False
-
-    call_turn_on = async_mock_service(hass, domain, "trigger")
     call_turn_off = async_mock_service(hass, domain, "turn_off")
 
     await hass.async_add_executor_job(acc.char_on.client_update_value, True)

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -81,10 +81,8 @@ async def test_outlet_set_state(hass, hk_driver, events):
 @pytest.mark.parametrize(
     "entity_id, attrs",
     [
-        ("automation.test", {}),
         ("input_boolean.test", {}),
         ("remote.test", {}),
-        ("script.test", {}),
         ("switch.test", {}),
     ],
 )
@@ -340,8 +338,47 @@ async def test_reset_switch(hass, hk_driver, events):
     assert len(events) == 1
 
 
-async def test_reset_switch_reload(hass, hk_driver, events):
-    """Test reset switch after script reload."""
+async def test_automation_switch(hass, hk_driver, events):
+    """Test if automation switch accessory is reset correctly."""
+    domain = "automation"
+    entity_id = "automation.test"
+
+    hass.states.async_set(entity_id, None)
+    await hass.async_block_till_done()
+    acc = Switch(hass, hk_driver, "Switch", entity_id, 2, None)
+    await acc.run()
+    await hass.async_block_till_done()
+
+    assert acc.activate_only is True
+    assert acc.char_on.value is False
+
+    call_turn_on = async_mock_service(hass, domain, "trigger")
+    call_turn_off = async_mock_service(hass, domain, "turn_off")
+
+    await hass.async_add_executor_job(acc.char_on.client_update_value, True)
+    await hass.async_block_till_done()
+    assert acc.char_on.value is True
+    assert call_turn_on
+    assert call_turn_on[0].data[ATTR_ENTITY_ID] == entity_id
+    assert len(events) == 1
+    assert events[-1].data[ATTR_VALUE] is None
+
+    future = dt_util.utcnow() + timedelta(seconds=1)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+    assert acc.char_on.value is False
+    assert len(events) == 1
+    assert not call_turn_off
+
+    await hass.async_add_executor_job(acc.char_on.client_update_value, False)
+    await hass.async_block_till_done()
+    assert acc.char_on.value is False
+    assert len(events) == 1
+
+
+async def test_script_switch(hass, hk_driver, events):
+    """Test if script switch accessory is reset correctly."""
+    domain = "script"
     entity_id = "script.test"
 
     hass.states.async_set(entity_id, None)
@@ -350,8 +387,28 @@ async def test_reset_switch_reload(hass, hk_driver, events):
     await acc.run()
     await hass.async_block_till_done()
 
-    assert acc.activate_only is False
+    assert acc.activate_only is True
+    assert acc.char_on.value is False
 
-    hass.states.async_set(entity_id, None)
+    call_turn_on = async_mock_service(hass, domain, "test")
+    call_turn_off = async_mock_service(hass, domain, "turn_off")
+
+    await hass.async_add_executor_job(acc.char_on.client_update_value, True)
+    await hass.async_block_till_done()
+    assert acc.char_on.value is True
+    assert call_turn_on
+    assert call_turn_on[0].data == {}
+    assert len(events) == 1
+    assert events[-1].data[ATTR_VALUE] is None
+
+    future = dt_util.utcnow() + timedelta(seconds=1)
+    async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
     assert acc.char_on.value is False
+    assert len(events) == 1
+    assert not call_turn_off
+
+    await hass.async_add_executor_job(acc.char_on.client_update_value, False)
+    await hass.async_block_till_done()
+    assert acc.char_on.value is False
+    assert len(events) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- Currently the on/off switches would enable or disable
  a script. This likely is not what is
  expected as `Hey Siri turn on "automation"` would appear
  to do nothing.

- Pressing the switch in HomeKit now runs the script instead.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
