### PR TITLE
Replace local Barrier CC constants with library enums

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from zwave_js_server.client import Client as ZwaveClient
+from zwave_js_server.const import BarrierState
 from zwave_js_server.model.value import Value as ZwaveValue
 
 from homeassistant.components.cover import (
@@ -28,15 +29,6 @@ from .discovery import ZwaveDiscoveryInfo
 from .entity import ZWaveBaseEntity
 
 LOGGER = logging.getLogger(__name__)
-
-BARRIER_TARGET_CLOSE = 0
-BARRIER_TARGET_OPEN = 255
-
-BARRIER_STATE_CLOSED = 0
-BARRIER_STATE_CLOSING = 252
-BARRIER_STATE_STOPPED = 253
-BARRIER_STATE_OPENING = 254
-BARRIER_STATE_OPEN = 255
 
 
 async def async_setup_entry(
@@ -172,14 +164,14 @@ class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):
         """Return if the cover is opening or not."""
         if self.info.primary_value.value is None:
             return None
-        return bool(self.info.primary_value.value == BARRIER_STATE_OPENING)
+        return bool(self.info.primary_value.value == BarrierState.OPENING)
 
     @property
     def is_closing(self) -> bool | None:
         """Return if the cover is closing or not."""
         if self.info.primary_value.value is None:
             return None
-        return bool(self.info.primary_value.value == BARRIER_STATE_CLOSING)
+        return bool(self.info.primary_value.value == BarrierState.CLOSING)
 
     @property
     def is_closed(self) -> bool | None:
@@ -190,15 +182,15 @@ class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):
         # issuing an open cover command. Return None in this case which
         # produces an unknown state and allows it to be resolved with an open
         # command.
-        if self.info.primary_value.value == BARRIER_STATE_STOPPED:
+        if self.info.primary_value.value == BarrierState.STOPPED:
             return None
 
-        return bool(self.info.primary_value.value == BARRIER_STATE_CLOSED)
+        return bool(self.info.primary_value.value == BarrierState.CLOSED)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the garage door."""
-        await self.info.node.async_set_value(self._target_state, BARRIER_TARGET_OPEN)
+        await self.info.node.async_set_value(self._target_state, BarrierState.OPEN)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the garage door."""
-        await self.info.node.async_set_value(self._target_state, BARRIER_TARGET_CLOSE)
+        await self.info.node.async_set_value(self._target_state, BarrierState.CLOSED)

--- a/homeassistant/components/zwave_js/switch.py
+++ b/homeassistant/components/zwave_js/switch.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from zwave_js_server.client import Client as ZwaveClient
+from zwave_js_server.const import BarrierEventSignalingSubsystemState
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -17,10 +18,6 @@ from .discovery import ZwaveDiscoveryInfo
 from .entity import ZWaveBaseEntity
 
 LOGGER = logging.getLogger(__name__)
-
-
-BARRIER_EVENT_SIGNALING_OFF = 0
-BARRIER_EVENT_SIGNALING_ON = 255
 
 
 async def async_setup_entry(
@@ -108,7 +105,7 @@ class ZWaveBarrierEventSignalingSwitch(ZWaveBaseEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.info.node.async_set_value(
-            self.info.primary_value, BARRIER_EVENT_SIGNALING_ON
+            self.info.primary_value, BarrierEventSignalingSubsystemState.ON
         )
         # this value is not refreshed, so assume success
         self._state = True
@@ -117,7 +114,7 @@ class ZWaveBarrierEventSignalingSwitch(ZWaveBaseEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.info.node.async_set_value(
-            self.info.primary_value, BARRIER_EVENT_SIGNALING_OFF
+            self.info.primary_value, BarrierEventSignalingSubsystemState.OFF
         )
         # this value is not refreshed, so assume success
         self._state = False
@@ -127,4 +124,6 @@ class ZWaveBarrierEventSignalingSwitch(ZWaveBaseEntity, SwitchEntity):
     def _update_state(self) -> None:
         self._state = None
         if self.info.primary_value.value is not None:
-            self._state = self.info.primary_value.value == BARRIER_EVENT_SIGNALING_ON
+            self._state = (
+                self.info.primary_value.value == BarrierEventSignalingSubsystemState.ON
+            )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace locally defined constants used in the zwave_js barrier cover platform with the Barrier CC enums provided by the upstream python library.

These enums were added after the platform code was merged, and I forgot to update when the supporting library version was eventually released.

Library enums are defined here:
https://github.com/home-assistant-libs/zwave-js-server-python/blob/ab1081bea0164d218b4ffc2c414f12fbcd96c3af/zwave_js_server/const.py#L374-L390

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
