### PR TITLE
Add support for tilt only covers to HomeKit

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -127,7 +127,7 @@ def get_accessory(hass, driver, state, aid, config):  # noqa: C901
             and features & cover.SUPPORT_SET_POSITION
         ):
             a_type = "Window"
-        elif features & cover.SUPPORT_SET_POSITION:
+        elif features & (cover.SUPPORT_SET_POSITION | cover.SUPPORT_SET_TILT_POSITION):
             a_type = "WindowCovering"
         elif features & (cover.SUPPORT_OPEN | cover.SUPPORT_CLOSE):
             a_type = "WindowCoveringBasic"

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -287,7 +287,7 @@ class OpeningDevice(OpeningDeviceBase, HomeAccessory):
             # since CHAR_CURRENT_POSITION/CHAR_TARGET_POSITION are required
             # by homekit, but really don't exist.
             _LOGGER.debug(
-                "%s does not support setting position, current position will be locked to closed.",
+                "%s does not support setting position, current position will be locked to closed",
                 self.entity_id,
             )
             target_args["properties"] = {PROP_MIN_VALUE: 0, PROP_MAX_VALUE: 0}

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -13,6 +13,7 @@ from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     DOMAIN,
+    SUPPORT_SET_POSITION,
     SUPPORT_SET_TILT_POSITION,
     SUPPORT_STOP,
 )
@@ -53,6 +54,8 @@ from .const import (
     HK_POSITION_GOING_TO_MAX,
     HK_POSITION_GOING_TO_MIN,
     HK_POSITION_STOPPED,
+    PROP_MAX_VALUE,
+    PROP_MIN_VALUE,
     SERV_GARAGE_DOOR_OPENER,
     SERV_WINDOW,
     SERV_WINDOW_COVERING,
@@ -273,12 +276,24 @@ class OpeningDevice(OpeningDeviceBase, HomeAccessory):
         """Initialize a WindowCovering accessory object."""
         super().__init__(*args, category=category, service=service)
         state = self.hass.states.get(self.entity_id)
-
         self.char_current_position = self.serv_cover.configure_char(
             CHAR_CURRENT_POSITION, value=0
         )
+        target_args = {"value": 0}
+        if self.features & SUPPORT_SET_POSITION:
+            target_args["setter_callback"] = self.move_cover
+        else:
+            # If its tilt only we lock the position state to 0 (closed)
+            # since CHAR_CURRENT_POSITION/CHAR_TARGET_POSITION are required
+            # by homekit, but really don't exist.
+            _LOGGER.debug(
+                "%s does not support setting position, current position will be locked to closed.",
+                self.entity_id,
+            )
+            target_args["properties"] = {PROP_MIN_VALUE: 0, PROP_MAX_VALUE: 0}
+
         self.char_target_position = self.serv_cover.configure_char(
-            CHAR_TARGET_POSITION, value=0, setter_callback=self.move_cover
+            CHAR_TARGET_POSITION, **target_args
         )
         self.char_position_state = self.serv_cover.configure_char(
             CHAR_POSITION_STATE, value=HK_POSITION_STOPPED

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -126,14 +126,28 @@ def test_types(type_name, entity_id, state, attrs, config):
             "Window",
             "cover.set_position",
             "open",
-            {ATTR_DEVICE_CLASS: "window", ATTR_SUPPORTED_FEATURES: 4},
+            {
+                ATTR_DEVICE_CLASS: "window",
+                ATTR_SUPPORTED_FEATURES: cover.SUPPORT_SET_POSITION,
+            },
         ),
-        ("WindowCovering", "cover.set_position", "open", {ATTR_SUPPORTED_FEATURES: 4}),
+        (
+            "WindowCovering",
+            "cover.set_position",
+            "open",
+            {ATTR_SUPPORTED_FEATURES: cover.SUPPORT_SET_POSITION},
+        ),
+        (
+            "WindowCovering",
+            "cover.tilt",
+            "open",
+            {ATTR_SUPPORTED_FEATURES: cover.SUPPORT_SET_TILT_POSITION},
+        ),
         (
             "WindowCoveringBasic",
             "cover.open_window",
             "open",
-            {ATTR_SUPPORTED_FEATURES: 3},
+            {ATTR_SUPPORTED_FEATURES: (cover.SUPPORT_OPEN | cover.SUPPORT_CLOSE)},
         ),
     ],
 )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Closes #48555

Tested with the demo entity `<state cover.pergola_roof=closed; current_tilt_position=70, friendly_name=Pergola Roof, supported_features=240 @ 2021-07-17T17:49:00.262494-10:00>`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
