### PR TITLE
Add DeviceRegistry template functions

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -906,14 +906,14 @@ def expand(hass: HomeAssistant, *args: Any) -> Iterable[State]:
     return sorted(found.values(), key=lambda a: a.entity_id)
 
 
-def device_entities(hass: HomeAssistant, device_id: str) -> Iterable[str]:
+def device_entities(hass: HomeAssistant, _device_id: str) -> Iterable[str]:
     """Get entity ids for entities tied to a device."""
     entity_reg = entity_registry.async_get(hass)
-    entries = entity_registry.async_entries_for_device(entity_reg, device_id)
+    entries = entity_registry.async_entries_for_device(entity_reg, _device_id)
     return [entry.entity_id for entry in entries]
 
 
-def to_device_id(hass: HomeAssistant, entity_id: str) -> str | None:
+def device_id(hass: HomeAssistant, entity_id: str) -> str | None:
     """Get a device ID from an entity ID."""
     if not isinstance(entity_id, str) or "." not in entity_id:
         raise TemplateError(f"Must provide an entity ID, got {entity_id}")  # type: ignore
@@ -932,7 +932,7 @@ def device_attr(hass: HomeAssistant, device_or_entity_id: str, attr_name: str) -
     device = None
     if (
         "." in device_or_entity_id
-        and (_device_id := to_device_id(hass, device_or_entity_id)) is not None
+        and (_device_id := device_id(hass, device_or_entity_id)) is not None
     ):
         device = device_reg.async_get(_device_id)
     elif "." not in device_or_entity_id:
@@ -1529,8 +1529,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["device_attr"] = hassfunction(device_attr)
         self.globals["is_device_attr"] = hassfunction(is_device_attr)
 
-        self.globals["to_device_id"] = hassfunction(to_device_id)
-        self.filters["to_device_id"] = pass_context(self.globals["to_device_id"])
+        self.globals["device_id"] = hassfunction(device_id)
+        self.filters["device_id"] = pass_context(self.globals["device_id"])
 
         if limited:
             # Only device_entities is available to limited templates, mark other
@@ -1555,7 +1555,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
                 "now",
                 "device_attr",
                 "is_device_attr",
-                "to_device_id",
+                "device_id",
             ]
             hass_filters = ["closest", "expand", "device_id"]
             for glob in hass_globals:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -913,20 +913,38 @@ def device_entities(hass: HomeAssistant, device_id: str) -> Iterable[str]:
     return [entry.entity_id for entry in entries]
 
 
-def device_attr(hass: HomeAssistant, device_id: str, attr_name: str) -> Any:
+def to_device_id(hass: HomeAssistant, entity_id: str) -> str | None:
+    """Get a device ID from an entity ID."""
+    entity_reg = entity_registry.async_get(hass)
+    entity = entity_reg.async_get(entity_id)
+    if entity is None:
+        return None
+    return entity.device_id
+
+
+def device_attr(hass: HomeAssistant, device_or_entity_id: str, attr_name: str) -> Any:
     """Get the device specific attribute."""
     device_reg = device_registry.async_get(hass)
-    device = device_reg.async_get(device_id)
+    if not isinstance(device_or_entity_id, str):
+        raise TemplateError("Must provide a device or entity ID")
+    device = None
+    if (
+        "." in device_or_entity_id
+        and (device_id := to_device_id(hass, device_or_entity_id)) is not None
+    ):
+        device = device_reg.async_get(device_id)
+    elif "." not in device_or_entity_id:
+        device = device_reg.async_get(device_or_entity_id)
     if device is None or not hasattr(device, attr_name):
         return None
     return getattr(device, attr_name)
 
 
 def is_device_attr(
-    hass: HomeAssistant, device_id: str, attr_name: str, attr_value: Any
+    hass: HomeAssistant, device_or_entity_id: str, attr_name: str, attr_value: Any
 ) -> bool:
     """Test if a device's attribute is a specific value."""
-    return bool(device_attr(hass, device_id, attr_name) == attr_value)
+    return bool(device_attr(hass, device_or_entity_id, attr_name) == attr_value)
 
 
 def closest(hass, *args):
@@ -1509,6 +1527,9 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["device_attr"] = hassfunction(device_attr)
         self.globals["is_device_attr"] = hassfunction(is_device_attr)
 
+        self.globals["to_device_id"] = hassfunction(to_device_id)
+        self.filters["to_device_id"] = pass_context(self.globals["to_device_id"])
+
         if limited:
             # Only device_entities is available to limited templates, mark other
             # functions and filters as unsupported.
@@ -1532,8 +1553,9 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
                 "now",
                 "device_attr",
                 "is_device_attr",
+                "to_device_id",
             ]
-            hass_filters = ["closest", "expand"]
+            hass_filters = ["closest", "expand", "to_device_id"]
             for glob in hass_globals:
                 self.globals[glob] = unsupported(glob)
             for filt in hass_filters:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -913,7 +913,7 @@ def device_entities(hass: HomeAssistant, device_id: str) -> Iterable[str]:
     return [entry.entity_id for entry in entries]
 
 
-def device_id(hass: HomeAssistant, entity_id: str) -> str | None:
+def to_device_id(hass: HomeAssistant, entity_id: str) -> str | None:
     """Get a device ID from an entity ID."""
     if not isinstance(entity_id, str) or "." not in entity_id:
         raise TemplateError(f"Must provide an entity ID, got {entity_id}")  # type: ignore
@@ -932,7 +932,7 @@ def device_attr(hass: HomeAssistant, device_or_entity_id: str, attr_name: str) -
     device = None
     if (
         "." in device_or_entity_id
-        and (_device_id := device_id(hass, device_or_entity_id)) is not None
+        and (_device_id := to_device_id(hass, device_or_entity_id)) is not None
     ):
         device = device_reg.async_get(_device_id)
     elif "." not in device_or_entity_id:
@@ -1529,8 +1529,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["device_attr"] = hassfunction(device_attr)
         self.globals["is_device_attr"] = hassfunction(is_device_attr)
 
-        self.globals["device_id"] = hassfunction(device_id)
-        self.filters["device_id"] = pass_context(self.globals["device_id"])
+        self.globals["to_device_id"] = hassfunction(to_device_id)
+        self.filters["to_device_id"] = pass_context(self.globals["to_device_id"])
 
         if limited:
             # Only device_entities is available to limited templates, mark other
@@ -1555,7 +1555,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
                 "now",
                 "device_attr",
                 "is_device_attr",
-                "device_id",
+                "to_device_id",
             ]
             hass_filters = ["closest", "expand", "device_id"]
             for glob in hass_globals:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -913,18 +913,20 @@ def device_entities(hass: HomeAssistant, device_id: str) -> Iterable[str]:
     return [entry.entity_id for entry in entries]
 
 
-def device_attr(hass: HomeAssistant, device_id: str, attr: str) -> Any:
+def device_attr(hass: HomeAssistant, device_id: str, attr_name: str) -> Any:
     """Get the device specific attribute."""
     device_reg = device_registry.async_get(hass)
     device = device_reg.async_get(device_id)
-    if device is None or not hasattr(device, attr):
+    if device is None or not hasattr(device, attr_name):
         return None
-    return getattr(device, attr)
+    return getattr(device, attr_name)
 
 
-def is_device_attr(hass: HomeAssistant, device_id: str, attr: str, value: Any) -> bool:
+def is_device_attr(
+    hass: HomeAssistant, device_id: str, attr_name: str, attr_value: Any
+) -> bool:
     """Test if a device's attribute is a specific value."""
-    return bool(device_attr(hass, device_id, attr) == value)
+    return bool(device_attr(hass, device_id, attr_name) == attr_value)
 
 
 def closest(hass, *args):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1585,8 +1585,8 @@ async def test_device_entities(hass):
     assert info.rate_limit is None
 
 
-async def test_to_device_id(hass):
-    """Test to_device_id function."""
+async def test_device_id(hass):
+    """Test device_id function."""
     config_entry = MockConfigEntry(domain="light")
     device_registry = mock_device_registry(hass)
     entity_registry = mock_registry(hass)
@@ -1602,25 +1602,25 @@ async def test_to_device_id(hass):
         "sensor", "test", "test_no_device", suggested_object_id="test"
     )
 
-    info = render_to_info(hass, "{{ 'sensor.fail' | to_device_id }}")
+    info = render_to_info(hass, "{{ 'sensor.fail' | device_id }}")
     assert_result_info(info, None)
     assert info.rate_limit is None
 
     with pytest.raises(TemplateError):
-        info = render_to_info(hass, "{{ 56 | to_device_id }}")
+        info = render_to_info(hass, "{{ 56 | device_id }}")
         assert_result_info(info, None)
 
     with pytest.raises(TemplateError):
-        info = render_to_info(hass, "{{ 'not_a_real_entity_id' | to_device_id }}")
+        info = render_to_info(hass, "{{ 'not_a_real_entity_id' | device_id }}")
         assert_result_info(info, None)
 
     info = render_to_info(
-        hass, f"{{{{ to_device_id('{entity_entry_no_device.entity_id}') }}}}"
+        hass, f"{{{{ device_id('{entity_entry_no_device.entity_id}') }}}}"
     )
     assert_result_info(info, None)
     assert info.rate_limit is None
 
-    info = render_to_info(hass, f"{{{{ to_device_id('{entity_entry.entity_id}') }}}}")
+    info = render_to_info(hass, f"{{{{ device_id('{entity_entry.entity_id}') }}}}")
     assert_result_info(info, device_entry.id)
     assert info.rate_limit is None
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1586,7 +1586,7 @@ async def test_device_entities(hass):
 
 
 async def test_to_device_id(hass):
-    """Test device_id function."""
+    """Test to_device_id function."""
     config_entry = MockConfigEntry(domain="light")
     device_registry = mock_device_registry(hass)
     entity_registry = mock_registry(hass)
@@ -1602,25 +1602,25 @@ async def test_to_device_id(hass):
         "sensor", "test", "test_no_device", suggested_object_id="test"
     )
 
-    info = render_to_info(hass, "{{ 'sensor.fail' | device_id }}")
+    info = render_to_info(hass, "{{ 'sensor.fail' | to_device_id }}")
     assert_result_info(info, None)
     assert info.rate_limit is None
 
     with pytest.raises(TemplateError):
-        info = render_to_info(hass, "{{ 56 | device_id }}")
+        info = render_to_info(hass, "{{ 56 | to_device_id }}")
         assert_result_info(info, None)
 
     with pytest.raises(TemplateError):
-        info = render_to_info(hass, "{{ 'not_a_real_entity_id' | device_id }}")
+        info = render_to_info(hass, "{{ 'not_a_real_entity_id' | to_device_id }}")
         assert_result_info(info, None)
 
     info = render_to_info(
-        hass, f"{{{{ device_id('{entity_entry_no_device.entity_id}') }}}}"
+        hass, f"{{{{ to_device_id('{entity_entry_no_device.entity_id}') }}}}"
     )
     assert_result_info(info, None)
     assert info.rate_limit is None
 
-    info = render_to_info(hass, f"{{{{ device_id('{entity_entry.entity_id}') }}}}")
+    info = render_to_info(hass, f"{{{{ to_device_id('{entity_entry.entity_id}') }}}}")
     assert_result_info(info, device_entry.id)
     assert info.rate_limit is None
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1586,7 +1586,7 @@ async def test_device_entities(hass):
 
 
 async def test_to_device_id(hass):
-    """Test to_device_id function."""
+    """Test device_id function."""
     config_entry = MockConfigEntry(domain="light")
     device_registry = mock_device_registry(hass)
     entity_registry = mock_registry(hass)
@@ -1602,17 +1602,25 @@ async def test_to_device_id(hass):
         "sensor", "test", "test_no_device", suggested_object_id="test"
     )
 
-    info = render_to_info(hass, "{{ 'sensor.fail' | to_device_id }}")
+    info = render_to_info(hass, "{{ 'sensor.fail' | device_id }}")
     assert_result_info(info, None)
     assert info.rate_limit is None
 
+    with pytest.raises(TemplateError):
+        info = render_to_info(hass, "{{ 56 | device_id }}")
+        assert_result_info(info, None)
+
+    with pytest.raises(TemplateError):
+        info = render_to_info(hass, "{{ 'not_a_real_entity_id' | device_id }}")
+        assert_result_info(info, None)
+
     info = render_to_info(
-        hass, f"{{{{ to_device_id('{entity_entry_no_device.entity_id}') }}}}"
+        hass, f"{{{{ device_id('{entity_entry_no_device.entity_id}') }}}}"
     )
     assert_result_info(info, None)
     assert info.rate_limit is None
 
-    info = render_to_info(hass, f"{{{{ to_device_id('{entity_entry.entity_id}') }}}}")
+    info = render_to_info(hass, f"{{{{ device_id('{entity_entry.entity_id}') }}}}")
     assert_result_info(info, device_entry.id)
     assert info.rate_limit is None
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1585,6 +1585,90 @@ async def test_device_entities(hass):
     assert info.rate_limit is None
 
 
+async def test_device_attr(hass):
+    """Test device_attr and is_device_attr functions."""
+    config_entry = MockConfigEntry(domain="light")
+    device_registry = mock_device_registry(hass)
+
+    # Test non existing device ids (device_attr)
+    info = render_to_info(hass, "{{ device_attr('abc123', 'id') }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ device_attr(56, 'id') }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test non existing device ids (is_device_attr)
+    info = render_to_info(hass, "{{ is_device_attr('abc123', 'id', 'test') }}")
+    assert_result_info(info, False)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ is_device_attr(56, 'id', 'test') }}")
+    assert_result_info(info, False)
+    assert info.rate_limit is None
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        model="test",
+    )
+
+    # Test non existent device attribute (device_attr)
+    info = render_to_info(
+        hass, f"{{{{ device_attr('{device_entry.id}', 'invalid_attr') }}}}"
+    )
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test non existent device attribute (is_device_attr)
+    info = render_to_info(
+        hass, f"{{{{ is_device_attr('{device_entry.id}', 'invalid_attr', 'test') }}}}"
+    )
+    assert_result_info(info, False)
+    assert info.rate_limit is None
+
+    # Test None device attribute (device_attr)
+    info = render_to_info(
+        hass, f"{{{{ device_attr('{device_entry.id}', 'manufacturer') }}}}"
+    )
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test None device attribute mismatch (is_device_attr)
+    info = render_to_info(
+        hass, f"{{{{ is_device_attr('{device_entry.id}', 'manufacturer', 'test') }}}}"
+    )
+    assert_result_info(info, False)
+    assert info.rate_limit is None
+
+    # Test None device attribute match (is_device_attr)
+    info = render_to_info(
+        hass, f"{{{{ is_device_attr('{device_entry.id}', 'manufacturer', None) }}}}"
+    )
+    assert_result_info(info, True)
+    assert info.rate_limit is None
+
+    # Test valid device attribute (device_attr
+    info = render_to_info(hass, f"{{{{ device_attr('{device_entry.id}', 'model') }}}}")
+    assert_result_info(info, "test")
+    assert info.rate_limit is None
+
+    # Test valid device attribute mismatch (is_device_attr)
+    info = render_to_info(
+        hass, f"{{{{ is_device_attr('{device_entry.id}', 'model', 'fail') }}}}"
+    )
+    assert_result_info(info, False)
+    assert info.rate_limit is None
+
+    # Test valid device attribute mismatch (is_device_attr)
+    info = render_to_info(
+        hass, f"{{{{ is_device_attr('{device_entry.id}', 'model', 'test') }}}}"
+    )
+    assert_result_info(info, True)
+    assert info.rate_limit is None
+
+
 def test_closest_function_to_coord(hass):
     """Test closest function to coord."""
     hass.states.async_set(


### PR DESCRIPTION
## Proposed change
Added three new template functions:
- `device_id(entity_id)`: Returns device_id
- `device_attr(device_or_entity_id, attr_name)`: Returns attribute from device registry
- `is_device_attr(device_or_entity_id, attr_name, attr_value`: Returns whether attribute from device registry matches `attr_value`

These functions will allow templates to get information from the device registry which can be useful for the `zwave_js` events since they sent on a device basis instead of on an entity basis.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18540

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
