### PR TITLE
Modify AirVisual states to be translatable

### DIFF
--- a/homeassistant/components/airvisual/sensor.py
+++ b/homeassistant/components/airvisual/sensor.py
@@ -37,6 +37,9 @@ ATTR_POLLUTANT_SYMBOL = "pollutant_symbol"
 ATTR_POLLUTANT_UNIT = "pollutant_unit"
 ATTR_REGION = "region"
 
+DEVICE_CLASS_POLLUTANT_LABEL = "airvisual__pollutant_label"
+DEVICE_CLASS_POLLUTANT_LEVEL = "airvisual__pollutant_level"
+
 SENSOR_KIND_AQI = "air_quality_index"
 SENSOR_KIND_BATTERY_LEVEL = "battery_level"
 SENSOR_KIND_CO2 = "carbon_dioxide"
@@ -105,22 +108,27 @@ NODE_PRO_SENSORS = [
     ),
 ]
 
-POLLUTANT_LABELS = {
-    "co": "Carbon Monoxide",
-    "n2": "Nitrogen Dioxide",
-    "o3": "Ozone",
-    "p1": "PM10",
-    "p2": "PM2.5",
-    "s2": "Sulfur Dioxide",
-}
+STATE_POLLUTANT_LABEL_CO = "co"
+STATE_POLLUTANT_LABEL_N2 = "n2"
+STATE_POLLUTANT_LABEL_O3 = "o3"
+STATE_POLLUTANT_LABEL_P1 = "p1"
+STATE_POLLUTANT_LABEL_P2 = "p2"
+STATE_POLLUTANT_LABEL_S2 = "s2"
+
+STATE_LEVEL_GOOD = "good"
+STATE_LEVEL_MODERATE = "moderate"
+STATE_LEVEL_UNHEALTHY_SENSITIVE = "unhealthy_sensitive"
+STATE_LEVEL_UNHEALTHY = "unhealthy"
+STATE_LEVEL_VERY_UNHEALTHY = "very_unhealthy"
+STATE_LEVEL_HAZARDOUS = "hazardous"
 
 POLLUTANT_LEVELS = {
-    (0, 50): ("Good", "mdi:emoticon-excited"),
-    (51, 100): ("Moderate", "mdi:emoticon-happy"),
-    (101, 150): ("Unhealthy for sensitive groups", "mdi:emoticon-neutral"),
-    (151, 200): ("Unhealthy", "mdi:emoticon-sad"),
-    (201, 300): ("Very unhealthy", "mdi:emoticon-dead"),
-    (301, 1000): ("Hazardous", "mdi:biohazard"),
+    (0, 50): (STATE_LEVEL_GOOD, "mdi:emoticon-excited"),
+    (51, 100): (STATE_LEVEL_MODERATE, "mdi:emoticon-happy"),
+    (101, 150): (STATE_LEVEL_UNHEALTHY_SENSITIVE, "mdi:emoticon-neutral"),
+    (151, 200): (STATE_LEVEL_UNHEALTHY, "mdi:emoticon-sad"),
+    (201, 300): (STATE_LEVEL_VERY_UNHEALTHY, "mdi:emoticon-dead"),
+    (301, 1000): (STATE_LEVEL_HAZARDOUS, "mdi:biohazard"),
 }
 
 POLLUTANT_UNITS = {
@@ -170,6 +178,10 @@ class AirVisualGeographySensor(AirVisualEntity, SensorEntity):
         """Initialize."""
         super().__init__(coordinator)
 
+        if kind == SENSOR_KIND_LEVEL:
+            self._attr_device_class = DEVICE_CLASS_POLLUTANT_LEVEL
+        elif kind == SENSOR_KIND_POLLUTANT:
+            self._attr_device_class = DEVICE_CLASS_POLLUTANT_LABEL
         self._attr_extra_state_attributes.update(
             {
                 ATTR_CITY: config_entry.data.get(CONF_CITY),
@@ -209,7 +221,7 @@ class AirVisualGeographySensor(AirVisualEntity, SensorEntity):
             self._attr_state = data[f"aqi{self._locale}"]
         elif self._kind == SENSOR_KIND_POLLUTANT:
             symbol = data[f"main{self._locale}"]
-            self._attr_state = POLLUTANT_LABELS[symbol]
+            self._attr_state = symbol
             self._attr_extra_state_attributes.update(
                 {
                     ATTR_POLLUTANT_SYMBOL: symbol,

--- a/homeassistant/components/airvisual/sensor.py
+++ b/homeassistant/components/airvisual/sensor.py
@@ -115,20 +115,20 @@ STATE_POLLUTANT_LABEL_P1 = "p1"
 STATE_POLLUTANT_LABEL_P2 = "p2"
 STATE_POLLUTANT_LABEL_S2 = "s2"
 
-STATE_LEVEL_GOOD = "good"
-STATE_LEVEL_MODERATE = "moderate"
-STATE_LEVEL_UNHEALTHY_SENSITIVE = "unhealthy_sensitive"
-STATE_LEVEL_UNHEALTHY = "unhealthy"
-STATE_LEVEL_VERY_UNHEALTHY = "very_unhealthy"
-STATE_LEVEL_HAZARDOUS = "hazardous"
+STATE_POLLUTANT_LEVEL_GOOD = "good"
+STATE_POLLUTANT_LEVEL_MODERATE = "moderate"
+STATE_POLLUTANT_LEVEL_UNHEALTHY_SENSITIVE = "unhealthy_sensitive"
+STATE_POLLUTANT_LEVEL_UNHEALTHY = "unhealthy"
+STATE_POLLUTANT_LEVEL_VERY_UNHEALTHY = "very_unhealthy"
+STATE_POLLUTANT_LEVEL_HAZARDOUS = "hazardous"
 
 POLLUTANT_LEVELS = {
-    (0, 50): (STATE_LEVEL_GOOD, "mdi:emoticon-excited"),
-    (51, 100): (STATE_LEVEL_MODERATE, "mdi:emoticon-happy"),
-    (101, 150): (STATE_LEVEL_UNHEALTHY_SENSITIVE, "mdi:emoticon-neutral"),
-    (151, 200): (STATE_LEVEL_UNHEALTHY, "mdi:emoticon-sad"),
-    (201, 300): (STATE_LEVEL_VERY_UNHEALTHY, "mdi:emoticon-dead"),
-    (301, 1000): (STATE_LEVEL_HAZARDOUS, "mdi:biohazard"),
+    (0, 50): (STATE_POLLUTANT_LEVEL_GOOD, "mdi:emoticon-excited"),
+    (51, 100): (STATE_POLLUTANT_LEVEL_MODERATE, "mdi:emoticon-happy"),
+    (101, 150): (STATE_POLLUTANT_LEVEL_UNHEALTHY_SENSITIVE, "mdi:emoticon-neutral"),
+    (151, 200): (STATE_POLLUTANT_LEVEL_UNHEALTHY, "mdi:emoticon-sad"),
+    (201, 300): (STATE_POLLUTANT_LEVEL_VERY_UNHEALTHY, "mdi:emoticon-dead"),
+    (301, 1000): (STATE_POLLUTANT_LEVEL_HAZARDOUS, "mdi:biohazard"),
 }
 
 POLLUTANT_UNITS = {

--- a/homeassistant/components/airvisual/strings.sensor.json
+++ b/homeassistant/components/airvisual/strings.sensor.json
@@ -1,0 +1,20 @@
+{
+  "state": {
+    "airvisual__pollutant_label": {
+      "co": "Carbon Monoxide",
+      "n2": "Nitrogen Dioxide",
+      "o3": "Ozone",
+      "p1": "PM10",
+      "p2": "PM2.5",
+      "s2": "Sulfur Dioxide"
+    },
+    "airvisual__pollutant_level": {
+      "good": "Good",
+      "moderate": "Moderate",
+      "unhealthy": "Unhealthy",
+      "unhealthy_sensitive": "Unhealthy for sensitive groups",
+      "very_unhealthy": "Very unhealthy",
+      "hazardous": "Hazardous"
+    }
+  }
+}

--- a/homeassistant/components/airvisual/translations/sensor.en.json
+++ b/homeassistant/components/airvisual/translations/sensor.en.json
@@ -1,0 +1,20 @@
+{
+    "state": {
+        "airvisual__pollutant_label": {
+            "co": "Carbon Monoxide",
+            "n2": "Nitrogen Dioxide",
+            "o3": "Ozone",
+            "p1": "PM10",
+            "p2": "PM2.5",
+            "s2": "Sulfur Dioxide"
+        },
+        "airvisual__pollutant_level": {
+            "good": "Good",
+            "hazardous": "Hazardous",
+            "moderate": "Moderate",
+            "unhealthy": "Unhealthy",
+            "unhealthy_sensitive": "Unhealthy for sensitive groups",
+            "very_unhealthy": "Very unhealthy"
+        }
+    }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
States for the "Pollutant Level" and "Main Pollutant" entities have changed; automations that depended on the old states will need to be updated:

Pollutant Level:

- `Good -> good`
- `Moderate -> moderate`
- `Unhealthy -> unhealthy`
- `Unhealthy for sensitive groups -> unhealthy_sensitive`
- `Very unhealthy -> very_unhealthy`
- `Hazardous -> hazardous`

Pollutant Label:

- `Carbon Monoxide -> co`
- `Nitrogen Dioxide -> n2`
- `Ozone -> o3`
- `PM10 -> p1`
- `PM2.5 -> p2`
- `Sulfur Dioxide -> s2`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR modifies the possible states for AirVisual "Pollutant Label" and "Pollutant Level" sensors so that their values can be translated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
