### PR TITLE
Make additional input for zwave_js device triggers optional

### DIFF
--- a/homeassistant/components/zwave_js/device_trigger.py
+++ b/homeassistant/components/zwave_js/device_trigger.py
@@ -92,7 +92,7 @@ BASE_VALUE_NOTIFICATION_EVENT_SCHEMA = BASE_EVENT_SCHEMA.extend(
         vol.Required(ATTR_PROPERTY): vol.Any(int, str),
         vol.Required(ATTR_PROPERTY_KEY): vol.Any(None, int, str),
         vol.Required(ATTR_ENDPOINT): vol.Coerce(int),
-        vol.Required(ATTR_VALUE): vol.Coerce(int),
+        vol.Optional(ATTR_VALUE): vol.Coerce(int),
         vol.Required(CONF_SUBTYPE): cv.string,
     }
 )
@@ -286,7 +286,8 @@ async def async_attach_trigger(
             copy_available_params(
                 config, event_data, [ATTR_PROPERTY, ATTR_PROPERTY_KEY, ATTR_ENDPOINT]
             )
-            event_data[ATTR_VALUE_RAW] = config[ATTR_VALUE]
+            if ATTR_VALUE in config:
+                event_data[ATTR_VALUE_RAW] = config[ATTR_VALUE]
         else:
             raise HomeAssistantError(f"Unhandled trigger type {trigger_type}")
 
@@ -366,6 +367,6 @@ async def async_get_trigger_capabilities(
                 vol.Range(min=value.metadata.min, max=value.metadata.max),
             )
 
-        return {"extra_fields": vol.Schema({vol.Required(ATTR_VALUE): value_schema})}
+        return {"extra_fields": vol.Schema({vol.Optional(ATTR_VALUE): value_schema})}
 
     return {}

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -68,6 +68,7 @@ async def test_if_notification_notification_fires(
         automation.DOMAIN,
         {
             automation.DOMAIN: [
+                # event, type, label
                 {
                     "trigger": {
                         "platform": "device",
@@ -84,6 +85,27 @@ async def test_if_notification_notification_fires(
                         "data_template": {
                             "some": (
                                 "event.notification.notification - "
+                                "{{ trigger.platform}} - "
+                                "{{ trigger.event.event_type}} - "
+                                "{{ trigger.event.data.command_class }}"
+                            )
+                        },
+                    },
+                },
+                # no type, event, label
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": device.id,
+                        "type": "event.notification.notification",
+                        "command_class": CommandClass.NOTIFICATION.value,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "event.notification.notification2 - "
                                 "{{ trigger.platform}} - "
                                 "{{ trigger.event.event_type}} - "
                                 "{{ trigger.event.data.command_class }}"
@@ -114,10 +136,15 @@ async def test_if_notification_notification_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 2
     assert calls[0].data[
         "some"
     ] == "event.notification.notification - device - zwave_js_notification - {}".format(
+        CommandClass.NOTIFICATION
+    )
+    assert calls[1].data[
+        "some"
+    ] == "event.notification.notification2 - device - zwave_js_notification - {}".format(
         CommandClass.NOTIFICATION
     )
 
@@ -166,6 +193,7 @@ async def test_if_entry_control_notification_fires(
         automation.DOMAIN,
         {
             automation.DOMAIN: [
+                # event_type and data_type
                 {
                     "trigger": {
                         "platform": "device",
@@ -181,6 +209,27 @@ async def test_if_entry_control_notification_fires(
                         "data_template": {
                             "some": (
                                 "event.notification.notification - "
+                                "{{ trigger.platform}} - "
+                                "{{ trigger.event.event_type}} - "
+                                "{{ trigger.event.data.command_class }}"
+                            )
+                        },
+                    },
+                },
+                # no event_type and data_type
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": device.id,
+                        "type": "event.notification.entry_control",
+                        "command_class": CommandClass.ENTRY_CONTROL.value,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "event.notification.notification2 - "
                                 "{{ trigger.platform}} - "
                                 "{{ trigger.event.event_type}} - "
                                 "{{ trigger.event.data.command_class }}"
@@ -205,10 +254,15 @@ async def test_if_entry_control_notification_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 2
     assert calls[0].data[
         "some"
     ] == "event.notification.notification - device - zwave_js_notification - {}".format(
+        CommandClass.ENTRY_CONTROL
+    )
+    assert calls[1].data[
+        "some"
+    ] == "event.notification.notification2 - device - zwave_js_notification - {}".format(
         CommandClass.ENTRY_CONTROL
     )
 
@@ -285,6 +339,7 @@ async def test_if_node_status_change_fires(
         automation.DOMAIN,
         {
             automation.DOMAIN: [
+                # from
                 {
                     "trigger": {
                         "platform": "device",
@@ -305,6 +360,26 @@ async def test_if_node_status_change_fires(
                         },
                     },
                 },
+                # no from or to
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": device.id,
+                        "entity_id": entity_id,
+                        "type": "state.node_status",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "state.node_status2 - "
+                                "{{ trigger.platform}} - "
+                                "{{ trigger.from_state.state }}"
+                            )
+                        },
+                    },
+                },
             ]
         },
     )
@@ -315,8 +390,9 @@ async def test_if_node_status_change_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 2
     assert calls[0].data["some"] == "state.node_status - device - alive"
+    assert calls[1].data["some"] == "state.node_status2 - device - alive"
 
 
 async def test_get_trigger_capabilities_node_status(
@@ -408,6 +484,7 @@ async def test_if_basic_value_notification_fires(
         automation.DOMAIN,
         {
             automation.DOMAIN: [
+                # value
                 {
                     "trigger": {
                         "platform": "device",
@@ -426,6 +503,31 @@ async def test_if_basic_value_notification_fires(
                         "data_template": {
                             "some": (
                                 "event.value_notification.basic - "
+                                "{{ trigger.platform}} - "
+                                "{{ trigger.event.event_type}} - "
+                                "{{ trigger.event.data.command_class }}"
+                            )
+                        },
+                    },
+                },
+                # no value
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "type": "event.value_notification.basic",
+                        "device_id": device.id,
+                        "command_class": CommandClass.BASIC.value,
+                        "property": "event",
+                        "property_key": None,
+                        "endpoint": 0,
+                        "subtype": "Endpoint 0",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "event.value_notification.basic2 - "
                                 "{{ trigger.platform}} - "
                                 "{{ trigger.event.event_type}} - "
                                 "{{ trigger.event.data.command_class }}"
@@ -465,10 +567,15 @@ async def test_if_basic_value_notification_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 2
     assert calls[0].data[
         "some"
     ] == "event.value_notification.basic - device - zwave_js_value_notification - {}".format(
+        CommandClass.BASIC
+    )
+    assert calls[1].data[
+        "some"
+    ] == "event.value_notification.basic2 - device - zwave_js_value_notification - {}".format(
         CommandClass.BASIC
     )
 
@@ -500,7 +607,7 @@ async def test_get_trigger_capabilities_basic_value_notification(
     ) == [
         {
             "name": "value",
-            "required": True,
+            "optional": True,
             "type": "integer",
             "valueMin": 0,
             "valueMax": 255,
@@ -542,6 +649,7 @@ async def test_if_central_scene_value_notification_fires(
         automation.DOMAIN,
         {
             automation.DOMAIN: [
+                # value
                 {
                     "trigger": {
                         "platform": "device",
@@ -560,6 +668,31 @@ async def test_if_central_scene_value_notification_fires(
                         "data_template": {
                             "some": (
                                 "event.value_notification.central_scene - "
+                                "{{ trigger.platform}} - "
+                                "{{ trigger.event.event_type}} - "
+                                "{{ trigger.event.data.command_class }}"
+                            )
+                        },
+                    },
+                },
+                # no value
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": device.id,
+                        "type": "event.value_notification.central_scene",
+                        "command_class": CommandClass.CENTRAL_SCENE.value,
+                        "property": "scene",
+                        "property_key": "001",
+                        "endpoint": 0,
+                        "subtype": "Endpoint 0 Scene 001",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "event.value_notification.central_scene2 - "
                                 "{{ trigger.platform}} - "
                                 "{{ trigger.event.event_type}} - "
                                 "{{ trigger.event.data.command_class }}"
@@ -606,10 +739,15 @@ async def test_if_central_scene_value_notification_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 2
     assert calls[0].data[
         "some"
     ] == "event.value_notification.central_scene - device - zwave_js_value_notification - {}".format(
+        CommandClass.CENTRAL_SCENE
+    )
+    assert calls[1].data[
+        "some"
+    ] == "event.value_notification.central_scene2 - device - zwave_js_value_notification - {}".format(
         CommandClass.CENTRAL_SCENE
     )
 
@@ -641,7 +779,7 @@ async def test_get_trigger_capabilities_central_scene_value_notification(
     ) == [
         {
             "name": "value",
-            "required": True,
+            "optional": True,
             "type": "select",
             "options": [(0, "KeyPressed"), (1, "KeyReleased"), (2, "KeyHeldDown")],
         },
@@ -682,6 +820,7 @@ async def test_if_scene_activation_value_notification_fires(
         automation.DOMAIN,
         {
             automation.DOMAIN: [
+                # value
                 {
                     "trigger": {
                         "platform": "device",
@@ -694,6 +833,31 @@ async def test_if_scene_activation_value_notification_fires(
                         "endpoint": 0,
                         "subtype": "Endpoint 0",
                         "value": 1,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "event.value_notification.scene_activation - "
+                                "{{ trigger.platform}} - "
+                                "{{ trigger.event.event_type}} - "
+                                "{{ trigger.event.data.command_class }}"
+                            )
+                        },
+                    },
+                },
+                # No value
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": device.id,
+                        "type": "event.value_notification.scene_activation",
+                        "command_class": CommandClass.SCENE_ACTIVATION.value,
+                        "property": "sceneId",
+                        "property_key": None,
+                        "endpoint": 0,
+                        "subtype": "Endpoint 0",
                     },
                     "action": {
                         "service": "test.automation",
@@ -739,10 +903,15 @@ async def test_if_scene_activation_value_notification_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 2
     assert calls[0].data[
         "some"
     ] == "event.value_notification.scene_activation - device - zwave_js_value_notification - {}".format(
+        CommandClass.SCENE_ACTIVATION
+    )
+    assert calls[1].data[
+        "some"
+    ] == "event.value_notification.scene_activation2 - device - zwave_js_value_notification - {}".format(
         CommandClass.SCENE_ACTIVATION
     )
 
@@ -774,7 +943,7 @@ async def test_get_trigger_capabilities_scene_activation_value_notification(
     ) == [
         {
             "name": "value",
-            "required": True,
+            "optional": True,
             "type": "integer",
             "valueMin": 1,
             "valueMax": 255,

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -863,7 +863,7 @@ async def test_if_scene_activation_value_notification_fires(
                         "service": "test.automation",
                         "data_template": {
                             "some": (
-                                "event.value_notification.scene_activation - "
+                                "event.value_notification.scene_activation2 - "
                                 "{{ trigger.platform}} - "
                                 "{{ trigger.event.event_type}} - "
                                 "{{ trigger.event.data.command_class }}"


### PR DESCRIPTION
## Proposed change
In most cases, we provide additional fields for `zwave_js` device triggers but they are all optional, all except the value notification events. This makes it so the additional field for value notification events is also optional. I consider this a bug fix because making these fields required was unintended.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
