### PR TITLE
Remove duplicate functions in modbus climate/sensor

### DIFF
--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 from abc import abstractmethod
 from datetime import timedelta
 import logging
+import struct
 from typing import Any
 
 from homeassistant.const import (
     CONF_ADDRESS,
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
+    CONF_COUNT,
     CONF_DELAY,
     CONF_DEVICE_CLASS,
     CONF_NAME,
+    CONF_OFFSET,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
+    CONF_STRUCTURE,
     STATE_ON,
 )
 from homeassistant.helpers.entity import Entity
@@ -30,11 +34,19 @@ from .const import (
     CALL_TYPE_WRITE_REGISTERS,
     CALL_TYPE_X_COILS,
     CALL_TYPE_X_REGISTER_HOLDINGS,
+    CONF_DATA_TYPE,
     CONF_INPUT_TYPE,
+    CONF_PRECISION,
+    CONF_SCALE,
     CONF_STATE_OFF,
     CONF_STATE_ON,
+    CONF_SWAP,
+    CONF_SWAP_BYTE,
+    CONF_SWAP_WORD,
+    CONF_SWAP_WORD_BYTE,
     CONF_VERIFY,
     CONF_WRITE_TYPE,
+    DATA_TYPE_STRING,
 )
 from .modbus import ModbusHub
 
@@ -88,6 +100,75 @@ class BasePlatform(Entity):
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._available
+
+
+class BaseStructPlatform(BasePlatform, RestoreEntity):
+    """Base class representing a sensor/climate."""
+
+    def __init__(self, hub: ModbusHub, config: dict) -> None:
+        """Initialize the switch."""
+        super().__init__(hub, config)
+        self._swap = config[CONF_SWAP]
+        self._data_type = config[CONF_DATA_TYPE]
+        self._structure = config.get(CONF_STRUCTURE)
+        self._precision = config[CONF_PRECISION]
+        self._scale = config[CONF_SCALE]
+        self._offset = config[CONF_OFFSET]
+        self._count = config[CONF_COUNT]
+
+    def _swap_registers(self, registers):
+        """Do swap as needed."""
+        if self._swap in [CONF_SWAP_BYTE, CONF_SWAP_WORD_BYTE]:
+            # convert [12][34] --> [21][43]
+            for i, register in enumerate(registers):
+                registers[i] = int.from_bytes(
+                    register.to_bytes(2, byteorder="little"),
+                    byteorder="big",
+                    signed=False,
+                )
+        if self._swap in [CONF_SWAP_WORD, CONF_SWAP_WORD_BYTE]:
+            # convert [12][34] ==> [34][12]
+            registers.reverse()
+        return registers
+
+    def unpack_structure_result(self, registers):
+        """Convert registers to proper result."""
+
+        registers = self._swap_registers(registers)
+        byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
+        if self._data_type == DATA_TYPE_STRING:
+            self._value = byte_string.decode()
+        else:
+            val = struct.unpack(self._structure, byte_string)
+
+            # Issue: https://github.com/home-assistant/core/issues/41944
+            # If unpack() returns a tuple greater than 1, don't try to process the value.
+            # Instead, return the values of unpack(...) separated by commas.
+            if len(val) > 1:
+                # Apply scale and precision to floats and ints
+                v_result = []
+                for entry in val:
+                    v_temp = self._scale * entry + self._offset
+
+                    # We could convert int to float, and the code would still work; however
+                    # we lose some precision, and unit tests will fail. Therefore, we do
+                    # the conversion only when it's absolutely necessary.
+                    if isinstance(v_temp, int) and self._precision == 0:
+                        v_result.append(str(v_temp))
+                    else:
+                        v_result.append(f"{float(v_temp):.{self._precision}f}")
+                self._value = ",".join(map(str, v_result))
+            else:
+                # Apply scale and precision to floats and ints
+                val = self._scale * val[0] + self._offset
+
+                # We could convert int to float, and the code would still work; however
+                # we lose some precision, and unit tests will fail. Therefore, we do
+                # the conversion only when it's absolutely necessary.
+                if isinstance(val, int) and self._precision == 0:
+                    self._value = str(val)
+                else:
+                    self._value = f"{float(val):.{self._precision}f}"
 
 
 class BaseSwitch(BasePlatform, RestoreEntity):

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -11,9 +11,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import (
-    CONF_COUNT,
     CONF_NAME,
-    CONF_OFFSET,
     CONF_STRUCTURE,
     CONF_TEMPERATURE_UNIT,
     PRECISION_TENTHS,
@@ -25,22 +23,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .base_platform import BasePlatform
+from .base_platform import BaseStructPlatform
 from .const import (
     ATTR_TEMPERATURE,
     CALL_TYPE_REGISTER_HOLDING,
     CALL_TYPE_WRITE_REGISTERS,
     CONF_CLIMATES,
-    CONF_DATA_TYPE,
     CONF_MAX_TEMP,
     CONF_MIN_TEMP,
-    CONF_PRECISION,
-    CONF_SCALE,
     CONF_STEP,
-    CONF_SWAP,
-    CONF_SWAP_BYTE,
-    CONF_SWAP_WORD,
-    CONF_SWAP_WORD_BYTE,
     CONF_TARGET_TEMP,
     DEFAULT_STRUCT_FORMAT,
     MODBUS_DOMAIN,
@@ -69,7 +60,7 @@ async def async_setup_platform(
     async_add_entities(entities)
 
 
-class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
+class ModbusThermostat(BaseStructPlatform, RestoreEntity, ClimateEntity):
     """Representation of a Modbus Thermostat."""
 
     def __init__(
@@ -82,17 +73,11 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
         self._target_temperature_register = config[CONF_TARGET_TEMP]
         self._target_temperature = None
         self._current_temperature = None
-        self._data_type = config[CONF_DATA_TYPE]
         self._structure = config[CONF_STRUCTURE]
-        self._count = config[CONF_COUNT]
-        self._precision = config[CONF_PRECISION]
-        self._scale = config[CONF_SCALE]
-        self._offset = config[CONF_OFFSET]
         self._unit = config[CONF_TEMPERATURE_UNIT]
         self._max_temp = config[CONF_MAX_TEMP]
         self._min_temp = config[CONF_MIN_TEMP]
         self._temp_step = config[CONF_STEP]
-        self._swap = config[CONF_SWAP]
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
@@ -175,21 +160,6 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
         self._available = result is not None
         await self.async_update()
 
-    def _swap_registers(self, registers):
-        """Do swap as needed."""
-        if self._swap in [CONF_SWAP_BYTE, CONF_SWAP_WORD_BYTE]:
-            # convert [12][34] --> [21][43]
-            for i, register in enumerate(registers):
-                registers[i] = int.from_bytes(
-                    register.to_bytes(2, byteorder="little"),
-                    byteorder="big",
-                    signed=False,
-                )
-        if self._swap in [CONF_SWAP_WORD, CONF_SWAP_WORD_BYTE]:
-            # convert [12][34] ==> [34][12]
-            registers.reverse()
-        return registers
-
     async def async_update(self, now=None):
         """Update Target & Current Temperature."""
         # remark "now" is a dummy parameter to avoid problems with
@@ -217,21 +187,7 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
             self._available = False
             return -1
 
-        registers = self._swap_registers(result.registers)
-        byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
-        val = struct.unpack(self._structure, byte_string)
-        if len(val) != 1 or not isinstance(val[0], (float, int)):
-            _LOGGER.error(
-                "Unable to parse result as a single int or float value; adjust your configuration. Result: %s",
-                str(val),
-            )
-            return -1
+        self.unpack_structure_result(result.registers)
 
-        val2 = val[0]
-        register_value = format(
-            (self._scale * val2) + self._offset, f".{self._precision}f"
-        )
-        register_value2 = float(register_value)
         self._available = True
-
-        return register_value2
+        return self._value

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -2,34 +2,16 @@
 from __future__ import annotations
 
 import logging
-import struct
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import (
-    CONF_COUNT,
-    CONF_NAME,
-    CONF_OFFSET,
-    CONF_SENSORS,
-    CONF_STRUCTURE,
-    CONF_UNIT_OF_MEASUREMENT,
-)
+from homeassistant.const import CONF_NAME, CONF_SENSORS, CONF_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .base_platform import BasePlatform
-from .const import (
-    CONF_DATA_TYPE,
-    CONF_PRECISION,
-    CONF_SCALE,
-    CONF_SWAP,
-    CONF_SWAP_BYTE,
-    CONF_SWAP_WORD,
-    CONF_SWAP_WORD_BYTE,
-    DATA_TYPE_STRING,
-    MODBUS_DOMAIN,
-)
+from .base_platform import BaseStructPlatform
+from .const import MODBUS_DOMAIN
 from .modbus import ModbusHub
 
 PARALLEL_UPDATES = 1
@@ -55,7 +37,7 @@ async def async_setup_platform(
     async_add_entities(sensors)
 
 
-class ModbusRegisterSensor(BasePlatform, RestoreEntity, SensorEntity):
+class ModbusRegisterSensor(BaseStructPlatform, RestoreEntity, SensorEntity):
     """Modbus register sensor."""
 
     def __init__(
@@ -66,13 +48,6 @@ class ModbusRegisterSensor(BasePlatform, RestoreEntity, SensorEntity):
         """Initialize the modbus register sensor."""
         super().__init__(hub, entry)
         self._unit_of_measurement = entry.get(CONF_UNIT_OF_MEASUREMENT)
-        self._count = int(entry[CONF_COUNT])
-        self._swap = entry[CONF_SWAP]
-        self._scale = entry[CONF_SCALE]
-        self._offset = entry[CONF_OFFSET]
-        self._precision = entry[CONF_PRECISION]
-        self._structure = entry.get(CONF_STRUCTURE)
-        self._data_type = entry[CONF_DATA_TYPE]
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
@@ -91,21 +66,6 @@ class ModbusRegisterSensor(BasePlatform, RestoreEntity, SensorEntity):
         """Return the unit of measurement."""
         return self._unit_of_measurement
 
-    def _swap_registers(self, registers):
-        """Do swap as needed."""
-        if self._swap in [CONF_SWAP_BYTE, CONF_SWAP_WORD_BYTE]:
-            # convert [12][34] --> [21][43]
-            for i, register in enumerate(registers):
-                registers[i] = int.from_bytes(
-                    register.to_bytes(2, byteorder="little"),
-                    byteorder="big",
-                    signed=False,
-                )
-        if self._swap in [CONF_SWAP_WORD, CONF_SWAP_WORD_BYTE]:
-            # convert [12][34] ==> [34][12]
-            registers.reverse()
-        return registers
-
     async def async_update(self, now=None):
         """Update the state of the sensor."""
         # remark "now" is a dummy parameter to avoid problems with
@@ -118,41 +78,6 @@ class ModbusRegisterSensor(BasePlatform, RestoreEntity, SensorEntity):
             self.async_write_ha_state()
             return
 
-        registers = self._swap_registers(result.registers)
-        byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
-        if self._data_type == DATA_TYPE_STRING:
-            self._value = byte_string.decode()
-        else:
-            val = struct.unpack(self._structure, byte_string)
-
-            # Issue: https://github.com/home-assistant/core/issues/41944
-            # If unpack() returns a tuple greater than 1, don't try to process the value.
-            # Instead, return the values of unpack(...) separated by commas.
-            if len(val) > 1:
-                # Apply scale and precision to floats and ints
-                v_result = []
-                for entry in val:
-                    v_temp = self._scale * entry + self._offset
-
-                    # We could convert int to float, and the code would still work; however
-                    # we lose some precision, and unit tests will fail. Therefore, we do
-                    # the conversion only when it's absolutely necessary.
-                    if isinstance(v_temp, int) and self._precision == 0:
-                        v_result.append(str(v_temp))
-                    else:
-                        v_result.append(f"{float(v_temp):.{self._precision}f}")
-                self._value = ",".join(map(str, v_result))
-            else:
-                # Apply scale and precision to floats and ints
-                val = self._scale * val[0] + self._offset
-
-                # We could convert int to float, and the code would still work; however
-                # we lose some precision, and unit tests will fail. Therefore, we do
-                # the conversion only when it's absolutely necessary.
-                if isinstance(val, int) and self._precision == 0:
-                    self._value = str(val)
-                else:
-                    self._value = f"{float(val):.{self._precision}f}"
-
+        self.unpack_structure_result(result.registers)
         self._available = True
         self.async_write_ha_state()


### PR DESCRIPTION
Convert all data types correctly for climate.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
swap_registers and the conversion from result.registers to the selected datatype, was implemented in both sensor and climate, but slightly different (and with the new data types, partly false in climate).

Moved the conversion to a base class.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
