### PR TITLE
Register LCN devices in device registry

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -22,7 +22,14 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_DIM_MODE, CONF_SK_NUM_TRIES, CONNECTION, DOMAIN, PLATFORMS
+from .const import (
+    CONF_DIM_MODE,
+    CONF_DOMAIN_DATA,
+    CONF_SK_NUM_TRIES,
+    CONNECTION,
+    DOMAIN,
+    PLATFORMS,
+)
 from .helpers import (
     AddressType,
     DeviceConnectionType,
@@ -31,6 +38,7 @@ from .helpers import (
     async_register_lcn_host_device,
     async_update_config_entry,
     generate_unique_id,
+    get_device_model,
     import_lcn_config,
 )
 from .schemas import CONFIG_SCHEMA  # noqa: F401
@@ -186,15 +194,13 @@ class LcnEntity(Entity):
     def device_info(self) -> DeviceInfo | None:
         """Return device specific attributes."""
         address = f"{'g' if self.address[2] else 'm'}{self.address[0]:03d}{self.address[1]:03d}"
-        hw_model = (
-            f"LCN {self.config[CONF_DOMAIN]} ({address}.{self.config[CONF_RESOURCE]})"
-        )
+        model = f"LCN {get_device_model(self.config[CONF_DOMAIN], self.config[CONF_DOMAIN_DATA])}"
 
         return {
             "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.name,
+            "name": f"{address}.{self.config[CONF_RESOURCE]}",
+            "model": model,
             "manufacturer": "Issendorff",
-            "model": hw_model,
             "via_device": (
                 DOMAIN,
                 generate_unique_id(self.entry_id, self.config[CONF_ADDRESS]),

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.typing import ConfigType
 
@@ -34,12 +33,12 @@ from .helpers import (
     AddressType,
     DeviceConnectionType,
     InputType,
-    async_register_lcn_address_devices,
-    async_register_lcn_host_device,
     async_update_config_entry,
     generate_unique_id,
     get_device_model,
     import_lcn_config,
+    register_lcn_address_devices,
+    register_lcn_host_device,
 )
 from .schemas import CONFIG_SCHEMA  # noqa: F401
 from .services import SERVICES
@@ -113,19 +112,9 @@ async def async_setup_entry(
     # Update config_entry with LCN device serials
     await async_update_config_entry(hass, config_entry)
 
-    # Cleanup entity and device registry, if we imported from configuration.yaml to
-    # remove orphans when entities were removed from configuration
-    if config_entry.source == config_entries.SOURCE_IMPORT:
-        entity_registry = await er.async_get_registry(hass)
-        entity_registry.async_clear_config_entry(config_entry.entry_id)
-
-        device_registry = await dr.async_get_registry(hass)
-        device_registry.async_clear_config_entry(config_entry.entry_id)
-        config_entry.source = config_entries.SOURCE_USER
-
     # register/update devices for host, modules and groups in device registry
-    await async_register_lcn_host_device(hass, config_entry)
-    await async_register_lcn_address_devices(hass, config_entry)
+    register_lcn_host_device(hass, config_entry)
+    register_lcn_address_devices(hass, config_entry)
 
     # forward config_entry to components
     hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -8,6 +8,7 @@ import pypck
 
 from homeassistant import config_entries
 from homeassistant.const import (
+    CONF_DOMAIN,
     CONF_IP_ADDRESS,
     CONF_NAME,
     CONF_PASSWORD,
@@ -153,14 +154,14 @@ class LcnEntity(Entity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        unique_device_id = generate_unique_id(
-            (
-                self.device_connection.seg_id,
-                self.device_connection.addr_id,
-                self.device_connection.is_group,
-            )
+        address = (
+            self.device_connection.seg_id,
+            self.device_connection.addr_id,
+            self.device_connection.is_group,
         )
-        return f"{self.entry_id}-{unique_device_id}-{self.config[CONF_RESOURCE]}"
+        domain_config = (self.config[CONF_DOMAIN], self.config[CONF_RESOURCE])
+
+        return generate_unique_id(self.entry_id, address, domain_config)
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -178,9 +178,9 @@ class LcnEntity(Entity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        domain_config = (self.config[CONF_DOMAIN], self.config[CONF_RESOURCE])
-
-        return generate_unique_id(self.entry_id, self.address, domain_config)
+        return generate_unique_id(
+            self.entry_id, self.address, self.config[CONF_RESOURCE]
+        )
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/homeassistant/components/lcn/config_flow.py
+++ b/homeassistant/components/lcn/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_DIM_MODE, CONF_SK_NUM_TRIES, DOMAIN
@@ -93,6 +94,14 @@ class LcnFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         entry = get_config_entry(self.hass, data)
         if entry:
             entry.source = config_entries.SOURCE_IMPORT
+
+            # Cleanup entity and device registry, if we imported from configuration.yaml to
+            # remove orphans when entities were removed from configuration
+            entity_registry = er.async_get(self.hass)
+            entity_registry.async_clear_config_entry(entry.entry_id)
+            device_registry = dr.async_get(self.hass)
+            device_registry.async_clear_config_entry(entry.entry_id)
+
             self.hass.config_entries.async_update_entry(entry, data=data)
             return self.async_abort(reason="existing_configuration_updated")
 

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -97,15 +97,14 @@ def get_resource(domain_name: str, domain_data: ConfigType) -> str:
 def generate_unique_id(
     entry_id: str,
     address: AddressType,
-    domain_config: tuple[str, str] | None = None,
+    resource: str | None = None,
 ) -> str:
     """Generate a unique_id from the given parameters."""
     unique_id = entry_id
     is_group = "g" if address[2] else "m"
     unique_id += f"-{is_group}{address[0]:03d}{address[1]:03d}"
-    if domain_config:
-        domain_name, resource = domain_config
-        unique_id += f"-{domain_name}-{resource}".lower()
+    if resource:
+        unique_id += f"-{resource}".lower()
     return unique_id
 
 

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -92,10 +92,19 @@ def get_resource(domain_name: str, domain_data: ConfigType) -> str:
     raise ValueError("Unknown domain")
 
 
-def generate_unique_id(address: AddressType) -> str:
+def generate_unique_id(
+    entry_id: str,
+    address: AddressType,
+    domain_config: tuple[str, str] | None = None,
+) -> str:
     """Generate a unique_id from the given parameters."""
+    unique_id = entry_id
     is_group = "g" if address[2] else "m"
-    return f"{is_group}{address[0]:03d}{address[1]:03d}"
+    unique_id += f"-{is_group}{address[0]:03d}{address[1]:03d}"
+    if domain_config:
+        domain_name, resource = domain_config
+        unique_id += f"-{domain_name}-{resource}".lower()
+    return unique_id
 
 
 def import_lcn_config(lcn_config: ConfigType) -> list[ConfigType]:

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -95,7 +95,9 @@ def get_resource(domain_name: str, domain_data: ConfigType) -> str:
 
 
 def generate_unique_id(
-    entry_id: str, address: AddressType, domain_config: tuple[str, str] | None = None,
+    entry_id: str,
+    address: AddressType,
+    domain_config: tuple[str, str] | None = None,
 ) -> str:
     """Generate a unique_id from the given parameters."""
     unique_id = entry_id

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -244,10 +244,15 @@ async def async_register_lcn_address_devices(
         identifiers = {(DOMAIN, generate_unique_id(config_entry.entry_id, address))}
 
         if device_config[CONF_ADDRESS][2]:  # is group
-            device_model = f"group (g{address[0]:03d}{address[1]:03d})"
+            device_model = f"LCN group (g{address[0]:03d}{address[1]:03d})"
             sw_version = None
         else:  # is module
-            device_model = f"module (m{address[0]:03d}{address[1]:03d})"
+            hardware_type = device_config[CONF_HARDWARE_TYPE]
+            if hardware_type in pypck.lcn_defs.HARDWARE_DESCRIPTIONS:
+                hardware_name = pypck.lcn_defs.HARDWARE_DESCRIPTIONS[hardware_type]
+            else:
+                hardware_name = pypck.lcn_defs.HARDWARE_DESCRIPTIONS[-1]
+            device_model = f"{hardware_name} (m{address[0]:03d}{address[1]:03d})"
             sw_version = f"{device_config[CONF_SOFTWARE_SERIAL]:06X}"
 
         device_registry.async_get_or_create(

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PORT,
     CONF_SENSORS,
+    CONF_SOURCE,
     CONF_SWITCHES,
     CONF_USERNAME,
 )
@@ -31,12 +32,14 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    BINSENSOR_PORTS,
     CONF_CLIMATES,
     CONF_CONNECTIONS,
     CONF_DIM_MODE,
     CONF_DOMAIN_DATA,
     CONF_HARDWARE_SERIAL,
     CONF_HARDWARE_TYPE,
+    CONF_OUTPUT,
     CONF_RESOURCE,
     CONF_SCENES,
     CONF_SK_NUM_TRIES,
@@ -44,6 +47,13 @@ from .const import (
     CONNECTION,
     DEFAULT_NAME,
     DOMAIN,
+    LED_PORTS,
+    LOGICOP_PORTS,
+    OUTPUT_PORTS,
+    S0_INPUTS,
+    SETPOINTS,
+    THRESHOLDS,
+    VARIABLES,
 )
 
 # typing
@@ -91,6 +101,29 @@ def get_resource(domain_name: str, domain_data: ConfigType) -> str:
         return f'{domain_data["source"]}.{domain_data["setpoint"]}'
     if domain_name == "scene":
         return f'{domain_data["register"]}.{domain_data["scene"]}'
+    raise ValueError("Unknown domain")
+
+
+def get_device_model(domain_name: str, domain_data: ConfigType) -> str:
+    """Return the model for the specified domain_data."""
+    if domain_name in ("switch", "light"):
+        return "Output" if domain_data[CONF_OUTPUT] in OUTPUT_PORTS else "Relay"
+    if domain_name in ("binary_sensor", "sensor"):
+        if domain_data[CONF_SOURCE] in BINSENSOR_PORTS:
+            return "Binary Sensor"
+        if domain_data[CONF_SOURCE] in VARIABLES + SETPOINTS + THRESHOLDS + S0_INPUTS:
+            return "Variable"
+        if domain_data[CONF_SOURCE] in LED_PORTS:
+            return "Led"
+        if domain_data[CONF_SOURCE] in LOGICOP_PORTS:
+            return "Logical Operation"
+        return "Key"
+    if domain_name == "cover":
+        return "Motor"
+    if domain_name == "climate":
+        return "Regulator"
+    if domain_name == "scene":
+        return "Scene"
     raise ValueError("Unknown domain")
 
 

--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -1,6 +1,7 @@
 """Support for LCN sensors."""
 from __future__ import annotations
 
+from itertools import chain
 from typing import cast
 
 import pypck
@@ -38,9 +39,8 @@ def create_lcn_sensor_entity(
         hass, entity_config[CONF_ADDRESS], config_entry
     )
 
-    if (
-        entity_config[CONF_DOMAIN_DATA][CONF_SOURCE]
-        in VARIABLES + SETPOINTS + THRESHOLDS + S0_INPUTS
+    if entity_config[CONF_DOMAIN_DATA][CONF_SOURCE] in chain(
+        VARIABLES, SETPOINTS, THRESHOLDS, S0_INPUTS
     ):
         return LcnVariableSensor(
             entity_config, config_entry.entry_id, device_connection

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -21,7 +21,13 @@ class MockModuleConnection(ModuleConnection):
     status_request_handler = AsyncMock()
     activate_status_request_handler = AsyncMock()
     cancel_status_request_handler = AsyncMock()
+    request_name = AsyncMock(return_value="TestModule")
     send_command = AsyncMock(return_value=True)
+
+    def __init__(self, *args, **kwargs):
+        """Construct ModuleConnection instance."""
+        super().__init__(*args, **kwargs)
+        self.serials_request_handler.serial_known.set()
 
 
 class MockGroupConnection(GroupConnection):

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -76,8 +76,7 @@ async def test_step_import_existing_host(hass):
     ],
 )
 async def test_step_import_error(hass, error, reason):
-    """Test for authentication error is handled correctly."""
-
+    """Test for error in import is handled correctly."""
     with patch(
         "pypck.connection.PchkConnectionManager.async_connect", side_effect=error
     ):

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -10,7 +10,7 @@ from pypck.connection import (
 from homeassistant import config_entries
 from homeassistant.components.lcn.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import MockPchkConnectionManager, init_integration, setup_component
 
@@ -59,13 +59,22 @@ async def test_async_setup_entry_update(hass, entry):
     dummy_entity = entity_registry.async_get_or_create(
         "switch", DOMAIN, "dummy", config_entry=entry
     )
+
+    # create dummy device for LCN platform as an orphan
+    device_registry = await dr.async_get_registry(hass)
+    dummy_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id, 0, 7, False)},
+        via_device=(DOMAIN, entry.entry_id),
+    )
+
     assert dummy_entity in entity_registry.entities.values()
+    assert dummy_device in device_registry.devices.values()
 
-    # add entity to hass and setup (should cleanup dummy entity)
-    entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    # add entry to hass and setup (should cleanup dummy device)
+    await init_integration(hass, entry)
 
+    assert dummy_device not in device_registry.devices.values()
     assert dummy_entity not in entity_registry.entities.values()
 
 

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -53,15 +53,16 @@ async def test_async_setup_entry_update(hass, entry):
     """Test a successful setup entry if entry with same id already exists."""
     # setup first entry
     entry.source = config_entries.SOURCE_IMPORT
+    entry.add_to_hass(hass)
 
     # create dummy entity for LCN platform as an orphan
-    entity_registry = await er.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     dummy_entity = entity_registry.async_get_or_create(
         "switch", DOMAIN, "dummy", config_entry=entry
     )
 
     # create dummy device for LCN platform as an orphan
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     dummy_device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id, 0, 7, False)},
@@ -71,8 +72,10 @@ async def test_async_setup_entry_update(hass, entry):
     assert dummy_entity in entity_registry.entities.values()
     assert dummy_device in device_registry.devices.values()
 
-    # add entry to hass and setup (should cleanup dummy device)
-    await init_integration(hass, entry)
+    # setup new entry with same data via import step (should cleanup dummy device)
+    await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=entry.data
+    )
 
     assert dummy_device not in device_registry.devices.values()
     assert dummy_entity not in entity_registry.entities.values()

--- a/tests/fixtures/lcn/config.json
+++ b/tests/fixtures/lcn/config.json
@@ -25,6 +25,11 @@
         "name": "Switch_Output1",
         "address": "s0.m7",
         "output": "output1"
+      },
+      {
+        "name": "Switch_Group5",
+        "address": "s0.g5",
+        "output": "relay1"
       }
     ]
   }

--- a/tests/fixtures/lcn/config_entry_pchk.json
+++ b/tests/fixtures/lcn/config_entry_pchk.json
@@ -13,6 +13,13 @@
       "hardware_serial": -1,
       "software_serial": -1,
       "hardware_type": -1
+    },
+    {
+      "address": [0, 5, true],
+      "name": "",
+      "hardware_serial": -1,
+      "software_serial": -1,
+      "hardware_type": -1
     }
   ],
   "entities": [
@@ -23,6 +30,15 @@
       "domain": "switch",
       "domain_data": {
         "output": "OUTPUT1"
+      }
+    },
+    {
+      "address": [0, 5, true],
+      "name": "Switch_Group5",
+      "resource": "relay1",
+      "domain": "switch",
+      "domain_data": {
+        "output": "RELAY1"
       }
     }
   ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds Home Assistant devices to all LCN hubs, modules (also groups) and entities and registers them in the device registry.

The LCN architecture:
Usually many Home Assistant LCN entities (switches, lights, sensors, ...) are provided by one single LCN hardware module. LCN modules are themselves connected via a hardware bus to a hub which exposes the hardware bus to an ethernet connection using a human readable protocol. The latter is used to access the whole system. This hierarchie can be well expressed in the device registry.
In addition some more information is requested from the LCN system like module names and serial numbers which will also be stored in the device registry and helps identifying the devices.

The tests have been adapted to reflect the changes.

So far no breaking change visible to the user.

This PR is the precondition to implement several LCN related device-triggers and device-actions (in particular the current service calls) in the future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
