### PR TITLE
Set modbus entity to non-available unless scan_interval=0

### DIFF
--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -68,6 +68,7 @@ class BasePlatform(Entity):
         self._value = None
         self._available = True
         self._scan_interval = int(entry[CONF_SCAN_INTERVAL])
+        self._available = self._scan_interval == 0
         self._call_active = False
 
     @abstractmethod

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONF_BINARY_SENSORS,
     CONF_DEVICE_CLASS,
     CONF_NAME,
+    CONF_SCAN_INTERVAL,
     CONF_SLAVE,
     STATE_OFF,
     STATE_ON,
@@ -144,6 +145,7 @@ async def test_service_binary_sensor_update(hass, mock_pymodbus):
                 {
                     CONF_NAME: SENSOR_NAME,
                     CONF_ADDRESS: 51,
+                    CONF_SCAN_INTERVAL: 0,
                 }
             ]
         },

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -104,6 +104,7 @@ async def test_service_climate_update(hass, mock_pymodbus):
                 CONF_TARGET_TEMP: 117,
                 CONF_ADDRESS: 117,
                 CONF_SLAVE: 10,
+                CONF_SCAN_INTERVAL: 0,
             }
         ]
     }
@@ -176,6 +177,7 @@ test_value.attributes = {ATTR_TEMPERATURE: 37}
                     CONF_NAME: CLIMATE_NAME,
                     CONF_TARGET_TEMP: 117,
                     CONF_ADDRESS: 117,
+                    CONF_SCAN_INTERVAL: 0,
                 }
             ],
         },

--- a/tests/components/modbus/test_cover.py
+++ b/tests/components/modbus/test_cover.py
@@ -211,6 +211,7 @@ async def test_service_cover_update(hass, mock_pymodbus):
                     CONF_STATE_CLOSING: 3,
                     CONF_STATUS_REGISTER: 1234,
                     CONF_STATUS_REGISTER_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    CONF_SCAN_INTERVAL: 0,
                 }
             ]
         },
@@ -232,11 +233,13 @@ async def test_service_cover_move(hass, mock_pymodbus):
                 CONF_NAME: COVER_NAME,
                 CONF_ADDRESS: 1234,
                 CONF_STATUS_REGISTER_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                CONF_SCAN_INTERVAL: 0,
             },
             {
                 CONF_NAME: f"{COVER_NAME}2",
                 CONF_INPUT_TYPE: CALL_TYPE_COIL,
                 CONF_ADDRESS: 1234,
+                CONF_SCAN_INTERVAL: 0,
             },
         ]
     }

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     CONF_PORT,
+    CONF_SCAN_INTERVAL,
     CONF_SLAVE,
     CONF_TYPE,
     STATE_OFF,
@@ -195,6 +196,7 @@ async def test_all_fan(hass, call_type, regs, verify, expected):
                 {
                     CONF_NAME: FAN_NAME,
                     CONF_ADDRESS: 1234,
+                    CONF_SCAN_INTERVAL: 0,
                 }
             ]
         },
@@ -219,11 +221,13 @@ async def test_fan_service_turn(hass, caplog, mock_pymodbus):
                     CONF_NAME: FAN_NAME,
                     CONF_ADDRESS: 17,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    CONF_SCAN_INTERVAL: 0,
                 },
                 {
                     CONF_NAME: f"{FAN_NAME}2",
                     CONF_ADDRESS: 17,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    CONF_SCAN_INTERVAL: 0,
                     CONF_VERIFY: {},
                 },
             ],

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     CONF_LIGHTS,
     CONF_NAME,
     CONF_PORT,
+    CONF_SCAN_INTERVAL,
     CONF_SLAVE,
     CONF_TYPE,
     STATE_OFF,
@@ -195,6 +196,7 @@ async def test_all_light(hass, call_type, regs, verify, expected):
                 {
                     CONF_NAME: LIGHT_NAME,
                     CONF_ADDRESS: 1234,
+                    CONF_SCAN_INTERVAL: 0,
                 }
             ]
         },
@@ -219,11 +221,13 @@ async def test_light_service_turn(hass, caplog, mock_pymodbus):
                     CONF_NAME: LIGHT_NAME,
                     CONF_ADDRESS: 17,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    CONF_SCAN_INTERVAL: 0,
                 },
                 {
                     CONF_NAME: f"{LIGHT_NAME}2",
                     CONF_ADDRESS: 17,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    CONF_SCAN_INTERVAL: 0,
                     CONF_VERIFY: {},
                 },
             ],

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_NAME,
     CONF_OFFSET,
+    CONF_SCAN_INTERVAL,
     CONF_SENSORS,
     CONF_SLAVE,
     CONF_STRUCTURE,
@@ -578,6 +579,7 @@ async def test_struct_sensor(hass, cfg, regs, expected):
                 {
                     CONF_NAME: SENSOR_NAME,
                     CONF_ADDRESS: 51,
+                    CONF_SCAN_INTERVAL: 0,
                 }
             ]
         },

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -210,6 +210,7 @@ async def test_all_switch(hass, call_type, regs, verify, expected):
                 {
                     CONF_NAME: SWITCH_NAME,
                     CONF_ADDRESS: 1234,
+                    CONF_SCAN_INTERVAL: 0,
                 }
             ]
         },
@@ -234,11 +235,13 @@ async def test_switch_service_turn(hass, caplog, mock_pymodbus):
                     CONF_NAME: SWITCH_NAME,
                     CONF_ADDRESS: 17,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    CONF_SCAN_INTERVAL: 0,
                 },
                 {
                     CONF_NAME: f"{SWITCH_NAME}2",
                     CONF_ADDRESS: 17,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    CONF_SCAN_INTERVAL: 0,
                     CONF_VERIFY: {},
                 },
             ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
All entities are set to unavailable during loading of modbus integration and remain so until data is received. Entities with scan_interval = 0 (entities without polling) are always available, to allow service calls.

The old configuration style with setting scan_interval: 9999 will cause the entity to be unavailable for 9999 seconds.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See above.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
