### PR TITLE
Add more Fritz sensors

### DIFF
--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -6,6 +6,8 @@ PLATFORMS = ["binary_sensor", "device_tracker", "sensor", "switch"]
 
 DATA_FRITZ = "fritz_data"
 
+DSL_CONNECTION = "dsl"
+
 DEFAULT_DEVICE_NAME = "Unknown device"
 DEFAULT_HOST = "192.168.178.1"
 DEFAULT_PORT = 49000

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -89,7 +89,6 @@ def _retrieve_gb_received_state(status: FritzStatus, last_value: str) -> float:
     return round(status.bytes_received / 1000 / 1000 / 1000, 1)  # type: ignore[no-any-return]
 
 
-
 def _retrieve_link_kb_s_sent_state(status: FritzStatus, last_value: str) -> float:
     """Return upload link rate."""
     return round(status.max_linked_bit_rate[0] / 1024, 1)  # type: ignore[no-any-return]
@@ -100,7 +99,7 @@ def _retrieve_link_kb_s_received_state(status: FritzStatus, last_value: str) -> 
     return round(status.max_linked_bit_rate[1] / 1024, 1)  # type: ignore[no-any-return]
 
 
-def _retrieve_link_noise_sent_state(status: FritzStatus, last_value: str) -> float:
+def _retrieve_link_noise_margin_sent_state(status: FritzStatus, last_value: str) -> float:
     """Return upload noise margin."""
     return status.noise_margin[0]  # type: ignore[no-any-return]
 
@@ -109,14 +108,16 @@ def _retrieve_link_noise_margin_received_state(status: FritzStatus, last_value: 
     """Return download noise margin."""
     return status.noise_margin[1]  # type: ignore[no-any-return]
 
-def _retrieve_link_noise_margin_sent_state(status: FritzStatus, last_value: str) -> float:
+
+def _retrieve_link_attenuation_sent_state(status: FritzStatus, last_value: str) -> float:
     """Return upload line attenuation."""
     return status.attenuation[0]  # type: ignore[no-any-return]
 
 
-def _retrieve_link_noise_received_state(status: FritzStatus, last_value: str) -> float:
+def _retrieve_link_attenuation_received_state(status: FritzStatus, last_value: str) -> float:
     """Return download line attenuation."""
     return status.attenuation[1]  # type: ignore[no-any-return]
+
 
 class SensorData(TypedDict, total=False):
     """Sensor data class."""
@@ -204,7 +205,7 @@ SENSOR_DATA = {
         name="Line noise margin sent in dB",
         unit_of_measurement="dB",
         icon="mdi:upload",
-        state_provider=_retrieve_link_noise_margin_sent_state;
+        state_provider=_retrieve_link_noise_margin_sent_state,
     ),
     "line_noise_margin_received": SensorData(
         name="Line noise margin received in dB",
@@ -212,11 +213,11 @@ SENSOR_DATA = {
         icon="mdi:download",
         state_provider=_retrieve_link_noise_margin_received_state,
     ),
-        "line_attenuation_sent": SensorData(
+    "line_attenuation_sent": SensorData(
         name="Line power attenuation sent in dB",
         unit_of_measurement="dB",
         icon="mdi:upload",
-        state_provider=_retrieve_link_attenuation_sent_state;
+        state_provider=_retrieve_link_attenuation_sent_state,
     ),
     "line_attenuation_received": SensorData(
         name="Line power received in dB",

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -197,7 +197,7 @@ SENSOR_DATA = {
     ),
     "line_kb_s_received": SensorData(
         name="Line capacity kb/s received",
-        unit_of_measurement="kb/s",
+        unit_of_measurement=DATA_RATE_KILOBITS_PER_SECOND,
         icon="mdi:download",
         state_provider=_retrieve_link_kb_s_received_state,
     ),

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -202,8 +202,8 @@ SENSOR_DATA = {
         state_provider=_retrieve_link_kb_s_received_state,
     ),
     "line_noise_margin_sent": SensorData(
-        name="Line noise margin sent in dB",
-        unit_of_measurement="dB",
+        name="Line noise margin sent",
+        unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         icon="mdi:upload",
         state_provider=_retrieve_link_noise_margin_sent_state,
     ),

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -220,8 +220,8 @@ SENSOR_DATA = {
         state_provider=_retrieve_link_attenuation_sent_state,
     ),
     "line_attenuation_received": SensorData(
-        name="Line power received in dB",
-        unit_of_measurement="dB",
+        name="Line power received",
+        unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         icon="mdi:download",
         state_provider=_retrieve_link_attenuation_received_state,
     ),

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -191,7 +191,7 @@ SENSOR_DATA = {
     ),
     "line_kb_s_sent": SensorData(
         name="Line capacity kb/s sent",
-        unit_of_measurement="kb/s",
+        unit_of_measurement=DATA_RATE_KILOBITS_PER_SECOND,
         icon="mdi:upload",
         state_provider=_retrieve_link_kb_s_sent_state
     ),

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -220,7 +220,7 @@ SENSOR_DATA = {
         state_provider=_retrieve_link_attenuation_sent_state,
     ),
     "line_attenuation_received": SensorData(
-        name="Line power received",
+        name="Line power attenuation received",
         unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         icon="mdi:download",
         state_provider=_retrieve_link_attenuation_received_state,

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -196,7 +196,7 @@ SENSOR_DATA = {
         state_provider=_retrieve_link_kb_s_sent_state
     ),
     "line_kb_s_received": SensorData(
-        name="Line capacity kb/s received",
+        name="Line capacity kbit/s received",
         unit_of_measurement=DATA_RATE_KILOBITS_PER_SECOND,
         icon="mdi:download",
         state_provider=_retrieve_link_kb_s_received_state,

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     DATA_RATE_KILOBITS_PER_SECOND,
     DATA_RATE_KILOBYTES_PER_SECOND,
     DEVICE_CLASS_TIMESTAMP,
+    SIGNAL_STRENGTH_DECIBELS,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -99,22 +100,30 @@ def _retrieve_link_kb_s_received_state(status: FritzStatus, last_value: str) -> 
     return round(status.max_linked_bit_rate[1] / 1024, 1)  # type: ignore[no-any-return]
 
 
-def _retrieve_link_noise_margin_sent_state(status: FritzStatus, last_value: str) -> float:
+def _retrieve_link_noise_margin_sent_state(
+    status: FritzStatus, last_value: str
+) -> float:
     """Return upload noise margin."""
     return status.noise_margin[0]  # type: ignore[no-any-return]
 
 
-def _retrieve_link_noise_margin_received_state(status: FritzStatus, last_value: str) -> float:
+def _retrieve_link_noise_margin_received_state(
+    status: FritzStatus, last_value: str
+) -> float:
     """Return download noise margin."""
     return status.noise_margin[1]  # type: ignore[no-any-return]
 
 
-def _retrieve_link_attenuation_sent_state(status: FritzStatus, last_value: str) -> float:
+def _retrieve_link_attenuation_sent_state(
+    status: FritzStatus, last_value: str
+) -> float:
     """Return upload line attenuation."""
     return status.attenuation[0]  # type: ignore[no-any-return]
 
 
-def _retrieve_link_attenuation_received_state(status: FritzStatus, last_value: str) -> float:
+def _retrieve_link_attenuation_received_state(
+    status: FritzStatus, last_value: str
+) -> float:
     """Return download line attenuation."""
     return status.attenuation[1]  # type: ignore[no-any-return]
 
@@ -193,7 +202,7 @@ SENSOR_DATA = {
         name="Line capacity kbit/s sent",
         unit_of_measurement=DATA_RATE_KILOBITS_PER_SECOND,
         icon="mdi:upload",
-        state_provider=_retrieve_link_kb_s_sent_state
+        state_provider=_retrieve_link_kb_s_sent_state,
     ),
     "line_kb_s_received": SensorData(
         name="Line capacity kbit/s received",

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -190,7 +190,7 @@ SENSOR_DATA = {
         state_provider=_retrieve_gb_received_state,
     ),
     "line_kb_s_sent": SensorData(
-        name="Line capacity kb/s sent",
+        name="Line capacity kbit/s sent",
         unit_of_measurement=DATA_RATE_KILOBITS_PER_SECOND,
         icon="mdi:upload",
         state_provider=_retrieve_link_kb_s_sent_state

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -208,8 +208,8 @@ SENSOR_DATA = {
         state_provider=_retrieve_link_noise_margin_sent_state,
     ),
     "line_noise_margin_received": SensorData(
-        name="Line noise margin received in dB",
-        unit_of_measurement="dB",
+        name="Line noise margin received",
+        unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         icon="mdi:download",
         state_provider=_retrieve_link_noise_margin_received_state,
     ),

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -214,8 +214,8 @@ SENSOR_DATA = {
         state_provider=_retrieve_link_noise_margin_received_state,
     ),
     "line_attenuation_sent": SensorData(
-        name="Line power attenuation sent in dB",
-        unit_of_measurement="dB",
+        name="Line power attenuation sent",
+        unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         icon="mdi:upload",
         state_provider=_retrieve_link_attenuation_sent_state,
     ),

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -89,6 +89,35 @@ def _retrieve_gb_received_state(status: FritzStatus, last_value: str) -> float:
     return round(status.bytes_received / 1000 / 1000 / 1000, 1)  # type: ignore[no-any-return]
 
 
+
+def _retrieve_link_kb_s_sent_state(status: FritzStatus, last_value: str) -> float:
+    """Return upload link rate."""
+    return round(status.max_linked_bit_rate[0] / 1024, 1)  # type: ignore[no-any-return]
+
+
+def _retrieve_link_kb_s_received_state(status: FritzStatus, last_value: str) -> float:
+    """Return download link rate."""
+    return round(status.max_linked_bit_rate[1] / 1024, 1)  # type: ignore[no-any-return]
+
+
+def _retrieve_link_noise_sent_state(status: FritzStatus, last_value: str) -> float:
+    """Return upload noise margin."""
+    return status.noise_margin[0]  # type: ignore[no-any-return]
+
+
+def _retrieve_link_noise_margin_received_state(status: FritzStatus, last_value: str) -> float:
+    """Return download noise margin."""
+    return status.noise_margin[1]  # type: ignore[no-any-return]
+
+def _retrieve_link_noise_margin_sent_state(status: FritzStatus, last_value: str) -> float:
+    """Return upload line attenuation."""
+    return status.attenuation[0]  # type: ignore[no-any-return]
+
+
+def _retrieve_link_noise_received_state(status: FritzStatus, last_value: str) -> float:
+    """Return download line attenuation."""
+    return status.attenuation[1]  # type: ignore[no-any-return]
+
 class SensorData(TypedDict, total=False):
     """Sensor data class."""
 
@@ -158,6 +187,42 @@ SENSOR_DATA = {
         unit_of_measurement=DATA_GIGABYTES,
         icon="mdi:download",
         state_provider=_retrieve_gb_received_state,
+    ),
+    "line_kb_s_sent": SensorData(
+        name="Line capacity kb/s sent",
+        unit_of_measurement="kb/s",
+        icon="mdi:upload",
+        state_provider=_retrieve_link_kb_s_sent_state
+    ),
+    "line_kb_s_received": SensorData(
+        name="Line capacity kb/s received",
+        unit_of_measurement="kb/s",
+        icon="mdi:download",
+        state_provider=_retrieve_link_kb_s_received_state,
+    ),
+    "line_noise_margin_sent": SensorData(
+        name="Line noise margin sent in dB",
+        unit_of_measurement="dB",
+        icon="mdi:upload",
+        state_provider=_retrieve_link_noise_margin_sent_state;
+    ),
+    "line_noise_margin_received": SensorData(
+        name="Line noise margin received in dB",
+        unit_of_measurement="dB",
+        icon="mdi:download",
+        state_provider=_retrieve_link_noise_margin_received_state,
+    ),
+        "line_attenuation_sent": SensorData(
+        name="Line power attenuation sent in dB",
+        unit_of_measurement="dB",
+        icon="mdi:upload",
+        state_provider=_retrieve_link_attenuation_sent_state;
+    ),
+    "line_attenuation_received": SensorData(
+        name="Line power received in dB",
+        unit_of_measurement="dB",
+        icon="mdi:download",
+        state_provider=_retrieve_link_attenuation_received_state,
     ),
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Added information about the upstream line accorrding to fritzconnection library (available since V1.5.0) .
New information available are _line sync speed_, _noise margin_ and _power attenuation_.

Upstream information
https://fritzconnection.readthedocs.io/en/1.5.0/sources/library.html

(Sorry had accidentally posted information inside comment section originally)
<!--

-->


## Type of change
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
<!--

-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

AVM Fritz!Box as router needed for testing
Tested with ADSL and VDSL lines on FritzBox 7590, 7490 and 7390. 
Tested with FritzBox4040 and ethernet upstream - failed gracefully (line information missing)
Not tested on cable internet / fiber. According to upstrem library should also work / fail gracefully.


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
