### PR TITLE
Recreate HomeKit accessories when calling the reset_accessory service

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -493,7 +493,12 @@ class HomeKit:
             if acc.entity_id not in entity_ids:
                 return
             acc.async_stop()
-            if new_acc := self._async_create_single_accessory([acc.entity_id]):
+            if not (state := self.hass.states.get(acc.entity_id)):
+                _LOGGER.warning(
+                    "The underlying entity %s disappeared during reset.", acc.entity
+                )
+                return
+            if new_acc := self._async_create_single_accessory([state]):
                 self.driver.accessory = new_acc
                 self.driver.config_changed()
             return

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -120,6 +120,10 @@ PORT_CLEANUP_CHECK_INTERVAL_SECS = 1
 
 MDNS_TARGET_IP = "224.0.0.251"
 
+_HOMEKIT_CONFIG_UPDATE_TIME = (
+    5  # number of seconds to wait for homekit to see the c# change
+)
+
 
 def _has_all_unique_names_and_ports(bridges):
     """Validate that each homekit bridge configured has a unique name."""
@@ -533,6 +537,7 @@ class HomeKit:
             return
 
         await self.async_config_changed()
+        await asyncio.sleep(_HOMEKIT_CONFIG_UPDATE_TIME)
         for state in new:
             self.add_bridge_accessory(state)
         await self.async_config_changed()

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -434,10 +434,12 @@ async def test_homekit_remove_accessory(hass, mock_zeroconf):
 
     homekit.driver = "driver"
     homekit.bridge = _mock_pyhap_bridge()
-    homekit.bridge.accessories = {"light.demo": "acc"}
+    acc_mock = MagicMock()
+    homekit.bridge.accessories = {6: acc_mock}
 
-    acc = homekit.remove_bridge_accessory("light.demo")
-    assert acc == "acc"
+    acc = homekit.remove_bridge_accessory(6)
+    assert acc is acc_mock
+    assert acc_mock.async_stop.called
     assert len(homekit.bridge.accessories) == 0
 
 
@@ -627,7 +629,44 @@ async def test_homekit_stop(hass):
 
 
 async def test_homekit_reset_accessories(hass, mock_zeroconf):
-    """Test adding too many accessories to HomeKit."""
+    """Test resetting HomeKit accessories."""
+    await async_setup_component(hass, "persistent_notification", {})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
+    )
+    entity_id = "light.demo"
+    hass.states.async_set("light.demo", "on")
+    homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE)
+
+    with patch(f"{PATH_HOMEKIT}.HomeKit", return_value=homekit), patch(
+        "pyhap.accessory.Bridge.add_accessory"
+    ) as mock_add_accessory, patch(
+        "pyhap.accessory_driver.AccessoryDriver.config_changed"
+    ) as hk_driver_config_changed, patch(
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
+    ):
+        await async_init_entry(hass, entry)
+
+        acc_mock = MagicMock()
+        aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
+        homekit.bridge.accessories = {aid: acc_mock}
+        homekit.status = STATUS_RUNNING
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_HOMEKIT_RESET_ACCESSORY,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert hk_driver_config_changed.call_count == 2
+        assert mock_add_accessory.called
+        homekit.status = STATUS_READY
+
+
+async def test_homekit_reset_accessories_state_missing(hass, mock_zeroconf):
+    """Test resetting HomeKit accessories when the state goes missing."""
     await async_setup_component(hass, "persistent_notification", {})
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
@@ -644,8 +683,9 @@ async def test_homekit_reset_accessories(hass, mock_zeroconf):
     ):
         await async_init_entry(hass, entry)
 
+        acc_mock = MagicMock()
         aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
-        homekit.bridge.accessories = {aid: "acc"}
+        homekit.bridge.accessories = {aid: acc_mock}
         homekit.status = STATUS_RUNNING
 
         await hass.services.async_call(
@@ -657,8 +697,8 @@ async def test_homekit_reset_accessories(hass, mock_zeroconf):
         await hass.async_block_till_done()
 
         assert hk_driver_config_changed.call_count == 2
-        assert mock_add_accessory.called
-        homekit.status = STATUS_READY
+        assert not mock_add_accessory.called
+        homekit.status = STATUS_STOPPED
 
 
 async def test_homekit_too_many_accessories(hass, hk_driver, caplog, mock_zeroconf):

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -644,6 +644,8 @@ async def test_homekit_reset_accessories(hass, mock_zeroconf):
         "pyhap.accessory_driver.AccessoryDriver.config_changed"
     ) as hk_driver_config_changed, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
+    ), patch.object(
+        homekit_base, "_HOMEKIT_CONFIG_UPDATE_TIME", 0
     ):
         await async_init_entry(hass, entry)
 
@@ -682,6 +684,8 @@ async def test_homekit_reset_accessories_not_supported(hass, mock_zeroconf):
         "pyhap.accessory_driver.AccessoryDriver.config_changed"
     ) as hk_driver_config_changed, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
+    ), patch.object(
+        homekit_base, "_HOMEKIT_CONFIG_UPDATE_TIME", 0
     ):
         await async_init_entry(hass, entry)
 
@@ -720,6 +724,8 @@ async def test_homekit_reset_accessories_state_missing(hass, mock_zeroconf):
         "pyhap.accessory_driver.AccessoryDriver.config_changed"
     ) as hk_driver_config_changed, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
+    ), patch.object(
+        homekit_base, "_HOMEKIT_CONFIG_UPDATE_TIME", 0
     ):
         await async_init_entry(hass, entry)
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Previously we only removed and then re-added the existing
  accessory. We now recreate the accessory as its underlying
  entity may have changed.

Part 1 of fixing #51495

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
