### PR TITLE
Enable pylint CodeStyle check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ good-names = [
 # no-self-use - little added value with too many false-positives
 # ---
 # Enable once current issues are fixed:
-# consider-using-namedtuple-or-dataclass (Pylint CodeStyle extension)
 # consider-using-assignment-expr (Pylint CodeStyle extension)
 disable = [
     "format",
@@ -180,7 +179,6 @@ disable = [
     "wrong-import-order",
     "consider-using-f-string",
     "no-self-use",
-    "consider-using-namedtuple-or-dataclass",
     "consider-using-assignment-expr",
 ]
 enable = [


### PR DESCRIPTION
## Proposed change
Followup to #53147 - This PR will enable the `consider-using-namedtuple-or-dataclass` check.

Emitted if dict values can be replaced by a `NamedTuple` or `dataclass`. Especially useful for sensor definitions. Currently they are mostly handled like the example from `metoffice/sensor.py` below - each sensor has a dict entry and the attributes are captured in a list or tuple. Later they are accessed via index lookup which is prone to errors, difficult to understand, and nearly impossible to type check. At least, the example has a comment explaining the individual fields but that isn't the norm.
https://github.com/home-assistant/core/blob/71a8ae3016aba7c1929ff47ab22e4f80b55b7cc3/homeassistant/components/metoffice/sensor.py#L37-L48
In contrast, this is how it could look like:
https://github.com/home-assistant/core/blob/71a8ae3016aba7c1929ff47ab22e4f80b55b7cc3/homeassistant/components/huawei_lte/sensor.py#L48-L67

--
The goal for this PR is to track which integrations still need to be updated. Preferably the respective code-owner would there integrations individually as it often requires a refactoring. Any help getting all issues fixed is appreciated.

--
Good examples: #53269, #53242, #53234, #53168

<details>
<summary><b>Progress</b></summary>

2021-07-20: 237 errors
2021-07-21: 231 errors
2021-07-27: 220 errors
2021-08-08: 212 errors
2021-08-15: 202 errors
2021-08-16: 198 errors
2021-08-24: 158 errors
2021-08-25: 149 errors
2021-08-30: 143 errors
2021-09-04: 124 errors
2021-09-06: 112 errors
2021-09-14: 103 errors
2021-09-25: 96 errors
2021-09-27: 89 errors
2021-09-29: 85 errors
2021-10-09: 77 errors
2021-10-12: 74 errors
2021-10-17: 71 errors
2021-10-21: 69 errors
2021-10-29: 67 errors
2021-11-05: 66 errors
2021-11-26: 65 errors
2021-12-13: 66 errors
2022-01-04: 67 errors
2022-01-15: 68 errors
2022-02-06: 66 errors
2022-02-13: 65 errors
2022-03-31: 66 errors
2022-06-01: 69 errors
</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
