### PR TITLE
Increase Mutesync update interval to stop 'Connection reset by peer'

### DIFF
--- a/homeassistant/components/mutesync/const.py
+++ b/homeassistant/components/mutesync/const.py
@@ -5,4 +5,4 @@ from typing import Final
 DOMAIN: Final = "mutesync"
 
 UPDATE_INTERVAL_NOT_IN_MEETING: Final = timedelta(seconds=10)
-UPDATE_INTERVAL_IN_MEETING: Final = timedelta(seconds=5)
+UPDATE_INTERVAL_IN_MEETING: Final = timedelta(seconds=10)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

My proposed change is to increase the `UPDATE_INTERVAL_IN_MEETING` interval from `5s` -> `10s` to avoid receiving `[Errno 104] Connection reset by peer` when polling for updates. 

### Rationale

Right now the codebase will update the `IN_MEETING` status every 5s. For the last month I've found that the status is updating too quickly for local polling and I get ~3 responses each minute that result in an `Unknown` state during a meeting. (But anything outside of a meeting with the slower polling never has an issue).

When I uncomment the section that swallows the generic error (https://github.com/home-assistant/core/blob/0327d0b6db4724a1229c209ba61d4da498d94d7a/homeassistant/components/mutesync/config_flow.py#L63-L64) I get the following logs in Home Assistant. 

```
2021-07-19 16:50:08 ERROR (MainThread) [custom_components.mutesync] Error requesting mutesync data: [Errno 104] Connection reset by peer
```

Due to this error, I believe the local polling is hitting Mutesync too frequently and should be increased. 

### Debugging

I met up with @currentoor to debug this a bit more and we determined the issue was not in the Mutesync client code, but instead the Home Assistant integration.

### `UPDATE_INTERVAL_IN_MEETING` Change results

![image](https://user-images.githubusercontent.com/3487107/126221688-9b52aa18-3cb1-470b-a1dd-d29a0b0a4869.png)

At arrow 1 the `UPDATE_INTERVAL_IN_MEETING` is 5. Full of errors and disconnects.
At arrow 2 the `UPDATE_INTERVAL_IN_MEETING` is 10. There are no errors during my 30 minutes of testing.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
