### PR TITLE
Auto recreate HomeKit TVs when the sources are out of sync

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -58,12 +58,14 @@ from .const import (
     CONF_LOW_BATTERY_THRESHOLD,
     DEFAULT_LOW_BATTERY_THRESHOLD,
     DEVICE_CLASS_PM25,
+    DOMAIN,
     EVENT_HOMEKIT_CHANGED,
     HK_CHARGING,
     HK_NOT_CHARGABLE,
     HK_NOT_CHARGING,
     MANUFACTURER,
     SERV_BATTERY_SERVICE,
+    SERVICE_HOMEKIT_RESET_ACCESSORY,
     TYPE_FAUCET,
     TYPE_OUTLET,
     TYPE_SHOWER,
@@ -451,6 +453,17 @@ class HomeAccessory(Accessory):
         self.hass.async_create_task(
             self.hass.services.async_call(
                 domain, service, service_data, context=context
+            )
+        )
+
+    @ha_callback
+    def async_reset(self):
+        """Reset and recreate an accessory."""
+        self.hass.async_create_task(
+            self.hass.services.async_call(
+                DOMAIN,
+                SERVICE_HOMEKIT_RESET_ACCESSORY,
+                {ATTR_ENTITY_ID: self.entity_id},
             )
         )
 

--- a/homeassistant/components/homekit/type_remotes.py
+++ b/homeassistant/components/homekit/type_remotes.py
@@ -166,7 +166,7 @@ class RemoteInputSelectAccessory(HomeAccessory):
             return
 
         _LOGGER.warning(
-            "%s: Source %s does not exist the source list",
+            "%s: Source %s does not exist the source list: %s",
             self.entity_id,
             source_name,
             possible_sources,

--- a/homeassistant/components/homekit/type_remotes.py
+++ b/homeassistant/components/homekit/type_remotes.py
@@ -165,7 +165,7 @@ class RemoteInputSelectAccessory(HomeAccessory):
             self.async_reset()
             return
 
-        _LOGGER.warning(
+        _LOGGER.debug(
             "%s: Source %s does not exist the source list: %s",
             self.entity_id,
             source_name,

--- a/homeassistant/components/homekit/type_remotes.py
+++ b/homeassistant/components/homekit/type_remotes.py
@@ -153,12 +153,8 @@ class RemoteInputSelectAccessory(HomeAccessory):
             if self.char_input_source.value != index:
                 self.char_input_source.set_value(index)
         elif hk_state:
-            _LOGGER.warning(
-                "%s: Sources out of sync. Restart Home Assistant",
-                self.entity_id,
-            )
-            if self.char_input_source.value != 0:
-                self.char_input_source.set_value(0)
+            # Sources are out of sync, recreate the accessory
+            self.async_reset()
 
 
 @TYPES.register("ActivityRemote")

--- a/homeassistant/components/homekit/type_remotes.py
+++ b/homeassistant/components/homekit/type_remotes.py
@@ -87,6 +87,7 @@ class RemoteInputSelectAccessory(HomeAccessory):
         features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
         self.source_key = source_key
+        self.source_list_key = source_list_key
         self.sources = []
         self.support_select_source = False
         if features & required_feature:
@@ -152,9 +153,26 @@ class RemoteInputSelectAccessory(HomeAccessory):
             index = self.sources.index(source_name)
             if self.char_input_source.value != index:
                 self.char_input_source.set_value(index)
-        elif hk_state:
+            return
+
+        possible_sources = new_state.attributes.get(self.source_list_key, [])
+        if source_name in possible_sources:
+            _LOGGER.debug(
+                "%s: Sources out of sync. Rebuilding Accessory",
+                self.entity_id,
+            )
             # Sources are out of sync, recreate the accessory
             self.async_reset()
+            return
+
+        _LOGGER.warning(
+            "%s: Source %s does not exist the source list",
+            self.entity_id,
+            source_name,
+            possible_sources,
+        )
+        if self.char_input_source.value != 0:
+            self.char_input_source.set_value(0)
 
 
 @TYPES.register("ActivityRemote")

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -242,7 +242,7 @@ async def test_media_player_television(hass, hk_driver, events, caplog):
     hass.states.async_set(entity_id, STATE_ON, {ATTR_INPUT_SOURCE: "HDMI 5"})
     await hass.async_block_till_done()
     assert acc.char_input_source.value == 0
-    assert caplog.records[-2].levelname == "WARNING"
+    assert caplog.records[-2].levelname == "DEBUG"
 
     # Set from HomeKit
     call_turn_on = async_mock_service(hass, DOMAIN, "turn_on")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->



- Requires #53199

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51495
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
