### PR TITLE
Add unique ID support to light, cover and media player groups

### DIFF
--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
     CONF_NAME,
+    CONF_UNIQUE_ID,
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING,
@@ -57,8 +58,9 @@ DEFAULT_NAME = "Cover Group"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Required(CONF_ENTITIES): cv.entities_domain(DOMAIN),
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
 )
 
@@ -70,7 +72,13 @@ async def async_setup_platform(
     discovery_info: dict[str, Any] | None = None,
 ) -> None:
     """Set up the Group Cover platform."""
-    async_add_entities([CoverGroup(config[CONF_NAME], config[CONF_ENTITIES])])
+    async_add_entities(
+        [
+            CoverGroup(
+                config.get(CONF_UNIQUE_ID), config[CONF_NAME], config[CONF_ENTITIES]
+            )
+        ]
+    )
 
 
 class CoverGroup(GroupEntity, CoverEntity):
@@ -82,7 +90,7 @@ class CoverGroup(GroupEntity, CoverEntity):
     _attr_current_cover_position: int | None = 100
     _attr_assumed_state: bool = True
 
-    def __init__(self, name: str, entities: list[str]) -> None:
+    def __init__(self, unique_id: str | None, name: str, entities: list[str]) -> None:
         """Initialize a CoverGroup entity."""
         self._entities = entities
         self._covers: dict[str, set[str]] = {
@@ -98,6 +106,7 @@ class CoverGroup(GroupEntity, CoverEntity):
 
         self._attr_name = name
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entities}
+        self._attr_unique_id = unique_id
 
     async def _update_supported_features_event(self, event: Event) -> None:
         self.async_set_context(event.context)

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -39,6 +39,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
     CONF_NAME,
+    CONF_UNIQUE_ID,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
@@ -55,6 +56,7 @@ DEFAULT_NAME = "Light Group"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Required(CONF_ENTITIES): cv.entities_domain(light.DOMAIN),
     }
 )
@@ -72,7 +74,11 @@ async def async_setup_platform(
 ) -> None:
     """Initialize light.group platform."""
     async_add_entities(
-        [LightGroup(cast(str, config.get(CONF_NAME)), config[CONF_ENTITIES])]
+        [
+            LightGroup(
+                config.get(CONF_UNIQUE_ID), config[CONF_NAME], config[CONF_ENTITIES]
+            )
+        ]
     )
 
 
@@ -86,13 +92,14 @@ class LightGroup(GroupEntity, light.LightEntity):
     _attr_min_mireds = 154
     _attr_should_poll = False
 
-    def __init__(self, name: str, entity_ids: list[str]) -> None:
+    def __init__(self, unique_id: str | None, name: str, entity_ids: list[str]) -> None:
         """Initialize a light group."""
         self._entity_ids = entity_ids
         self._white_value: int | None = None
 
         self._attr_name = name
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
+        self._attr_unique_id = unique_id
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -48,6 +48,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
     CONF_NAME,
+    CONF_UNIQUE_ID,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -71,8 +72,9 @@ DEFAULT_NAME = "Media Group"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Required(CONF_ENTITIES): cv.entities_domain(DOMAIN),
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
 )
 
@@ -84,17 +86,24 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the Media Group platform."""
-    async_add_entities([MediaGroup(config[CONF_NAME], config[CONF_ENTITIES])])
+    async_add_entities(
+        [
+            MediaGroup(
+                config.get(CONF_UNIQUE_ID), config[CONF_NAME], config[CONF_ENTITIES]
+            )
+        ]
+    )
 
 
 class MediaGroup(MediaPlayerEntity):
     """Representation of a Media Group."""
 
-    def __init__(self, name: str, entities: list[str]) -> None:
+    def __init__(self, unique_id: str | None, name: str, entities: list[str]) -> None:
         """Initialize a Media Group entity."""
         self._name = name
         self._state: str | None = None
         self._supported_features: int = 0
+        self._attr_unique_id = unique_id
 
         self._entities = entities
         self._features: dict[str, set[str]] = {

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
+    CONF_UNIQUE_ID,
     SERVICE_CLOSE_COVER,
     SERVICE_CLOSE_COVER_TILT,
     SERVICE_OPEN_COVER,
@@ -32,6 +33,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -77,6 +79,7 @@ CONFIG_ATTRIBUTES = {
     DOMAIN: {
         "platform": "group",
         CONF_ENTITIES: [DEMO_COVER, DEMO_COVER_POS, DEMO_COVER_TILT, DEMO_TILT],
+        CONF_UNIQUE_ID: "unique_identifier",
     }
 }
 
@@ -219,6 +222,11 @@ async def test_attributes(hass, setup_comp):
 
     state = hass.states.get(COVER_GROUP)
     assert state.attributes[ATTR_ASSUMED_STATE] is True
+
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get(COVER_GROUP)
+    assert entry
+    assert entry.unique_id == "unique_identifier"
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_TILT_ONLY, 2)])

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -44,6 +44,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 
@@ -58,6 +59,7 @@ async def test_default_state(hass):
                 "platform": DOMAIN,
                 "entities": ["light.kitchen", "light.bedroom"],
                 "name": "Bedroom Group",
+                "unique_id": "unique_identifier",
             }
         },
     )
@@ -76,6 +78,11 @@ async def test_default_state(hass):
     assert state.attributes.get(ATTR_WHITE_VALUE) is None
     assert state.attributes.get(ATTR_EFFECT_LIST) is None
     assert state.attributes.get(ATTR_EFFECT) is None
+
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get("light.bedroom_group")
+    assert entry
+    assert entry.unique_id == "unique_identifier"
 
 
 async def test_state_reporting(hass):
@@ -1064,7 +1071,7 @@ async def test_invalid_service_calls(hass):
     """Test invalid service call arguments get discarded."""
     add_entities = MagicMock()
     await group.async_setup_platform(
-        hass, {"entities": ["light.test1", "light.test2"]}, add_entities
+        hass, {"name": "test", "entities": ["light.test1", "light.test2"]}, add_entities
     )
     await hass.async_block_till_done()
     await hass.async_start()

--- a/tests/components/group/test_media_player.py
+++ b/tests/components/group/test_media_player.py
@@ -49,6 +49,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 
@@ -73,6 +74,7 @@ async def test_default_state(hass):
                 "platform": DOMAIN,
                 "entities": ["media_player.player_1", "media_player.player_2"],
                 "name": "Media group",
+                "unique_id": "unique_identifier",
             }
         },
     )
@@ -88,6 +90,11 @@ async def test_default_state(hass):
         "media_player.player_1",
         "media_player.player_2",
     ]
+
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get("media_player.media_group")
+    assert entry
+    assert entry.unique_id == "unique_identifier"
 
 
 async def test_state_reporting(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds support for setting a unique ID on domain-specific groups:

- `light`
- `cover`
- `media_player`


Adding a unique ID allows for:
- Assigning groups to area's
- Manage entity_id/icons/names from the UI

Example (works with demo integration):

```yaml
light:
  - platform: group
    name: "Light group: Unique"
    unique_id: very_unique_group_identifier
    entities:
      - light.ceiling_lights
      - light.kitchen_lights
```

![image](https://user-images.githubusercontent.com/195327/126313032-9c9d31c5-0b88-4554-ac1d-11a259a09f30.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18560

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
