### PR TITLE
Add webOS Smart TV config flow support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1161,7 +1161,9 @@ omit =
     homeassistant/components/waze_travel_time/__init__.py
     homeassistant/components/waze_travel_time/helpers.py
     homeassistant/components/waze_travel_time/sensor.py
-    homeassistant/components/webostv/*
+    homeassistant/components/webostv/__init__.py
+    homeassistant/components/webostv/media_player.py
+    homeassistant/components/webostv/notify.py
     homeassistant/components/whois/sensor.py
     homeassistant/components/wiffi/*
     homeassistant/components/wink/*

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -154,7 +154,7 @@ async def async_setup_entry(hass, config_entry):
             "notify",
             DOMAIN,
             {
-                CONF_NAME: config_entry.data[CONF_NAME],
+                CONF_NAME: config_entry.title,
                 ATTR_CONFIG_ENTRY_ID: config_entry.entry_id,
             },
             hass.data[DOMAIN],

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -1,39 +1,40 @@
 """Support for LG webOS Smart TV."""
 import asyncio
 from contextlib import suppress
-import json
 import logging
-import os
 
 from aiopylgtv import PyLGTVCmdException, PyLGTVPairException, WebOsClient
-from sqlitedict import SqliteDict
 import voluptuous as vol
 from websockets.exceptions import ConnectionClosed
 
+from homeassistant.components import notify as hass_notify
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_COMMAND,
     ATTR_ENTITY_ID,
+    CONF_CLIENT_SECRET,
     CONF_CUSTOMIZE,
     CONF_HOST,
     CONF_ICON,
     CONF_NAME,
     EVENT_HOMEASSISTANT_STOP,
 )
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import (
     ATTR_BUTTON,
+    ATTR_CONFIG_ENTRY_ID,
     ATTR_PAYLOAD,
     ATTR_SOUND_OUTPUT,
     CONF_ON_ACTION,
     CONF_SOURCES,
     DEFAULT_NAME,
     DOMAIN,
+    PLATFORMS,
     SERVICE_BUTTON,
     SERVICE_COMMAND,
     SERVICE_SELECT_SOUND_OUTPUT,
-    WEBOSTV_CONFIG_FILE,
 )
 
 CUSTOMIZE_SCHEMA = vol.Schema(
@@ -41,22 +42,25 @@ CUSTOMIZE_SCHEMA = vol.Schema(
 )
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.All(
-            cv.ensure_list,
-            [
-                vol.Schema(
-                    {
-                        vol.Optional(CONF_CUSTOMIZE, default={}): CUSTOMIZE_SCHEMA,
-                        vol.Required(CONF_HOST): cv.string,
-                        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-                        vol.Optional(CONF_ON_ACTION): cv.SCRIPT_SCHEMA,
-                        vol.Optional(CONF_ICON): cv.string,
-                    }
-                )
-            ],
-        )
-    },
+    vol.All(
+        cv.deprecated(DOMAIN),
+        {
+            DOMAIN: vol.All(
+                cv.ensure_list,
+                [
+                    vol.Schema(
+                        {
+                            vol.Optional(CONF_CUSTOMIZE, default={}): CUSTOMIZE_SCHEMA,
+                            vol.Required(CONF_HOST): cv.string,
+                            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                            vol.Optional(CONF_ON_ACTION): cv.SCRIPT_SCHEMA,
+                            vol.Optional(CONF_ICON): cv.string,
+                        }
+                    )
+                ],
+            )
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
 
@@ -82,9 +86,48 @@ SERVICE_TO_METHOD = {
 _LOGGER = logging.getLogger(__name__)
 
 
+class CannotConnect(Exception):
+    """Error to indicate we cannot connect."""
+
+
 async def async_setup(hass, config):
     """Set up the LG WebOS TV platform."""
-    hass.data[DOMAIN] = {}
+    hass.data.setdefault(DOMAIN, {})
+    if DOMAIN not in config:
+        return True
+
+    for conf in config[DOMAIN]:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
+    """Set the config entry up."""
+    if not config_entry.options:
+        config = config_entry.data
+        options = {}
+
+        # Get Turn_on service
+        options[CONF_ON_ACTION] = config.get(CONF_ON_ACTION)
+
+        # Get Preferred Sources
+        if sources := config.get(CONF_CUSTOMIZE, {}).get(CONF_SOURCES):
+            options[CONF_SOURCES] = sources
+            if isinstance(sources, list) is False:
+                options[CONF_SOURCES] = sources.split(",")
+
+        hass.config_entries.async_update_entry(config_entry, options=options)
+
+    host = config_entry.data[CONF_HOST]
+    key = config_entry.data[CONF_CLIENT_SECRET]
+
+    client = await WebOsClient.create(host, client_key=key)
+    await async_connect(client)
 
     async def async_service_handler(service):
         method = SERVICE_TO_METHOD.get(service.service)
@@ -98,55 +141,43 @@ async def async_setup(hass, config):
             DOMAIN, service, async_service_handler, schema=schema
         )
 
-    tasks = [async_setup_tv(hass, config, conf) for conf in config[DOMAIN]]
-    if tasks:
-        await asyncio.gather(*tasks)
+    hass.data[DOMAIN][config_entry.entry_id] = client
+    hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
 
+    # set up notify platform, no entry support for notify component yet,
+    # have to use discovery to load platform.
+    hass.async_create_task(
+        discovery.async_load_platform(
+            hass,
+            "notify",
+            DOMAIN,
+            {
+                CONF_NAME: config_entry.data[CONF_NAME],
+                ATTR_CONFIG_ENTRY_ID: config_entry.entry_id,
+            },
+            hass.data[DOMAIN],
+        )
+    )
+
+    if not config_entry.update_listeners:
+        config_entry.async_on_unload(
+            config_entry.add_update_listener(async_update_options)
+        )
+
+    async def async_on_stop(_event):
+        """Unregister callbacks and disconnect."""
+        client.clear_state_update_callbacks()
+        await client.disconnect()
+
+    config_entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_on_stop)
+    )
     return True
 
 
-def convert_client_keys(config_file):
-    """In case the config file contains JSON, convert it to a Sqlite config file."""
-    # Return early if config file is non-existing
-    if not os.path.isfile(config_file):
-        return
-
-    # Try to parse the file as being JSON
-    with open(config_file) as json_file:
-        try:
-            json_conf = json.load(json_file)
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            json_conf = None
-
-    # If the file contains JSON, convert it to an Sqlite DB
-    if json_conf:
-        _LOGGER.warning("LG webOS TV client-key file is being migrated to Sqlite!")
-
-        # Clean the JSON file
-        os.remove(config_file)
-
-        # Write the data to the Sqlite DB
-        with SqliteDict(config_file) as conf:
-            for host, key in json_conf.items():
-                conf[host] = key
-            conf.commit()
-
-
-async def async_setup_tv(hass, config, conf):
-    """Set up a LG WebOS TV based on host parameter."""
-
-    host = conf[CONF_HOST]
-    config_file = hass.config.path(WEBOSTV_CONFIG_FILE)
-    await hass.async_add_executor_job(convert_client_keys, config_file)
-
-    client = await WebOsClient.create(host, config_file)
-    hass.data[DOMAIN][host] = {"client": client}
-
-    if client.is_registered():
-        await async_setup_tv_finalize(hass, config, conf, client)
-    else:
-        _LOGGER.warning("LG webOS TV %s needs to be paired", host)
-        await async_request_configuration(hass, config, conf, client)
+async def async_update_options(hass, config_entry):
+    """Update options."""
+    await hass.config_entries.async_reload(config_entry.entry_id)
 
 
 async def async_connect(client):
@@ -163,55 +194,35 @@ async def async_connect(client):
         await client.connect()
 
 
-async def async_setup_tv_finalize(hass, config, conf, client):
-    """Make initial connection attempt and call platform setup."""
+async def async_control_connect(host: str, key: str) -> WebOsClient:
+    """LG Connection."""
+    client = await WebOsClient.create(host, client_key=key)
+    try:
+        await client.connect()
+    except PyLGTVPairException as err:
+        _LOGGER.warning("Connected to LG webOS TV %s but not paired", host)
+        raise PyLGTVPairException(err) from err
+    except (
+        OSError,
+        ConnectionClosed,
+        ConnectionRefusedError,
+        PyLGTVCmdException,
+        asyncio.TimeoutError,
+        asyncio.CancelledError,
+    ) as err:
+        raise CannotConnect(f"Error connecting to LG webOS TV {host}") from err
 
-    async def async_on_stop(event):
-        """Unregister callbacks and disconnect."""
+    return client
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    client = hass.data[DOMAIN][entry.entry_id]
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        await hass_notify.async_reload(hass, DOMAIN)
         client.clear_state_update_callbacks()
         await client.disconnect()
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_on_stop)
-
-    await async_connect(client)
-    hass.async_create_task(
-        hass.helpers.discovery.async_load_platform("media_player", DOMAIN, conf, config)
-    )
-    hass.async_create_task(
-        hass.helpers.discovery.async_load_platform("notify", DOMAIN, conf, config)
-    )
-
-
-async def async_request_configuration(hass, config, conf, client):
-    """Request configuration steps from the user."""
-    host = conf.get(CONF_HOST)
-    name = conf.get(CONF_NAME)
-    configurator = hass.components.configurator
-
-    async def lgtv_configuration_callback(data):
-        """Handle actions when configuration callback is called."""
-        try:
-            await client.connect()
-        except PyLGTVPairException:
-            _LOGGER.warning("Connected to LG webOS TV %s but not paired", host)
-            return
-        except (
-            OSError,
-            ConnectionClosed,
-            asyncio.TimeoutError,
-            asyncio.CancelledError,
-            PyLGTVCmdException,
-        ):
-            _LOGGER.error("Unable to connect to host %s", host)
-            return
-
-        await async_setup_tv_finalize(hass, config, conf, client)
-        configurator.async_request_done(request_id)
-
-    request_id = configurator.async_request_config(
-        name,
-        lgtv_configuration_callback,
-        description="Click start and accept the pairing request on your TV.",
-        description_image="/static/images/config_webos.png",
-        submit_caption="Start pairing request",
-    )
+    return unload_ok

--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -116,9 +116,6 @@ def _async_migrate_options_from_data(hass, config_entry):
     config = config_entry.data
     options = {}
 
-    # Get Turn_on service
-    options[CONF_ON_ACTION] = config.get(CONF_ON_ACTION)
-
     # Get Preferred Sources
     if sources := config.get(CONF_CUSTOMIZE, {}).get(CONF_SOURCES):
         options[CONF_SOURCES] = sources

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -76,7 +76,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 continue
 
             if self._uuid and not entry.unique_id:
-                _LOGGER.error(
+                _LOGGER.debug(
                     "Updating unique_id for host %s, unique_id: %s",
                     self._host,
                     self._uuid,

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -190,7 +190,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         )
 
 
-async def async_default_sources(host, key) -> list | None:
+async def async_default_sources(host, key):
     """Construct sources list."""
     try:
         client = await async_control_connect(host, key)

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -1,0 +1,186 @@
+"""Config flow to configure webostv component."""
+from urllib.parse import urlparse
+
+from aiopylgtv import PyLGTVPairException
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components import ssdp
+from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST, CONF_NAME
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
+
+from . import CannotConnect, async_control_connect
+from .const import CONF_ON_ACTION, CONF_SOURCES, DEFAULT_NAME, DOMAIN, ON_ACTION_DOCS
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """WebosTV configuration flow."""
+
+    VERSION = 1
+
+    def __init__(self):
+        """Initialize workflow."""
+        self._user_input = {}
+        self._force_pairing = False
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+    async def async_step_import(self, import_info):
+        """Set the config entry up from yaml."""
+        self._force_pairing = True
+        return await self.async_step_user(import_info)
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        errors = {}
+        if user_input is not None:
+            self._user_input = user_input
+            self.context["title_placeholders"] = {
+                "name": user_input.get(CONF_NAME, CONF_HOST)
+            }
+            if self._force_pairing:
+                return await self.async_step_pairing({})
+
+            return await self.async_step_pairing()
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_pairing(self, user_input=None):
+        """Display pairing form."""
+        errors = {}
+        if user_input is not None:
+            try:
+                client = await async_control_connect(self._user_input[CONF_HOST], None)
+            except PyLGTVPairException:
+                return self.async_abort(reason="error_pairing")
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            else:
+                return await self.async_step_register(self._user_input, client)
+
+        return self.async_show_form(
+            step_id="pairing",
+            errors=errors,
+        )
+
+    async def async_step_register(self, user_input, client=None):
+        """Register entity."""
+        if client.is_registered():
+            if client.client_key is None:
+                return self.async_abort(reason="client_key_not_found")
+
+            await self.async_set_unique_id(client.software_info["device_id"])
+            self._abort_if_unique_id_configured()
+
+            data = {
+                CONF_HOST: self._user_input[CONF_HOST],
+                CONF_NAME: self._user_input[CONF_NAME],
+                CONF_CLIENT_SECRET: client.client_key,
+            }
+            return self.async_create_entry(
+                title=user_input.get(CONF_NAME, CONF_HOST), data=data
+            )
+
+        return await self.async_step_user()
+
+    async def async_step_ssdp(self, discovery_info):
+        """Handle a discovered Webostv device."""
+        user_input = {
+            CONF_HOST: urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname,
+            CONF_NAME: discovery_info[ssdp.ATTR_UPNP_FRIENDLY_NAME],
+        }
+        self.context["title_placeholders"] = {"name": user_input[CONF_NAME]}
+        self._force_pairing = True
+        return await self.async_step_user(user_input)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+        self.options = config_entry.options
+        self.host = config_entry.data[CONF_HOST]
+        self.key = config_entry.data[CONF_CLIENT_SECRET]
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        errors = {}
+        if user_input is not None:
+            if user_input.get(CONF_ON_ACTION) and not self.hass.states.get(
+                user_input.get(CONF_ON_ACTION)
+            ):
+                errors["base"] = "script_notfound"
+            elif (
+                user_input.get(CONF_ON_ACTION)
+                and (self.hass.states.get(user_input.get(CONF_ON_ACTION))).domain
+                != "script"
+            ):
+                errors["base"] = "script_notfound"
+            if "base" not in errors:
+                options_input = {
+                    CONF_ON_ACTION: user_input.get(CONF_ON_ACTION),
+                    CONF_SOURCES: user_input[CONF_SOURCES],
+                }
+                return self.async_create_entry(title="", data=options_input)
+
+        # Get turn on service
+        script_turn_on = self.options.get(CONF_ON_ACTION, "")
+
+        # Get sources
+        sources = self.options.get(CONF_SOURCES, "")
+        sources_list = await async_default_sources(self.host, self.key)
+        if sources_list is None:
+            errors["base"] = "cannot_retrieve"
+
+        options_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_ON_ACTION,
+                    description={"suggested_value": script_turn_on},
+                ): str,
+                vol.Optional(
+                    CONF_SOURCES,
+                    description={"suggested_value": sources},
+                ): cv.multi_select(sources_list),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=options_schema,
+            errors=errors,
+            description_placeholders={"docs_url": ON_ACTION_DOCS},
+        )
+
+
+async def async_default_sources(host, key) -> list:
+    """Construct sources list."""
+    sources = []
+    try:
+        client = await async_control_connect(host, key)
+    except CannotConnect:
+        return None
+
+    for app in client.apps.values():
+        sources.append(app["title"])
+    for source in client.inputs.values():
+        sources.append(source["label"])
+
+    return sources

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow to configure webostv component."""
 from __future__ import annotations
 
+import logging
 from urllib.parse import urlparse
 
 from aiopylgtv import PyLGTVPairException
@@ -30,6 +31,8 @@ DATA_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """WebosTV configuration flow."""
@@ -38,8 +41,9 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self):
         """Initialize workflow."""
-        self._user_input = {}
-        self._force_pairing = False
+        self._host = None
+        self._name = None
+        self._uuid = None
 
     @staticmethod
     @callback
@@ -49,74 +53,82 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_info):
         """Set the config entry up from yaml."""
-        self._force_pairing = True
-        return await self.async_step_user(import_info)
+        self._host = import_info[CONF_HOST]
+        self._name = import_info.get(CONF_NAME) or import_info[CONF_HOST]
+        return await self.async_step_pairing()
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         errors = {}
         if user_input is not None:
-            self._user_input = user_input
-            self.context["title_placeholders"] = {
-                "name": user_input.get(CONF_NAME, CONF_HOST)
-            }
-
+            self._host = user_input[CONF_HOST]
+            self._name = user_input[CONF_NAME]
             return await self.async_step_pairing()
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
 
+    async def async_check_configured_entry(self):
+        """Check if entry is configured, update unique_id if needed."""
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.data[CONF_HOST] != self._host:
+                continue
+
+            if self._uuid and not entry.unique_id:
+                _LOGGER.error(
+                    "Updating unique_id for host %s, unique_id: %s",
+                    self._host,
+                    self._uuid,
+                )
+                self.hass.config_entries.async_update_entry(entry, unique_id=self._uuid)
+
+            return True
+
+        return False
+
     async def async_step_pairing(self, user_input=None):
         """Display pairing form."""
+        if await self.async_check_configured_entry():
+            return self.async_abort(reason="already_configured")
+
+        self.context[CONF_HOST] = self._host
+        self.context["title_placeholders"] = {"name": self._name}
         errors = {}
-        if user_input is not None or self._force_pairing:
+
+        if (
+            self.context["source"] == config_entries.SOURCE_IMPORT
+            or user_input is not None
+        ):
             try:
-                client = await async_control_connect(self._user_input[CONF_HOST], None)
+                client = await async_control_connect(self._host, None)
             except PyLGTVPairException:
                 return self.async_abort(reason="error_pairing")
             except WEBOSTV_EXCEPTIONS:
                 errors["base"] = "cannot_connect"
             else:
-                return await self.async_step_register(self._user_input, client)
+                data = {CONF_HOST: self._host, CONF_CLIENT_SECRET: client.client_key}
+                return self.async_create_entry(title=self._name, data=data)
 
-        return self.async_show_form(
-            step_id="pairing",
-            errors=errors,
-        )
-
-    async def async_step_register(self, user_input, client=None):
-        """Register entity."""
-        if not client.is_registered():
-            return await self.async_step_user()
-
-        if client.client_key is None:
-            return self.async_abort(reason="client_key_not_found")
-
-        await self.async_set_unique_id(client.software_info["device_id"])
-        self._abort_if_unique_id_configured(
-            updates={CONF_HOST: self._user_input[CONF_HOST]}
-        )
-
-        data = {
-            CONF_HOST: self._user_input[CONF_HOST],
-            CONF_NAME: self._user_input[CONF_NAME],
-            CONF_CLIENT_SECRET: client.client_key,
-        }
-
-        return self.async_create_entry(
-            title=user_input.get(CONF_NAME, CONF_HOST), data=data
-        )
+        return self.async_show_form(step_id="pairing", errors=errors)
 
     async def async_step_ssdp(self, discovery_info):
-        """Handle a discovered Webostv device."""
-        user_input = {
-            CONF_HOST: urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname,
-            CONF_NAME: discovery_info[ssdp.ATTR_UPNP_FRIENDLY_NAME],
-        }
-        self.context["title_placeholders"] = {"name": user_input[CONF_NAME]}
-        self._force_pairing = True
-        return await self.async_step_user(user_input)
+        """Handle a flow initialized by discovery."""
+        self._host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
+        self._name = discovery_info[ssdp.ATTR_UPNP_FRIENDLY_NAME]
+
+        uuid = discovery_info[ssdp.ATTR_UPNP_UDN]
+        if uuid.startswith("uuid:"):
+            uuid = uuid[5:]
+        await self.async_set_unique_id(uuid)
+        self._abort_if_unique_id_configured({CONF_HOST: self._host})
+
+        for progress in self._async_in_progress():
+            if progress.get("context", {}).get(CONF_HOST) == self._host:
+                return self.async_abort(reason="already_in_progress")
+
+        self._uuid = uuid
+        return await self.async_step_pairing()
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -6,7 +6,8 @@ from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
 
 DOMAIN = "webostv"
 PLATFORMS = ["media_player"]
-
+DATA_CONFIG_ENTRY = "config_entry"
+DATA_HASS_CONFIG = "hass_config"
 DEFAULT_NAME = "LG webOS Smart TV"
 
 ATTR_BUTTON = "button"

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -1,4 +1,9 @@
 """Constants used for LG webOS Smart TV."""
+import asyncio
+
+from aiopylgtv import PyLGTVCmdException
+from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
+
 DOMAIN = "webostv"
 PLATFORMS = ["media_player"]
 
@@ -19,3 +24,13 @@ SERVICE_SELECT_SOUND_OUTPUT = "select_sound_output"
 LIVE_TV_APP_ID = "com.webos.app.livetv"
 
 ON_ACTION_DOCS = "https://www.home-assistant.io/integrations/webostv#turn-on-action"
+
+WEBOSTV_EXCEPTIONS = (
+    OSError,
+    ConnectionClosed,
+    ConnectionClosedOK,
+    ConnectionRefusedError,
+    PyLGTVCmdException,
+    asyncio.TimeoutError,
+    asyncio.CancelledError,
+)

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -1,9 +1,11 @@
 """Constants used for LG webOS Smart TV."""
 DOMAIN = "webostv"
+PLATFORMS = ["media_player"]
 
 DEFAULT_NAME = "LG webOS Smart TV"
 
 ATTR_BUTTON = "button"
+ATTR_CONFIG_ENTRY_ID = "entry_id"
 ATTR_PAYLOAD = "payload"
 ATTR_SOUND_OUTPUT = "sound_output"
 
@@ -16,4 +18,4 @@ SERVICE_SELECT_SOUND_OUTPUT = "select_sound_output"
 
 LIVE_TV_APP_ID = "com.webos.app.livetv"
 
-WEBOSTV_CONFIG_FILE = "webostv.conf"
+ON_ACTION_DOCS = "https://www.home-assistant.io/integrations/webostv#turn-on-action"

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -24,8 +24,6 @@ SERVICE_SELECT_SOUND_OUTPUT = "select_sound_output"
 
 LIVE_TV_APP_ID = "com.webos.app.livetv"
 
-ON_ACTION_DOCS = "https://www.home-assistant.io/integrations/webostv#turn-on-action"
-
 WEBOSTV_EXCEPTIONS = (
     OSError,
     ConnectionClosed,

--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -1,9 +1,17 @@
 {
   "domain": "webostv",
   "name": "LG webOS Smart TV",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/webostv",
   "requirements": ["aiopylgtv==0.4.0"],
   "dependencies": ["configurator"],
   "codeowners": ["@bendavid"],
+  "ssdp": [{
+    "manufacturer": "LG Electronics.",
+    "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1"
+  }, {
+    "manufacturer": "LG Electronics",
+    "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1"
+  }],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/webostv/manifest.json
+++ b/homeassistant/components/webostv/manifest.json
@@ -4,7 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/webostv",
   "requirements": ["aiopylgtv==0.4.0"],
-  "dependencies": ["configurator"],
   "codeowners": ["@bendavid"],
   "ssdp": [{
     "manufacturer": "LG Electronics.",

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -24,7 +24,6 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    CONF_NAME,
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
     STATE_OFF,
@@ -65,7 +64,7 @@ SCAN_INTERVAL = timedelta(seconds=10)
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the LG webOS Smart TV platform."""
     unique_id = config_entry.unique_id
-    name = config_entry.data.get(CONF_NAME)
+    name = config_entry.title
     sources = config_entry.options.get(CONF_SOURCES)
     turn_on_action = config_entry.options.get(CONF_ON_ACTION)
     client = hass.data[DOMAIN][config_entry.entry_id]

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -304,19 +304,25 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
     @property
     def device_info(self):
         """Return device information."""
-        if self._client.system_info is None and self.state == STATE_OFF:
-            return {
-                "identifiers": {(DOMAIN, self._unique_id)},
-            }
-        maj_v = self._client.software_info.get("major_ver")
-        min_v = self._client.software_info.get("minor_ver")
-        return {
+        device_info = {
             "identifiers": {(DOMAIN, self._unique_id)},
             "manufacturer": "LG",
             "name": self._name,
-            "model": self._client.system_info.get("modelName"),
-            "sw_version": f"{maj_v}.{min_v}",
         }
+
+        if self._client.system_info is None and self.state == STATE_OFF:
+            return device_info
+
+        maj_v = self._client.software_info.get("major_ver")
+        min_v = self._client.software_info.get("minor_ver")
+        if maj_v and min_v:
+            device_info["sw_version"] = f"{maj_v}.{min_v}"
+
+        model = self._client.system_info.get("modelName")
+        if model:
+            device_info["model"] = model
+
+        return device_info
 
     @property
     def extra_state_attributes(self):

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -37,6 +37,7 @@ from .const import (
     ATTR_SOUND_OUTPUT,
     CONF_ON_ACTION,
     CONF_SOURCES,
+    DATA_CONFIG_ENTRY,
     DOMAIN,
     LIVE_TV_APP_ID,
     WEBOSTV_EXCEPTIONS,
@@ -67,7 +68,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     name = config_entry.title
     sources = config_entry.options.get(CONF_SOURCES)
     turn_on_action = config_entry.options.get(CONF_ON_ACTION)
-    client = hass.data[DOMAIN][config_entry.entry_id]
+    client = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id]
     on_script = None
 
     if turn_on_action:
@@ -122,7 +123,9 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
 
     async def async_added_to_hass(self):
         """Connect and subscribe to dispatcher signals and state updates."""
-        async_dispatcher_connect(self.hass, DOMAIN, self.async_signal_handler)
+        self.async_on_remove(
+            async_dispatcher_connect(self.hass, DOMAIN, self.async_signal_handler)
+        )
 
         await self._client.register_state_update_callback(
             self.async_handle_state_update

--- a/homeassistant/components/webostv/notify.py
+++ b/homeassistant/components/webostv/notify.py
@@ -6,7 +6,7 @@ from aiopylgtv import PyLGTVPairException
 from homeassistant.components.notify import ATTR_DATA, BaseNotificationService
 from homeassistant.const import CONF_ICON, CONF_NAME
 
-from .const import ATTR_CONFIG_ENTRY_ID, DOMAIN, WEBOSTV_EXCEPTIONS
+from .const import ATTR_CONFIG_ENTRY_ID, DATA_CONFIG_ENTRY, DOMAIN, WEBOSTV_EXCEPTIONS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ async def async_get_service(hass, _config, discovery_info=None):
         return None
 
     name = discovery_info.get(CONF_NAME)
-    client = hass.data[DOMAIN][discovery_info[ATTR_CONFIG_ENTRY_ID]]
+    client = hass.data[DOMAIN][DATA_CONFIG_ENTRY][discovery_info[ATTR_CONFIG_ENTRY_ID]]
 
     return LgWebOSNotificationService(client, name)
 

--- a/homeassistant/components/webostv/notify.py
+++ b/homeassistant/components/webostv/notify.py
@@ -6,36 +6,32 @@ from aiopylgtv import PyLGTVCmdException, PyLGTVPairException
 from websockets.exceptions import ConnectionClosed
 
 from homeassistant.components.notify import ATTR_DATA, BaseNotificationService
-from homeassistant.const import CONF_HOST, CONF_ICON
+from homeassistant.const import CONF_ICON, CONF_NAME
 
-from . import DOMAIN
+from .const import ATTR_CONFIG_ENTRY_ID, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_get_service(hass, config, discovery_info=None):
+async def async_get_service(hass, _config, discovery_info=None):
     """Return the notify service."""
 
     if discovery_info is None:
         return None
 
-    host = discovery_info.get(CONF_HOST)
-    icon_path = discovery_info.get(CONF_ICON)
+    name = discovery_info.get(CONF_NAME)
+    client = hass.data[DOMAIN][discovery_info[ATTR_CONFIG_ENTRY_ID]]
 
-    client = hass.data[DOMAIN][host]["client"]
-
-    svc = LgWebOSNotificationService(client, icon_path)
-
-    return svc
+    return LgWebOSNotificationService(client, name)
 
 
 class LgWebOSNotificationService(BaseNotificationService):
     """Implement the notification service for LG WebOS TV."""
 
-    def __init__(self, client, icon_path):
+    def __init__(self, client, name):
         """Initialize the service."""
+        self._name = name
         self._client = client
-        self._icon_path = icon_path
 
     async def async_send_message(self, message="", **kwargs):
         """Send a message to the tv."""
@@ -44,9 +40,7 @@ class LgWebOSNotificationService(BaseNotificationService):
                 await self._client.connect()
 
             data = kwargs.get(ATTR_DATA)
-            icon_path = (
-                data.get(CONF_ICON, self._icon_path) if data else self._icon_path
-            )
+            icon_path = data.get(CONF_ICON, "") if data else None
             await self._client.send_message(message, icon_path=icon_path)
         except PyLGTVPairException:
             _LOGGER.error("Pairing with TV failed")
@@ -55,6 +49,7 @@ class LgWebOSNotificationService(BaseNotificationService):
         except (
             OSError,
             ConnectionClosed,
+            ConnectionRefusedError,
             asyncio.TimeoutError,
             asyncio.CancelledError,
             PyLGTVCmdException,

--- a/homeassistant/components/webostv/notify.py
+++ b/homeassistant/components/webostv/notify.py
@@ -1,14 +1,12 @@
 """Support for LG WebOS TV notification service."""
-import asyncio
 import logging
 
-from aiopylgtv import PyLGTVCmdException, PyLGTVPairException
-from websockets.exceptions import ConnectionClosed
+from aiopylgtv import PyLGTVPairException
 
 from homeassistant.components.notify import ATTR_DATA, BaseNotificationService
 from homeassistant.const import CONF_ICON, CONF_NAME
 
-from .const import ATTR_CONFIG_ENTRY_ID, DOMAIN
+from .const import ATTR_CONFIG_ENTRY_ID, DOMAIN, WEBOSTV_EXCEPTIONS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,12 +44,5 @@ class LgWebOSNotificationService(BaseNotificationService):
             _LOGGER.error("Pairing with TV failed")
         except FileNotFoundError:
             _LOGGER.error("Icon %s not found", icon_path)
-        except (
-            OSError,
-            ConnectionClosed,
-            ConnectionRefusedError,
-            asyncio.TimeoutError,
-            asyncio.CancelledError,
-            PyLGTVCmdException,
-        ):
+        except WEBOSTV_EXCEPTIONS:
             _LOGGER.error("TV unreachable")

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -28,9 +28,8 @@
     "step": {
       "init": {
         "title": "Options for webOS Smart TV",
-        "description": "Home Assistant is able to turn on a LG webOS Smart TV if you specify a script. [Read documentation]({docs_url})",
+        "description": "Select enabled sources",
         "data": {
-          "turn_on_action": "Script used to turn on the TV (ex: script.wake_on_lan)",
           "sources": "Sources list"
         }
       }

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -36,7 +36,7 @@
       }
     },
     "error": {
-      "script_notfound": "Script not found",
+      "script_not_found": "Script not found",
       "cannot_retrieve": "Unable to retrieve the list of sources. Make sure device is switched on"
     }
   }

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -20,8 +20,8 @@
     },
     "abort": {
       "error_pairing": "Connected to LG webOS TV but not paired",
-      "client_key_not_found": "Client key not found",
-      "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
   "options": {

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "flow_title": "LG webOS Smart TV",
+    "step": {
+      "user": {
+        "title": "Connect to webOS TV",
+        "description": "Turn on TV, fill the following fields click submit",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "name": "[%key:common::config_flow::data::name%]"
+        }
+      },
+      "pairing": {
+        "title": "webOS TV Pairing",
+        "description": "Click submit and accept the pairing request on your TV.\n\n![Image](/static/images/config_webos.png)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please turn on your TV or check ip address"
+    },
+    "abort": {
+      "error_pairing": "Connected to LG webOS TV but not paired",
+      "client_key_not_found": "Client key not found",
+      "already_configured_device": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options for webOS Smart TV",
+        "description": "Home Assistant is able to turn on a LG webOS Smart TV if you specify a script. [Read documentation]({docs_url})",
+        "data": {
+          "turn_on_action": "Script used to turn on the TV (ex: script.wake_on_lan)",
+          "sources": "Sources list"
+        }
+      }
+    },
+    "error": {
+      "script_notfound": "Script not found",
+      "cannot_retrieve": "Unable to retrieve the list of sources. Make sure device is switched on"
+    }
+  }
+}

--- a/homeassistant/components/webostv/translations/en.json
+++ b/homeassistant/components/webostv/translations/en.json
@@ -36,7 +36,7 @@
       }
     },
     "error": {
-      "script_notfound": "Script not found",
+      "script_not_found": "Script not found",
       "cannot_retrieve": "Unable to retrieve the list of sources. Make sure device is switched on"
     }
   }

--- a/homeassistant/components/webostv/translations/en.json
+++ b/homeassistant/components/webostv/translations/en.json
@@ -20,8 +20,8 @@
     },
     "abort": {
       "error_pairing": "Connected to LG webOS TV but not paired",
-      "client_key_not_found": "Client key not found",
-      "already_configured_device": "Device is already configured"
+      "already_in_progress": "Configuration flow is already in progress",
+      "already_configured": "Device is already configured"
     }
   },
   "options": {

--- a/homeassistant/components/webostv/translations/en.json
+++ b/homeassistant/components/webostv/translations/en.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "flow_title": "LG webOS Smart TV",
+    "step": {
+      "user": {
+        "title": "Connect to webOS TV",
+        "description": "Turn on TV, fill the following fields click submit",
+        "data": {
+          "host": "Hostname",
+          "name": "Name"
+        }
+      },
+      "pairing": {
+        "title": "webOS TV Pairing",
+        "description": "Click submit and accept the pairing request on your TV.\n\n![Image](/static/images/config_webos.png)"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect, please turn on your TV or check ip address"
+    },
+    "abort": {
+      "error_pairing": "Connected to LG webOS TV but not paired",
+      "client_key_not_found": "Client key not found",
+      "already_configured_device": "Device is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options for Webos Smart TV",
+        "description": "Home Assistant is able to turn on a LG webOS Smart TV if you specify an script. [Read documentation]({docs_url})",
+        "data": {
+          "turn_on_action": "Script used to turn on TV (ex: script.wake_on_lan)",
+          "sources": "Sources list"
+        }
+      }
+    },
+    "error": {
+      "script_notfound": "Script not found",
+      "cannot_retrieve": "Unable to retrieve the list of sources. Make sure device is switched on"
+    }
+  }
+}

--- a/homeassistant/components/webostv/translations/en.json
+++ b/homeassistant/components/webostv/translations/en.json
@@ -28,9 +28,8 @@
     "step": {
       "init": {
         "title": "Options for Webos Smart TV",
-        "description": "Home Assistant is able to turn on a LG webOS Smart TV if you specify an script. [Read documentation]({docs_url})",
+        "description": "Select enabled sources",
         "data": {
-          "turn_on_action": "Script used to turn on TV (ex: script.wake_on_lan)",
           "sources": "Sources list"
         }
       }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -285,6 +285,7 @@ FLOWS = [
     "volumio",
     "wallbox",
     "waze_travel_time",
+    "webostv",
     "wemo",
     "wiffi",
     "wilight",

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -206,6 +206,16 @@ SSDP = {
             "st": "urn:schemas-upnp-org:device:InternetGatewayDevice:2"
         }
     ],
+    "webostv": [
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",
+            "manufacturer": "LG Electronics."
+        },
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",
+            "manufacturer": "LG Electronics"
+        }
+    ],
     "wemo": [
         {
             "manufacturer": "Belkin International Inc."

--- a/tests/components/webostv/__init__.py
+++ b/tests/components/webostv/__init__.py
@@ -1,1 +1,29 @@
 """Tests for the WebOS TV integration."""
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.components.webostv.const import DOMAIN
+from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST, CONF_ICON, CONF_NAME
+
+from tests.common import MockConfigEntry
+
+TV_NAME = "fake"
+ENTITY_ID = f"{MP_DOMAIN}.{TV_NAME}"
+
+
+async def setup_webostv(hass):
+    """Initialize webostv and media_player for tests."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "1.2.3.4",
+            CONF_NAME: TV_NAME,
+            CONF_CLIENT_SECRET: "0123456789",
+            CONF_ICON: "mdi:test",
+        },
+        unique_id="00:01:02:03:04:05",
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    return entry

--- a/tests/components/webostv/__init__.py
+++ b/tests/components/webostv/__init__.py
@@ -2,6 +2,7 @@
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.webostv.const import DOMAIN
 from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
@@ -21,7 +22,11 @@ async def setup_webostv(hass):
     )
     entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
+    await async_setup_component(
+        hass,
+        DOMAIN,
+        {DOMAIN: {CONF_HOST: "1.2.3.4"}},
+    )
     await hass.async_block_till_done()
 
     return entry

--- a/tests/components/webostv/__init__.py
+++ b/tests/components/webostv/__init__.py
@@ -1,7 +1,7 @@
 """Tests for the WebOS TV integration."""
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.webostv.const import DOMAIN
-from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST, CONF_ICON, CONF_NAME
+from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST
 
 from tests.common import MockConfigEntry
 
@@ -15,11 +15,9 @@ async def setup_webostv(hass):
         domain=DOMAIN,
         data={
             CONF_HOST: "1.2.3.4",
-            CONF_NAME: TV_NAME,
             CONF_CLIENT_SECRET: "0123456789",
-            CONF_ICON: "mdi:test",
         },
-        unique_id="00:01:02:03:04:05",
+        title=TV_NAME,
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -1,0 +1,21 @@
+"""Common fixtures and objects for the LG webOS integration tests."""
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    """Patch of client library for tests."""
+    with patch(
+        "homeassistant.components.webostv.WebOsClient", autospec=True
+    ) as mock_client_class:
+        mock_client_class.create.return_value = mock_client_class.return_value
+        client = mock_client_class.return_value
+        client.software_info = {"device_id": "00:01:02:03:04:05"}
+        client.system_info = {"modelName": "TVFAKE"}
+        client.client_key = "0123456789"
+        client.apps = {0: {"title": "Applicaiton01"}}
+        client.inputs = {0: {"label": "Input01"}, 1: {"label": "Input02"}}
+
+        yield client

--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -22,6 +22,12 @@ MOCK_YAML_CONFIG = {
     CONF_ICON: "mdi:test",
 }
 
+MOCK_DISCOVERY_INFO = {
+    ssdp.ATTR_SSDP_LOCATION: "http://1.2.3.4",
+    ssdp.ATTR_UPNP_FRIENDLY_NAME: "LG Webostv",
+    ssdp.ATTR_UPNP_UDN: "uuid:some-fake-uuid",
+}
+
 
 async def test_form_import(hass, client):
     """Test we can import yaml config."""
@@ -79,7 +85,7 @@ async def test_form(hass, client):
     await hass.async_block_till_done()
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["data"]["name"] == "fake"
+    assert result["title"] == "fake"
 
 
 async def test_options_flow(hass, client):
@@ -186,8 +192,8 @@ async def test_form_pairexception(hass, client):
     assert result2["reason"] == "error_pairing"
 
 
-async def test_form_updates_unique_id(hass, client):
-    """Test duplicated unique_id."""
+async def test_entry_already_configured(hass, client):
+    """Test entry already configured."""
     await setup_webostv(hass)
     assert client
 
@@ -197,78 +203,77 @@ async def test_form_updates_unique_id(hass, client):
         data=MOCK_YAML_CONFIG,
     )
 
-    assert result["type"] == RESULT_TYPE_FORM
-    assert result["step_id"] == "pairing"
-
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={},
-    )
-    await hass.async_block_till_done()
-
-    assert result2["type"] == RESULT_TYPE_ABORT
-    assert result2["reason"] == "already_configured"
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
 
 
 async def test_form_ssdp(hass, client):
     """Test that the ssdp confirmation form is served."""
     assert client
 
-    discovery_info = {
-        ssdp.ATTR_SSDP_LOCATION: "http://hostname",
-        ssdp.ATTR_UPNP_FRIENDLY_NAME: "LG Webostv",
-    }
-
     with patch("homeassistant.components.webostv.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={CONF_SOURCE: SOURCE_SSDP}, data=discovery_info
+            DOMAIN, context={CONF_SOURCE: SOURCE_SSDP}, data=MOCK_DISCOVERY_INFO
         )
     await hass.async_block_till_done()
 
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "LG Webostv"
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "pairing"
 
 
-async def test_pairing_failed_form(hass, client):
-    """Test pairing form."""
+async def test_ssdp_in_progress(hass, client):
+    """Test abort if ssdp paring is already in progress."""
+    assert client
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_USER},
         data=MOCK_YAML_CONFIG,
     )
-
-    assert result["type"] == RESULT_TYPE_FORM
-    assert result["step_id"] == "pairing"
-
-    client.is_registered.return_value = False
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
-
     await hass.async_block_till_done()
 
-    assert result2["type"] == RESULT_TYPE_FORM
-    assert result2["step_id"] == "user"
-
-
-async def test_client_key_missing(hass, client):
-    """Test abort if missing client key."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={CONF_SOURCE: config_entries.SOURCE_USER},
-        data=MOCK_YAML_CONFIG,
-    )
-
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "pairing"
 
-    client.is_registered.return_value = True
-    client.client_key = None
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
+    result2 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_SSDP}, data=MOCK_DISCOVERY_INFO
     )
-
     await hass.async_block_till_done()
 
     assert result2["type"] == RESULT_TYPE_ABORT
-    assert result2["reason"] == "client_key_not_found"
+    assert result2["reason"] == "already_in_progress"
+
+
+async def test_ssdp_update_uuid(hass, client):
+    """Test that ssdp updates existing host entry uuid."""
+    entry = await setup_webostv(hass)
+    assert client
+    assert entry.unique_id is None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_SSDP}, data=MOCK_DISCOVERY_INFO
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.unique_id == MOCK_DISCOVERY_INFO[ssdp.ATTR_UPNP_UDN][5:]
+
+
+async def test_ssdp_not_update_uuid(hass, client):
+    """Test that ssdp not updates different host."""
+    entry = await setup_webostv(hass)
+    assert client
+    assert entry.unique_id is None
+
+    discovery_info = MOCK_DISCOVERY_INFO.copy()
+    discovery_info.update({ssdp.ATTR_SSDP_LOCATION: "http://1.2.3.5"})
+
+    result2 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_SSDP}, data=discovery_info
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["step_id"] == "pairing"
+    assert entry.unique_id is None

--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -5,7 +5,6 @@ from aiopylgtv import PyLGTVPairException
 
 from homeassistant import config_entries
 from homeassistant.components import ssdp
-from homeassistant.components.webostv import CannotConnect
 from homeassistant.components.webostv.const import CONF_ON_ACTION, CONF_SOURCES, DOMAIN
 from homeassistant.config_entries import SOURCE_SSDP
 from homeassistant.const import CONF_HOST, CONF_ICON, CONF_NAME, CONF_SOURCE
@@ -107,7 +106,7 @@ async def test_options_flow(hass, client):
     assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result2["data"][CONF_ON_ACTION] == "script.test"
 
-    client.connect = Mock(side_effect=CannotConnect("error"))
+    client.connect = Mock(side_effect=ConnectionRefusedError())
     result3 = await hass.config_entries.options.async_init(entry.entry_id)
 
     await hass.async_block_till_done()
@@ -159,7 +158,7 @@ async def test_form_cannot_connect(hass, client):
         data=MOCK_YAML_CONFIG,
     )
 
-    client.connect = Mock(side_effect=CannotConnect("error"))
+    client.connect = Mock(side_effect=ConnectionRefusedError())
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )

--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -1,0 +1,364 @@
+"""Test the WebOS Tv config flow."""
+from unittest.mock import patch
+
+from aiopylgtv import PyLGTVPairException
+
+from homeassistant import config_entries
+from homeassistant.components import ssdp
+from homeassistant.components.webostv import CannotConnect
+from homeassistant.components.webostv.const import CONF_ON_ACTION, CONF_SOURCES, DOMAIN
+from homeassistant.config_entries import SOURCE_SSDP
+from homeassistant.const import (
+    CONF_CLIENT_SECRET,
+    CONF_HOST,
+    CONF_ICON,
+    CONF_NAME,
+    CONF_SOURCE,
+)
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+from tests.common import MockConfigEntry
+
+MOCK_YAML_CONFIG = {
+    CONF_HOST: "1.2.3.4",
+    CONF_NAME: "fake",
+    CONF_ICON: "mdi:test",
+}
+
+MOCK_CONFIG_ENTRY = {
+    CONF_HOST: "1.2.3.4",
+    CONF_CLIENT_SECRET: "0123456789",
+}
+
+
+async def test_form_import(hass, client):
+    """Test we can import yaml config."""
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ), patch("homeassistant.components.webostv.async_setup", return_value=True), patch(
+        "homeassistant.components.webostv.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={CONF_SOURCE: config_entries.SOURCE_IMPORT},
+            data=MOCK_YAML_CONFIG,
+        )
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "fake"
+
+
+async def test_form(hass, client):
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: config_entries.SOURCE_USER},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: config_entries.SOURCE_USER},
+        data=MOCK_YAML_CONFIG,
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "pairing"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: config_entries.SOURCE_USER},
+        data=MOCK_YAML_CONFIG,
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "pairing"
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ), patch("homeassistant.components.webostv.async_setup", return_value=True), patch(
+        "homeassistant.components.webostv.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["data"]["name"] == "fake"
+
+
+async def test_options_flow(hass, client):
+    """Test options config flow."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_ENTRY,
+        unique_id="00:01:02:03:04:05",
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("script.test", "off", {"domain": "script"})
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ):
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ON_ACTION: "script.test",
+                CONF_SOURCES: ["Input01", "Input02"],
+            },
+        )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["data"][CONF_ON_ACTION] == "script.test"
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ), patch(
+        "homeassistant.components.webostv.config_flow.async_default_sources",
+        return_value=None,
+    ):
+        result3 = await hass.config_entries.options.async_init(entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    assert result3["type"] == RESULT_TYPE_FORM
+    assert result3["errors"] == {"base": "cannot_retrieve"}
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        side_effect=CannotConnect("devicenotfound"),
+    ):
+        result4 = await hass.config_entries.options.async_init(entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    assert result4["type"] == RESULT_TYPE_FORM
+    assert result4["errors"] == {"base": "cannot_retrieve"}
+
+
+async def test_options_script_incorrect_flow(hass, client):
+    """Test json format incorrect in options config flow."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_ENTRY,
+        unique_id="00:01:02:03:04:05",
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("script.fake", "off", {"domain": "script"})
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ):
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_ON_ACTION: "script.test"},
+        )
+
+    await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "script_notfound"}
+
+    hass.states.async_set("fake.test", "off", {"domain": "fake"})
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ):
+        result3 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_ON_ACTION: "fake.test"},
+        )
+
+    await hass.async_block_till_done()
+
+    assert result3["type"] == RESULT_TYPE_FORM
+    assert result3["errors"] == {"base": "script_notfound"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: config_entries.SOURCE_USER},
+        data=MOCK_YAML_CONFIG,
+    )
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_pairexception(hass):
+    """Test pairing exception."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: config_entries.SOURCE_USER},
+        data=MOCK_YAML_CONFIG,
+    )
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        side_effect=PyLGTVPairException("error"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "error_pairing"
+
+
+async def test_form_updates_unique_id(hass, client):
+    """Test duplicated unique_id."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_ENTRY,
+        unique_id="00:01:02:03:04:05",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: config_entries.SOURCE_USER},
+        data=MOCK_YAML_CONFIG,
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "pairing"
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+    await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "already_configured"
+
+
+async def test_form_ssdp(hass, client):
+    """Test that the ssdp confirmation form is served."""
+    discovery_info = {
+        ssdp.ATTR_SSDP_LOCATION: "http://hostname",
+        ssdp.ATTR_UPNP_FRIENDLY_NAME: "LG Webostv",
+    }
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ), patch("homeassistant.components.webostv.async_setup", return_value=True), patch(
+        "homeassistant.components.webostv.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={CONF_SOURCE: SOURCE_SSDP}, data=discovery_info
+        )
+
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "LG Webostv"
+
+
+async def test_pairing_failed_form(hass, client):
+    """Test pairing form."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: config_entries.SOURCE_USER},
+        data=MOCK_YAML_CONFIG,
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "pairing"
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ):
+        client.is_registered.return_value = False
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["step_id"] == "user"
+
+
+async def test_client_key_missing(hass, client):
+    """Test abort if missing client key."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: config_entries.SOURCE_USER},
+        data=MOCK_YAML_CONFIG,
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "pairing"
+
+    with patch(
+        "homeassistant.components.webostv.config_flow.async_control_connect",
+        return_value=client,
+    ):
+        client.is_registered.return_value = True
+        client.client_key = None
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "client_key_not_found"

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -1,11 +1,4 @@
 """The tests for the LG webOS media player platform."""
-import json
-import os
-from unittest.mock import patch
-
-import pytest
-from sqlitedict import SqliteDict
-
 from homeassistant.components import media_player
 from homeassistant.components.media_player.const import (
     ATTR_INPUT_SOURCE,
@@ -18,49 +11,38 @@ from homeassistant.components.webostv.const import (
     DOMAIN,
     SERVICE_BUTTON,
     SERVICE_COMMAND,
-    WEBOSTV_CONFIG_FILE,
 )
 from homeassistant.const import (
     ATTR_COMMAND,
     ATTR_ENTITY_ID,
     CONF_HOST,
+    CONF_ICON,
     CONF_NAME,
     SERVICE_VOLUME_MUTE,
 )
-from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
 
 NAME = "fake"
 ENTITY_ID = f"{media_player.DOMAIN}.{NAME}"
 
 
-@pytest.fixture(name="client")
-def client_fixture():
-    """Patch of client library for tests."""
-    with patch(
-        "homeassistant.components.webostv.WebOsClient", autospec=True
-    ) as mock_client_class:
-        mock_client_class.create.return_value = mock_client_class.return_value
-        client = mock_client_class.return_value
-        client.software_info = {"device_id": "a1:b1:c1:d1:e1:f1"}
-        client.client_key = "0123456789"
-        yield client
-
-
 async def setup_webostv(hass):
     """Initialize webostv and media_player for tests."""
-    assert await async_setup_component(
-        hass,
-        DOMAIN,
-        {DOMAIN: {CONF_HOST: "fake", CONF_NAME: NAME}},
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "1.2.3.4",
+            CONF_NAME: NAME,
+            "client_secret": "0123456789",
+            CONF_ICON: "mdi:test",
+        },
+        unique_id="00:01:02:03:04:05",
     )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-
-
-@pytest.fixture
-def cleanup_config(hass):
-    """Test cleanup, remove the config file."""
-    yield
-    os.remove(hass.config.path(WEBOSTV_CONFIG_FILE))
 
 
 async def test_mute(hass, client):
@@ -72,7 +54,10 @@ async def test_mute(hass, client):
         ATTR_ENTITY_ID: ENTITY_ID,
         ATTR_MEDIA_VOLUME_MUTED: True,
     }
-    await hass.services.async_call(media_player.DOMAIN, SERVICE_VOLUME_MUTE, data)
+
+    assert await hass.services.async_call(
+        media_player.DOMAIN, SERVICE_VOLUME_MUTE, data, True
+    )
     await hass.async_block_till_done()
 
     client.set_mute.assert_called_once()
@@ -139,37 +124,3 @@ async def test_command_with_optional_arg(hass, client):
     client.request.assert_called_with(
         "test", payload={"target": "https://www.google.com"}
     )
-
-
-async def test_migrate_keyfile_to_sqlite(hass, client, cleanup_config):
-    """Test migration from JSON key-file to Sqlite based one."""
-    key = "3d5b1aeeb98e"
-    # Create config file with JSON content
-    config_file = hass.config.path(WEBOSTV_CONFIG_FILE)
-    with open(config_file, "w+") as file:
-        json.dump({"host": key}, file)
-
-    # Run the component setup
-    await setup_webostv(hass)
-
-    # Assert that the config file is a Sqlite database which contains the key
-    with SqliteDict(config_file) as conf:
-        assert conf.get("host") == key
-
-
-async def test_dont_migrate_sqlite_keyfile(hass, client, cleanup_config):
-    """Test that migration is not performed and setup still succeeds when config file is already an Sqlite DB."""
-    key = "3d5b1aeeb98e"
-
-    # Create config file with Sqlite DB
-    config_file = hass.config.path(WEBOSTV_CONFIG_FILE)
-    with SqliteDict(config_file) as conf:
-        conf["host"] = key
-        conf.commit()
-
-    # Run the component setup
-    await setup_webostv(hass)
-
-    # Assert that the config file is still an Sqlite database and setup didn't fail
-    with SqliteDict(config_file) as conf:
-        assert conf.get("host") == key

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -1,5 +1,5 @@
 """The tests for the LG webOS media player platform."""
-from homeassistant.components import media_player
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.media_player.const import (
     ATTR_INPUT_SOURCE,
     ATTR_MEDIA_VOLUME_MUTED,
@@ -12,42 +12,13 @@ from homeassistant.components.webostv.const import (
     SERVICE_BUTTON,
     SERVICE_COMMAND,
 )
-from homeassistant.const import (
-    ATTR_COMMAND,
-    ATTR_ENTITY_ID,
-    CONF_HOST,
-    CONF_ICON,
-    CONF_NAME,
-    SERVICE_VOLUME_MUTE,
-)
+from homeassistant.const import ATTR_COMMAND, ATTR_ENTITY_ID, SERVICE_VOLUME_MUTE
 
-from tests.common import MockConfigEntry
-
-NAME = "fake"
-ENTITY_ID = f"{media_player.DOMAIN}.{NAME}"
-
-
-async def setup_webostv(hass):
-    """Initialize webostv and media_player for tests."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_HOST: "1.2.3.4",
-            CONF_NAME: NAME,
-            "client_secret": "0123456789",
-            CONF_ICON: "mdi:test",
-        },
-        unique_id="00:01:02:03:04:05",
-    )
-    entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+from . import ENTITY_ID, setup_webostv
 
 
 async def test_mute(hass, client):
     """Test simple service call."""
-
     await setup_webostv(hass)
 
     data = {
@@ -55,9 +26,7 @@ async def test_mute(hass, client):
         ATTR_MEDIA_VOLUME_MUTED: True,
     }
 
-    assert await hass.services.async_call(
-        media_player.DOMAIN, SERVICE_VOLUME_MUTE, data, True
-    )
+    assert await hass.services.async_call(MP_DOMAIN, SERVICE_VOLUME_MUTE, data, True)
     await hass.async_block_till_done()
 
     client.set_mute.assert_called_once()
@@ -65,14 +34,13 @@ async def test_mute(hass, client):
 
 async def test_select_source_with_empty_source_list(hass, client):
     """Ensure we don't call client methods when we don't have sources."""
-
     await setup_webostv(hass)
 
     data = {
         ATTR_ENTITY_ID: ENTITY_ID,
         ATTR_INPUT_SOURCE: "nonexistent",
     }
-    await hass.services.async_call(media_player.DOMAIN, SERVICE_SELECT_SOURCE, data)
+    await hass.services.async_call(MP_DOMAIN, SERVICE_SELECT_SOURCE, data)
     await hass.async_block_till_done()
 
     client.launch_app.assert_not_called()
@@ -81,7 +49,6 @@ async def test_select_source_with_empty_source_list(hass, client):
 
 async def test_button(hass, client):
     """Test generic button functionality."""
-
     await setup_webostv(hass)
 
     data = {


### PR DESCRIPTION
## TODO
- <s> Read old keys from json file or new keys from `sqlitedict` and use them when importing yaml config - this will support updating from any existing core versions </s> 
https://github.com/home-assistant/core/pull/63996
- <s> Make sure entity `unique_id` is not changed so that we don't create new entities - currently `client_key` is used as entity `unique_id` - either keep it this way or migrate to something based on something fixed in the device: `uuid` / `device_id` (mac address) </s> 
https://github.com/home-assistant/core/pull/63817
https://github.com/home-assistant/core/pull/63996
- <s> Change turn on action from script to device trigger </s> 
https://github.com/home-assistant/core/pull/53752 
https://github.com/home-assistant/core/pull/63950
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- [Turn on action](https://www.home-assistant.io/integrations/webostv/#turn-on-action) for turning on the TV via `WakeOnLan` or `HDMI-CEC` was using a service call via `YAML`, to enable adding an action to turn on the TV without `YAML` the turn on action is changed to use a `device trigger`. A device automation can be setup to execute when the `media_player` is asked to turn on.
- <s>When updating from versions bellow 2021.4.0 the TV will need to be re-paired due to old key storing format.</s> 
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**This is a continue of the work started by @Cyr-ius in PR https://github.com/home-assistant/core/pull/50352 - credit for most of the work here goes to him, Thanks!**

Add config flow support to LG webOS Smart TV integration:
- Automatically discover devices via SSDP
- Migrate existing entries without need to re-pair
- Add options flow to set a turn on script and selecting available sources

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #50352
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
