### PR TITLE
Migrate forecast solar to v2

### DIFF
--- a/homeassistant/components/forecast_solar/const.py
+++ b/homeassistant/components/forecast_solar/const.py
@@ -1,6 +1,7 @@
 """Constants for the Forecast.Solar integration."""
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Final
 
 from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
@@ -27,12 +28,14 @@ SENSORS: list[ForecastSolarSensor] = [
     ForecastSolarSensor(
         key="energy_production_today",
         name="Estimated Energy Production - Today",
+        state=lambda estimate: estimate.energy_production_today / 1000,
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
     ),
     ForecastSolarSensor(
         key="energy_production_tomorrow",
         name="Estimated Energy Production - Tomorrow",
+        state=lambda estimate: estimate.energy_production_tomorrow / 1000,
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
     ),
@@ -50,11 +53,16 @@ SENSORS: list[ForecastSolarSensor] = [
         key="power_production_now",
         name="Estimated Power Production - Now",
         device_class=DEVICE_CLASS_POWER,
+        state=lambda estimate: estimate.power_production_now / 1000,
         state_class=STATE_CLASS_MEASUREMENT,
         unit_of_measurement=POWER_WATT,
     ),
     ForecastSolarSensor(
         key="power_production_next_hour",
+        state=lambda estimate: estimate.power_production_at_time(
+            estimate.now() + timedelta(hours=1)
+        )
+        / 1000,
         name="Estimated Power Production - Next Hour",
         device_class=DEVICE_CLASS_POWER,
         entity_registry_enabled_default=False,
@@ -62,6 +70,10 @@ SENSORS: list[ForecastSolarSensor] = [
     ),
     ForecastSolarSensor(
         key="power_production_next_12hours",
+        state=lambda estimate: estimate.power_production_at_time(
+            estimate.now() + timedelta(hours=12)
+        )
+        / 1000,
         name="Estimated Power Production - Next 12 Hours",
         device_class=DEVICE_CLASS_POWER,
         entity_registry_enabled_default=False,
@@ -69,6 +81,10 @@ SENSORS: list[ForecastSolarSensor] = [
     ),
     ForecastSolarSensor(
         key="power_production_next_24hours",
+        state=lambda estimate: estimate.power_production_at_time(
+            estimate.now() + timedelta(hours=24)
+        )
+        / 1000,
         name="Estimated Power Production - Next 24 Hours",
         device_class=DEVICE_CLASS_POWER,
         entity_registry_enabled_default=False,
@@ -77,11 +93,13 @@ SENSORS: list[ForecastSolarSensor] = [
     ForecastSolarSensor(
         key="energy_current_hour",
         name="Estimated Energy Production - This Hour",
+        state=lambda estimate: estimate.energy_current_hour / 1000,
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
     ),
     ForecastSolarSensor(
         key="energy_next_hour",
+        state=lambda estimate: estimate.sum_energy_production(1) / 1000,
         name="Estimated Energy Production - Next Hour",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,

--- a/homeassistant/components/forecast_solar/manifest.json
+++ b/homeassistant/components/forecast_solar/manifest.json
@@ -3,7 +3,7 @@
   "name": "Forecast.Solar",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/forecast_solar",
-  "requirements": ["forecast_solar==1.3.1"],
+  "requirements": ["forecast_solar==2.0.0"],
   "codeowners": ["@klaasnicolaas", "@frenck"],
   "quality_scale": "platinum",
   "iot_class": "cloud_polling"

--- a/homeassistant/components/forecast_solar/models.py
+++ b/homeassistant/components/forecast_solar/models.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, Callable
+
+from forecast_solar.models import Estimate
 
 
 @dataclass
@@ -13,5 +16,6 @@ class ForecastSolarSensor:
 
     device_class: str | None = None
     entity_registry_enabled_default: bool = True
+    state: Callable[[Estimate], Any] | None = None
     state_class: str | None = None
     unit_of_measurement: str | None = None

--- a/homeassistant/components/forecast_solar/sensor.py
+++ b/homeassistant/components/forecast_solar/sensor.py
@@ -66,7 +66,13 @@ class ForecastSolarSensorEntity(CoordinatorEntity, SensorEntity):
     @property
     def state(self) -> StateType:
         """Return the state of the sensor."""
-        state: StateType | datetime = getattr(self.coordinator.data, self._sensor.key)
+        if self._sensor.state is None:
+            state: StateType | datetime = getattr(
+                self.coordinator.data, self._sensor.key
+            )
+        else:
+            state = self._sensor.state(self.coordinator.data)
+
         if isinstance(state, datetime):
             return state.isoformat()
         return state

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -624,7 +624,7 @@ fnvhash==0.1.0
 foobot_async==1.0.0
 
 # homeassistant.components.forecast_solar
-forecast_solar==1.3.1
+forecast_solar==2.0.0
 
 # homeassistant.components.fortios
 fortiosapi==1.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -342,7 +342,7 @@ fnvhash==0.1.0
 foobot_async==1.0.0
 
 # homeassistant.components.forecast_solar
-forecast_solar==1.3.1
+forecast_solar==2.0.0
 
 # homeassistant.components.freebox
 freebox-api==0.0.10

--- a/tests/components/forecast_solar/conftest.py
+++ b/tests/components/forecast_solar/conftest.py
@@ -1,9 +1,10 @@
 """Fixtures for Forecast.Solar integration tests."""
 
-import datetime
+from datetime import datetime, timedelta
 from typing import Generator
 from unittest.mock import MagicMock, patch
 
+from forecast_solar import models
 import pytest
 
 from homeassistant.components.forecast_solar.const import (
@@ -16,6 +17,7 @@ from homeassistant.components.forecast_solar.const import (
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
@@ -54,24 +56,31 @@ def mock_forecast_solar() -> Generator[None, MagicMock, None]:
         "homeassistant.components.forecast_solar.ForecastSolar", autospec=True
     ) as forecast_solar_mock:
         forecast_solar = forecast_solar_mock.return_value
+        now = datetime(2021, 6, 27, 6, 0, tzinfo=dt_util.DEFAULT_TIME_ZONE)
 
-        estimate = MagicMock()
+        estimate = MagicMock(spec_set=models.Estimate)
+        estimate.now.return_value = now
         estimate.timezone = "Europe/Amsterdam"
-        estimate.energy_production_today = 100
-        estimate.energy_production_tomorrow = 200
-        estimate.power_production_now = 300
-        estimate.power_highest_peak_time_today = datetime.datetime(
-            2021, 6, 27, 13, 0, tzinfo=datetime.timezone.utc
+        estimate.energy_production_today = 100000
+        estimate.energy_production_tomorrow = 200000
+        estimate.power_production_now = 300000
+        estimate.power_highest_peak_time_today = datetime(
+            2021, 6, 27, 13, 0, tzinfo=dt_util.DEFAULT_TIME_ZONE
         )
-        estimate.power_highest_peak_time_tomorrow = datetime.datetime(
-            2021, 6, 27, 14, 0, tzinfo=datetime.timezone.utc
+        estimate.power_highest_peak_time_tomorrow = datetime(
+            2021, 6, 27, 14, 0, tzinfo=dt_util.DEFAULT_TIME_ZONE
         )
-        estimate.power_production_next_hour = 400
-        estimate.power_production_next_6hours = 500
-        estimate.power_production_next_12hours = 600
-        estimate.power_production_next_24hours = 700
-        estimate.energy_current_hour = 800
-        estimate.energy_next_hour = 900
+        estimate.energy_current_hour = 800000
+
+        estimate.power_production_at_time.side_effect = {
+            now + timedelta(hours=1): 400000,
+            now + timedelta(hours=12): 600000,
+            now + timedelta(hours=24): 700000,
+        }.get
+
+        estimate.sum_energy_production.side_effect = {
+            1: 900000,
+        }.get
 
         forecast_solar.estimate.return_value = estimate
         yield forecast_solar

--- a/tests/components/forecast_solar/test_sensor.py
+++ b/tests/components/forecast_solar/test_sensor.py
@@ -40,7 +40,7 @@ async def test_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_energy_production_today"
-    assert state.state == "100"
+    assert state.state == "100.0"
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)
         == "Estimated Energy Production - Today"
@@ -55,7 +55,7 @@ async def test_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_energy_production_tomorrow"
-    assert state.state == "200"
+    assert state.state == "200.0"
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)
         == "Estimated Energy Production - Tomorrow"
@@ -96,7 +96,7 @@ async def test_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_power_production_now"
-    assert state.state == "300"
+    assert state.state == "300.0"
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME) == "Estimated Power Production - Now"
     )
@@ -110,7 +110,7 @@ async def test_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_energy_current_hour"
-    assert state.state == "800"
+    assert state.state == "800.0"
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)
         == "Estimated Energy Production - This Hour"
@@ -125,7 +125,7 @@ async def test_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_energy_next_hour"
-    assert state.state == "900"
+    assert state.state == "900.0"
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)
         == "Estimated Energy Production - Next Hour"
@@ -175,17 +175,17 @@ async def test_disabled_by_default(
         (
             "power_production_next_12hours",
             "Estimated Power Production - Next 12 Hours",
-            "600",
+            "600.0",
         ),
         (
             "power_production_next_24hours",
             "Estimated Power Production - Next 24 Hours",
-            "700",
+            "700.0",
         ),
         (
             "power_production_next_hour",
             "Estimated Power Production - Next Hour",
-            "400",
+            "400.0",
         ),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump forecast_solar to v2

Requires https://github.com/home-assistant-libs/forecast_solar/pull/13

This is not a breaking change. Just some data processing (W -> kW, Wh -> kWh) has been moved into HA (as it's processing the API data to our liking) and using new helper methods.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
