### PR TITLE
Handle more Sonos snapshot restore scenarios

### DIFF
--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -837,8 +837,8 @@ class SonosSpeaker:
                 speakers_to_unjoin.update(
                     {
                         s
-                        for s in speaker.sonos_group
-                        if s not in speaker.snapshot_group and not s.is_coordinator
+                        for s in speaker.sonos_group[1:]
+                        if s not in speaker.snapshot_group
                     }
                 )
 

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -14,7 +14,7 @@ import async_timeout
 from pysonos.core import MUSIC_SRC_LINE_IN, MUSIC_SRC_RADIO, MUSIC_SRC_TV, SoCo
 from pysonos.data_structures import DidlAudioBroadcast, DidlPlaylistContainer
 from pysonos.events_base import Event as SonosEvent, SubscriptionBase
-from pysonos.exceptions import SoCoException
+from pysonos.exceptions import SoCoException, SoCoUPnPException
 from pysonos.music_library import MusicLibrary
 from pysonos.plugins.sharelink import ShareLinkPlugin
 from pysonos.snapshot import Snapshot
@@ -810,7 +810,15 @@ class SonosSpeaker:
                     speaker.media.playback_status == SONOS_STATE_PLAYING
                     and "Pause" in speaker.soco.available_actions
                 ):
-                    speaker.soco.pause()
+                    try:
+                        speaker.soco.pause()
+                    except SoCoUPnPException as exc:
+                        _LOGGER.debug(
+                            "Pause failed during restore of %s: %s",
+                            speaker.zone_name,
+                            speaker.soco.available_actions,
+                            exc_info=exc,
+                        )
 
             groups = []
             speakers_to_unjoin = set()

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -821,38 +821,39 @@ class SonosSpeaker:
                         )
 
             groups = []
+            if not with_group:
+                return groups
+
+            # Unjoin non-coordinator speakers not contained in the desired snapshot group
+            #
+            # If a coordinator is unjoined from its group, another speaker from the group
+            # will inherit the coordinator's playqueue and its own playqueue will be lost
             speakers_to_unjoin = set()
+            for speaker in speakers:
+                if speaker.sonos_group == speaker.snapshot_group:
+                    continue
 
-            if with_group:
-                # Unjoin non-coordinator speakers not contained in the desired snapshot group
-                #
-                # If a coordinator is unjoined from its group, another speaker from the group
-                # will inherit the coordinator's playqueue and its own playqueue will be lost
-                for speaker in speakers:
-                    if speaker.sonos_group == speaker.snapshot_group:
-                        continue
+                speakers_to_unjoin.update(
+                    {
+                        s
+                        for s in speaker.sonos_group
+                        if s not in speaker.snapshot_group and not s.is_coordinator
+                    }
+                )
 
-                    speakers_to_unjoin.update(
-                        {
-                            s
-                            for s in speaker.sonos_group
-                            if s not in speaker.snapshot_group and not s.is_coordinator
-                        }
-                    )
+            for speaker in speakers_to_unjoin:
+                speaker.unjoin()
 
-                for speaker in speakers_to_unjoin:
-                    speaker.unjoin()
-
-                # Bring back the original group topology
-                for speaker in (s for s in speakers if s.snapshot_group):
-                    assert speaker.snapshot_group is not None
-                    if speaker.snapshot_group[0] == speaker:
-                        if (
-                            speaker.snapshot_group != speaker.sonos_group
-                            and speaker.snapshot_group != [speaker]
-                        ):
-                            speaker.join(speaker.snapshot_group)
-                        groups.append(speaker.snapshot_group.copy())
+            # Bring back the original group topology
+            for speaker in (s for s in speakers if s.snapshot_group):
+                assert speaker.snapshot_group is not None
+                if speaker.snapshot_group[0] == speaker:
+                    if (
+                        speaker.snapshot_group != speaker.sonos_group
+                        and speaker.snapshot_group != [speaker]
+                    ):
+                        speaker.join(speaker.snapshot_group)
+                    groups.append(speaker.snapshot_group.copy())
 
             return groups
 

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -25,6 +25,7 @@ from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as ent_reg
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
@@ -867,6 +868,11 @@ class SonosSpeaker:
 
         # Find all affected players
         speakers_set = {s for s in speakers if s.soco_snapshot}
+        if missing_snapshots := set(speakers) - speakers_set:
+            raise HomeAssistantError(
+                f"Restore failed, speakers are missing snapshots: {[s.zone_name for s in missing_snapshots]}"
+            )
+
         if with_group:
             for speaker in [s for s in speakers_set if s.snapshot_group]:
                 assert speaker.snapshot_group is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Sonos speaker regrouping behavior may change during snapshot restores for certain layouts. Previously, speakers which were joined after a snapshot was taken were not unjoined during restores. Restored groups are now recreated to exactly match the snapshot. If `sonos.restore` is called with `with_group: True` (the default) on individual speakers (instead of `entity_id: all`) **and** speakers were joined after snapshots were taken, then it is possible to create groups which did not previously exist.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Sonos snapshot restore call did not properly handle certain speaker groupings and would commonly fail with a timeout error. For example, snapshotting a single speaker, joining it to another, and then restoring the snapshot would unconditionally fail.

This PR makes a few changes:
* Unjoin speakers from the current group if they do not belong to the restored snapshot
* ~~Leave an existing group intact if possible if the snapshotted speaker needs to be removed~~
* Avoid unnecessary join operations if the group is already consistent
* Guard the `pause()` call if the speaker's current state does not support it
* Raise an exception if a restore is attempted without a snapshot

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #43190
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
