### PR TITLE
Update to PyVicare 1.0

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -1,7 +1,9 @@
 """The ViCare integration."""
+from contextlib import contextmanager
 import enum
 import logging
 
+from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
 from PyViCare.PyViCareDevice import Device
 from PyViCare.PyViCareFuelCell import FuelCell
 from PyViCare.PyViCareGazBoiler import GazBoiler
@@ -9,6 +11,7 @@ from PyViCare.PyViCareHeatPump import HeatPump
 import voluptuous as vol
 
 from homeassistant.const import (
+    CONF_CLIENT_ID,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
@@ -23,7 +26,6 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["climate", "sensor", "binary_sensor", "water_heater"]
 
 DOMAIN = "vicare"
-PYVICARE_ERROR = "error"
 VICARE_API = "api"
 VICARE_NAME = "name"
 VICARE_HEATING_TYPE = "heating_type"
@@ -42,12 +44,22 @@ class HeatingType(enum.Enum):
     fuelcell = "fuelcell"
 
 
+@contextmanager
+def catch_not_supported():
+    """Catch PyViCareNotSupportedFeatureError exceptions and return None."""
+    try:
+        yield None
+    except PyViCareNotSupportedFeatureError:
+        pass
+
+
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
                 vol.Required(CONF_USERNAME): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
+                vol.Required(CONF_CLIENT_ID): cv.string,
                 vol.Optional(CONF_SCAN_INTERVAL, default=60): vol.All(
                     cv.time_period, lambda value: value.total_seconds()
                 ),
@@ -71,7 +83,7 @@ def setup(hass, config):
         params["circuit"] = conf[CONF_CIRCUIT]
 
     params["cacheDuration"] = conf.get(CONF_SCAN_INTERVAL)
-
+    params["client_id"] = conf.get(CONF_CLIENT_ID)
     heating_type = conf[CONF_HEATING_TYPE]
 
     try:

--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -1,9 +1,7 @@
 """The ViCare integration."""
-from contextlib import contextmanager
 import enum
 import logging
 
-from PyViCare.PyViCare import PyViCareNotSupportedFeatureError
 from PyViCare.PyViCareDevice import Device
 from PyViCare.PyViCareFuelCell import FuelCell
 from PyViCare.PyViCareGazBoiler import GazBoiler
@@ -42,15 +40,6 @@ class HeatingType(enum.Enum):
     gas = "gas"
     heatpump = "heatpump"
     fuelcell = "fuelcell"
-
-
-@contextmanager
-def catch_not_supported():
-    """Catch PyViCareNotSupportedFeatureError exceptions and return None."""
-    try:
-        yield None
-    except PyViCareNotSupportedFeatureError:
-        pass
 
 
 CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/components/vicare/binary_sensor.py
+++ b/homeassistant/components/vicare/binary_sensor.py
@@ -1,6 +1,7 @@
 """Viessmann ViCare sensor device."""
 import logging
 
+from PyViCare.PyViCare import PyViCareRateLimitError
 import requests
 
 from homeassistant.components.binary_sensor import (
@@ -11,11 +12,11 @@ from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 
 from . import (
     DOMAIN as VICARE_DOMAIN,
-    PYVICARE_ERROR,
     VICARE_API,
     VICARE_HEATING_TYPE,
     VICARE_NAME,
     HeatingType,
+    catch_not_supported,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,10 +30,6 @@ SENSOR_BURNER_ACTIVE = "burner_active"
 
 # heatpump sensors
 SENSOR_COMPRESSOR_ACTIVE = "compressor_active"
-SENSOR_HEATINGROD_OVERALL = "heatingrod_overall"
-SENSOR_HEATINGROD_LEVEL1 = "heatingrod_level1"
-SENSOR_HEATINGROD_LEVEL2 = "heatingrod_level2"
-SENSOR_HEATINGROD_LEVEL3 = "heatingrod_level3"
 
 SENSOR_TYPES = {
     SENSOR_CIRCULATION_PUMP_ACTIVE: {
@@ -52,26 +49,6 @@ SENSOR_TYPES = {
         CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
         CONF_GETTER: lambda api: api.getCompressorActive(),
     },
-    SENSOR_HEATINGROD_OVERALL: {
-        CONF_NAME: "Heating rod overall",
-        CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        CONF_GETTER: lambda api: api.getHeatingRodStatusOverall(),
-    },
-    SENSOR_HEATINGROD_LEVEL1: {
-        CONF_NAME: "Heating rod level 1",
-        CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        CONF_GETTER: lambda api: api.getHeatingRodStatusLevel1(),
-    },
-    SENSOR_HEATINGROD_LEVEL2: {
-        CONF_NAME: "Heating rod level 2",
-        CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        CONF_GETTER: lambda api: api.getHeatingRodStatusLevel2(),
-    },
-    SENSOR_HEATINGROD_LEVEL3: {
-        CONF_NAME: "Heating rod level 3",
-        CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        CONF_GETTER: lambda api: api.getHeatingRodStatusLevel3(),
-    },
 }
 
 SENSORS_GENERIC = [SENSOR_CIRCULATION_PUMP_ACTIVE]
@@ -80,10 +57,6 @@ SENSORS_BY_HEATINGTYPE = {
     HeatingType.gas: [SENSOR_BURNER_ACTIVE],
     HeatingType.heatpump: [
         SENSOR_COMPRESSOR_ACTIVE,
-        SENSOR_HEATINGROD_OVERALL,
-        SENSOR_HEATINGROD_LEVEL1,
-        SENSOR_HEATINGROD_LEVEL2,
-        SENSOR_HEATINGROD_LEVEL3,
     ],
     HeatingType.fuelcell: [SENSOR_BURNER_ACTIVE],
 }
@@ -126,7 +99,7 @@ class ViCareBinarySensor(BinarySensorEntity):
     @property
     def available(self):
         """Return True if entity is available."""
-        return self._state is not None and self._state != PYVICARE_ERROR
+        return self._state is not None
 
     @property
     def unique_id(self):
@@ -151,8 +124,11 @@ class ViCareBinarySensor(BinarySensorEntity):
     def update(self):
         """Update state of sensor."""
         try:
-            self._state = self._sensor[CONF_GETTER](self._api)
+            with catch_not_supported() as self._state:
+                self._state = self._sensor[CONF_GETTER](self._api)
         except requests.exceptions.ConnectionError:
             _LOGGER.error("Unable to retrieve data from ViCare server")
         except ValueError:
             _LOGGER.error("Unable to decode data from ViCare server")
+        except PyViCareRateLimitError as limit_exception:
+            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)

--- a/homeassistant/components/vicare/binary_sensor.py
+++ b/homeassistant/components/vicare/binary_sensor.py
@@ -1,7 +1,8 @@
 """Viessmann ViCare sensor device."""
+from contextlib import suppress
 import logging
 
-from PyViCare.PyViCare import PyViCareRateLimitError
+from PyViCare.PyViCare import PyViCareNotSupportedFeatureError, PyViCareRateLimitError
 import requests
 
 from homeassistant.components.binary_sensor import (
@@ -16,7 +17,6 @@ from . import (
     VICARE_HEATING_TYPE,
     VICARE_NAME,
     HeatingType,
-    catch_not_supported,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -124,7 +124,7 @@ class ViCareBinarySensor(BinarySensorEntity):
     def update(self):
         """Update state of sensor."""
         try:
-            with catch_not_supported() as self._state:
+            with suppress(PyViCareNotSupportedFeatureError):
                 self._state = self._sensor[CONF_GETTER](self._api)
         except requests.exceptions.ConnectionError:
             _LOGGER.error("Unable to retrieve data from ViCare server")

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -1,7 +1,8 @@
 """Viessmann ViCare climate device."""
+from contextlib import suppress
 import logging
 
-from PyViCare.PyViCare import PyViCareRateLimitError
+from PyViCare.PyViCare import PyViCareNotSupportedFeatureError, PyViCareRateLimitError
 import requests
 import voluptuous as vol
 
@@ -26,7 +27,6 @@ from . import (
     VICARE_HEATING_TYPE,
     VICARE_NAME,
     HeatingType,
-    catch_not_supported,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -138,11 +138,11 @@ class ViCareClimate(ClimateEntity):
         """Let HA know there has been an update from the ViCare API."""
         try:
             _room_temperature = None
-            with catch_not_supported() as _room_temperature:
+            with suppress(PyViCareNotSupportedFeatureError):
                 _room_temperature = self._api.getRoomTemperature()
 
             _supply_temperature = None
-            with catch_not_supported() as _supply_temperature:
+            with suppress(PyViCareNotSupportedFeatureError):
                 _supply_temperature = self._api.getSupplyTemperature()
 
             if _room_temperature is not None:
@@ -152,13 +152,13 @@ class ViCareClimate(ClimateEntity):
             else:
                 self._current_temperature = None
 
-            with catch_not_supported() as self._current_program:
+            with suppress(PyViCareNotSupportedFeatureError):
                 self._current_program = self._api.getActiveProgram()
 
-            with catch_not_supported() as self._target_temperature:
+            with suppress(PyViCareNotSupportedFeatureError):
                 self._target_temperature = self._api.getCurrentDesiredTemperature()
 
-            with catch_not_supported() as self._current_mode:
+            with suppress(PyViCareNotSupportedFeatureError):
                 self._current_mode = self._api.getActiveMode()
 
             # Update the generic device attributes
@@ -168,22 +168,22 @@ class ViCareClimate(ClimateEntity):
             self._attributes["active_vicare_program"] = self._current_program
             self._attributes["active_vicare_mode"] = self._current_mode
 
-            with catch_not_supported() as self._attributes["heating_curve_slope"]:
+            with suppress(PyViCareNotSupportedFeatureError):
                 self._attributes[
                     "heating_curve_slope"
                 ] = self._api.getHeatingCurveSlope()
 
-            with catch_not_supported() as self._attributes["heating_curve_shift"]:
+            with suppress(PyViCareNotSupportedFeatureError):
                 self._attributes[
                     "heating_curve_shift"
                 ] = self._api.getHeatingCurveShift()
 
             # Update the specific device attributes
             if self._heating_type == HeatingType.gas:
-                with catch_not_supported() as self._current_action:
+                with suppress(PyViCareNotSupportedFeatureError):
                     self._current_action = self._api.getBurnerActive()
             elif self._heating_type == HeatingType.heatpump:
-                with catch_not_supported() as self._current_action:
+                with suppress(PyViCareNotSupportedFeatureError):
                     self._current_action = self._api.getCompressorActive()
         except requests.exceptions.ConnectionError:
             _LOGGER.error("Unable to retrieve data from ViCare server")

--- a/homeassistant/components/vicare/manifest.json
+++ b/homeassistant/components/vicare/manifest.json
@@ -3,6 +3,6 @@
   "name": "Viessmann ViCare",
   "documentation": "https://www.home-assistant.io/integrations/vicare",
   "codeowners": ["@oischinger"],
-  "requirements": ["PyViCare==0.2.5"],
+  "requirements": ["PyViCare==1.0.0"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -1,6 +1,7 @@
 """Viessmann ViCare sensor device."""
 import logging
 
+from PyViCare.PyViCare import PyViCareRateLimitError
 import requests
 
 from homeassistant.components.sensor import SensorEntity
@@ -21,11 +22,11 @@ from homeassistant.const import (
 
 from . import (
     DOMAIN as VICARE_DOMAIN,
-    PYVICARE_ERROR,
     VICARE_API,
     VICARE_HEATING_TYPE,
     VICARE_NAME,
     HeatingType,
+    catch_not_supported,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -350,7 +351,7 @@ class ViCareSensor(SensorEntity):
     @property
     def available(self):
         """Return True if entity is available."""
-        return self._state is not None and self._state != PYVICARE_ERROR
+        return self._state is not None
 
     @property
     def unique_id(self):
@@ -385,8 +386,11 @@ class ViCareSensor(SensorEntity):
     def update(self):
         """Update state of sensor."""
         try:
-            self._state = self._sensor[CONF_GETTER](self._api)
+            with catch_not_supported() as self._state:
+                self._state = self._sensor[CONF_GETTER](self._api)
         except requests.exceptions.ConnectionError:
             _LOGGER.error("Unable to retrieve data from ViCare server")
         except ValueError:
             _LOGGER.error("Unable to decode data from ViCare server")
+        except PyViCareRateLimitError as limit_exception:
+            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -1,7 +1,8 @@
 """Viessmann ViCare sensor device."""
+from contextlib import suppress
 import logging
 
-from PyViCare.PyViCare import PyViCareRateLimitError
+from PyViCare.PyViCare import PyViCareNotSupportedFeatureError, PyViCareRateLimitError
 import requests
 
 from homeassistant.components.sensor import SensorEntity
@@ -26,7 +27,6 @@ from . import (
     VICARE_HEATING_TYPE,
     VICARE_NAME,
     HeatingType,
-    catch_not_supported,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -386,7 +386,7 @@ class ViCareSensor(SensorEntity):
     def update(self):
         """Update state of sensor."""
         try:
-            with catch_not_supported() as self._state:
+            with suppress(PyViCareNotSupportedFeatureError):
                 self._state = self._sensor[CONF_GETTER](self._api)
         except requests.exceptions.ConnectionError:
             _LOGGER.error("Unable to retrieve data from ViCare server")

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -1,7 +1,8 @@
 """Viessmann ViCare water_heater device."""
+from contextlib import suppress
 import logging
 
-from PyViCare.PyViCare import PyViCareRateLimitError
+from PyViCare.PyViCare import PyViCareNotSupportedFeatureError, PyViCareRateLimitError
 import requests
 
 from homeassistant.components.water_heater import (
@@ -10,13 +11,7 @@ from homeassistant.components.water_heater import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, TEMP_CELSIUS
 
-from . import (
-    DOMAIN as VICARE_DOMAIN,
-    VICARE_API,
-    VICARE_HEATING_TYPE,
-    VICARE_NAME,
-    catch_not_supported,
-)
+from . import DOMAIN as VICARE_DOMAIN, VICARE_API, VICARE_HEATING_TYPE, VICARE_NAME
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,17 +77,17 @@ class ViCareWater(WaterHeaterEntity):
     def update(self):
         """Let HA know there has been an update from the ViCare API."""
         try:
-            with catch_not_supported() as self._current_temperature:
+            with suppress(PyViCareNotSupportedFeatureError):
                 self._current_temperature = (
                     self._api.getDomesticHotWaterStorageTemperature()
                 )
 
-            with catch_not_supported() as self._target_temperature:
+            with suppress(PyViCareNotSupportedFeatureError):
                 self._target_temperature = (
                     self._api.getDomesticHotWaterConfiguredTemperature()
                 )
 
-            with catch_not_supported() as self._current_mode:
+            with suppress(PyViCareNotSupportedFeatureError):
                 self._current_mode = self._api.getActiveMode()
 
         except requests.exceptions.ConnectionError:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -61,7 +61,7 @@ PyTransportNSW==0.1.1
 PyTurboJPEG==1.5.0
 
 # homeassistant.components.vicare
-PyViCare==0.2.5
+PyViCare==1.0.0
 
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.13.4


### PR DESCRIPTION
PyVicare 1.0 uses the official API from Viessmann for controlling their devices.
PyVicare < 1.0 is not working anymore since Viessmann blocked all unauthorized access.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Viessmann introduced a new API to control their devices. The original (inofficial API) was shut down which renders the Home Assistant integration useless. This change restores the integration by upgrading to PyViCare 1.0.0.
This involves adding a new client_id parameter. It must be set with an API key from the Viessmann developer portal.

Please register and create your private API key. Follow these steps to create your API key:

1. Register and login in the [Viessmann Developer Portal](https://developer.viessmann.com).
2. In the menu navigate to API Keys.
3. Create a new OAuth client using following data:
```
Name: PyViCare
Google reCAPTCHA: Disabled
Redirect URIs: vicare://oauth-callback/everest
```
4. Copy the Client ID to the configuration, e.g.
`client_id="XXXXXXXXXXXXXX"`

Please not that not all previous properties are available in the new API. Missing properties were removed and might be added later if they are available again.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update to PyVicare 1.x and introduce a new mandatory config option client_id

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51960 #53074
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
