### PR TITLE
Re-configuration possibilities for Synology DSM

### DIFF
--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -309,13 +309,12 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
 
     def _async_get_existing_entry(self, discovered_mac: str) -> ConfigEntry | None:
         """See if we already have a configured NAS with this MAC address."""
-        existing_entry: ConfigEntry | None = None
         for entry in self._async_current_entries():
             if discovered_mac in [
                 mac.replace("-", "") for mac in entry.data.get(CONF_MAC, [])
             ]:
-                existing_entry = entry
-        return existing_entry
+                return entry
+        return None
 
 
 class SynologyDSMOptionsFlowHandler(OptionsFlow):

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -228,14 +228,14 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input.get(CONF_VOLUMES):
             config_data[CONF_VOLUMES] = user_input[CONF_VOLUMES]
 
-        if existing_entry and self.reauth_conf:
+        if existing_entry:
             self.hass.config_entries.async_update_entry(
                 existing_entry, data=config_data
             )
             await self.hass.config_entries.async_reload(existing_entry.entry_id)
-            return self.async_abort(reason="reauth_successful")
-        if existing_entry:
-            return self.async_abort(reason="already_configured")
+            if self.reauth_conf:
+                return self.async_abort(reason="reauth_successful")
+            return self.async_abort(reason="reconfigure_successful")
 
         return self.async_create_entry(title=host, data=config_data)
 

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -251,7 +251,7 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
         # The serial of the NAS is actually its MAC address.
 
         existing_entry: ConfigEntry | None = None
-        for entry in self.hass.config_entries.async_entries(DOMAIN):
+        for entry in self._async_current_entries():
             if discovered_mac in [
                 mac.replace("-", "") for mac in entry.data.get(CONF_MAC, [])
             ]:

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -250,12 +250,7 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
         # Synology NAS can broadcast on multiple IP addresses, since they can be connected to multiple ethernets.
         # The serial of the NAS is actually its MAC address.
 
-        existing_entry: ConfigEntry | None = None
-        for entry in self._async_current_entries():
-            if discovered_mac in [
-                mac.replace("-", "") for mac in entry.data.get(CONF_MAC, [])
-            ]:
-                existing_entry = entry
+        existing_entry = self._async_get_existing_entry(discovered_mac)
 
         if existing_entry and existing_entry.data[CONF_HOST] != parsed_url.hostname:
             _LOGGER.debug(
@@ -311,6 +306,16 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
         self.saved_user_input = {}
 
         return await self.async_step_user(user_input)
+
+    def _async_get_existing_entry(self, discovered_mac: str) -> ConfigEntry | None:
+        """See if we already have a configured NAS with this MAC address."""
+        existing_entry: ConfigEntry | None = None
+        for entry in self._async_current_entries():
+            if discovered_mac in [
+                mac.replace("-", "") for mac in entry.data.get(CONF_MAC, [])
+            ]:
+                existing_entry = entry
+        return existing_entry
 
 
 class SynologyDSMOptionsFlowHandler(OptionsFlow):

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -48,7 +48,8 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "Re-configuration was successful"
     }
   },
   "options": {

--- a/homeassistant/components/synology_dsm/translations/de.json
+++ b/homeassistant/components/synology_dsm/translations/de.json
@@ -2,7 +2,8 @@
     "config": {
         "abort": {
             "already_configured": "Ger\u00e4t ist bereits konfiguriert",
-            "reauth_successful": "Die erneute Authentifizierung war erfolgreich"
+            "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
+            "reconfigure_successful": "Die Anpassung der Konfiguration war erfolgreich"
         },
         "error": {
             "cannot_connect": "Verbindung fehlgeschlagen",

--- a/homeassistant/components/synology_dsm/translations/en.json
+++ b/homeassistant/components/synology_dsm/translations/en.json
@@ -2,7 +2,8 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
-            "reauth_successful": "Re-authentication was successful"
+            "reauth_successful": "Re-authentication was successful",
+            "reconfigure_successful": "Re-configuration was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -305,22 +305,29 @@ async def test_reauth(hass: HomeAssistant, service: MagicMock):
         assert result["reason"] == "reauth_successful"
 
 
-async def test_abort_if_already_setup(hass: HomeAssistant, service: MagicMock):
-    """Test we abort if the account is already setup."""
+async def test_reconfig_user(hass: HomeAssistant, service: MagicMock):
+    """Test re-configuration of already existing entry by user."""
     MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_HOST: HOST, CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+        data={
+            CONF_HOST: "wrong_host",
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
         unique_id=SERIAL,
     ).add_to_hass(hass)
 
-    # Should fail, same HOST:PORT (flow)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_HOST: HOST, CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data={CONF_HOST: HOST, CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "reconfigure_successful"
 
 
 async def test_login_failed(hass: HomeAssistant, service: MagicMock):
@@ -379,14 +386,14 @@ async def test_missing_data_after_login(hass: HomeAssistant, service_failed: Mag
     assert result["errors"] == {"base": "missing_data"}
 
 
-async def test_form_ssdp_already_configured(hass: HomeAssistant, service: MagicMock):
-    """Test ssdp abort when the serial number is already configured."""
+async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
+    """Test re-configuration of already existing entry by ssdp."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_HOST: HOST,
+            CONF_HOST: "wrong_host",
             CONF_USERNAME: USERNAME,
             CONF_PASSWORD: PASSWORD,
             CONF_MAC: MACS,
@@ -404,6 +411,7 @@ async def test_form_ssdp_already_configured(hass: HomeAssistant, service: MagicM
         },
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "reconfigure_successful"
 
 
 async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -386,34 +386,6 @@ async def test_missing_data_after_login(hass: HomeAssistant, service_failed: Mag
     assert result["errors"] == {"base": "missing_data"}
 
 
-async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
-    """Test re-configuration of already existing entry by ssdp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_HOST: "wrong_host",
-            CONF_USERNAME: USERNAME,
-            CONF_PASSWORD: PASSWORD,
-            CONF_MAC: MACS,
-        },
-        unique_id=SERIAL,
-    ).add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_SSDP},
-        data={
-            ssdp.ATTR_SSDP_LOCATION: "http://192.168.1.5:5000",
-            ssdp.ATTR_UPNP_FRIENDLY_NAME: "mydsm",
-            ssdp.ATTR_UPNP_SERIAL: "001132XXXX59",  # Existing in MACS[0], but SSDP does not have `-`
-        },
-    )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "reconfigure_successful"
-
-
 async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):
     """Test we can setup from ssdp."""
     await setup.async_setup_component(hass, "persistent_notification", {})
@@ -448,6 +420,62 @@ async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):
     assert result["data"].get("device_token") is None
     assert result["data"].get(CONF_DISKS) is None
     assert result["data"].get(CONF_VOLUMES) is None
+
+
+async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
+    """Test re-configuration of already existing entry by ssdp."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "wrong_host",
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_MAC: MACS,
+        },
+        unique_id=SERIAL,
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data={
+            ssdp.ATTR_SSDP_LOCATION: "http://192.168.1.5:5000",
+            ssdp.ATTR_UPNP_FRIENDLY_NAME: "mydsm",
+            ssdp.ATTR_UPNP_SERIAL: "001132XXXX59",  # Existing in MACS[0], but SSDP does not have `-`
+        },
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+async def test_existing_ssdp(hass: HomeAssistant, service: MagicMock):
+    """Test abort of already existing entry by ssdp."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.5",
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_MAC: MACS,
+        },
+        unique_id=SERIAL,
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data={
+            ssdp.ATTR_SSDP_LOCATION: "http://192.168.1.5:5000",
+            ssdp.ATTR_UPNP_FRIENDLY_NAME: "mydsm",
+            ssdp.ATTR_UPNP_SERIAL: "001132XXXX59",  # Existing in MACS[0], but SSDP does not have `-`
+        },
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
 
 
 async def test_options_flow(hass: HomeAssistant, service: MagicMock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With this when adding a new configuration, it is checked if there is an already existing configuration entry (_identified by serial number_) than this will be proper updated with new given configuration and reloaded, instead of creating a new entry.
Furthermore, when via SSDP an as new supposed NAS is detected, but an corresponding configuration entry (_again identified by serial number_) is found, than the existing entry will be updated (_only host field_)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51352
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
