### PR TITLE
Use NamedTuple - epsonworkforce

### DIFF
--- a/homeassistant/components/epsonworkforce/sensor.py
+++ b/homeassistant/components/epsonworkforce/sensor.py
@@ -1,5 +1,8 @@
 """Support for Epson Workforce Printer."""
+from __future__ import annotations
+
 from datetime import timedelta
+from typing import NamedTuple
 
 from epsonprinter_pkg.epsonprinterapi import EpsonPrinterAPI
 import voluptuous as vol
@@ -9,13 +12,46 @@ from homeassistant.const import CONF_HOST, CONF_MONITORED_CONDITIONS, PERCENTAGE
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
-MONITORED_CONDITIONS = {
-    "black": ["Ink level Black", PERCENTAGE, "mdi:water"],
-    "photoblack": ["Ink level Photoblack", PERCENTAGE, "mdi:water"],
-    "magenta": ["Ink level Magenta", PERCENTAGE, "mdi:water"],
-    "cyan": ["Ink level Cyan", PERCENTAGE, "mdi:water"],
-    "yellow": ["Ink level Yellow", PERCENTAGE, "mdi:water"],
-    "clean": ["Cleaning level", PERCENTAGE, "mdi:water"],
+
+class MonitoredConditionsMetadata(NamedTuple):
+    """Metadata for an individual montiored condition."""
+
+    name: str
+    icon: str
+    unit_of_measurement: str
+
+
+MONITORED_CONDITIONS: dict[str, MonitoredConditionsMetadata] = {
+    "black": MonitoredConditionsMetadata(
+        "Ink level Black",
+        icon="mdi:water",
+        unit_of_measurement=PERCENTAGE,
+    ),
+    "photoblack": MonitoredConditionsMetadata(
+        "Ink level Photoblack",
+        icon="mdi:water",
+        unit_of_measurement=PERCENTAGE,
+    ),
+    "magenta": MonitoredConditionsMetadata(
+        "Ink level Magenta",
+        icon="mdi:water",
+        unit_of_measurement=PERCENTAGE,
+    ),
+    "cyan": MonitoredConditionsMetadata(
+        "Ink level Cyan",
+        icon="mdi:water",
+        unit_of_measurement=PERCENTAGE,
+    ),
+    "yellow": MonitoredConditionsMetadata(
+        "Ink level Yellow",
+        icon="mdi:water",
+        unit_of_measurement=PERCENTAGE,
+    ),
+    "clean": MonitoredConditionsMetadata(
+        "Cleaning level",
+        icon="mdi:water",
+        unit_of_measurement=PERCENTAGE,
+    ),
 }
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -52,24 +88,10 @@ class EpsonPrinterCartridge(SensorEntity):
         self._api = api
 
         self._id = cartridgeidx
-        self._name = MONITORED_CONDITIONS[self._id][0]
-        self._unit = MONITORED_CONDITIONS[self._id][1]
-        self._icon = MONITORED_CONDITIONS[self._id][2]
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return self._icon
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit the value is expressed in."""
-        return self._unit
+        metadata = MONITORED_CONDITIONS[self._id]
+        self._attr_name = metadata.name
+        self._attr_icon = metadata.icon
+        self._attr_unit_of_measurement = metadata.unit_of_measurement
 
     @property
     def state(self):


### PR DESCRIPTION
## Proposed change
Update `epsonworkforce` to use NamedTuple for sensor metadata.
-> #53201

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
