### PR TITLE
Add a homekit.unpair service to forcefully remove pairings

### DIFF
--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -99,6 +99,7 @@ HOMEKIT_MODES = [HOMEKIT_MODE_BRIDGE, HOMEKIT_MODE_ACCESSORY]
 # #### HomeKit Component Services ####
 SERVICE_HOMEKIT_START = "start"
 SERVICE_HOMEKIT_RESET_ACCESSORY = "reset_accessory"
+SERVICE_HOMEKIT_UNPAIR = "unpair"
 
 # #### String Constants ####
 BRIDGE_MODEL = "Bridge"

--- a/homeassistant/components/homekit/services.yaml
+++ b/homeassistant/components/homekit/services.yaml
@@ -14,3 +14,9 @@ reset_accessory:
   target:
     entity: {}
 
+unpair:
+  name: Unpair an accessory or bridge
+  description: Forcefully remove all pairings from an accessory to allow re-pairing. Use this service if the accessory is no longer responsive, and you want to avoid deleting and re-adding the entry. Room locations, and accessory preferences will be lost.
+  target:
+    device:
+      integration: homekit

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -35,11 +35,13 @@ from homeassistant.components.homekit.const import (
     HOMEKIT_MODE_BRIDGE,
     SERVICE_HOMEKIT_RESET_ACCESSORY,
     SERVICE_HOMEKIT_START,
+    SERVICE_HOMEKIT_UNPAIR,
 )
 from homeassistant.components.homekit.util import get_persist_fullpath_for_entry_id
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
+    ATTR_DEVICE_ID,
     ATTR_ENTITY_ID,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_IP_ADDRESS,
@@ -52,7 +54,7 @@ from homeassistant.const import (
     SERVICE_RELOAD,
     STATE_ON,
 )
-from homeassistant.core import State
+from homeassistant.core import HomeAssistantError, State
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.entityfilter import (
     CONF_EXCLUDE_DOMAINS,
@@ -666,6 +668,126 @@ async def test_homekit_reset_accessories(hass, mock_zeroconf):
         assert hk_driver_config_changed.call_count == 2
         assert mock_add_accessory.called
         homekit.status = STATUS_READY
+
+
+async def test_homekit_unpair(hass, device_reg, mock_zeroconf):
+    """Test unpairing HomeKit accessories."""
+    await async_setup_component(hass, "persistent_notification", {})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
+    )
+    entity_id = "light.demo"
+    hass.states.async_set("light.demo", "on")
+    homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE)
+
+    with patch(f"{PATH_HOMEKIT}.HomeKit", return_value=homekit), patch(
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
+    ):
+        await async_init_entry(hass, entry)
+
+        acc_mock = MagicMock()
+        acc_mock.entity_id = entity_id
+        aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
+        homekit.bridge.accessories = {aid: acc_mock}
+        homekit.status = STATUS_RUNNING
+
+        state = homekit.driver.state
+        state.paired_clients = {"client1": "any"}
+        formatted_mac = device_registry.format_mac(state.mac)
+        hk_bridge_dev = device_reg.async_get_device(
+            {}, {(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)}
+        )
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_HOMEKIT_UNPAIR,
+            {ATTR_DEVICE_ID: hk_bridge_dev.id},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert state.paired_clients == {}
+        homekit.status = STATUS_STOPPED
+
+
+async def test_homekit_unpair_missing_device_id(hass, device_reg, mock_zeroconf):
+    """Test unpairing HomeKit accessories with invalid device id."""
+    await async_setup_component(hass, "persistent_notification", {})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
+    )
+    entity_id = "light.demo"
+    hass.states.async_set("light.demo", "on")
+    homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE)
+
+    with patch(f"{PATH_HOMEKIT}.HomeKit", return_value=homekit), patch(
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
+    ):
+        await async_init_entry(hass, entry)
+
+        acc_mock = MagicMock()
+        acc_mock.entity_id = entity_id
+        aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
+        homekit.bridge.accessories = {aid: acc_mock}
+        homekit.status = STATUS_RUNNING
+
+        state = homekit.driver.state
+        state.paired_clients = {"client1": "any"}
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_HOMEKIT_UNPAIR,
+                {ATTR_DEVICE_ID: "notvalid"},
+                blocking=True,
+            )
+        await hass.async_block_till_done()
+        state.paired_clients = {"client1": "any"}
+        homekit.status = STATUS_STOPPED
+
+
+async def test_homekit_unpair_not_homekit_device(hass, device_reg, mock_zeroconf):
+    """Test unpairing HomeKit accessories with a non-homekit device id."""
+    await async_setup_component(hass, "persistent_notification", {})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
+    )
+    not_homekit_entry = MockConfigEntry(
+        domain="not_homekit", data={CONF_NAME: "mock_name", CONF_PORT: 12345}
+    )
+    entity_id = "light.demo"
+    hass.states.async_set("light.demo", "on")
+    homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE)
+
+    with patch(f"{PATH_HOMEKIT}.HomeKit", return_value=homekit), patch(
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
+    ):
+        await async_init_entry(hass, entry)
+
+        acc_mock = MagicMock()
+        acc_mock.entity_id = entity_id
+        aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
+        homekit.bridge.accessories = {aid: acc_mock}
+        homekit.status = STATUS_RUNNING
+
+        device_entry = device_reg.async_get_or_create(
+            config_entry_id=not_homekit_entry.entry_id,
+            sw_version="0.16.0",
+            model="Powerwall 2",
+            manufacturer="Tesla",
+            connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        )
+
+        state = homekit.driver.state
+        state.paired_clients = {"client1": "any"}
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_HOMEKIT_UNPAIR,
+                {ATTR_DEVICE_ID: device_entry.id},
+                blocking=True,
+            )
+        await hass.async_block_till_done()
+        state.paired_clients = {"client1": "any"}
+        homekit.status = STATUS_STOPPED
 
 
 async def test_homekit_reset_accessories_not_supported(hass, mock_zeroconf):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a homekit.unpair service to forcefully remove pairings

- Sometimes homekit will go unresponsive because a pairing for a specific
  device is missing. To avoid deleting the config entry and recreating
  it, which can be a painful process if there are many bridged entities,
  the homekit.unpair service allows forceful removal of the pairings so
  the accessory can be paired again.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18577

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
