### PR TITLE
Broadlink, remove attr_current_power_w and add sensor

### DIFF
--- a/homeassistant/components/broadlink/const.py
+++ b/homeassistant/components/broadlink/const.py
@@ -7,7 +7,13 @@ DOMAIN = "broadlink"
 
 DOMAINS_AND_TYPES = {
     REMOTE_DOMAIN: {"RM4MINI", "RM4PRO", "RMMINI", "RMMINIB", "RMPRO"},
-    SENSOR_DOMAIN: {"A1", "RM4MINI", "RM4PRO", "RMPRO"},
+    SENSOR_DOMAIN: {
+        "A1",
+        "RM4MINI",
+        "RM4PRO",
+        "RMPRO",
+        "SP2",
+    },
     SWITCH_DOMAIN: {
         "BG1",
         "MP1",

--- a/homeassistant/components/broadlink/const.py
+++ b/homeassistant/components/broadlink/const.py
@@ -13,6 +13,9 @@ DOMAINS_AND_TYPES = {
         "RM4PRO",
         "RMPRO",
         "SP2",
+        "SP3S",
+        "SP4",
+        "SP4B",
     },
     SWITCH_DOMAIN: {
         "BG1",

--- a/homeassistant/components/broadlink/const.py
+++ b/homeassistant/components/broadlink/const.py
@@ -12,7 +12,7 @@ DOMAINS_AND_TYPES = {
         "RM4MINI",
         "RM4PRO",
         "RMPRO",
-        "SP2",
+        "SP2S",
         "SP3S",
         "SP4",
         "SP4B",

--- a/homeassistant/components/broadlink/sensor.py
+++ b/homeassistant/components/broadlink/sensor.py
@@ -6,12 +6,13 @@ import voluptuous as vol
 from homeassistant.components.sensor import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
     PLATFORM_SCHEMA,
     STATE_CLASS_MEASUREMENT,
     SensorEntity,
 )
-from homeassistant.const import CONF_HOST, PERCENTAGE, TEMP_CELSIUS
+from homeassistant.const import CONF_HOST, PERCENTAGE, POWER_WATT, TEMP_CELSIUS
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
@@ -37,6 +38,12 @@ SENSOR_TYPES = {
     ),
     "light": ("Light", None, DEVICE_CLASS_ILLUMINANCE, None),
     "noise": ("Noise", None, None, None),
+    "power": (
+        "Current power",
+        POWER_WATT,
+        DEVICE_CLASS_POWER,
+        STATE_CLASS_MEASUREMENT,
+    ),
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -232,14 +232,12 @@ class BroadlinkSP2Switch(BroadlinkSP1Switch):
         """Initialize the switch."""
         super().__init__(device, *args, **kwargs)
         self._attr_is_on = self._coordinator.data["pwr"]
-        self._attr_current_power_w = self._coordinator.data.get("power")
 
     @callback
     def update_data(self):
         """Update data."""
         if self._coordinator.last_update_success:
             self._attr_is_on = self._coordinator.data["pwr"]
-            self._attr_current_power_w = self._coordinator.data.get("power")
         self.async_write_ha_state()
 
 


### PR DESCRIPTION
 Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

 <!--
   You are amazing! Thanks for contributing to our project!
   Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
 -->
 ## Breaking change
 <!--
   If your PR contains a breaking change for existing users, it is important
   to tell them what breaks, how to make it work again and why we did this.
   This piece of text is published with the release notes, so it helps if you
   write it towards our users, not us.
   Note: Remove this section if this PR is NOT a breaking change.
 -->
 Broadlink, remove attr_current_power_w and add sensor. The dedicated sensor needs to be used from now on.

 ## Proposed change
 <!--
   Describe the big picture of your changes here to communicate to the
   maintainers why we should accept this pull request. If it fixes a bug
   or resolves a feature request, be sure to link to that issue in the
   additional information section.
 -->
 Broadlink, remove attr_current_power_w and add sensor

I do not have any of these switches, so not able to test this.
@felipediel  Could you have a look?
#53308

 ## Type of change
 <!--
   What type of change does your PR introduce to Home Assistant?
   NOTE: Please, check only 1! box!
   If your PR requires multiple boxes to be checked, you'll most likely need to
   split it into multiple PRs. This makes things easier and faster to code review.
 -->

 - [ ] Dependency upgrade
 - [ ] Bugfix (non-breaking change which fixes an issue)
 - [ ] New integration (thank you!)
 - [ ] New feature (which adds functionality to an existing integration)
 - [x] Breaking change (fix/feature causing existing functionality to break)
 - [ ] Code quality improvements to existing code or addition of tests

 ## Additional information
 <!--
   Details are important, and help maintainers processing your PR.
   Please be sure to fill out additional details, if applicable.
 -->

 - This PR fixes or closes issue: fixes #53308
 - This PR is related to issue: #
 - Link to documentation pull request: 

 ## Checklist
 <!--
   Put an `x` in the boxes that apply. You can also fill these out after
   creating the PR. If you're unsure about any of them, don't hesitate to ask.
   We're here to help! This is simply a reminder of what we are going to look
   for before merging your code.
 -->

 - [ ] The code change is tested and works locally.
 - [x] Local tests pass. **Your PR cannot be merged unless tests pass**
 - [x] There is no commented out code in this PR.
 - [x] I have followed the [development checklist][dev-checklist]
 - [x] The code has been formatted using Black (`black --fast homeassistant tests`)
 - [ ] Tests have been added to verify that the new code works.

 If user exposed functionality or configuration variables are added/changed:

 - [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

 If the code communicates with devices, web services, or third-party tools:

 - [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
       Updated and included derived files by running: `python3 -m script.hassfest`.
 - [ ] New or updated dependencies have been added to `requirements_all.txt`.  
       Updated by running `python3 -m script.gen_requirements_all`.
 - [ ] Untested files have been added to `.coveragerc`.

 The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
 <!--
   The Integration Quality Scale scores an integration on the code quality
   and user experience. Each level of the quality scale consists of a list
   of requirements. We highly recommend getting your integration scored!
 -->

 - [ ] No score or internal
 - [ ] 🥈 Silver
 - [ ] 🥇 Gold
 - [ ] 🏆 Platinum

 <!--
   This project is very active and we have a high turnover of pull requests.

   Unfortunately, the number of incoming pull requests is higher than what our
   reviewers can review and merge so there is a long backlog of pull requests
   waiting for review. You can help here!
   
   By reviewing another pull request, you will help raise the code quality of
   that pull request and the final review will be faster. This way the general
   pace of pull request reviews will go up and your wait time will go down.
   
   When picking a pull request to review, try to choose one that hasn't yet
   been reviewed.

   Thanks for helping out!
 -->

 To help with the load of incoming pull requests:

 - [ ] I have reviewed two other [open pull requests][prs] in this repository.

 [prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

 <!--
   Thank you for contributing <3

   Below, some useful links you could explore:
 -->
 [dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
 [manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
 [quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
 [docs-repository]: https://github.com/home-assistant/home-assistant.io
