### PR TITLE
Ignore Sonos Boost devices during discovery v2

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 from soco import events_asyncio
 import soco.config as soco_config
 from soco.core import SoCo
-from soco.exceptions import SoCoException
+from soco.exceptions import NotSupportedException, SoCoException
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -87,6 +87,7 @@ class SonosData:
         self.alarms: dict[str, SonosAlarms] = {}
         self.topology_condition = asyncio.Condition()
         self.hosts_heartbeat = None
+        self.discovery_ignored: set[str] = set()
         self.discovery_known: set[str] = set()
         self.boot_counts: dict[str, int] = {}
 
@@ -137,21 +138,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-def _create_soco(ip_address: str, source: SoCoCreationSource) -> SoCo | None:
-    """Create a soco instance and return if successful."""
-    try:
-        soco = SoCo(ip_address)
-        # Ensure that the player is available and UID is cached
-        _ = soco.uid
-        _ = soco.volume
-        return soco
-    except (OSError, SoCoException) as ex:
-        _LOGGER.warning(
-            "Failed to connect to %s player '%s': %s", source.value, ip_address, ex
-        )
-    return None
-
-
 class SonosDiscoveryManager:
     """Manage sonos discovery."""
 
@@ -164,6 +150,26 @@ class SonosDiscoveryManager:
         self.data = data
         self.hosts = hosts
         self.discovery_lock = asyncio.Lock()
+
+    def _create_soco(self, ip_address: str, source: SoCoCreationSource) -> SoCo | None:
+        """Create a soco instance and return if successful."""
+        if ip_address in self.data.discovery_ignored:
+            return None
+
+        try:
+            soco = SoCo(ip_address)
+            # Ensure that the player is available and UID is cached
+            uid = soco.uid
+            _ = soco.volume
+            return soco
+        except NotSupportedException as exc:
+            _LOGGER.debug("Device %s is not supported, ignoring: %s", uid, exc)
+            self.data.discovery_ignored.add(ip_address)
+        except (OSError, SoCoException) as ex:
+            _LOGGER.warning(
+                "Failed to connect to %s player '%s': %s", source.value, ip_address, ex
+            )
+        return None
 
     async def _async_stop_event_listener(self, event: Event) -> None:
         await asyncio.gather(
@@ -213,7 +219,7 @@ class SonosDiscoveryManager:
             if known_uid:
                 dispatcher_send(self.hass, f"{SONOS_SEEN}-{known_uid}")
             else:
-                soco = _create_soco(ip_addr, SoCoCreationSource.CONFIGURED)
+                soco = self._create_soco(ip_addr, SoCoCreationSource.CONFIGURED)
                 if soco and soco.is_visible:
                     self._discovered_player(soco)
 
@@ -222,7 +228,7 @@ class SonosDiscoveryManager:
         )
 
     def _discovered_ip(self, ip_address):
-        soco = _create_soco(ip_address, SoCoCreationSource.DISCOVERED)
+        soco = self._create_soco(ip_address, SoCoCreationSource.DISCOVERED)
         if soco and soco.is_visible:
             self._discovered_player(soco)
 
@@ -238,7 +244,7 @@ class SonosDiscoveryManager:
             if boot_seqnum and boot_seqnum > self.data.boot_counts[uid]:
                 self.data.boot_counts[uid] = boot_seqnum
                 if soco := await self.hass.async_add_executor_job(
-                    _create_soco, discovered_ip, SoCoCreationSource.REBOOTED
+                    self._create_soco, discovered_ip, SoCoCreationSource.REBOOTED
                 ):
                     async_dispatcher_send(self.hass, f"{SONOS_REBOOTED}-{uid}", soco)
             else:

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sonos",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sonos",
-  "requirements": ["soco==0.23.1"],
+  "requirements": ["soco==0.23.2"],
   "dependencies": ["ssdp"],
   "after_dependencies": ["plex", "zeroconf"],
   "zeroconf": ["_sonos._tcp.local."],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2148,7 +2148,7 @@ smhi-pkg==1.0.15
 snapcast==2.1.3
 
 # homeassistant.components.sonos
-soco==0.23.1
+soco==0.23.2
 
 # homeassistant.components.solaredge_local
 solaredge-local==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1177,7 +1177,7 @@ smarthab==0.21
 smhi-pkg==1.0.15
 
 # homeassistant.components.sonos
-soco==0.23.1
+soco==0.23.2
 
 # homeassistant.components.solaredge
 solaredge==0.0.2

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1,8 +1,8 @@
 """Tests for the Sonos Media Player platform."""
 from unittest.mock import PropertyMock
 
-from pysonos.exceptions import NotSupportedException
 import pytest
+from soco.exceptions import NotSupportedException
 
 from homeassistant.components.sonos import DATA_SONOS, DOMAIN, media_player
 from homeassistant.const import STATE_IDLE

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1,4 +1,7 @@
 """Tests for the Sonos Media Player platform."""
+from unittest.mock import PropertyMock
+
+from pysonos.exceptions import NotSupportedException
 import pytest
 
 from homeassistant.components.sonos import DATA_SONOS, DOMAIN, media_player
@@ -38,6 +41,16 @@ async def test_async_setup_entry_discover(hass, config_entry, discover):
 
     media_player = hass.states.get("media_player.zone_a")
     assert media_player.state == STATE_IDLE
+
+
+async def test_discovery_ignore_unsupported_device(hass, config_entry, soco, caplog):
+    """Test discovery setup."""
+    message = f"GetVolume not supported on {soco.ip_address}"
+    type(soco).volume = PropertyMock(side_effect=NotSupportedException(message))
+    await setup_platform(hass, config_entry, {})
+
+    assert message in caplog.text
+    assert not hass.data[DATA_SONOS].discovered
 
 
 async def test_services(hass, config_entry, config, hass_read_only_user):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Uses a new feature in the `pysonos` library to detect Sonos Boost devices, which do not support volume reporting. These started to appear when switching to the new SSDP/Zeroconf discovery methods instead of the one provided by `pysonos`.

A previous PR (#52845) tried to avoid connecting to Boost devices, but the discovery payloads sometimes do not contain enough information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52716
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
