### PR TITLE
Ensure PyPI packages can still be installed on high latency connections

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -14,6 +14,7 @@ import homeassistant.util.package as pkg_util
 
 # mypy: disallow-any-generics
 
+PIP_TIMEOUT = "60"  # The default is too low when the internet connection is satellite or high latency
 DATA_PIP_LOCK = "pip_lock"
 DATA_PKG_CACHE = "pkg_cache"
 DATA_INTEGRATIONS_WITH_REQS = "integrations_with_reqs"
@@ -169,6 +170,7 @@ def pip_kwargs(config_dir: str | None) -> dict[str, Any]:
     kwargs = {
         "constraints": os.path.join(os.path.dirname(__file__), CONSTRAINT_FILE),
         "no_cache_dir": is_docker,
+        "timeout": PIP_TIMEOUT,
     }
     if "WHEELS_LINKS" in os.environ:
         kwargs["find_links"] = os.environ["WHEELS_LINKS"]

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -14,7 +14,7 @@ import homeassistant.util.package as pkg_util
 
 # mypy: disallow-any-generics
 
-PIP_TIMEOUT = "60"  # The default is too low when the internet connection is satellite or high latency
+PIP_TIMEOUT = 60  # The default is too low when the internet connection is satellite or high latency
 DATA_PIP_LOCK = "pip_lock"
 DATA_PKG_CACHE = "pkg_cache"
 DATA_INTEGRATIONS_WITH_REQS = "integrations_with_reqs"

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -63,6 +63,7 @@ def install_package(
     target: str | None = None,
     constraints: str | None = None,
     find_links: str | None = None,
+    timeout: int | None = None,
     no_cache_dir: bool | None = False,
 ) -> bool:
     """Install a package on PyPi. Accepts pip compatible package strings.
@@ -73,6 +74,8 @@ def install_package(
     _LOGGER.info("Attempting install of %s", package)
     env = os.environ.copy()
     args = [sys.executable, "-m", "pip", "install", "--quiet", package]
+    if timeout:
+        args += ["--timeout", str(timeout)]
     if no_cache_dir:
         args.append("--no-cache-dir")
     if upgrade:

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -38,6 +38,7 @@ async def test_requirement_installed_in_venv(hass):
         assert mock_install.call_args == call(
             "package==0.0.1",
             constraints=os.path.join("ha_package_path", CONSTRAINT_FILE),
+            timeout=60,
             no_cache_dir=False,
         )
 
@@ -59,6 +60,7 @@ async def test_requirement_installed_in_deps(hass):
             "package==0.0.1",
             target=hass.config.path("deps"),
             constraints=os.path.join("ha_package_path", CONSTRAINT_FILE),
+            timeout=60,
             no_cache_dir=False,
         )
 
@@ -304,6 +306,7 @@ async def test_install_with_wheels_index(hass):
             "hello==1.0.0",
             find_links="https://wheels.hass.io/test",
             constraints=os.path.join("ha_package_path", CONSTRAINT_FILE),
+            timeout=60,
             no_cache_dir=True,
         )
 
@@ -327,6 +330,7 @@ async def test_install_on_docker(hass):
         assert mock_inst.call_args == call(
             "hello==1.0.0",
             constraints=os.path.join("ha_package_path", CONSTRAINT_FILE),
+            timeout=60,
             no_cache_dir=True,
         )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I've been having a lot of internet connection fun in the last 48 hours and
found that when I switch to my backup wireless link, Home Assistant couldn't
update packages because the latency is too high. By switching to a 60s timeout
everything works (just slowly).

Should make onboarding more reliable for those without the best
internet connections.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
- The default timeout of 15s is too low for satellite or tethering