### PR TITLE
Replace util.get_local_ip in favor of components.network.async_get_source_ip() - part 2

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -4,7 +4,8 @@ import logging
 from aiohttp import web
 import voluptuous as vol
 
-from homeassistant import util
+from homeassistant.components.network import async_get_source_ip
+from homeassistant.components.network.const import PUBLIC_TARGET_IP
 from homeassistant.const import (
     CONF_ENTITIES,
     CONF_TYPE,
@@ -105,7 +106,8 @@ ATTR_EMULATED_HUE_NAME = "emulated_hue_name"
 
 async def async_setup(hass, yaml_config):
     """Activate the emulated_hue component."""
-    config = Config(hass, yaml_config.get(DOMAIN, {}))
+    local_ip = await async_get_source_ip(hass, PUBLIC_TARGET_IP)
+    config = Config(hass, yaml_config.get(DOMAIN, {}), local_ip)
 
     app = web.Application()
     app["hass"] = hass
@@ -156,7 +158,6 @@ async def async_setup(hass, yaml_config):
         nonlocal protocol
         nonlocal site
         nonlocal runner
-        await config.async_setup()
 
         _, protocol = await listen
 
@@ -186,7 +187,7 @@ async def async_setup(hass, yaml_config):
 class Config:
     """Hold configuration variables for the emulated hue bridge."""
 
-    def __init__(self, hass, conf):
+    def __init__(self, hass, conf, local_ip):
         """Initialize the instance."""
         self.hass = hass
         self.type = conf.get(CONF_TYPE)
@@ -204,11 +205,7 @@ class Config:
         # Get the IP address that will be passed to the Echo during discovery
         self.host_ip_addr = conf.get(CONF_HOST_IP)
         if self.host_ip_addr is None:
-            self.host_ip_addr = util.get_local_ip()
-            _LOGGER.info(
-                "Listen IP address not specified, auto-detected address is %s",
-                self.host_ip_addr,
-            )
+            self.host_ip_addr = local_ip
 
         # Get the port that the Hue bridge will listen on
         self.listen_port = conf.get(CONF_LISTEN_PORT)

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -108,6 +108,7 @@ async def async_setup(hass, yaml_config):
     """Activate the emulated_hue component."""
     local_ip = await async_get_source_ip(hass, PUBLIC_TARGET_IP)
     config = Config(hass, yaml_config.get(DOMAIN, {}), local_ip)
+    await config.async_setup()
 
     app = web.Application()
     app["hass"] = hass

--- a/homeassistant/components/emulated_hue/manifest.json
+++ b/homeassistant/components/emulated_hue/manifest.json
@@ -3,6 +3,7 @@
   "name": "Emulated Hue",
   "documentation": "https://www.home-assistant.io/integrations/emulated_hue",
   "requirements": ["aiohttp_cors==0.7.0"],
+  "dependencies": ["network"],
   "after_dependencies": ["http"],
   "codeowners": [],
   "quality_scale": "internal",

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -244,6 +244,7 @@ def hue_client(loop, hass_hue, hass_client_no_auth):
                 "scene.light_off": {emulated_hue.CONF_ENTITY_HIDDEN: False},
             },
         },
+        "127.0.0.1",
     )
     config.numbers = ENTITY_IDS_BY_NUMBER
 
@@ -322,7 +323,7 @@ async def test_lights_all_dimmable(hass, hass_client_no_auth):
             {emulated_hue.DOMAIN: hue_config},
         )
         await hass.async_block_till_done()
-    config = Config(None, hue_config)
+    config = Config(None, hue_config, "127.0.0.1")
     config.numbers = ENTITY_IDS_BY_NUMBER
     web_app = hass.http.app
     HueOneLightStateView(config).register(web_app, web_app.router)

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -14,7 +14,7 @@ from tests.common import async_fire_time_changed
 
 async def test_config_google_home_entity_id_to_number(hass, hass_storage):
     """Test config adheres to the type."""
-    conf = Config(hass, {"type": "google_home"})
+    conf = Config(hass, {"type": "google_home"}, "127.0.0.1")
     hass_storage[DATA_KEY] = {
         "version": DATA_VERSION,
         "key": DATA_KEY,
@@ -45,7 +45,7 @@ async def test_config_google_home_entity_id_to_number(hass, hass_storage):
 
 async def test_config_google_home_entity_id_to_number_altered(hass, hass_storage):
     """Test config adheres to the type."""
-    conf = Config(hass, {"type": "google_home"})
+    conf = Config(hass, {"type": "google_home"}, "127.0.0.1")
     hass_storage[DATA_KEY] = {
         "version": DATA_VERSION,
         "key": DATA_KEY,
@@ -76,7 +76,7 @@ async def test_config_google_home_entity_id_to_number_altered(hass, hass_storage
 
 async def test_config_google_home_entity_id_to_number_empty(hass, hass_storage):
     """Test config adheres to the type."""
-    conf = Config(hass, {"type": "google_home"})
+    conf = Config(hass, {"type": "google_home"}, "127.0.0.1")
     hass_storage[DATA_KEY] = {"version": DATA_VERSION, "key": DATA_KEY, "data": {}}
 
     await conf.async_setup()
@@ -100,7 +100,7 @@ async def test_config_google_home_entity_id_to_number_empty(hass, hass_storage):
 
 def test_config_alexa_entity_id_to_number():
     """Test config adheres to the type."""
-    conf = Config(None, {"type": "alexa"})
+    conf = Config(None, {"type": "alexa"}, "127.0.0.1")
 
     number = conf.entity_id_to_number("light.test")
     assert number == "light.test"

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -1,7 +1,6 @@
 """The tests for the emulated Hue component."""
 import json
 import unittest
-from unittest.mock import patch
 
 from aiohttp import web
 import defusedxml.ElementTree as ET

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -1,6 +1,7 @@
 """The tests for the emulated Hue component."""
 import json
 import unittest
+from unittest.mock import patch
 
 from aiohttp import web
 import defusedxml.ElementTree as ET


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Remove `util.get_local_ip()` in favor of `components.network.async_get_source_ip()`

Previous implementation was determining local ip based on the routing versus a fixed public ip"8.8.8.8".
New function instead allows to choice the destination and determine local_ip based on the source interface needed to get there.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove `util.get_local_ip()` in favor of `components.network.async_get_source_ip()
`
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
