### PR TITLE
Add support for power data from Koogeek SW2 via homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -46,5 +46,6 @@ HOMEKIT_ACCESSORY_DISPATCH = {
 CHARACTERISTIC_PLATFORMS = {
     CharacteristicsTypes.Vendor.EVE_ENERGY_WATT: "sensor",
     CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY: "sensor",
+    CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY_2: "sensor",
     CharacteristicsTypes.get_uuid(CharacteristicsTypes.TEMPERATURE_CURRENT): "sensor",
 }

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit Controller",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "requirements": ["aiohomekit==0.5.1"],
+  "requirements": ["aiohomekit==0.6.0"],
   "zeroconf": ["_hap._tcp.local."],
   "after_dependencies": ["zeroconf"],
   "codeowners": ["@Jc2k", "@bdraco"],

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -37,6 +37,12 @@ SIMPLE_SENSOR = {
         "state_class": STATE_CLASS_MEASUREMENT,
         "unit": "watts",
     },
+    CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY_2: {
+        "name": "Real Time Energy",
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "unit": "watts",
+    },
     CharacteristicsTypes.get_uuid(CharacteristicsTypes.TEMPERATURE_CURRENT): {
         "name": "Current Temperature",
         "device_class": DEVICE_CLASS_TEMPERATURE,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -178,7 +178,7 @@ aioguardian==1.0.8
 aioharmony==0.2.7
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.5.1
+aiohomekit==0.6.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -115,7 +115,7 @@ aioguardian==1.0.8
 aioharmony==0.2.7
 
 # homeassistant.components.homekit_controller
-aiohomekit==0.5.1
+aiohomekit==0.6.0
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
@@ -1,0 +1,67 @@
+"""
+Make sure that existing Koogeek SW2 is enumerated correctly.
+
+This Koogeek device has a custom power sensor that extra handling.
+
+It should have 2 entities - the actual switch and a sensor for power usage.
+"""
+
+from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_COLOR
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.components.homekit_controller.common import (
+    Helper,
+    setup_accessories_from_file,
+    setup_test_accessories,
+)
+
+LIGHT_ON = ("lightbulb", "on")
+
+
+async def test_koogeek_ls1_setup(hass):
+    """Test that a Koogeek LS1 can be correctly setup in HA."""
+    accessories = await setup_accessories_from_file(hass, "koogeek_sw2.json")
+    config_entry, pairing = await setup_test_accessories(hass, accessories)
+
+    entity_registry = er.async_get(hass)
+
+    # Assert that the switch entity is correctly added to the entity registry
+    entry = entity_registry.async_get("switch.koogeek_sw2_187a91")
+    assert entry.unique_id == "homekit-CNNT061751001372-8"
+
+    helper = Helper(
+        hass, "switch.koogeek_sw2_187a91", pairing, accessories[0], config_entry
+    )
+    state = await helper.poll_and_get_state()
+
+    # Assert that the friendly name is detected correctly
+    assert state.attributes["friendly_name"] == "Koogeek-SW2-187A91"
+
+    device_registry = dr.async_get(hass)
+
+    device = device_registry.async_get(entry.device_id)
+    assert device.manufacturer == "Koogeek"
+    assert device.name == "Koogeek-SW2-187A91"
+    assert device.model == "KH02CN"
+    assert device.sw_version == "1.0.3"
+    assert device.via_device_id is None
+
+    # Assert that the power sensor entity is correctly added to the entity registry
+    entry = entity_registry.async_get("sensor.koogeek_sw2_187a91_real_time_energy")
+    assert entry.unique_id == "homekit-CNNT061751001372-aid:1-sid:14-cid:14"
+
+    helper = Helper(
+        hass,
+        "sensor.koogeek_sw2_187a91_real_time_energy",
+        pairing,
+        accessories[0],
+        config_entry,
+    )
+    state = await helper.poll_and_get_state()
+
+    # Assert that the friendly name is detected correctly
+    assert state.attributes["friendly_name"] == "Koogeek-SW2-187A91 - Real Time Energy"
+
+    device_registry = dr.async_get(hass)
+
+    assert device.id == entry.device_id

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
@@ -6,7 +6,6 @@ This Koogeek device has a custom power sensor that extra handling.
 It should have 2 entities - the actual switch and a sensor for power usage.
 """
 
-from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_COLOR
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.homekit_controller.common import (
@@ -14,8 +13,6 @@ from tests.components.homekit_controller.common import (
     setup_accessories_from_file,
     setup_test_accessories,
 )
-
-LIGHT_ON = ("lightbulb", "on")
 
 
 async def test_koogeek_ls1_setup(hass):

--- a/tests/fixtures/homekit_controller/koogeek_sw2.json
+++ b/tests/fixtures/homekit_controller/koogeek_sw2.json
@@ -1,0 +1,265 @@
+[
+    {
+        "aid": 1,
+        "services": [
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 2,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Koogeek-SW2-187A91"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 3,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "value": "Koogeek"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 4,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "value": "KH02CN"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 5,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "value": "CNNT061751001372"
+                    },
+                    {
+                        "format": "bool",
+                        "iid": 6,
+                        "perms": [
+                            "pw"
+                        ],
+                        "type": "00000014-0000-1000-8000-0026BB765291"
+                    },
+                    {
+                        "format": "string",
+                        "iid": 7,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "value": "1.0.3"
+                    }
+                ],
+                "iid": 1,
+                "stype": "accessory-information",
+                "type": "0000003E-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "ev": true,
+                        "format": "bool",
+                        "iid": 9,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "string",
+                        "iid": 10,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Switch 1"
+                    }
+                ],
+                "iid": 8,
+                "primary": true,
+                "stype": "switch",
+                "type": "00000049-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "ev": true,
+                        "format": "bool",
+                        "iid": 12,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "value": false
+                    },
+                    {
+                        "format": "string",
+                        "iid": 13,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "Switch 2"
+                    }
+                ],
+                "iid": 11,
+                "primary": true,
+                "stype": "switch",
+                "type": "00000049-0000-1000-8000-0026BB765291"
+            },
+            {
+                "characteristics": [
+                    {
+                        "format": "string",
+                        "iid": 15,
+                        "maxLen": 64,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "value": "custom service"
+                    },
+                    {
+                        "description": "Current Time",
+                        "format": "int",
+                        "iid": 16,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "7BBBA961-EB2D-11E5-A837-0800200C9A66",
+                        "value": 1599731035
+                    },
+                    {
+                        "description": "Time Zone",
+                        "format": "int",
+                        "iid": 17,
+                        "perms": [
+                            "pr",
+                            "pw"
+                        ],
+                        "type": "7BBBA980-EB2D-11E5-A837-0800200C9A66",
+                        "value": 16
+                    },
+                    {
+                        "description": "Current Power",
+                        "ev": false,
+                        "format": "int",
+                        "iid": 18,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "type": "7BBBA96E-EB2D-11E5-A837-0800200C9A66",
+                        "value": 0
+                    },
+                    {
+                        "description": "Power Consumption Today",
+                        "format": "data",
+                        "iid": 19,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "7BBBA96F-EB2D-11E5-A837-0800200C9A66",
+                        "value": "9pcBAL4GAAC1BgAAtgYAAELhAABXIwAAtgYAAKcGAABHOQAA1aMAAP//////////////////////////////////////////////////////////////////////////"
+                    },
+                    {
+                        "description": "Power Consumption last 2 Month",
+                        "format": "data",
+                        "iid": 20,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "7BBBA972-EB2D-11E5-A837-0800200C9A66",
+                        "value": "/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACCFAEA5HkIADGbAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                    },
+                    {
+                        "description": "Power Consumption last 12 Month",
+                        "format": "data",
+                        "iid": 21,
+                        "perms": [
+                            "pr"
+                        ],
+                        "type": "7BBBA970-EB2D-11E5-A837-0800200C9A66",
+                        "value": "//////////////////////////////////////////+XKQ0A////////////////"
+                    }
+                ],
+                "hidden": true,
+                "iid": 14,
+                "stype": "Unknown Service: 7BBBA977-EB2D-11E5-A837-0800200C9A66",
+                "type": "7BBBA977-EB2D-11E5-A837-0800200C9A66"
+            },
+            {
+                "characteristics": [
+                    {
+                        "description": "FW Upgrade supported types",
+                        "format": "string",
+                        "iid": 23,
+                        "perms": [
+                            "pr",
+                            "hd"
+                        ],
+                        "type": "151909D2-3802-11E4-916C-0800200C9A66",
+                        "value": "url,data"
+                    },
+                    {
+                        "description": "FW Upgrade URL",
+                        "format": "string",
+                        "iid": 24,
+                        "maxLen": 256,
+                        "perms": [
+                            "pw",
+                            "hd"
+                        ],
+                        "type": "151909D1-3802-11E4-916C-0800200C9A66"
+                    },
+                    {
+                        "description": "FW Upgrade Status",
+                        "ev": false,
+                        "format": "int",
+                        "iid": 25,
+                        "perms": [
+                            "pr",
+                            "ev",
+                            "hd"
+                        ],
+                        "type": "151909D6-3802-11E4-916C-0800200C9A66",
+                        "value": 0
+                    },
+                    {
+                        "description": "FW Upgrade Data",
+                        "format": "data",
+                        "iid": 26,
+                        "perms": [
+                            "pw",
+                            "hd"
+                        ],
+                        "type": "151909D7-3802-11E4-916C-0800200C9A66"
+                    }
+                ],
+                "hidden": true,
+                "iid": 22,
+                "stype": "Unknown Service: 151909D0-3802-11E4-916C-0800200C9A66",
+                "type": "151909D0-3802-11E4-916C-0800200C9A66"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We support the custom real time energy characteristic for some Koogeek devices already but it turns out there is another uuid used for the same data on other devices. This PR adds support for it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/27220 (see last comment from @cwendigo)
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
