### PR TITLE
Support group events for AC switches and binary sensors. Fixes #53065.

### DIFF
--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -233,7 +233,7 @@ class RfxtrxBinarySensor(RfxtrxEntity, BinarySensorEntity):
     @callback
     def _handle_event(self, event, device_id):
         """Check if event applies to me and update."""
-        if device_id != self._device_id:
+        if not self._event_applies(event, device_id):
             return
 
         _LOGGER.debug(

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -19,6 +19,7 @@ COMMAND_ON_LIST = [
     "On",
     "Up",
     "Stop",
+    "Group on",
     "Open (inline relay)",
     "Stop (inline relay)",
     "Enable sun automation",
@@ -26,9 +27,15 @@ COMMAND_ON_LIST = [
 
 COMMAND_OFF_LIST = [
     "Off",
+    "Group off",
     "Down",
     "Close (inline relay)",
     "Disable sun automation",
+]
+
+COMMAND_GROUP_LIST = [
+    "Group on",
+    "Group off",
 ]
 
 ATTR_EVENT = "event"

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -117,12 +117,10 @@ class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):
     @callback
     def _handle_event(self, event, device_id):
         """Check if event applies to me and update."""
-        if device_id != self._device_id:
-            return
+        if self._event_applies(event, device_id):
+            self._apply_event(event)
 
-        self._apply_event(event)
-
-        self.async_write_ha_state()
+            self.async_write_ha_state()
 
     @property
     def is_on(self):

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -121,7 +121,7 @@ async def test_several(hass, rfxtrx):
         devices={
             "0b1100cd0213c7f230010f71": {},
             "0b1100100118cdea02010f70": {},
-            "0b1100101118cdea02010f70": {},
+            "0b1100100118cdea03010f70": {},
         }
     )
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -141,10 +141,20 @@ async def test_several(hass, rfxtrx):
     assert state.state == "off"
     assert state.attributes.get("friendly_name") == "AC 118cdea:2"
 
-    state = hass.states.get("binary_sensor.ac_1118cdea_2")
+    state = hass.states.get("binary_sensor.ac_118cdea_3")
     assert state
     assert state.state == "off"
-    assert state.attributes.get("friendly_name") == "AC 1118cdea:2"
+    assert state.attributes.get("friendly_name") == "AC 118cdea:3"
+
+    # "2: Group on"
+    await rfxtrx.signal("0b1100100118cdea03040f70")
+    assert hass.states.get("binary_sensor.ac_118cdea_2").state == "on"
+    assert hass.states.get("binary_sensor.ac_118cdea_3").state == "on"
+
+    # "2: Group off"
+    await rfxtrx.signal("0b1100100118cdea03030f70")
+    assert hass.states.get("binary_sensor.ac_118cdea_2").state == "off"
+    assert hass.states.get("binary_sensor.ac_118cdea_3").state == "off"
 
 
 async def test_discover(hass, rfxtrx_automatic):

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -125,6 +125,62 @@ async def test_repetitions(hass, rfxtrx, repetitions):
     assert rfxtrx.transport.send.call_count == repetitions
 
 
+async def test_switch_events(hass, rfxtrx):
+    """Event test with 2 switches."""
+    entry_data = create_rfx_test_cfg(
+        devices={
+            "0b1100cd0213c7f205010f51": {"signal_repetitions": 1},
+            "0b1100cd0213c7f210010f51": {"signal_repetitions": 1},
+        }
+    )
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.ac_213c7f2_16")
+    assert state
+    assert state.state == "off"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:16"
+
+    state = hass.states.get("switch.ac_213c7f2_5")
+    assert state
+    assert state.state == "off"
+    assert state.attributes.get("friendly_name") == "AC 213c7f2:5"
+
+    # "16: On"
+    await rfxtrx.signal("0b1100100213c7f210010f70")
+    assert hass.states.get("switch.ac_213c7f2_5").state == "off"
+    assert hass.states.get("switch.ac_213c7f2_16").state == "on"
+
+    # "16: Off"
+    await rfxtrx.signal("0b1100100213c7f210000f70")
+    assert hass.states.get("switch.ac_213c7f2_5").state == "off"
+    assert hass.states.get("switch.ac_213c7f2_16").state == "off"
+
+    # "5: On"
+    await rfxtrx.signal("0b1100100213c7f205010f70")
+    assert hass.states.get("switch.ac_213c7f2_5").state == "on"
+    assert hass.states.get("switch.ac_213c7f2_16").state == "off"
+
+    # "5: Off"
+    await rfxtrx.signal("0b1100100213c7f205000f70")
+    assert hass.states.get("switch.ac_213c7f2_5").state == "off"
+    assert hass.states.get("switch.ac_213c7f2_16").state == "off"
+
+    # "16: Group on"
+    await rfxtrx.signal("0b1100100213c7f210040f70")
+    assert hass.states.get("switch.ac_213c7f2_5").state == "on"
+    assert hass.states.get("switch.ac_213c7f2_16").state == "on"
+
+    # "16: Group off"
+    await rfxtrx.signal("0b1100100213c7f210030f70")
+    assert hass.states.get("switch.ac_213c7f2_5").state == "off"
+    assert hass.states.get("switch.ac_213c7f2_16").state == "off"
+
+
 async def test_discover_switch(hass, rfxtrx_automatic):
     """Test with discovery of switches."""
     rfxtrx = rfxtrx_automatic


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement support for AC "Group on/off" events in the `rfxtrx` component.

Previously, the physical state of a relay could update with a "Group" signal without Home Assistant updating the corresponding entities.
With this change, Home Assistant will understand "Group" events and send them to all switches and binary sensor entities in the group.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53065

The change has been tested on my own HA connected to a [RFXtrx443XL](http://www.rfxcom.com/RFXtrx433XL) controller. The "Group off" signal was received from the remote and correctly understood. (I don't have a remote with a "Group on" button.)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
