### PR TITLE
Handle homekit accessories where the pairing flag is wrong

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -3,6 +3,7 @@ import logging
 import re
 
 import aiohomekit
+from aiohomekit.exceptions import AuthenticationError
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -270,7 +271,29 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # invalid. Remove it automatically.
         existing = find_existing_host(self.hass, hkid)
         if not paired and existing:
-            await self.hass.config_entries.async_remove(existing.entry_id)
+            if self.controller is None:
+                await self._async_setup_controller()
+
+            pairing = self.controller.load_pairing(
+                existing.data["AccessoryPairingID"], existing.data
+            )
+            try:
+                await pairing.list_accessories_and_characteristics()
+                _LOGGER.debug(
+                    "%s (%s - %s) claims to be unpaired but isn't. It's implementation of HomeKit is defective or a zeroconf relay is broadcasting stale data",
+                    name,
+                    model,
+                    hkid,
+                )
+                return self.async_abort(reason="already_paired")
+            except AuthenticationError:
+                _LOGGER.debug(
+                    "%s (%s - %s) is unpaired. Removing invalid pairing for this device",
+                    name,
+                    model,
+                    hkid,
+                )
+                await self.hass.config_entries.async_remove(existing.entry_id)
 
         # Set unique-id and error out if it's already configured
         self._abort_if_unique_id_configured(updates=updated_ip_port)

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -275,7 +275,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 await self._async_setup_controller()
 
             pairing = self.controller.load_pairing(
-                existing.data["AccessoryPairingID"], existing.data
+                existing.data["AccessoryPairingID"], dict(existing.data)
             )
             try:
                 await pairing.list_accessories_and_characteristics()

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -4,6 +4,7 @@ import unittest.mock
 from unittest.mock import AsyncMock, patch
 
 import aiohomekit
+from aiohomekit.exceptions import AuthenticationError
 from aiohomekit.model import Accessories, Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
@@ -351,8 +352,48 @@ async def test_discovery_does_not_ignore_non_homekit(hass, controller):
     assert result["type"] == "form"
 
 
+async def test_discovery_broken_pairing_flag(hass, controller):
+    """
+    There is already a config entry for the pairing and its pairing flag is wrong in zeroconf.
+
+    We have seen this particular implementation error in 2 different devices.
+    """
+    await controller.add_paired_device(Accessories(), "00:00:00:00:00:00")
+
+    MockConfigEntry(
+        domain="homekit_controller",
+        data={"AccessoryPairingID": "00:00:00:00:00:00"},
+        unique_id="00:00:00:00:00:00",
+    ).add_to_hass(hass)
+
+    # We just added a mock config entry so it must be visible in hass
+    assert len(hass.config_entries.async_entries()) == 1
+
+    device = setup_mock_accessory(controller)
+    discovery_info = get_device_discovery_info(device)
+
+    # Make sure that we are pairable
+    assert discovery_info["properties"]["sf"] != 0x0
+
+    # Device is discovered
+    result = await hass.config_entries.flow.async_init(
+        "homekit_controller",
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    # Should still be paired.
+    config_entry_count = len(hass.config_entries.async_entries())
+    assert config_entry_count == 1
+
+    # Even though discovered as pairable, we bail out as already paired.
+    assert result["reason"] == "already_paired"
+
+
 async def test_discovery_invalid_config_entry(hass, controller):
     """There is already a config entry for the pairing id but it's invalid."""
+    pairing = await controller.add_paired_device(Accessories(), "00:00:00:00:00:00")
+
     MockConfigEntry(
         domain="homekit_controller",
         data={"AccessoryPairingID": "00:00:00:00:00:00"},
@@ -366,11 +407,16 @@ async def test_discovery_invalid_config_entry(hass, controller):
     discovery_info = get_device_discovery_info(device)
 
     # Device is discovered
-    result = await hass.config_entries.flow.async_init(
-        "homekit_controller",
-        context={"source": config_entries.SOURCE_ZEROCONF},
-        data=discovery_info,
-    )
+    with patch.object(
+        pairing,
+        "list_accessories_and_characteristics",
+        side_effect=AuthenticationError("Invalid pairing keys"),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            "homekit_controller",
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=discovery_info,
+        )
 
     # Discovery of a HKID that is in a pairable state but for which there is
     # already a config entry - in that case the stale config entry is


### PR DESCRIPTION
## Proposed change

Some Homekit devices lie and say they are unpaired when they aren't. The existing code will automatically remove a config entry for such a device (what good is the config entry if the device isn't paired to anything?). But the pairing was actually working, the zeroconf metadata is just incorrect.

So we no longer trust the zeroconf metadata alone and now double check that our pairing keys are actually invalid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/51764
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
