### PR TITLE
Add zwave_js WS API commands to get statistics

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1546,7 +1546,7 @@ async def websocket_subscribe_controller_statistics(
             unsub()
 
     @callback
-    def forward_progress(event: dict) -> None:
+    def forward_stats(event: dict) -> None:
         statistics: ControllerStatistics = event["statistics_updated"]
         connection.send_message(
             websocket_api.event_message(
@@ -1562,7 +1562,7 @@ async def websocket_subscribe_controller_statistics(
     controller = client.driver.controller
 
     msg[DATA_UNSUBSCRIBE] = unsubs = [
-        controller.on("statistics updated", forward_progress)
+        controller.on("statistics updated", forward_stats)
     ]
     connection.subscriptions[msg["id"]] = async_cleanup
 
@@ -1606,7 +1606,7 @@ async def websocket_subscribe_node_statistics(
             unsub()
 
     @callback
-    def forward_progress(event: dict) -> None:
+    def forward_stats(event: dict) -> None:
         statistics: NodeStatistics = event["statistics_updated"]
         connection.send_message(
             websocket_api.event_message(
@@ -1620,7 +1620,7 @@ async def websocket_subscribe_node_statistics(
             )
         )
 
-    msg[DATA_UNSUBSCRIBE] = unsubs = [node.on("statistics updated", forward_progress)]
+    msg[DATA_UNSUBSCRIBE] = unsubs = [node.on("statistics updated", forward_stats)]
     connection.subscriptions[msg["id"]] = async_cleanup
 
     connection.send_result(msg[ID], _get_node_statistics_dict(node.statistics))

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -19,13 +19,14 @@ from zwave_js_server.exceptions import (
     SetValueFailed,
 )
 from zwave_js_server.firmware import begin_firmware_update
+from zwave_js_server.model.controller import ControllerStatistics
 from zwave_js_server.model.firmware import (
     FirmwareUpdateFinished,
     FirmwareUpdateProgress,
 )
 from zwave_js_server.model.log_config import LogConfig
 from zwave_js_server.model.log_message import LogMessage
-from zwave_js_server.model.node import Node
+from zwave_js_server.model.node import Node, NodeStatistics
 from zwave_js_server.util.node import async_set_config_parameter
 
 from homeassistant.components import websocket_api
@@ -200,6 +201,10 @@ def async_register_api(hass: HomeAssistant) -> None:
     )
     websocket_api.async_register_command(hass, websocket_check_for_config_updates)
     websocket_api.async_register_command(hass, websocket_install_config_update)
+    websocket_api.async_register_command(
+        hass, websocket_subscribe_controller_statistics
+    )
+    websocket_api.async_register_command(hass, websocket_subscribe_node_statistics)
     hass.http.register_view(DumpView())
     hass.http.register_view(FirmwareUploadView())
 
@@ -1348,7 +1353,16 @@ async def websocket_subscribe_firmware_update_status(
     msg: dict,
     node: Node,
 ) -> None:
-    """Subsribe to the status of a firmware update."""
+    """Subscribe to the status of a firmware update."""
+
+    def _get_firmware_update_progress_dict(
+        progress: FirmwareUpdateProgress,
+    ) -> dict[str, int]:
+        """Get a dictionary of firmware update progress."""
+        return {
+            "sent_fragments": progress.sent_fragments,
+            "total_fragments": progress.total_fragments,
+        }
 
     @callback
     def async_cleanup() -> None:
@@ -1364,8 +1378,7 @@ async def websocket_subscribe_firmware_update_status(
                 msg[ID],
                 {
                     "event": event["event"],
-                    "sent_fragments": progress.sent_fragments,
-                    "total_fragments": progress.total_fragments,
+                    **_get_firmware_update_progress_dict(progress),
                 },
             )
         )
@@ -1390,15 +1403,10 @@ async def websocket_subscribe_firmware_update_status(
     ]
     connection.subscriptions[msg["id"]] = async_cleanup
 
-    result = (
-        {
-            "sent_fragments": node.firmware_update_progress.sent_fragments,
-            "total_fragments": node.firmware_update_progress.total_fragments,
-        }
-        if node.firmware_update_progress
-        else None
+    progress = node.firmware_update_progress
+    connection.send_result(
+        msg[ID], _get_firmware_update_progress_dict(progress) if progress else None
     )
-    connection.send_result(msg[ID], result)
 
 
 class FirmwareUploadView(HomeAssistantView):
@@ -1495,3 +1503,124 @@ async def websocket_install_config_update(
     """Check for config updates."""
     success = await client.driver.async_install_config_update()
     connection.send_result(msg[ID], success)
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "zwave_js/subscribe_controller_statistics",
+        vol.Required(ENTRY_ID): str,
+    }
+)
+@websocket_api.async_response
+@async_get_entry
+async def websocket_subscribe_controller_statistics(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict,
+    entry: ConfigEntry,
+    client: Client,
+) -> None:
+    """Subsribe to the statistics updates for a controller."""
+
+    def _get_controller_statistics_dict(
+        statistics: ControllerStatistics,
+    ) -> dict[str, int]:
+        """Get dictionary of controller statistics."""
+        return {
+            "messages_tx": statistics.messages_tx,
+            "messages_rx": statistics.messages_rx,
+            "messages_dropped_tx": statistics.messages_dropped_tx,
+            "messages_dropped_rx": statistics.messages_dropped_rx,
+            "nak": statistics.nak,
+            "can": statistics.can,
+            "timeout_ack": statistics.timeout_ack,
+            "timout_response": statistics.timeout_response,
+            "timeout_callback": statistics.timeout_callback,
+        }
+
+    @callback
+    def async_cleanup() -> None:
+        """Remove signal listeners."""
+        for unsub in unsubs:
+            unsub()
+
+    @callback
+    def forward_progress(event: dict) -> None:
+        statistics: ControllerStatistics = event["statistics_updated"]
+        connection.send_message(
+            websocket_api.event_message(
+                msg[ID],
+                {
+                    "event": event["event"],
+                    "source": "controller",
+                    **_get_controller_statistics_dict(statistics),
+                },
+            )
+        )
+
+    controller = client.driver.controller
+
+    msg[DATA_UNSUBSCRIBE] = unsubs = [
+        controller.on("statistics updated", forward_progress)
+    ]
+    connection.subscriptions[msg["id"]] = async_cleanup
+
+    connection.send_result(
+        msg[ID], _get_controller_statistics_dict(controller.statistics)
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "zwave_js/subscribe_node_statistics",
+        vol.Required(ENTRY_ID): str,
+        vol.Required(NODE_ID): int,
+    }
+)
+@websocket_api.async_response
+@async_get_node
+async def websocket_subscribe_node_statistics(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict,
+    node: Node,
+) -> None:
+    """Subsribe to the statistics updates for a node."""
+
+    def _get_node_statistics_dict(statistics: NodeStatistics) -> dict[str, int]:
+        """Get dictionary of node statistics."""
+        return {
+            "commands_tx": statistics.commands_tx,
+            "commands_rx": statistics.commands_rx,
+            "commands_dropped_tx": statistics.commands_dropped_tx,
+            "commands_dropped_rx": statistics.commands_dropped_rx,
+            "timeout_response": statistics.timeout_response,
+        }
+
+    @callback
+    def async_cleanup() -> None:
+        """Remove signal listeners."""
+        for unsub in unsubs:
+            unsub()
+
+    @callback
+    def forward_progress(event: dict) -> None:
+        statistics: NodeStatistics = event["statistics_updated"]
+        connection.send_message(
+            websocket_api.event_message(
+                msg[ID],
+                {
+                    "event": event["event"],
+                    "source": "node",
+                    "node_id": node.node_id,
+                    **_get_node_statistics_dict(statistics),
+                },
+            )
+        )
+
+    msg[DATA_UNSUBSCRIBE] = unsubs = [node.on("statistics updated", forward_progress)]
+    connection.subscriptions[msg["id"]] = async_cleanup
+
+    connection.send_result(msg[ID], _get_node_statistics_dict(node.statistics))

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1337,6 +1337,16 @@ async def websocket_abort_firmware_update(
     connection.send_result(msg[ID])
 
 
+def _get_firmware_update_progress_dict(
+    progress: FirmwareUpdateProgress,
+) -> dict[str, int]:
+    """Get a dictionary of firmware update progress."""
+    return {
+        "sent_fragments": progress.sent_fragments,
+        "total_fragments": progress.total_fragments,
+    }
+
+
 @websocket_api.require_admin
 @websocket_api.websocket_command(
     {
@@ -1354,15 +1364,6 @@ async def websocket_subscribe_firmware_update_status(
     node: Node,
 ) -> None:
     """Subscribe to the status of a firmware update."""
-
-    def _get_firmware_update_progress_dict(
-        progress: FirmwareUpdateProgress,
-    ) -> dict[str, int]:
-        """Get a dictionary of firmware update progress."""
-        return {
-            "sent_fragments": progress.sent_fragments,
-            "total_fragments": progress.total_fragments,
-        }
 
     @callback
     def async_cleanup() -> None:
@@ -1505,6 +1506,23 @@ async def websocket_install_config_update(
     connection.send_result(msg[ID], success)
 
 
+def _get_controller_statistics_dict(
+    statistics: ControllerStatistics,
+) -> dict[str, int]:
+    """Get dictionary of controller statistics."""
+    return {
+        "messages_tx": statistics.messages_tx,
+        "messages_rx": statistics.messages_rx,
+        "messages_dropped_tx": statistics.messages_dropped_tx,
+        "messages_dropped_rx": statistics.messages_dropped_rx,
+        "nak": statistics.nak,
+        "can": statistics.can,
+        "timeout_ack": statistics.timeout_ack,
+        "timout_response": statistics.timeout_response,
+        "timeout_callback": statistics.timeout_callback,
+    }
+
+
 @websocket_api.require_admin
 @websocket_api.websocket_command(
     {
@@ -1522,22 +1540,6 @@ async def websocket_subscribe_controller_statistics(
     client: Client,
 ) -> None:
     """Subsribe to the statistics updates for a controller."""
-
-    def _get_controller_statistics_dict(
-        statistics: ControllerStatistics,
-    ) -> dict[str, int]:
-        """Get dictionary of controller statistics."""
-        return {
-            "messages_tx": statistics.messages_tx,
-            "messages_rx": statistics.messages_rx,
-            "messages_dropped_tx": statistics.messages_dropped_tx,
-            "messages_dropped_rx": statistics.messages_dropped_rx,
-            "nak": statistics.nak,
-            "can": statistics.can,
-            "timeout_ack": statistics.timeout_ack,
-            "timout_response": statistics.timeout_response,
-            "timeout_callback": statistics.timeout_callback,
-        }
 
     @callback
     def async_cleanup() -> None:
@@ -1571,6 +1573,17 @@ async def websocket_subscribe_controller_statistics(
     )
 
 
+def _get_node_statistics_dict(statistics: NodeStatistics) -> dict[str, int]:
+    """Get dictionary of node statistics."""
+    return {
+        "commands_tx": statistics.commands_tx,
+        "commands_rx": statistics.commands_rx,
+        "commands_dropped_tx": statistics.commands_dropped_tx,
+        "commands_dropped_rx": statistics.commands_dropped_rx,
+        "timeout_response": statistics.timeout_response,
+    }
+
+
 @websocket_api.require_admin
 @websocket_api.websocket_command(
     {
@@ -1588,16 +1601,6 @@ async def websocket_subscribe_node_statistics(
     node: Node,
 ) -> None:
     """Subsribe to the statistics updates for a node."""
-
-    def _get_node_statistics_dict(statistics: NodeStatistics) -> dict[str, int]:
-        """Get dictionary of node statistics."""
-        return {
-            "commands_tx": statistics.commands_tx,
-            "commands_rx": statistics.commands_rx,
-            "commands_dropped_tx": statistics.commands_dropped_tx,
-            "commands_dropped_rx": statistics.commands_dropped_rx,
-            "timeout_response": statistics.timeout_response,
-        }
 
     @callback
     def async_cleanup() -> None:

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -2703,3 +2703,195 @@ async def test_install_config_update(hass, client, integration, hass_ws_client):
 
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_FOUND
+
+
+async def test_subscribe_controller_statistics(
+    hass, integration, client, hass_ws_client
+):
+    """Test the subscribe_controller_statistics command."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "zwave_js/subscribe_controller_statistics",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {
+        "messages_tx": 0,
+        "messages_rx": 0,
+        "messages_dropped_tx": 0,
+        "messages_dropped_rx": 0,
+        "nak": 0,
+        "can": 0,
+        "timeout_ack": 0,
+        "timout_response": 0,
+        "timeout_callback": 0,
+    }
+
+    # Fire statistics updated
+    event = Event(
+        "statistics updated",
+        {
+            "source": "controller",
+            "event": "statistics updated",
+            "statistics": {
+                "messagesTX": 1,
+                "messagesRX": 1,
+                "messagesDroppedTX": 1,
+                "messagesDroppedRX": 1,
+                "NAK": 1,
+                "CAN": 1,
+                "timeoutACK": 1,
+                "timeoutResponse": 1,
+                "timeoutCallback": 1,
+            },
+        },
+    )
+    client.driver.controller.receive_event(event)
+    msg = await ws_client.receive_json()
+    assert msg["event"] == {
+        "event": "statistics updated",
+        "source": "controller",
+        "messages_tx": 1,
+        "messages_rx": 1,
+        "messages_dropped_tx": 1,
+        "messages_dropped_rx": 1,
+        "nak": 1,
+        "can": 1,
+        "timeout_ack": 1,
+        "timout_response": 1,
+        "timeout_callback": 1,
+    }
+
+    # Test sending command with improper entry ID fails
+    await ws_client.send_json(
+        {
+            ID: 2,
+            TYPE: "zwave_js/subscribe_controller_statistics",
+            ENTRY_ID: "fake_entry_id",
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/subscribe_controller_statistics",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_LOADED
+
+
+async def test_subscribe_node_statistics(
+    hass, multisensor_6, integration, client, hass_ws_client
+):
+    """Test the subscribe_node_statistics command."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "zwave_js/subscribe_node_statistics",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: multisensor_6.node_id,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {
+        "commands_tx": 0,
+        "commands_rx": 0,
+        "commands_dropped_tx": 0,
+        "commands_dropped_rx": 0,
+        "timeout_response": 0,
+    }
+
+    # Fire statistics updated
+    event = Event(
+        "statistics updated",
+        {
+            "source": "node",
+            "event": "statistics updated",
+            "nodeId": multisensor_6.node_id,
+            "statistics": {
+                "commandsTX": 1,
+                "commandsRX": 1,
+                "commandsDroppedTX": 1,
+                "commandsDroppedRX": 1,
+                "timeoutResponse": 1,
+            },
+        },
+    )
+    client.driver.controller.receive_event(event)
+    msg = await ws_client.receive_json()
+    assert msg["event"] == {
+        "event": "statistics updated",
+        "source": "node",
+        "node_id": multisensor_6.node_id,
+        "commands_tx": 1,
+        "commands_rx": 1,
+        "commands_dropped_tx": 1,
+        "commands_dropped_rx": 1,
+        "timeout_response": 1,
+    }
+
+    # Test sending command with improper entry ID fails
+    await ws_client.send_json(
+        {
+            ID: 2,
+            TYPE: "zwave_js/subscribe_node_statistics",
+            ENTRY_ID: "fake_entry_id",
+            NODE_ID: multisensor_6.node_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
+    # Test sending command with improper node ID fails
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/subscribe_node_statistics",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: multisensor_6.node_id + 100,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 4,
+            TYPE: "zwave_js/subscribe_node_statistics",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: multisensor_6.node_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_LOADED


### PR DESCRIPTION
## Proposed change
The two new commands will allow the frontend to subscribe to statistics updates on nodes and the controller. Since the event payload is very similar, and the event name is the same, I added a `source` to the event as well as the node ID for the node in question.

I also made a code quality change to firmware update progress events to stay consistent with these subscriptions

cc @cgarwood 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
