### PR TITLE
Update spider integration to support HEM

### DIFF
--- a/homeassistant/components/spider/const.py
+++ b/homeassistant/components/spider/const.py
@@ -3,4 +3,4 @@
 DOMAIN = "spider"
 DEFAULT_SCAN_INTERVAL = 300
 
-PLATFORMS = ["climate", "switch"]
+PLATFORMS = ["climate", "switch", "sensor"]

--- a/homeassistant/components/spider/sensor.py
+++ b/homeassistant/components/spider/sensor.py
@@ -128,16 +128,6 @@ class SpiderPowerPlugPower(SensorEntity):
         """Return the current power usage in W."""
         return round(self.power_plug.current_energy_consumption)
 
-    @property
-    def unit_of_measurement(self) -> str:
-        """Return the unit of measurement."""
-        return POWER_WATT
-
-    @property
-    def device_class(self) -> str:
-        """Return the device class."""
-        return DEVICE_CLASS_POWER
-
     def update(self) -> None:
         """Get the latest data."""
         self.power_plug = self.api.get_power_plug(self.power_plug.id)

--- a/homeassistant/components/spider/sensor.py
+++ b/homeassistant/components/spider/sensor.py
@@ -1,5 +1,5 @@
 """Support for Spider Powerplugs (energy & power)."""
-from datetime import date, datetime
+from datetime import datetime
 
 from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
 from homeassistant.const import (
@@ -9,6 +9,7 @@ from homeassistant.const import (
     POWER_WATT,
 )
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 
@@ -16,18 +17,13 @@ from .const import DOMAIN
 async def async_setup_entry(hass, config, async_add_entities):
     """Initialize a Spider Power Plug."""
     api = hass.data[DOMAIN][config.entry_id]
-    async_add_entities(
-        [
-            SpiderPowerPlugEnergy(api, entity)
-            for entity in await hass.async_add_executor_job(api.get_power_plugs)
-        ]
-    )
-    async_add_entities(
-        [
-            SpiderPowerPlugPower(api, entity)
-            for entity in await hass.async_add_executor_job(api.get_power_plugs)
-        ]
-    )
+    entities = []
+
+    for entity in await hass.async_add_executor_job(api.get_power_plugs):
+        entities.append(SpiderPowerPlugEnergy(api, entity))
+        entities.append(SpiderPowerPlugPower(api, entity))
+
+    async_add_entities(entities)
 
 
 class SpiderPowerPlugEnergy(SensorEntity):
@@ -40,16 +36,14 @@ class SpiderPowerPlugEnergy(SensorEntity):
     def __init__(self, api, power_plug) -> None:
         """Initialize the Spider Power Plug."""
         self.api = api
-        self.attr_name = f"{power_plug.name} Total Energy"
-        self.id = f"{power_plug.id}_total_energy"
         self.power_plug = power_plug
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device_info of the device."""
         return {
-            "identifiers": {(DOMAIN, self.id)},
-            "name": self.attr_name,
+            "identifiers": {(DOMAIN, self.power_plug.id)},
+            "name": self.power_plug.name,
             "manufacturer": self.power_plug.manufacturer,
             "model": self.power_plug.model,
         }
@@ -57,12 +51,12 @@ class SpiderPowerPlugEnergy(SensorEntity):
     @property
     def unique_id(self) -> str:
         """Return the ID of this sensor."""
-        return self.id
+        return f"{self.power_plug.id}_total_energy_today"
 
     @property
     def name(self) -> str:
         """Return the name of the sensor if any."""
-        return self.attr_name
+        return f"{self.power_plug.name} Total Energy Today"
 
     @property
     def state(self) -> float:
@@ -71,8 +65,10 @@ class SpiderPowerPlugEnergy(SensorEntity):
 
     @property
     def last_reset(self) -> datetime:
-        """Return the time when the sensor was last reset, if any."""
-        return datetime.combine(date.today(), datetime.min.time())
+        """Return the time when last reset; Every midnight."""
+        return dt_util.as_utc(
+            dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        )
 
     def update(self) -> None:
         """Get the latest data."""
@@ -85,19 +81,18 @@ class SpiderPowerPlugPower(SensorEntity):
     _attr_device_class = DEVICE_CLASS_POWER
     _attr_state_class = STATE_CLASS_MEASUREMENT
     _attr_unit_of_measurement = POWER_WATT
+
     def __init__(self, api, power_plug) -> None:
         """Initialize the Spider Power Plug."""
         self.api = api
-        self.attr_name = f"{power_plug.name} Power Consumption"
-        self.id = f"{power_plug.id}_power_consumption"
         self.power_plug = power_plug
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device_info of the device."""
         return {
-            "identifiers": {(DOMAIN, self.id)},
-            "name": self.attr_name,
+            "identifiers": {(DOMAIN, self.power_plug.id)},
+            "name": self.power_plug.name,
             "manufacturer": self.power_plug.manufacturer,
             "model": self.power_plug.model,
         }
@@ -105,12 +100,12 @@ class SpiderPowerPlugPower(SensorEntity):
     @property
     def unique_id(self) -> str:
         """Return the ID of this sensor."""
-        return self.id
+        return f"{self.power_plug.id}_power_consumption"
 
     @property
     def name(self) -> str:
         """Return the name of the sensor if any."""
-        return self.attr_name
+        return f"{self.power_plug.name} Power Consumption"
 
     @property
     def state(self) -> float:

--- a/homeassistant/components/spider/sensor.py
+++ b/homeassistant/components/spider/sensor.py
@@ -70,21 +70,6 @@ class SpiderPowerPlugEnergy(SensorEntity):
         return round(self.power_plug.today_energy_consumption / 1000, 2)
 
     @property
-    def unit_of_measurement(self) -> str:
-        """Return the unit of measurement."""
-        return ENERGY_KILO_WATT_HOUR
-
-    @property
-    def device_class(self) -> str:
-        """Return the device class."""
-        return DEVICE_CLASS_ENERGY
-
-    @property
-    def state_class(self) -> str:
-        """Return the state class."""
-        return STATE_CLASS_MEASUREMENT
-
-    @property
     def last_reset(self) -> datetime:
         """Return the time when the sensor was last reset, if any."""
         return datetime.combine(date.today(), datetime.min.time())

--- a/homeassistant/components/spider/sensor.py
+++ b/homeassistant/components/spider/sensor.py
@@ -33,6 +33,10 @@ async def async_setup_entry(hass, config, async_add_entities):
 class SpiderPowerPlugEnergy(SensorEntity):
     """Representation of a Spider Power Plug (energy)."""
 
+    _attr_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+    _attr_device_class = DEVICE_CLASS_ENERGY
+    _attr_state_class = STATE_CLASS_MEASUREMENT
+
     def __init__(self, api, power_plug) -> None:
         """Initialize the Spider Power Plug."""
         self.api = api

--- a/homeassistant/components/spider/sensor.py
+++ b/homeassistant/components/spider/sensor.py
@@ -93,6 +93,9 @@ class SpiderPowerPlugEnergy(SensorEntity):
 class SpiderPowerPlugPower(SensorEntity):
     """Representation of a Spider Power Plug (power)."""
 
+    _attr_device_class = DEVICE_CLASS_POWER
+    _attr_state_class = STATE_CLASS_MEASUREMENT
+    _attr_unit_of_measurement = POWER_WATT
     def __init__(self, api, power_plug) -> None:
         """Initialize the Spider Power Plug."""
         self.api = api

--- a/homeassistant/components/spider/sensor.py
+++ b/homeassistant/components/spider/sensor.py
@@ -1,0 +1,140 @@
+"""Support for Spider Powerplugs (energy & power)."""
+from datetime import date, datetime
+
+from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
+from homeassistant.const import (
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_POWER,
+    ENERGY_KILO_WATT_HOUR,
+    POWER_WATT,
+)
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(hass, config, async_add_entities):
+    """Initialize a Spider Power Plug."""
+    api = hass.data[DOMAIN][config.entry_id]
+    async_add_entities(
+        [
+            SpiderPowerPlugEnergy(api, entity)
+            for entity in await hass.async_add_executor_job(api.get_power_plugs)
+        ]
+    )
+    async_add_entities(
+        [
+            SpiderPowerPlugPower(api, entity)
+            for entity in await hass.async_add_executor_job(api.get_power_plugs)
+        ]
+    )
+
+
+class SpiderPowerPlugEnergy(SensorEntity):
+    """Representation of a Spider Power Plug (energy)."""
+
+    def __init__(self, api, power_plug) -> None:
+        """Initialize the Spider Power Plug."""
+        self.api = api
+        self.attr_name = f"{power_plug.name} Total Energy"
+        self.id = f"{power_plug.id}_total_energy"
+        self.power_plug = power_plug
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device_info of the device."""
+        return {
+            "identifiers": {(DOMAIN, self.id)},
+            "name": self.attr_name,
+            "manufacturer": self.power_plug.manufacturer,
+            "model": self.power_plug.model,
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Return the ID of this sensor."""
+        return self.id
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor if any."""
+        return self.attr_name
+
+    @property
+    def state(self) -> float:
+        """Return todays energy usage in Kwh."""
+        return round(self.power_plug.today_energy_consumption / 1000, 2)
+
+    @property
+    def unit_of_measurement(self) -> str:
+        """Return the unit of measurement."""
+        return ENERGY_KILO_WATT_HOUR
+
+    @property
+    def device_class(self) -> str:
+        """Return the device class."""
+        return DEVICE_CLASS_ENERGY
+
+    @property
+    def state_class(self) -> str:
+        """Return the state class."""
+        return STATE_CLASS_MEASUREMENT
+
+    @property
+    def last_reset(self) -> datetime:
+        """Return the time when the sensor was last reset, if any."""
+        return datetime.combine(date.today(), datetime.min.time())
+
+    def update(self) -> None:
+        """Get the latest data."""
+        self.power_plug = self.api.get_power_plug(self.power_plug.id)
+
+
+class SpiderPowerPlugPower(SensorEntity):
+    """Representation of a Spider Power Plug (power)."""
+
+    def __init__(self, api, power_plug) -> None:
+        """Initialize the Spider Power Plug."""
+        self.api = api
+        self.attr_name = f"{power_plug.name} Power Consumption"
+        self.id = f"{power_plug.id}_power_consumption"
+        self.power_plug = power_plug
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device_info of the device."""
+        return {
+            "identifiers": {(DOMAIN, self.id)},
+            "name": self.attr_name,
+            "manufacturer": self.power_plug.manufacturer,
+            "model": self.power_plug.model,
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Return the ID of this sensor."""
+        return self.id
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor if any."""
+        return self.attr_name
+
+    @property
+    def state(self) -> float:
+        """Return the current power usage in W."""
+        return round(self.power_plug.current_energy_consumption)
+
+    @property
+    def unit_of_measurement(self) -> str:
+        """Return the unit of measurement."""
+        return POWER_WATT
+
+    @property
+    def device_class(self) -> str:
+        """Return the device class."""
+        return DEVICE_CLASS_POWER
+
+    def update(self) -> None:
+        """Get the latest data."""
+        self.power_plug = self.api.get_power_plug(self.power_plug.id)

--- a/homeassistant/components/spider/switch.py
+++ b/homeassistant/components/spider/switch.py
@@ -44,16 +44,6 @@ class SpiderPowerPlug(SwitchEntity):
         return self.power_plug.name
 
     @property
-    def current_power_w(self):
-        """Return the current power usage in W."""
-        return round(self.power_plug.current_energy_consumption)
-
-    @property
-    def today_energy_kwh(self):
-        """Return the current power usage in Kwh."""
-        return round(self.power_plug.today_energy_consumption / 1000, 2)
-
-    @property
     def is_on(self):
         """Return true if switch is on. Standby is on."""
         return self.power_plug.is_on
@@ -73,4 +63,4 @@ class SpiderPowerPlug(SwitchEntity):
 
     def update(self):
         """Get the latest data."""
-        self.power_plug = self.api.get_power_plug(self.unique_id)
+        self.power_plug = self.api.get_power_plug(self.power_plug.id)


### PR DESCRIPTION
## Breaking change
The property current_power_w and today_energy_kwh of switch entities were moved into own sensors.


## Proposed change
Based upon https://github.com/home-assistant/architecture/discussions/579


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/53323
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/579
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
