### PR TITLE
Expose OpenGarage controller variables as attrs

### DIFF
--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -12,6 +12,8 @@ from homeassistant.components.cover import (
     CoverEntity,
 )
 from homeassistant.const import (
+    ATTR_NAME,
+    ATTR_TEMPERATURE,
     CONF_COVERS,
     CONF_HOST,
     CONF_NAME,
@@ -30,8 +32,15 @@ from homeassistant.helpers.device_registry import format_mac
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_DISTANCE_SENSOR = "distance_sensor"
+ATTR_SWITCH_SENSOR = "switch_sensor"
 ATTR_DOOR_STATE = "door_state"
+ATTR_VEHICLE_STATUS = "vehicle_status"
+ATTR_READ_COUNT = "read_count"
+ATTR_FIRMWARE_VERSION = "firmware_version"
+ATTR_MAC_ADDRESS = "mac_address"
+ATTR_WIFI_CHIP_ID = "wifi_chip_id"
 ATTR_SIGNAL_STRENGTH = "wifi_signal"
+ATTR_HUMIDITY = "humidity"
 
 CONF_DEVICE_KEY = "device_key"
 
@@ -153,12 +162,30 @@ class OpenGarageCover(CoverEntity):
             self._state = state
 
         _LOGGER.debug("%s status: %s", self._name, self._state)
-        if status.get("rssi") is not None:
-            self._extra_state_attributes[ATTR_SIGNAL_STRENGTH] = status.get("rssi")
         if status.get("dist") is not None:
             self._extra_state_attributes[ATTR_DISTANCE_SENSOR] = status.get("dist")
+        if status.get("sn2") is not None:
+            self._extra_state_attributes[ATTR_SWITCH_SENSOR] = status.get("sn2")
         if self._state is not None:
             self._extra_state_attributes[ATTR_DOOR_STATE] = self._state
+        if status.get("vehicle") is not None:
+            self._extra_state_attributes[ATTR_VEHICLE_STATUS] = status.get("vehicle")
+        if status.get("rcnt") is not None:
+            self._extra_state_attributes[ATTR_READ_COUNT] = status.get("rcnt")
+        if status.get("fwv") is not None:
+            self._extra_state_attributes[ATTR_FIRMWARE_VERSION] = status.get("fwv")
+        if status.get("name") is not None:
+            self._extra_state_attributes[ATTR_NAME] = status.get("name")
+        if status.get("mac") is not None:
+            self._extra_state_attributes[ATTR_MAC_ADDRESS] = status.get("mac")
+        if status.get("cid") is not None:
+            self._extra_state_attributes[ATTR_WIFI_CHIP_ID] = status.get("cid")
+        if status.get("rssi") is not None:
+            self._extra_state_attributes[ATTR_SIGNAL_STRENGTH] = status.get("rssi")
+        if status.get("temp") is not None:
+            self._extra_state_attributes[ATTR_TEMPERATURE] = status.get("temp")
+        if status.get("humid") is not None:
+            self._extra_state_attributes[ATTR_HUMIDITY] = status.get("humid")
 
         self._available = True
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Exposes OpenGarage's controller state from the underlying API (https://github.com/OpenGarage/OpenGarage-Firmware/blob/master/docs/OGAPI1.1.2.pdf) as attributes, much as the existing `rssi` and `dist` sensors are. This allows visibility and acting upon door and vehicle state, other statistics, secondary sensor values (switch, temperature and humidity), and access to dynamic configuration variables.

Existing attrs are maintained, just reorganised for readability in the order in which variables are described in the underlying API documentation.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
