### PR TITLE
Replace util.get_local_ip in favor of components.network.async_get_source_ip() - part 3

### DIFF
--- a/homeassistant/components/emulated_roku/__init__.py
+++ b/homeassistant/components/emulated_roku/__init__.py
@@ -1,7 +1,9 @@
 """Support for Roku API emulation."""
 import voluptuous as vol
 
-from homeassistant import config_entries, util
+from homeassistant import config_entries
+from homeassistant.components.network import async_get_source_ip
+from homeassistant.components.network.const import PUBLIC_TARGET_IP
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
@@ -71,7 +73,8 @@ async def async_setup_entry(hass, config_entry):
 
     name = config[CONF_NAME]
     listen_port = config[CONF_LISTEN_PORT]
-    host_ip = config.get(CONF_HOST_IP) or util.get_local_ip()
+    local_ip = await async_get_source_ip(hass, PUBLIC_TARGET_IP)
+    host_ip = config.get(CONF_HOST_IP) or local_ip
     advertise_ip = config.get(CONF_ADVERTISE_IP)
     advertise_port = config.get(CONF_ADVERTISE_PORT)
     upnp_bind_multicast = config.get(CONF_UPNP_BIND_MULTICAST)

--- a/homeassistant/components/emulated_roku/__init__.py
+++ b/homeassistant/components/emulated_roku/__init__.py
@@ -73,8 +73,9 @@ async def async_setup_entry(hass, config_entry):
 
     name = config[CONF_NAME]
     listen_port = config[CONF_LISTEN_PORT]
-    local_ip = await async_get_source_ip(hass, PUBLIC_TARGET_IP)
-    host_ip = config.get(CONF_HOST_IP) or local_ip
+    host_ip = config.get(CONF_HOST_IP) or await async_get_source_ip(
+        hass, PUBLIC_TARGET_IP
+    )
     advertise_ip = config.get(CONF_ADVERTISE_IP)
     advertise_port = config.get(CONF_ADVERTISE_PORT)
     upnp_bind_multicast = config.get(CONF_UPNP_BIND_MULTICAST)

--- a/homeassistant/components/emulated_roku/manifest.json
+++ b/homeassistant/components/emulated_roku/manifest.json
@@ -4,6 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/emulated_roku",
   "requirements": ["emulated_roku==0.2.1"],
+  "dependencies": ["network"],
   "codeowners": [],
   "iot_class": "local_push"
 }

--- a/tests/components/emulated_roku/test_init.py
+++ b/tests/components/emulated_roku/test_init.py
@@ -93,7 +93,11 @@ async def test_setup_entry_successful(hass):
 async def test_unload_entry(hass):
     """Test being able to unload an entry."""
     entry = Mock()
-    entry.data = {"name": "Emulated Roku Test", "listen_port": 8060}
+    entry.data = {
+        "name": "Emulated Roku Test",
+        "listen_port": 8060,
+        emulated_roku.CONF_HOST_IP: "1.2.3.5",
+    }
 
     with patch(
         "homeassistant.components.emulated_roku.binding.EmulatedRokuServer",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Remove `util.get_local_ip()` in favor of `components.network.async_get_source_ip()`

Previous implementation was determining local ip based on the routing versus a fixed public ip"8.8.8.8".
New function instead allows to choice the destination and determine local_ip based on the source interface needed to get there.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove `util.get_local_ip()` in favor of `components.network.async_get_source_ip()
`
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
