### PR TITLE
Test KNX events

### DIFF
--- a/tests/components/knx/conftest.py
+++ b/tests/components/knx/conftest.py
@@ -19,6 +19,8 @@ from homeassistant.setup import async_setup_component
 class KNXTestKit:
     """Test helper for the KNX integration."""
 
+    INDIVIDUAL_ADDRESS = "1.2.3"
+
     def __init__(self, hass: HomeAssistant):
         """Init KNX test helper class."""
         self.hass: HomeAssistant = hass
@@ -148,7 +150,7 @@ class KNXTestKit:
                 destination_address=GroupAddress(group_address),
                 direction=TelegramDirection.INCOMING,
                 payload=payload,
-                source_address=IndividualAddress("1.2.3"),
+                source_address=IndividualAddress(self.INDIVIDUAL_ADDRESS),
             )
         )
         await self.hass.async_block_till_done()

--- a/tests/components/knx/test_events.py
+++ b/tests/components/knx/test_events.py
@@ -1,8 +1,11 @@
 """Test KNX events."""
+
 from homeassistant.components.knx import CONF_KNX_EVENT_FILTER
 from homeassistant.core import HomeAssistant
 
 from .conftest import KNXTestKit
+
+from tests.common import async_capture_events
 
 
 async def test_knx_event(hass: HomeAssistant, knx: KNXTestKit):
@@ -17,12 +20,10 @@ async def test_knx_event(hass: HomeAssistant, knx: KNXTestKit):
     test_address_c_1 = "2/6/4"
     test_address_c_2 = "2/6/5"
     test_address_d = "5/4/3"
-    events = []
+    events = async_capture_events(hass, "knx_event")
 
-    def listener(event):
-        events.append(event)
-
-    def test_event_data(address, payload):
+    async def test_event_data(address, payload):
+        await hass.async_block_till_done()
         assert len(events) == 1
         event = events.pop()
         assert event.data["data"] == payload
@@ -37,7 +38,6 @@ async def test_knx_event(hass: HomeAssistant, knx: KNXTestKit):
             )
         assert event.data["source"] == KNXTestKit.INDIVIDUAL_ADDRESS
 
-    hass.bus.async_listen("knx_event", listener)
     await knx.setup_integration(
         {
             CONF_KNX_EVENT_FILTER: [
@@ -50,33 +50,34 @@ async def test_knx_event(hass: HomeAssistant, knx: KNXTestKit):
     )
 
     # no event received
+    await hass.async_block_till_done()
     assert len(events) == 0
 
     # receive telegrams for group addresses matching the filter
     await knx.receive_write(test_address_a_1, True)
-    test_event_data(test_address_a_1, True)
+    await test_event_data(test_address_a_1, True)
 
     await knx.receive_response(test_address_a_2, False)
-    test_event_data(test_address_a_2, False)
+    await test_event_data(test_address_a_2, False)
 
     await knx.receive_write(test_address_b_1, (1,))
-    test_event_data(test_address_b_1, (1,))
+    await test_event_data(test_address_b_1, (1,))
 
     await knx.receive_response(test_address_b_2, (255,))
-    test_event_data(test_address_b_2, (255,))
+    await test_event_data(test_address_b_2, (255,))
 
     await knx.receive_write(test_address_c_1, (89, 43, 34, 11))
-    test_event_data(test_address_c_1, (89, 43, 34, 11))
+    await test_event_data(test_address_c_1, (89, 43, 34, 11))
 
     await knx.receive_response(test_address_c_2, (255, 255, 255, 255))
-    test_event_data(test_address_c_2, (255, 255, 255, 255))
+    await test_event_data(test_address_c_2, (255, 255, 255, 255))
 
     await knx.receive_read(test_address_d)
-    test_event_data(test_address_d, None)
+    await test_event_data(test_address_d, None)
 
     # receive telegrams for group addresses not matching the filter
-    events = []
     await knx.receive_write("0/5/0", True)
     await knx.receive_write("1/7/0", True)
     await knx.receive_write("2/6/6", True)
+    await hass.async_block_till_done()
     assert len(events) == 0

--- a/tests/components/knx/test_events.py
+++ b/tests/components/knx/test_events.py
@@ -1,0 +1,82 @@
+"""Test KNX events."""
+from homeassistant.components.knx import CONF_KNX_EVENT_FILTER
+from homeassistant.core import HomeAssistant
+
+from .conftest import KNXTestKit
+
+
+async def test_knx_event(hass: HomeAssistant, knx: KNXTestKit):
+    """Test `knx_event` event."""
+    test_group_a = "0/4/*"
+    test_address_a_1 = "0/4/0"
+    test_address_a_2 = "0/4/100"
+    test_group_b = "1/3-6/*"
+    test_address_b_1 = "1/3/0"
+    test_address_b_2 = "1/6/200"
+    test_group_c = "2/6/4,5"
+    test_address_c_1 = "2/6/4"
+    test_address_c_2 = "2/6/5"
+    test_address_d = "5/4/3"
+    events = []
+
+    def listener(event):
+        events.append(event)
+
+    def test_event_data(address, payload):
+        assert len(events) == 1
+        event = events.pop()
+        assert event.data["data"] == payload
+        assert event.data["direction"] == "Incoming"
+        assert event.data["destination"] == address
+        if payload is None:
+            assert event.data["telegramtype"] == "GroupValueRead"
+        else:
+            assert event.data["telegramtype"] in (
+                "GroupValueWrite",
+                "GroupValueResponse",
+            )
+        assert event.data["source"] == KNXTestKit.INDIVIDUAL_ADDRESS
+
+    hass.bus.async_listen("knx_event", listener)
+    await knx.setup_integration(
+        {
+            CONF_KNX_EVENT_FILTER: [
+                test_group_a,
+                test_group_b,
+                test_group_c,
+                test_address_d,
+            ]
+        }
+    )
+
+    # no event received
+    assert len(events) == 0
+
+    # receive telegrams for group addresses matching the filter
+    await knx.receive_write(test_address_a_1, True)
+    test_event_data(test_address_a_1, True)
+
+    await knx.receive_response(test_address_a_2, False)
+    test_event_data(test_address_a_2, False)
+
+    await knx.receive_write(test_address_b_1, (1,))
+    test_event_data(test_address_b_1, (1,))
+
+    await knx.receive_response(test_address_b_2, (255,))
+    test_event_data(test_address_b_2, (255,))
+
+    await knx.receive_write(test_address_c_1, (89, 43, 34, 11))
+    test_event_data(test_address_c_1, (89, 43, 34, 11))
+
+    await knx.receive_response(test_address_c_2, (255, 255, 255, 255))
+    test_event_data(test_address_c_2, (255, 255, 255, 255))
+
+    await knx.receive_read(test_address_d)
+    test_event_data(test_address_d, None)
+
+    # receive telegrams for group addresses not matching the filter
+    events = []
+    await knx.receive_write("0/5/0", True)
+    await knx.receive_write("1/7/0", True)
+    await knx.receive_write("2/6/6", True)
+    assert len(events) == 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Test KNX event `knx_event`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
