### PR TITLE
Add an explicit nest dependency on google-cloud-pubsub==2.1.0

### DIFF
--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -4,7 +4,11 @@
   "config_flow": true,
   "dependencies": ["ffmpeg", "http"],
   "documentation": "https://www.home-assistant.io/integrations/nest",
-  "requirements": ["python-nest==4.1.0", "google-nest-sdm==0.3.0"],
+  "requirements": [
+    "python-nest==4.1.0",
+    "google-nest-sdm==0.3.0",
+    "google-cloud-pubsub==2.1.0"
+  ],
   "codeowners": ["@allenporter"],
   "quality_scale": "platinum",
   "dhcp": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -700,6 +700,7 @@ goalzero==0.1.7
 google-api-python-client==1.6.4
 
 # homeassistant.components.google_pubsub
+# homeassistant.components.nest
 google-cloud-pubsub==2.1.0
 
 # homeassistant.components.google_cloud

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -403,6 +403,7 @@ goalzero==0.1.7
 google-api-python-client==1.6.4
 
 # homeassistant.components.google_pubsub
+# homeassistant.components.nest
 google-cloud-pubsub==2.1.0
 
 # homeassistant.components.nest


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a dependency to avoid dependency mismatch with grpcio pins within home-assistant. This
is a workaround until grpcio is updated (i don't have an arm device to test)

The original issue is reproduced with:
```
$ mkdir ha_test
$ cd ha_test
$ python3 --version
Python 3.8.10
$ python3 -m venv .
$ source bin/activate
(venv) $ python3 -m pip install wheel
(venv) $ pip3 install homeassistant
$ pip3 freeze | grep google-cloud-pubsub
$ hass
```
Then navigate through install and attempt to add the nest integration which fails with:
```
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (grpcio 1.31.0 (/home/allen/ha_test/lib/python3.8/site-packages), Requirement.parse('grpcio<2.0dev,>=1.38.1'), {'google-cloud-pubsub'})
```

```
$ pip3 freeze | grep google-cloud-pubsub
google-cloud-pubsub==2.6.1
```

I was previously assuming that the pin in `requirements_all.txt` was being used at runtime, so I was hoping that specifying that here would ensure its not using a newer version.

This seems like a broader issue where I would expect mismatches would happen all the time.  As an alternative, is there a better method (e.g. resolve the pins in `requirements_all.txt` at runtime?) I'm not familiar with home these packages are loaded, and didn't look closer yet.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #53427
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
