### PR TITLE
System Bridge v2.3.0+ - Data from WebSocket

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1007,8 +1007,9 @@ omit =
     homeassistant/components/synology_srm/device_tracker.py
     homeassistant/components/syslog/notify.py
     homeassistant/components/system_bridge/__init__.py
-    homeassistant/components/system_bridge/const.py
     homeassistant/components/system_bridge/binary_sensor.py
+    homeassistant/components/system_bridge/const.py
+    homeassistant/components/system_bridge/coordinator.py
     homeassistant/components/system_bridge/sensor.py
     homeassistant/components/systemmonitor/sensor.py
     homeassistant/components/tado/*

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -68,15 +68,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await bridge.async_get_information()
     except BridgeAuthenticationException as exception:
         raise ConfigEntryAuthFailed(
-            "Authentication failed for %s (%s)",
-            entry.title,
-            entry.data[CONF_HOST],
+            f"Authentication failed for {entry.title} ({entry.data[CONF_HOST]})"
         ) from exception
     except BRIDGE_CONNECTION_ERRORS as exception:
         raise ConfigEntryNotReady(
-            "Could not connect to %s (%s).",
-            entry.title,
-            entry.data[CONF_HOST],
+            f"Could not connect to {entry.title} ({entry.data[CONF_HOST]})."
         ) from exception
 
     coordinator = SystemBridgeDataUpdateCoordinator(hass, bridge, _LOGGER, entry=entry)
@@ -104,9 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 await asyncio.sleep(1)
     except asyncio.TimeoutError as exception:
         raise ConfigEntryNotReady(
-            "Timed out waiting for %s (%s).",
-            entry.title,
-            entry.data[CONF_HOST],
+            f"Timed out waiting for {entry.title} ({entry.data[CONF_HOST]})."
         ) from exception
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -193,7 +193,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ]
 
         # Ensure disconnected and cleanup stop sub
-        await coordinator.bridge.disconnect()
+        await coordinator.bridge.async_close_websocket()
         if coordinator.unsub:
             coordinator.unsub()
 

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -57,7 +57,7 @@ SERVICE_OPEN_SCHEMA = vol.Schema(
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up System Bridge from a config entry."""
-    client = Bridge(
+    bridge = Bridge(
         BridgeClient(aiohttp_client.async_get_clientsession(hass)),
         f"http://{entry.data[CONF_HOST]}:{entry.data[CONF_PORT]}",
         entry.data[CONF_API_KEY],
@@ -65,14 +65,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         async with async_timeout.timeout(60):
-            await client.async_get_information()
-            await client.async_get_system()
+            await bridge.async_get_information()
     except BridgeAuthenticationException as exception:
         raise ConfigEntryAuthFailed from exception
     except BRIDGE_CONNECTION_ERRORS as exception:
         raise ConfigEntryNotReady("Could not connect to System Bridge.") from exception
 
-    coordinator = SystemBridgeDataUpdateCoordinator(hass, _LOGGER, entry=entry)
+    coordinator = SystemBridgeDataUpdateCoordinator(bridge, hass, _LOGGER, entry=entry)
     await coordinator.async_config_entry_first_refresh()
 
     # Wait for initial data

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -75,20 +75,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     # Wait for initial data
-    async with async_timeout.timeout(60):
-        while (
-            coordinator.bridge.battery is None
-            or coordinator.bridge.cpu is None
-            or coordinator.bridge.filesystem is None
-            or coordinator.bridge.information is None
-            or coordinator.bridge.memory is None
-            or coordinator.bridge.network is None
-            or coordinator.bridge.os is None
-            or coordinator.bridge.processes is None
-            or coordinator.bridge.system is None
-        ):
-            _LOGGER.debug("Waiting for initial data")
-            await asyncio.sleep(1)
+    try:
+        async with async_timeout.timeout(120):
+            while (
+                coordinator.bridge.battery is None
+                or coordinator.bridge.cpu is None
+                or coordinator.bridge.filesystem is None
+                or coordinator.bridge.information is None
+                or coordinator.bridge.memory is None
+                or coordinator.bridge.network is None
+                or coordinator.bridge.os is None
+                or coordinator.bridge.processes is None
+                or coordinator.bridge.system is None
+            ):
+                _LOGGER.debug("Waiting for initial data")
+                await asyncio.sleep(1)
+    except asyncio.TimeoutError as exception:
+        raise ConfigEntryNotReady("Timed out waiting for System Bridge.") from exception
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -206,7 +206,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     return unload_ok
 
 
-class BridgeEntity(CoordinatorEntity):
+class SystemBridgeEntity(CoordinatorEntity):
     """Defines a base System Bridge entity."""
 
     def __init__(
@@ -253,7 +253,7 @@ class BridgeEntity(CoordinatorEntity):
         return self._enabled_default
 
 
-class BridgeDeviceEntity(BridgeEntity):
+class SystemBridgeDeviceEntity(SystemBridgeEntity):
     """Defines a System Bridge device entity."""
 
     @property

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -64,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     try:
-        async with async_timeout.timeout(60):
+        async with async_timeout.timeout(30):
             await bridge.async_get_information()
     except BridgeAuthenticationException as exception:
         raise ConfigEntryAuthFailed(
@@ -84,7 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Wait for initial data
     try:
-        async with async_timeout.timeout(120):
+        async with async_timeout.timeout(60):
             while (
                 coordinator.bridge.battery is None
                 or coordinator.bridge.cpu is None

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -67,9 +67,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         async with async_timeout.timeout(60):
             await bridge.async_get_information()
     except BridgeAuthenticationException as exception:
-        raise ConfigEntryAuthFailed from exception
+        raise ConfigEntryAuthFailed(
+            "Authentication failed for %s (%s)",
+            entry.title,
+            entry.data[CONF_HOST],
+        ) from exception
     except BRIDGE_CONNECTION_ERRORS as exception:
-        raise ConfigEntryNotReady("Could not connect to System Bridge.") from exception
+        raise ConfigEntryNotReady(
+            "Could not connect to %s (%s).",
+            entry.title,
+            entry.data[CONF_HOST],
+        ) from exception
 
     coordinator = SystemBridgeDataUpdateCoordinator(hass, bridge, _LOGGER, entry=entry)
     await coordinator.async_config_entry_first_refresh()
@@ -95,7 +103,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
                 await asyncio.sleep(1)
     except asyncio.TimeoutError as exception:
-        raise ConfigEntryNotReady("Timed out waiting for System Bridge.") from exception
+        raise ConfigEntryNotReady(
+            "Timed out waiting for %s (%s).",
+            entry.title,
+            entry.data[CONF_HOST],
+        ) from exception
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -88,7 +88,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 or coordinator.bridge.processes is None
                 or coordinator.bridge.system is None
             ):
-                _LOGGER.debug("Waiting for initial data from %s", entry.data[CONF_HOST])
+                _LOGGER.debug(
+                    "Waiting for initial data from %s (%s)",
+                    entry.title,
+                    entry.data[CONF_HOST],
+                )
                 await asyncio.sleep(1)
     except asyncio.TimeoutError as exception:
         raise ConfigEntryNotReady("Timed out waiting for System Bridge.") from exception

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -71,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except BRIDGE_CONNECTION_ERRORS as exception:
         raise ConfigEntryNotReady("Could not connect to System Bridge.") from exception
 
-    coordinator = SystemBridgeDataUpdateCoordinator(bridge, hass, _LOGGER, entry=entry)
+    coordinator = SystemBridgeDataUpdateCoordinator(hass, bridge, _LOGGER, entry=entry)
     await coordinator.async_config_entry_first_refresh()
 
     # Wait for initial data

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -65,8 +65,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         async with async_timeout.timeout(60):
-            await client.async_get_information(),
-            await client.async_get_system(),
+            await client.async_get_information()
+            await client.async_get_system()
     except BridgeAuthenticationException as exception:
         raise ConfigEntryAuthFailed from exception
     except BRIDGE_CONNECTION_ERRORS as exception:
@@ -88,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             or coordinator.bridge.processes is None
             or coordinator.bridge.system is None
         ):
-            _LOGGER.debug("No data yet, waiting..")
+            _LOGGER.debug("Waiting for initial data")
             await asyncio.sleep(1)
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -88,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 or coordinator.bridge.processes is None
                 or coordinator.bridge.system is None
             ):
-                _LOGGER.debug("Waiting for initial data")
+                _LOGGER.debug("Waiting for initial data from %s", entry.data[CONF_HOST])
                 await asyncio.sleep(1)
     except asyncio.TimeoutError as exception:
         raise ConfigEntryNotReady("Timed out waiting for System Bridge.") from exception

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from . import BridgeDeviceEntity
+from . import SystemBridgeDeviceEntity
 from .const import DOMAIN
 
 
@@ -23,10 +23,12 @@ async def async_setup_entry(
     bridge: Bridge = coordinator.data
 
     if bridge.battery.hasBattery:
-        async_add_entities([BridgeBatteryIsChargingBinarySensor(coordinator, bridge)])
+        async_add_entities(
+            [SystemBridgeBatteryIsChargingBinarySensor(coordinator, bridge)]
+        )
 
 
-class BridgeBinarySensor(BridgeDeviceEntity, BinarySensorEntity):
+class SystemBridgeBinarySensor(SystemBridgeDeviceEntity, BinarySensorEntity):
     """Defines a System Bridge binary sensor."""
 
     def __init__(
@@ -50,7 +52,7 @@ class BridgeBinarySensor(BridgeDeviceEntity, BinarySensorEntity):
         return self._device_class
 
 
-class BridgeBatteryIsChargingBinarySensor(BridgeBinarySensor):
+class SystemBridgeBatteryIsChargingBinarySensor(SystemBridgeBinarySensor):
     """Defines a Battery is charging binary sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -9,23 +9,21 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import SystemBridgeDeviceEntity
 from .const import DOMAIN
+from .coordinator import SystemBridgeDataUpdateCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up System Bridge binary sensor based on a config entry."""
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    bridge: Bridge = coordinator.data
+    coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    bridge: Bridge = coordinator.bridge
 
-    if bridge.battery.hasBattery:
-        async_add_entities(
-            [SystemBridgeBatteryIsChargingBinarySensor(coordinator, bridge)]
-        )
+    if bridge.battery and bridge.battery.hasBattery:
+        async_add_entities([SystemBridgeBatteryIsChargingBinarySensor(coordinator)])
 
 
 class SystemBridgeBinarySensor(SystemBridgeDeviceEntity, BinarySensorEntity):
@@ -33,8 +31,7 @@ class SystemBridgeBinarySensor(SystemBridgeDeviceEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
-        bridge: Bridge,
+        coordinator: SystemBridgeDataUpdateCoordinator,
         key: str,
         name: str,
         icon: str | None,
@@ -44,7 +41,7 @@ class SystemBridgeBinarySensor(SystemBridgeDeviceEntity, BinarySensorEntity):
         """Initialize System Bridge binary sensor."""
         self._device_class = device_class
 
-        super().__init__(coordinator, bridge, key, name, icon, enabled_by_default)
+        super().__init__(coordinator, key, name, icon, enabled_by_default)
 
     @property
     def device_class(self) -> str | None:
@@ -55,11 +52,10 @@ class SystemBridgeBinarySensor(SystemBridgeDeviceEntity, BinarySensorEntity):
 class SystemBridgeBatteryIsChargingBinarySensor(SystemBridgeBinarySensor):
     """Defines a Battery is charging binary sensor."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
+    def __init__(self, coordinator: SystemBridgeDataUpdateCoordinator) -> None:
         """Initialize System Bridge binary sensor."""
         super().__init__(
             coordinator,
-            bridge,
             "battery_is_charging",
             "Battery Is Charging",
             None,

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -20,7 +20,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up System Bridge binary sensor based on a config entry."""
     coordinator: SystemBridgeDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    bridge: Bridge = coordinator.bridge
+    bridge: Bridge = coordinator.data
 
     if bridge.battery and bridge.battery.hasBattery:
         async_add_entities([SystemBridgeBatteryIsChargingBinarySensor(coordinator)])

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -16,7 +16,7 @@ from systembridge.objects.events import Event
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -54,7 +54,6 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
         self.logger.debug("New event from System Bridge: %s", event.name)
         self.async_set_updated_data(self.bridge)
 
-    @callback
     async def _setup_websocket(self) -> None:
         """Use WebSocket for updates, instead of polling."""
 

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -36,6 +36,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
     ) -> None:
         """Initialize global System Bridge data updater."""
         self.bridge = bridge
+        self.title = entry.title
         self.host = entry.data[CONF_HOST]
         self.unsub: Callable | None = None
 
@@ -51,7 +52,9 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
     async def async_handle_event(self, event: Event):
         """Handle System Bridge events from the WebSocket."""
         # No need to update anything, as everything is updated in the caller
-        self.logger.debug("New event from %s: %s", self.host, event.name)
+        self.logger.debug(
+            "New event from %s (%s): %s", self.title, self.host, event.name
+        )
         self.async_set_updated_data(self.bridge)
 
     async def _listen_for_events(self) -> None:

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -108,9 +108,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
             if self.unsub:
                 self.unsub()
                 self.unsub = None
-            raise ConfigEntryAuthFailed(
-                f"Authentication failed for {self.title} ({self.host})"
-            ) from exception
+            raise ConfigEntryAuthFailed() from exception
         except (*BRIDGE_CONNECTION_ERRORS, ConnectionRefusedError) as exception:
             if self.unsub:
                 self.unsub()

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -1,0 +1,98 @@
+"""DataUpdateCoordinator for System Bridge."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Callable
+
+from systembridge import Bridge
+from systembridge.client import BridgeClient
+from systembridge.exceptions import BridgeConnectionClosedException, BridgeException
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_HOST,
+    CONF_PORT,
+    EVENT_HOMEASSISTANT_STOP,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN
+
+
+class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
+    """Class to manage fetching System Bridge data from single endpoint."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        LOGGER: logging.Logger,
+        *,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize global System Bridge data updater."""
+        self.bridge = Bridge(
+            BridgeClient(async_get_clientsession(hass)),
+            f"http://{entry.data[CONF_HOST]}:{entry.data[CONF_PORT]}",
+            entry.data[CONF_API_KEY],
+        )
+        self.host = entry.data[CONF_HOST]
+        self.unsub: Callable | None = None
+
+        super().__init__(hass, LOGGER, name=DOMAIN)
+
+    def update_listeners(self) -> None:
+        """Call update on all listeners."""
+        for update_callback in self._listeners:
+            update_callback()
+
+    @callback
+    def _use_websocket(self) -> None:
+        """Use WebSocket for updates, instead of polling."""
+
+        async def listen() -> None:
+            """Listen for state changes via WebSocket."""
+            try:
+                await self.bridge.async_connect_websocket(
+                    self.host,
+                    (await self.bridge.async_get_setting("network", "wsPort")).value,
+                )
+            except BridgeException as exception:
+                self.logger.error(exception)
+                if self.unsub:
+                    self.unsub()
+                    self.unsub = None
+                return
+
+            try:
+                await self.bridge.listen_for_events(
+                    callback=self.async_set_updated_data
+                )
+            except BridgeConnectionClosedException as exception:
+                self.last_update_success = False
+                self.logger.info(exception)
+            except BridgeException as exception:
+                self.last_update_success = False
+                self.update_listeners()
+                self.logger.error(exception)
+
+        async def close_websocket(_) -> None:
+            """Close WebSocket connection."""
+            await self.bridge.async_disconnect_websocket()
+
+        # Clean disconnect WebSocket on Home Assistant shutdown
+        self.unsub = self.hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STOP, close_websocket
+        )
+
+        # Start listening
+        asyncio.create_task(listen())
+
+    async def _async_update_data(self) -> Bridge:
+        """Update System Bridge data from WebSocket."""
+        if not self.bridge.websocket_connected:
+            self._use_websocket()
+        return self.bridge

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -88,7 +88,6 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
                     "battery",
                     "cpu",
                     "filesystem",
-                    "information",
                     "memory",
                     "network",
                     "os",

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -77,7 +77,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
         except BridgeConnectionClosedException as exception:
             self.last_update_success = False
             self.logger.info(
-                "Websocket Connection Closed for %s (%s). Will retry. %s",
+                "Websocket Connection Closed for %s (%s). Will retry: %s",
                 self.title,
                 self.host,
                 exception,
@@ -86,7 +86,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
             self.last_update_success = False
             self.update_listeners()
             self.logger.warning(
-                "Exception occurred for %s (%s). Will retry. %s",
+                "Exception occurred for %s (%s). Will retry: %s",
                 self.title,
                 self.host,
                 exception,

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -109,14 +109,14 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
                 self.unsub()
                 self.unsub = None
             raise ConfigEntryAuthFailed(
-                "Authentication failed for %s (%s)", self.title, self.host
+                f"Authentication failed for {self.title} ({self.host})"
             ) from exception
         except (*BRIDGE_CONNECTION_ERRORS, ConnectionRefusedError) as exception:
             if self.unsub:
                 self.unsub()
                 self.unsub = None
             raise UpdateFailed(
-                "Could not connect to %s (%s).", self.title, self.host
+                f"Could not connect to {self.title} ({self.host})."
             ) from exception
         asyncio.create_task(self._listen_for_events())
 

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -51,7 +51,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
     async def async_handle_event(self, event: Event):
         """Handle System Bridge events from the WebSocket."""
         # No need to update anything, as everything is updated in the caller
-        self.logger.debug("New event from System Bridge: %s", event.name)
+        self.logger.debug("New event from %s: %s", self.host, event.name)
         self.async_set_updated_data(self.bridge)
 
     async def _listen_for_events(self) -> None:
@@ -80,7 +80,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
             self.logger.warning("Exception occurred. Will retry. %s", exception)
 
     async def _setup_websocket(self) -> None:
-        """Use WebSocket for updates, instead of polling."""
+        """Use WebSocket for updates."""
 
         try:
             self.logger.debug(

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -97,7 +97,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
                 self.unsub()
                 self.unsub = None
             raise ConfigEntryAuthFailed from exception
-        except BRIDGE_CONNECTION_ERRORS as exception:
+        except (*BRIDGE_CONNECTION_ERRORS, ConnectionRefusedError) as exception:
             if self.unsub:
                 self.unsub()
                 self.unsub = None

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -28,8 +28,8 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[Bridge]):
 
     def __init__(
         self,
-        bridge: Bridge,
         hass: HomeAssistant,
+        bridge: Bridge,
         LOGGER: logging.Logger,
         *,
         entry: ConfigEntry,

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -3,7 +3,7 @@
   "name": "System Bridge",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/system_bridge",
-  "requirements": ["systembridge==2.0.4"],
+  "requirements": ["systembridge==2.0.5"],
   "codeowners": ["@timmo001"],
   "zeroconf": ["_system-bridge._udp.local."],
   "after_dependencies": ["zeroconf"],

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -3,7 +3,7 @@
   "name": "System Bridge",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/system_bridge",
-  "requirements": ["systembridge==2.0.1"],
+  "requirements": ["systembridge==2.0.2"],
   "codeowners": ["@timmo001"],
   "zeroconf": ["_system-bridge._udp.local."],
   "after_dependencies": ["zeroconf"],

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -3,10 +3,10 @@
   "name": "System Bridge",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/system_bridge",
-  "requirements": ["systembridge==2.0.0"],
+  "requirements": ["systembridge==2.0.1"],
   "codeowners": ["@timmo001"],
   "zeroconf": ["_system-bridge._udp.local."],
   "after_dependencies": ["zeroconf"],
   "quality_scale": "silver",
-  "iot_class": "local_polling"
+  "iot_class": "local_push"
 }

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -3,7 +3,7 @@
   "name": "System Bridge",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/system_bridge",
-  "requirements": ["systembridge==2.0.2"],
+  "requirements": ["systembridge==2.0.3"],
   "codeowners": ["@timmo001"],
   "zeroconf": ["_system-bridge._udp.local."],
   "after_dependencies": ["zeroconf"],

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -3,7 +3,7 @@
   "name": "System Bridge",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/system_bridge",
-  "requirements": ["systembridge==2.0.5"],
+  "requirements": ["systembridge==2.0.6"],
   "codeowners": ["@timmo001"],
   "zeroconf": ["_system-bridge._udp.local."],
   "after_dependencies": ["zeroconf"],

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -3,7 +3,7 @@
   "name": "System Bridge",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/system_bridge",
-  "requirements": ["systembridge==2.0.3"],
+  "requirements": ["systembridge==2.0.4"],
   "codeowners": ["@timmo001"],
   "zeroconf": ["_system-bridge._udp.local."],
   "after_dependencies": ["zeroconf"],

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -3,7 +3,7 @@
   "name": "System Bridge",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/system_bridge",
-  "requirements": ["systembridge==1.1.5"],
+  "requirements": ["systembridge==2.0.0"],
   "codeowners": ["@timmo001"],
   "zeroconf": ["_system-bridge._udp.local."],
   "after_dependencies": ["zeroconf"],

--- a/homeassistant/components/system_bridge/sensor.py
+++ b/homeassistant/components/system_bridge/sensor.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from . import BridgeDeviceEntity
+from . import SystemBridgeDeviceEntity
 from .const import DOMAIN
 
 ATTR_AVAILABLE = "available"
@@ -45,30 +45,30 @@ async def async_setup_entry(
     bridge: Bridge = coordinator.data
 
     entities = [
-        BridgeCpuSpeedSensor(coordinator, bridge),
-        BridgeCpuTemperatureSensor(coordinator, bridge),
-        BridgeCpuVoltageSensor(coordinator, bridge),
+        SystemBridgeCpuSpeedSensor(coordinator, bridge),
+        SystemBridgeCpuTemperatureSensor(coordinator, bridge),
+        SystemBridgeCpuVoltageSensor(coordinator, bridge),
         *(
-            BridgeFilesystemSensor(coordinator, bridge, key)
+            SystemBridgeFilesystemSensor(coordinator, bridge, key)
             for key, _ in bridge.filesystem.fsSize.items()
         ),
-        BridgeMemoryFreeSensor(coordinator, bridge),
-        BridgeMemoryUsedSensor(coordinator, bridge),
-        BridgeMemoryUsedPercentageSensor(coordinator, bridge),
-        BridgeKernelSensor(coordinator, bridge),
-        BridgeOsSensor(coordinator, bridge),
-        BridgeProcessesLoadSensor(coordinator, bridge),
-        BridgeBiosVersionSensor(coordinator, bridge),
+        SystemBridgeMemoryFreeSensor(coordinator, bridge),
+        SystemBridgeMemoryUsedSensor(coordinator, bridge),
+        SystemBridgeMemoryUsedPercentageSensor(coordinator, bridge),
+        SystemBridgeKernelSensor(coordinator, bridge),
+        SystemBridgeOsSensor(coordinator, bridge),
+        SystemBridgeProcessesLoadSensor(coordinator, bridge),
+        SystemBridgeBiosVersionSensor(coordinator, bridge),
     ]
 
     if bridge.battery.hasBattery:
-        entities.append(BridgeBatterySensor(coordinator, bridge))
-        entities.append(BridgeBatteryTimeRemainingSensor(coordinator, bridge))
+        entities.append(SystemBridgeBatterySensor(coordinator, bridge))
+        entities.append(SystemBridgeBatteryTimeRemainingSensor(coordinator, bridge))
 
     async_add_entities(entities)
 
 
-class BridgeSensor(BridgeDeviceEntity, SensorEntity):
+class SystemBridgeSensor(SystemBridgeDeviceEntity, SensorEntity):
     """Defines a System Bridge sensor."""
 
     def __init__(
@@ -99,7 +99,7 @@ class BridgeSensor(BridgeDeviceEntity, SensorEntity):
         return self._unit_of_measurement
 
 
-class BridgeBatterySensor(BridgeSensor):
+class SystemBridgeBatterySensor(SystemBridgeSensor):
     """Defines a Battery sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -122,7 +122,7 @@ class BridgeBatterySensor(BridgeSensor):
         return bridge.battery.percent
 
 
-class BridgeBatteryTimeRemainingSensor(BridgeSensor):
+class SystemBridgeBatteryTimeRemainingSensor(SystemBridgeSensor):
     """Defines the Battery Time Remaining sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -147,7 +147,7 @@ class BridgeBatteryTimeRemainingSensor(BridgeSensor):
         return str(datetime.now() + timedelta(minutes=bridge.battery.timeRemaining))
 
 
-class BridgeCpuSpeedSensor(BridgeSensor):
+class SystemBridgeCpuSpeedSensor(SystemBridgeSensor):
     """Defines a CPU speed sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -170,7 +170,7 @@ class BridgeCpuSpeedSensor(BridgeSensor):
         return bridge.cpu.currentSpeed.avg
 
 
-class BridgeCpuTemperatureSensor(BridgeSensor):
+class SystemBridgeCpuTemperatureSensor(SystemBridgeSensor):
     """Defines a CPU temperature sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -193,7 +193,7 @@ class BridgeCpuTemperatureSensor(BridgeSensor):
         return bridge.cpu.temperature.main
 
 
-class BridgeCpuVoltageSensor(BridgeSensor):
+class SystemBridgeCpuVoltageSensor(SystemBridgeSensor):
     """Defines a CPU voltage sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -216,7 +216,7 @@ class BridgeCpuVoltageSensor(BridgeSensor):
         return bridge.cpu.cpu.voltage
 
 
-class BridgeFilesystemSensor(BridgeSensor):
+class SystemBridgeFilesystemSensor(SystemBridgeSensor):
     """Defines a filesystem sensor."""
 
     def __init__(
@@ -260,7 +260,7 @@ class BridgeFilesystemSensor(BridgeSensor):
         }
 
 
-class BridgeMemoryFreeSensor(BridgeSensor):
+class SystemBridgeMemoryFreeSensor(SystemBridgeSensor):
     """Defines a memory free sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -287,7 +287,7 @@ class BridgeMemoryFreeSensor(BridgeSensor):
         )
 
 
-class BridgeMemoryUsedSensor(BridgeSensor):
+class SystemBridgeMemoryUsedSensor(SystemBridgeSensor):
     """Defines a memory used sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -314,7 +314,7 @@ class BridgeMemoryUsedSensor(BridgeSensor):
         )
 
 
-class BridgeMemoryUsedPercentageSensor(BridgeSensor):
+class SystemBridgeMemoryUsedPercentageSensor(SystemBridgeSensor):
     """Defines a memory used percentage sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -341,7 +341,7 @@ class BridgeMemoryUsedPercentageSensor(BridgeSensor):
         )
 
 
-class BridgeKernelSensor(BridgeSensor):
+class SystemBridgeKernelSensor(SystemBridgeSensor):
     """Defines a kernel sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -364,7 +364,7 @@ class BridgeKernelSensor(BridgeSensor):
         return bridge.os.kernel
 
 
-class BridgeOsSensor(BridgeSensor):
+class SystemBridgeOsSensor(SystemBridgeSensor):
     """Defines an OS sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -387,7 +387,7 @@ class BridgeOsSensor(BridgeSensor):
         return f"{bridge.os.distro} {bridge.os.release}"
 
 
-class BridgeProcessesLoadSensor(BridgeSensor):
+class SystemBridgeProcessesLoadSensor(SystemBridgeSensor):
     """Defines a Processes Load sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:
@@ -429,7 +429,7 @@ class BridgeProcessesLoadSensor(BridgeSensor):
         return attrs
 
 
-class BridgeBiosVersionSensor(BridgeSensor):
+class SystemBridgeBiosVersionSensor(SystemBridgeSensor):
     """Defines a bios version sensor."""
 
     def __init__(self, coordinator: DataUpdateCoordinator, bridge: Bridge) -> None:

--- a/homeassistant/components/system_bridge/sensor.py
+++ b/homeassistant/components/system_bridge/sensor.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
         SystemBridgeCpuVoltageSensor(coordinator),
         *(
             SystemBridgeFilesystemSensor(coordinator, key)
-            for key, _ in coordinator.bridge.filesystem.fsSize.items()
+            for key, _ in coordinator.data.filesystem.fsSize.items()
         ),
         SystemBridgeMemoryFreeSensor(coordinator),
         SystemBridgeMemoryUsedSensor(coordinator),
@@ -60,7 +60,7 @@ async def async_setup_entry(
         SystemBridgeBiosVersionSensor(coordinator),
     ]
 
-    if coordinator.bridge.battery.hasBattery:
+    if coordinator.data.battery.hasBattery:
         entities.append(SystemBridgeBatterySensor(coordinator))
         entities.append(SystemBridgeBatteryTimeRemainingSensor(coordinator))
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2233,7 +2233,7 @@ swisshydrodata==0.1.0
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.2
+systembridge==2.0.3
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2233,7 +2233,7 @@ swisshydrodata==0.1.0
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridge==1.1.5
+systembridge==2.0.0
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2233,7 +2233,7 @@ swisshydrodata==0.1.0
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.0
+systembridge==2.0.1
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2233,7 +2233,7 @@ swisshydrodata==0.1.0
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.3
+systembridge==2.0.4
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2233,7 +2233,7 @@ swisshydrodata==0.1.0
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.1
+systembridge==2.0.2
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2233,7 +2233,7 @@ swisshydrodata==0.1.0
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.5
+systembridge==2.0.6
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2233,7 +2233,7 @@ swisshydrodata==0.1.0
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.4
+systembridge==2.0.5
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.16

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1232,7 +1232,7 @@ sunwatcher==0.2.1
 surepy==0.7.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.1
+systembridge==2.0.2
 
 # homeassistant.components.tellduslive
 tellduslive==0.10.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1232,7 +1232,7 @@ sunwatcher==0.2.1
 surepy==0.7.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.5
+systembridge==2.0.6
 
 # homeassistant.components.tellduslive
 tellduslive==0.10.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1232,7 +1232,7 @@ sunwatcher==0.2.1
 surepy==0.7.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.3
+systembridge==2.0.4
 
 # homeassistant.components.tellduslive
 tellduslive==0.10.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1232,7 +1232,7 @@ sunwatcher==0.2.1
 surepy==0.7.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.2
+systembridge==2.0.3
 
 # homeassistant.components.tellduslive
 tellduslive==0.10.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1232,7 +1232,7 @@ sunwatcher==0.2.1
 surepy==0.7.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.0
+systembridge==2.0.1
 
 # homeassistant.components.tellduslive
 tellduslive==0.10.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1232,7 +1232,7 @@ sunwatcher==0.2.1
 surepy==0.7.0
 
 # homeassistant.components.system_bridge
-systembridge==2.0.4
+systembridge==2.0.5
 
 # homeassistant.components.tellduslive
 tellduslive==0.10.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1232,7 +1232,7 @@ sunwatcher==0.2.1
 surepy==0.7.0
 
 # homeassistant.components.system_bridge
-systembridge==1.1.5
+systembridge==2.0.0
 
 # homeassistant.components.tellduslive
 tellduslive==0.10.11

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -55,79 +55,24 @@ FIXTURE_ZEROCONF_BAD = {
     },
 }
 
-FIXTURE_OS = {
-    "platform": "linux",
-    "distro": "Ubuntu",
-    "release": "20.10",
-    "codename": "Groovy Gorilla",
-    "kernel": "5.8.0-44-generic",
-    "arch": "x64",
-    "hostname": "test-bridge",
-    "fqdn": "test-bridge.local",
-    "codepage": "UTF-8",
-    "logofile": "ubuntu",
-    "serial": "abcdefghijklmnopqrstuvwxyz",
-    "build": "",
-    "servicepack": "",
-    "uefi": True,
-    "users": [],
-}
 
-
-FIXTURE_NETWORK = {
-    "connections": [],
-    "gatewayDefault": "192.168.1.1",
-    "interfaceDefault": "wlp2s0",
-    "interfaces": {
-        "wlp2s0": {
-            "iface": "wlp2s0",
-            "ifaceName": "wlp2s0",
-            "ip4": "1.1.1.1",
-            "mac": FIXTURE_MAC_ADDRESS,
-        },
+FIXTURE_INFORMATION = {
+    "address": "http://test-bridge:9170",
+    "apiPort": 9170,
+    "fqdn": "test-bridge",
+    "host": "test-bridge",
+    "ip": "1.1.1.1",
+    "mac": FIXTURE_MAC_ADDRESS,
+    "updates": {
+        "available": False,
+        "newer": False,
+        "url": "https://github.com/timmo001/system-bridge/releases/tag/v2.3.2",
+        "version": {"current": "2.3.2", "new": "2.3.2"},
     },
-    "stats": {},
-}
-
-FIXTURE_SYSTEM = {
-    "baseboard": {
-        "manufacturer": "System manufacturer",
-        "model": "Model",
-        "version": "Rev X.0x",
-        "serial": "1234567",
-        "assetTag": "",
-        "memMax": 134217728,
-        "memSlots": 4,
-    },
-    "bios": {
-        "vendor": "System vendor",
-        "version": "12345",
-        "releaseDate": "2019-11-13",
-        "revision": "",
-    },
-    "chassis": {
-        "manufacturer": "Default string",
-        "model": "",
-        "type": "Desktop",
-        "version": "Default string",
-        "serial": "Default string",
-        "assetTag": "",
-        "sku": "",
-    },
-    "system": {
-        "manufacturer": "System manufacturer",
-        "model": "System Product Name",
-        "version": "System Version",
-        "serial": "System Serial Number",
-        "uuid": "abc123-def456",
-        "sku": "SKU",
-        "virtual": False,
-    },
-    "uuid": {
-        "os": FIXTURE_UUID,
-        "hardware": "abc123-def456",
-        "macs": [FIXTURE_MAC_ADDRESS],
-    },
+    "uuid": FIXTURE_UUID,
+    "version": "2.3.2",
+    "websocketAddress": "ws://test-bridge:9172",
+    "websocketPort": 9172,
 }
 
 
@@ -151,9 +96,7 @@ async def test_user_flow(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] is None
 
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/os", json=FIXTURE_OS)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/network", json=FIXTURE_NETWORK)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/system", json=FIXTURE_SYSTEM)
+    aioclient_mock.get(f"{FIXTURE_BASE_URL}/information", json=FIXTURE_INFORMATION)
 
     with patch(
         "homeassistant.components.system_bridge.async_setup_entry",
@@ -181,9 +124,9 @@ async def test_form_invalid_auth(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] is None
 
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/os", exc=BridgeAuthenticationException)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/network", exc=BridgeAuthenticationException)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/system", exc=BridgeAuthenticationException)
+    aioclient_mock.get(
+        f"{FIXTURE_BASE_URL}/information", exc=BridgeAuthenticationException
+    )
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], FIXTURE_USER_INPUT
@@ -206,9 +149,9 @@ async def test_form_cannot_connect(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] is None
 
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/os", exc=ClientConnectionError)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/network", exc=ClientConnectionError)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/system", exc=ClientConnectionError)
+    aioclient_mock.get(
+        f"{FIXTURE_BASE_URL}/information", exc=BridgeAuthenticationException
+    )
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], FIXTURE_USER_INPUT
@@ -220,7 +163,7 @@ async def test_form_cannot_connect(
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_unknow_error(
+async def test_form_unknown_error(
     hass, aiohttp_client, aioclient_mock, current_request_with_host
 ) -> None:
     """Test we handle unknown error."""
@@ -232,10 +175,9 @@ async def test_form_unknow_error(
     assert result["errors"] is None
 
     with patch(
-        "homeassistant.components.system_bridge.config_flow.Bridge.async_get_os",
+        "homeassistant.components.system_bridge.config_flow.Bridge.async_get_information",
         side_effect=Exception("Boom"),
     ):
-
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], FIXTURE_USER_INPUT
         )
@@ -257,9 +199,9 @@ async def test_reauth_authorization_error(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "authenticate"
 
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/network", exc=BridgeAuthenticationException)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/os", exc=BridgeAuthenticationException)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/system", exc=BridgeAuthenticationException)
+    aioclient_mock.get(
+        f"{FIXTURE_BASE_URL}/information", exc=BridgeAuthenticationException
+    )
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], FIXTURE_AUTH_INPUT
@@ -282,9 +224,7 @@ async def test_reauth_connection_error(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "authenticate"
 
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/os", exc=ClientConnectionError)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/network", exc=ClientConnectionError)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/system", exc=ClientConnectionError)
+    aioclient_mock.get(f"{FIXTURE_BASE_URL}/information", exc=ClientConnectionError)
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], FIXTURE_AUTH_INPUT
@@ -312,9 +252,7 @@ async def test_reauth_flow(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "authenticate"
 
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/os", json=FIXTURE_OS)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/network", json=FIXTURE_NETWORK)
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/system", json=FIXTURE_SYSTEM)
+    aioclient_mock.get(f"{FIXTURE_BASE_URL}/information", json=FIXTURE_INFORMATION)
 
     with patch(
         "homeassistant.components.system_bridge.async_setup_entry",
@@ -345,9 +283,7 @@ async def test_zeroconf_flow(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert not result["errors"]
 
-    aioclient_mock.get(f"{FIXTURE_ZEROCONF_BASE_URL}/os", json=FIXTURE_OS)
-    aioclient_mock.get(f"{FIXTURE_ZEROCONF_BASE_URL}/network", json=FIXTURE_NETWORK)
-    aioclient_mock.get(f"{FIXTURE_ZEROCONF_BASE_URL}/system", json=FIXTURE_SYSTEM)
+    aioclient_mock.get(f"{FIXTURE_BASE_URL}/information", json=FIXTURE_INFORMATION)
 
     with patch(
         "homeassistant.components.system_bridge.async_setup_entry",
@@ -378,11 +314,7 @@ async def test_zeroconf_cannot_connect(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert not result["errors"]
 
-    aioclient_mock.get(f"{FIXTURE_ZEROCONF_BASE_URL}/os", exc=ClientConnectionError)
-    aioclient_mock.get(
-        f"{FIXTURE_ZEROCONF_BASE_URL}/network", exc=ClientConnectionError
-    )
-    aioclient_mock.get(f"{FIXTURE_ZEROCONF_BASE_URL}/system", exc=ClientConnectionError)
+    aioclient_mock.get(f"{FIXTURE_BASE_URL}/information", exc=ClientConnectionError)
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], FIXTURE_AUTH_INPUT

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -290,7 +290,7 @@ async def test_zeroconf_flow(
     assert not result["errors"]
 
     aioclient_mock.get(
-        f"{FIXTURE_BASE_URL}/information",
+        f"{FIXTURE_ZEROCONF_BASE_URL}/information",
         headers={"Content-Type": "application/json"},
         json=FIXTURE_INFORMATION,
     )
@@ -324,7 +324,9 @@ async def test_zeroconf_cannot_connect(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert not result["errors"]
 
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/information", exc=ClientConnectionError)
+    aioclient_mock.get(
+        f"{FIXTURE_ZEROCONF_BASE_URL}/information", exc=ClientConnectionError
+    )
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], FIXTURE_AUTH_INPUT

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -149,9 +149,7 @@ async def test_form_cannot_connect(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] is None
 
-    aioclient_mock.get(
-        f"{FIXTURE_BASE_URL}/information", exc=BridgeAuthenticationException
-    )
+    aioclient_mock.get(f"{FIXTURE_BASE_URL}/information", exc=ClientConnectionError)
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], FIXTURE_USER_INPUT

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -96,7 +96,11 @@ async def test_user_flow(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] is None
 
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/information", json=FIXTURE_INFORMATION)
+    aioclient_mock.get(
+        f"{FIXTURE_BASE_URL}/information",
+        headers={"Content-Type": "application/json"},
+        json=FIXTURE_INFORMATION,
+    )
 
     with patch(
         "homeassistant.components.system_bridge.async_setup_entry",
@@ -250,7 +254,11 @@ async def test_reauth_flow(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "authenticate"
 
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/information", json=FIXTURE_INFORMATION)
+    aioclient_mock.get(
+        f"{FIXTURE_BASE_URL}/information",
+        headers={"Content-Type": "application/json"},
+        json=FIXTURE_INFORMATION,
+    )
 
     with patch(
         "homeassistant.components.system_bridge.async_setup_entry",
@@ -281,7 +289,11 @@ async def test_zeroconf_flow(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert not result["errors"]
 
-    aioclient_mock.get(f"{FIXTURE_BASE_URL}/information", json=FIXTURE_INFORMATION)
+    aioclient_mock.get(
+        f"{FIXTURE_BASE_URL}/information",
+        headers={"Content-Type": "application/json"},
+        json=FIXTURE_INFORMATION,
+    )
 
     with patch(
         "homeassistant.components.system_bridge.async_setup_entry",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates integration (with some cleanup) to use the WebSocket on System Bridge. This will change the integration to a `local_push` class as all the data sensor now comes from the application instead of polling.

Package changes:

https://github.com/timmo001/system-bridge-connector-py/releases
https://github.com/timmo001/system-bridge-connector-py/compare/v1.1.5...v2.0.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (which adds functionality to an existing integration)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18603

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

<!--
- [ ] No score or internal
-->
- [x] 🥈 Silver
<!--
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
-->

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
