### PR TITLE
Add select_next and select_previous services to Select

### DIFF
--- a/homeassistant/components/select/const.py
+++ b/homeassistant/components/select/const.py
@@ -2,9 +2,13 @@
 
 DOMAIN = "select"
 
+ATTR_CYCLE = "cycle"
 ATTR_OPTIONS = "options"
 ATTR_OPTION = "option"
 
+CONF_CYCLE = "cycle"
 CONF_OPTION = "option"
 
 SERVICE_SELECT_OPTION = "select_option"
+SERVICE_SELECT_NEXT = "select_next"
+SERVICE_SELECT_PREVIOUS = "select_previous"

--- a/homeassistant/components/select/device_action.py
+++ b/homeassistant/components/select/device_action.py
@@ -18,17 +18,37 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import get_capability
 from homeassistant.helpers.typing import ConfigType
 
-from .const import ATTR_OPTION, ATTR_OPTIONS, CONF_OPTION, DOMAIN, SERVICE_SELECT_OPTION
+from .const import (
+    ATTR_CYCLE,
+    ATTR_OPTION,
+    ATTR_OPTIONS,
+    CONF_CYCLE,
+    CONF_OPTION,
+    DOMAIN,
+    SERVICE_SELECT_NEXT,
+    SERVICE_SELECT_OPTION,
+    SERVICE_SELECT_PREVIOUS,
+)
 
-ACTION_TYPES = {"select_option"}
+ACTION_TYPES = {SERVICE_SELECT_OPTION, SERVICE_SELECT_NEXT, SERVICE_SELECT_PREVIOUS}
 
-ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+SELECT_OPTION_ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_TYPE): vol.Equal(SERVICE_SELECT_OPTION),
         vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
         vol.Required(CONF_OPTION): str,
     }
 )
+
+OFFSET_OPTION_ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In({SERVICE_SELECT_NEXT, SERVICE_SELECT_PREVIOUS}),
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+        vol.Optional(CONF_CYCLE, default=True): bool,
+    }
+)
+
+ACTION_SCHEMA = vol.Any(SELECT_OPTION_ACTION_SCHEMA, OFFSET_OPTION_ACTION_SCHEMA)
 
 
 async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
@@ -39,36 +59,62 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
             CONF_DEVICE_ID: device_id,
             CONF_DOMAIN: DOMAIN,
             CONF_ENTITY_ID: entry.entity_id,
-            CONF_TYPE: "select_option",
+            CONF_TYPE: conf_type,
         }
+        for conf_type in [
+            SERVICE_SELECT_OPTION,
+            SERVICE_SELECT_NEXT,
+            SERVICE_SELECT_PREVIOUS,
+        ]
         for entry in entity_registry.async_entries_for_device(registry, device_id)
         if entry.domain == DOMAIN
     ]
 
 
 async def async_call_action_from_config(
-    hass: HomeAssistant, config: dict, variables: dict, context: Context | None
+    hass: HomeAssistant, config: ConfigType, variables: dict, context: Context | None
 ) -> None:
     """Execute a device action."""
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {
-            ATTR_ENTITY_ID: config[CONF_ENTITY_ID],
-            ATTR_OPTION: config[CONF_OPTION],
-        },
-        blocking=True,
-        context=context,
-    )
+    action_type = config[CONF_TYPE]
+    if action_type == SERVICE_SELECT_OPTION:
+        await hass.services.async_call(
+            DOMAIN,
+            action_type,
+            {
+                ATTR_ENTITY_ID: config[CONF_ENTITY_ID],
+                ATTR_OPTION: config[CONF_OPTION],
+            },
+            blocking=True,
+            context=context,
+        )
+    else:
+        await hass.services.async_call(
+            DOMAIN,
+            action_type,
+            {
+                ATTR_ENTITY_ID: config[CONF_ENTITY_ID],
+                ATTR_CYCLE: config[CONF_CYCLE],
+            },
+            blocking=True,
+            context=context,
+        )
 
 
 async def async_get_action_capabilities(
     hass: HomeAssistant, config: ConfigType
 ) -> dict[str, Any]:
     """List action capabilities."""
-    try:
-        options = get_capability(hass, config[CONF_ENTITY_ID], ATTR_OPTIONS) or []
-    except HomeAssistantError:
-        options = []
+    action_type = config[CONF_TYPE]
 
-    return {"extra_fields": vol.Schema({vol.Required(CONF_OPTION): vol.In(options)})}
+    if action_type == SERVICE_SELECT_OPTION:
+        try:
+            options = get_capability(hass, config[CONF_ENTITY_ID], ATTR_OPTIONS) or []
+        except HomeAssistantError:
+            options = []
+        return {
+            "extra_fields": vol.Schema({vol.Required(CONF_OPTION): vol.In(options)})
+        }
+    else:
+        return {
+            "extra_fields": vol.Schema({vol.Optional(CONF_CYCLE, default=True): bool})
+        }

--- a/homeassistant/components/select/device_action.py
+++ b/homeassistant/components/select/device_action.py
@@ -61,11 +61,7 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
             CONF_ENTITY_ID: entry.entity_id,
             CONF_TYPE: conf_type,
         }
-        for conf_type in [
-            SERVICE_SELECT_OPTION,
-            SERVICE_SELECT_NEXT,
-            SERVICE_SELECT_PREVIOUS,
-        ]
+        for conf_type in ACTION_TYPES
         for entry in entity_registry.async_entries_for_device(registry, device_id)
         if entry.domain == DOMAIN
     ]
@@ -114,7 +110,4 @@ async def async_get_action_capabilities(
         return {
             "extra_fields": vol.Schema({vol.Required(CONF_OPTION): vol.In(options)})
         }
-    else:
-        return {
-            "extra_fields": vol.Schema({vol.Optional(CONF_CYCLE, default=True): bool})
-        }
+    return {"extra_fields": vol.Schema({vol.Optional(CONF_CYCLE, default=True): bool})}

--- a/homeassistant/components/select/services.yaml
+++ b/homeassistant/components/select/services.yaml
@@ -12,3 +12,35 @@ select_option:
       example: '"Item A"'
       selector:
         text:
+
+select_next:
+  name: Next
+  description: Select next option of an select entity.
+  target:
+    entity:
+      domain: select
+  fields:
+    cycle:
+      name: Cycle
+      description: Loop to the first option if the last is currently selected.
+      required: false
+      default: true
+      example: true
+      selector:
+        boolean:
+
+select_previous:
+  name: Previous
+  description: Select previous option of an select entity.
+  target:
+    entity:
+      domain: select
+  fields:
+    cycle:
+      name: Cycle
+      description: Loop to the last option if the first is currently selected.
+      required: false
+      default: true
+      example: true
+      selector:
+        boolean:

--- a/tests/components/demo/test_select.py
+++ b/tests/components/demo/test_select.py
@@ -3,10 +3,13 @@
 import pytest
 
 from homeassistant.components.select.const import (
+    ATTR_CYCLE,
     ATTR_OPTION,
     ATTR_OPTIONS,
     DOMAIN,
+    SERVICE_SELECT_NEXT,
     SERVICE_SELECT_OPTION,
+    SERVICE_SELECT_PREVIOUS,
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
@@ -64,6 +67,68 @@ async def test_select_option(hass: HomeAssistant) -> None:
         DOMAIN,
         SERVICE_SELECT_OPTION,
         {ATTR_OPTION: "light_speed", ATTR_ENTITY_ID: ENTITY_SPEED},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "light_speed"
+
+
+async def test_select_next(hass: HomeAssistant) -> None:
+    """Test selecting a next option."""
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "ridiculous_speed"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_NEXT,
+        {ATTR_CYCLE: True, ATTR_ENTITY_ID: ENTITY_SPEED},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "ludicrous_speed"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_NEXT,
+        {ATTR_ENTITY_ID: ENTITY_SPEED},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "light_speed"
+
+
+async def test_select_previous(hass: HomeAssistant) -> None:
+    """Test selecting a previous option."""
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "ridiculous_speed"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_PREVIOUS,
+        {ATTR_CYCLE: True, ATTR_ENTITY_ID: ENTITY_SPEED},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "light_speed"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_PREVIOUS,
+        {ATTR_CYCLE: False, ATTR_ENTITY_ID: ENTITY_SPEED},
         blocking=True,
     )
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Similar to Input Select, adding these services for looping through options.
My personal use case for this is looping through WLED presets which is currently quite manual and hacky but I imagine there are other use cases as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18619

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
