### PR TITLE
Fix various zeroconf IPv6 compatibility issues

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -155,14 +155,21 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
             if not adapter["enabled"]:
                 continue
             if ipv4s := adapter["ipv4"]:
-                interfaces.append(ipv4s[0]["address"])
-            elif ipv6s := adapter["ipv6"]:
-                interfaces.append(ipv6s[0]["scope_id"])
+                interfaces.extend(
+                    ipv4["address"]
+                    for ipv4 in ipv4s
+                    if not ipaddress.ip_address(ipv4["address"]).is_loopback
+                )
+            if adapter["ipv6"]:
+                ifi = socket.if_nametoindex(adapter["name"])
+                interfaces.append(ifi)
 
     ipv6 = True
     if not any(adapter["enabled"] and adapter["ipv6"] for adapter in adapters):
         ipv6 = False
         zc_args["ip_version"] = IPVersion.V4Only
+    else:
+        zc_args["ip_version"] = IPVersion.All
 
     aio_zc = await _async_get_instance(hass, **zc_args)
     zeroconf = cast(HaZeroconf, aio_zc.zeroconf)
@@ -195,6 +202,32 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
+def _get_announced_addresses(
+    adapters: list[Adapter],
+    first_ip: bytes | None = None,
+) -> list[bytes]:
+    """Return a list of IP addresses to announce via zeroconf.
+
+    If first_ip is not None, it will be the first address in the list.
+    """
+    addresses = {
+        addr.packed
+        for addr in [
+            ipaddress.ip_address(ip["address"])
+            for adapter in adapters
+            if adapter["enabled"]
+            for ip in cast(list, adapter["ipv6"]) + cast(list, adapter["ipv4"])
+        ]
+        if not (addr.is_unspecified or addr.is_loopback)
+    }
+    if first_ip:
+        address_list = [first_ip]
+        address_list.extend(addresses - set({first_ip}))
+    else:
+        address_list = list(addresses)
+    return address_list
+
+
 async def _async_register_hass_zc_service(
     hass: HomeAssistant, aio_zc: HaAsyncZeroconf, uuid: str
 ) -> None:
@@ -223,12 +256,15 @@ async def _async_register_hass_zc_service(
     # Set old base URL based on external or internal
     params["base_url"] = params["external_url"] or params["internal_url"]
 
-    host_ip = await async_get_source_ip(hass, target_ip=MDNS_TARGET_IP)
+    adapters = await network.async_get_adapters(hass)
 
-    try:
+    # Puts the default IPv4 address first in the list to preserve compatibility,
+    # because some mDNS implementations ignores anything but the first announced address.
+    host_ip = await async_get_source_ip(hass, target_ip=MDNS_TARGET_IP)
+    host_ip_pton = None
+    if host_ip:
         host_ip_pton = socket.inet_pton(socket.AF_INET, host_ip)
-    except OSError:
-        host_ip_pton = socket.inet_pton(socket.AF_INET6, host_ip)
+    address_list = _get_announced_addresses(adapters, host_ip_pton)
 
     _suppress_invalid_properties(params)
 
@@ -236,7 +272,7 @@ async def _async_register_hass_zc_service(
         ZEROCONF_TYPE,
         name=f"{valid_location_name}.{ZEROCONF_TYPE}",
         server=f"{uuid}.local.",
-        addresses=[host_ip_pton],
+        addresses=address_list,
         port=hass.http.server_port,
         properties=params,
     )


### PR DESCRIPTION
Currently Home Assistant zeroconf service only listens on IPv4 address and announces IPv4 A records. This PR will make  Home Assistant listen on both IPv4 and IPv6 addresses and announce A & AAAA records.

1. If `_async_use_default_interface()` returns `True` (in most cases),
zeroconf only listens on the IPv4 address in IPv4/IPv6 dual-stack environment.
This is because the parameter `ip_version` in `Zeroconf::__init__()`
defaults to `IPVersion.V4Only` when `interfaces` is `InterfaceChoice.Default`.
This PR explicitly sets `ip_version` to `IPVersion.All` if any adapter has an IPv6 address.

2. If `_async_use_default_interface()` returns `False`, the [existing logic
to collect adapter scope IDs][1] doesn't work because `adapter["ipv6"][0]["scope_id"]`
only has a value if and only if `adapter["ipv6"][0]` is a link-local address.
In an IPv6 environment, it is very common to have multiple addresses associated to
a single adapter. In such case, it is very likely that `adapter["ipv6"][0]` is
not a link-local address because the order in list `adapter["ipv6"]` is not certain.

3. Currently home asistant only announces IPv4 records via mDNS,
because the input of the records are from `async_get_source_ip` with a hardcoded
`target_ip=MDNS_TARGET_IP`, which is [IPv4 only][2].
Furthermore, this function doesn't support IPv6 either because it (and its inner function) has a lot of
hardcoded IPv4 specific stuffs like `adapter["ipv4"]` (see [here][3]) and `socket.AF_INET` (see [here][4]).

The current approach is determining the source IPv4 address by connecting a UDP socket to `224.0.0.251`
then `getsockaddr` from the socket, which is tricky and I doubt it is actually useful.
However we can't determine the source IPv6 address using a similar approach
because the IPv6 equivalent of `224.0.0.251`, `ff02::fb`, is link-local scoped, so `getsockaddr` will always
return a link-local address.

This PR will make zeroconf announce all enabled IPv4 and IPv6 addresses via mDNS. To make sure it will not break the compatibility with existing clients, the current source IPv4 address will always be in the first address in the announced address list.

[1]: https://github.com/home-assistant/core/blob/46c3495ae06a589bf76c1f6dfe9dee7975ccba79/homeassistant/components/zeroconf/__init__.py#L155
[2]: https://github.com/home-assistant/core/blob/46c3495ae06a589bf76c1f6dfe9dee7975ccba79/homeassistant/components/zeroconf/__init__.py#L221
[3]: https://github.com/home-assistant/core/blob/46c3495ae06a589bf76c1f6dfe9dee7975ccba79/homeassistant/components/network/__init__.py#L41
[4]: https://github.com/home-assistant/core/blob/46c3495ae06a589bf76c1f6dfe9dee7975ccba79/homeassistant/components/network/util.py#L144

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
