### PR TITLE
Make sure that vocolinc flowerbud humidity sensor is exposed (via homekit_controller)

### DIFF
--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -49,4 +49,7 @@ CHARACTERISTIC_PLATFORMS = {
     CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY_2: "sensor",
     CharacteristicsTypes.Vendor.VOCOLINC_HUMIDIFIER_SPRAY_LEVEL: "number",
     CharacteristicsTypes.get_uuid(CharacteristicsTypes.TEMPERATURE_CURRENT): "sensor",
+    CharacteristicsTypes.get_uuid(
+        CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT
+    ): "sensor",
 }

--- a/homeassistant/components/homekit_controller/humidifier.py
+++ b/homeassistant/components/homekit_controller/humidifier.py
@@ -41,7 +41,6 @@ class HomeKitHumidifier(HomeKitEntity, HumidifierEntity):
         """Define the homekit characteristics the entity cares about."""
         return [
             CharacteristicsTypes.ACTIVE,
-            CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT,
             CharacteristicsTypes.CURRENT_HUMIDIFIER_DEHUMIDIFIER_STATE,
             CharacteristicsTypes.TARGET_HUMIDIFIER_DEHUMIDIFIER_STATE,
             CharacteristicsTypes.RELATIVE_HUMIDITY_HUMIDIFIER_THRESHOLD,
@@ -143,7 +142,6 @@ class HomeKitDehumidifier(HomeKitEntity, HumidifierEntity):
         """Define the homekit characteristics the entity cares about."""
         return [
             CharacteristicsTypes.ACTIVE,
-            CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT,
             CharacteristicsTypes.CURRENT_HUMIDIFIER_DEHUMIDIFIER_STATE,
             CharacteristicsTypes.TARGET_HUMIDIFIER_DEHUMIDIFIER_STATE,
             CharacteristicsTypes.RELATIVE_HUMIDITY_HUMIDIFIER_THRESHOLD,

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -53,6 +53,16 @@ SIMPLE_SENSOR = {
         "probe": lambda char: char.service.type
         != ServicesTypes.get_uuid(ServicesTypes.TEMPERATURE_SENSOR),
     },
+    CharacteristicsTypes.get_uuid(CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT): {
+        "name": "Current Humidity",
+        "device_class": DEVICE_CLASS_HUMIDITY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+        "unit": PERCENTAGE,
+        # This sensor is only for humidity characteristics that are not part
+        # of a temperature sensor service.
+        "probe": lambda char: char.service.type
+        != ServicesTypes.get_uuid(ServicesTypes.HUMIDITY_SENSOR),
+    },
 }
 
 

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -59,7 +59,7 @@ SIMPLE_SENSOR = {
         "state_class": STATE_CLASS_MEASUREMENT,
         "unit": PERCENTAGE,
         # This sensor is only for humidity characteristics that are not part
-        # of a temperature sensor service.
+        # of a humidity sensor service.
         "probe": lambda char: char.service.type
         != ServicesTypes.get_uuid(ServicesTypes.HUMIDITY_SENSOR),
     },

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
@@ -68,3 +68,25 @@ async def test_vocolinc_flowerbud_setup(hass):
 
     # The sensor and switch should be part of the same device
     assert entry.device_id == device.id
+
+    # Assert the humidity sensory is detected
+    entry = entity_registry.async_get(
+        "sensor.vocolinc_flowerbud_0d324b_current_humidity"
+    )
+    assert entry.unique_id == "homekit-AM01121849000327-aid:1-sid:30-cid:30"
+
+    helper = Helper(
+        hass,
+        "sensor.vocolinc_flowerbud_0d324b_current_humidity",
+        pairing,
+        accessories[0],
+        config_entry,
+    )
+    state = await helper.poll_and_get_state()
+    assert (
+        state.attributes["friendly_name"]
+        == "VOCOlinc-Flowerbud-0d324b - Current Humidity"
+    )
+
+    # The sensor and humidifier should be part of the same device
+    assert entry.device_id == device.id


### PR DESCRIPTION
## Proposed change

We added support for the Vocolinc Flowerbud via homekit_controller a few releases ago (as a humidifier). However we never exposed it's humidity sensor. This fixes that oversight.

The humidity sensor is a seperate entity linked to the humidifier via the device registry. AIUI, this should allow e.g. `homekit` to automatically link the humidity sensor back to the humidifier too.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/42943
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
