### PR TITLE
KNX: Support for HS-color lights

### DIFF
--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -496,8 +496,12 @@ class LightSchema(KNXPlatformSchema):
     CONF_COLOR_TEMP_ADDRESS = "color_temperature_address"
     CONF_COLOR_TEMP_STATE_ADDRESS = "color_temperature_state_address"
     CONF_COLOR_TEMP_MODE = "color_temperature_mode"
+    CONF_HUE_ADDRESS = "hue_address"
+    CONF_HUE_STATE_ADDRESS = "hue_state_address"
     CONF_RGBW_ADDRESS = "rgbw_address"
     CONF_RGBW_STATE_ADDRESS = "rgbw_state_address"
+    CONF_SATURATION_ADDRESS = "saturation_address"
+    CONF_SATURATION_STATE_ADDRESS = "saturation_state_address"
     CONF_XYY_ADDRESS = "xyy_address"
     CONF_XYY_STATE_ADDRESS = "xyy_state_address"
     CONF_MIN_KELVIN = "min_kelvin"
@@ -514,7 +518,18 @@ class LightSchema(KNXPlatformSchema):
     CONF_BLUE = "blue"
     CONF_WHITE = "white"
 
-    COLOR_SCHEMA = vol.Schema(
+    _hs_color_inclusion_msg = (
+        "'hue_address', 'saturation_address' and 'brightness_address'"
+        " are required for hs_color configuration"
+    )
+    HS_COLOR_SCHEMA = {
+        vol.Optional(CONF_HUE_ADDRESS): ga_list_validator,
+        vol.Optional(CONF_HUE_STATE_ADDRESS): ga_list_validator,
+        vol.Optional(CONF_SATURATION_ADDRESS): ga_list_validator,
+        vol.Optional(CONF_SATURATION_STATE_ADDRESS): ga_list_validator,
+    }
+
+    INDIVIDUAL_COLOR_SCHEMA = vol.Schema(
         {
             vol.Optional(KNX_ADDRESS): ga_list_validator,
             vol.Optional(CONF_STATE_ADDRESS): ga_list_validator,
@@ -536,18 +551,18 @@ class LightSchema(KNXPlatformSchema):
                         CONF_RED,
                         "individual_colors",
                         msg="'red', 'green' and 'blue' are required for individual colors configuration",
-                    ): COLOR_SCHEMA,
+                    ): INDIVIDUAL_COLOR_SCHEMA,
                     vol.Inclusive(
                         CONF_GREEN,
                         "individual_colors",
                         msg="'red', 'green' and 'blue' are required for individual colors configuration",
-                    ): COLOR_SCHEMA,
+                    ): INDIVIDUAL_COLOR_SCHEMA,
                     vol.Inclusive(
                         CONF_BLUE,
                         "individual_colors",
                         msg="'red', 'green' and 'blue' are required for individual colors configuration",
-                    ): COLOR_SCHEMA,
-                    vol.Optional(CONF_WHITE): COLOR_SCHEMA,
+                    ): INDIVIDUAL_COLOR_SCHEMA,
+                    vol.Optional(CONF_WHITE): INDIVIDUAL_COLOR_SCHEMA,
                 },
                 vol.Exclusive(CONF_COLOR_ADDRESS, "color"): ga_list_validator,
                 vol.Optional(CONF_COLOR_STATE_ADDRESS): ga_list_validator,
@@ -556,6 +571,7 @@ class LightSchema(KNXPlatformSchema):
                 vol.Optional(
                     CONF_COLOR_TEMP_MODE, default=DEFAULT_COLOR_TEMP_MODE
                 ): vol.All(vol.Upper, cv.enum(ColorTempModes)),
+                **HS_COLOR_SCHEMA,
                 vol.Exclusive(CONF_RGBW_ADDRESS, "color"): ga_list_validator,
                 vol.Optional(CONF_RGBW_STATE_ADDRESS): ga_list_validator,
                 vol.Exclusive(CONF_XYY_ADDRESS, "color"): ga_list_validator,
@@ -569,20 +585,39 @@ class LightSchema(KNXPlatformSchema):
             }
         ),
         vol.Any(
-            # either global "address" or "individual_colors" is required
             vol.Schema(
+                {vol.Required(KNX_ADDRESS): object},
+                extra=vol.ALLOW_EXTRA,
+            ),
+            vol.Schema(  # brightness addresses are required in INDIVIDUAL_COLOR_SCHEMA
+                {vol.Required(CONF_INDIVIDUAL_COLORS): object},
+                extra=vol.ALLOW_EXTRA,
+            ),
+            msg="either 'address' or 'individual_colors' is required",
+        ),
+        vol.Any(
+            vol.Schema(  # 'brightness' is non-optional for hs-color
                 {
-                    # brightness addresses are required in COLOR_SCHEMA
-                    vol.Required(CONF_INDIVIDUAL_COLORS): object,
+                    vol.Inclusive(
+                        CONF_BRIGHTNESS_ADDRESS, "hs_color", msg=_hs_color_inclusion_msg
+                    ): object,
+                    vol.Inclusive(
+                        CONF_HUE_ADDRESS, "hs_color", msg=_hs_color_inclusion_msg
+                    ): object,
+                    vol.Inclusive(
+                        CONF_SATURATION_ADDRESS, "hs_color", msg=_hs_color_inclusion_msg
+                    ): object,
                 },
                 extra=vol.ALLOW_EXTRA,
             ),
-            vol.Schema(
+            vol.Schema(  # hs-colors not used
                 {
-                    vol.Required(KNX_ADDRESS): object,
+                    vol.Optional(CONF_HUE_ADDRESS): None,
+                    vol.Optional(CONF_SATURATION_ADDRESS): None,
                 },
                 extra=vol.ALLOW_EXTRA,
             ),
+            msg=_hs_color_inclusion_msg,
         ),
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support for HS-color (DPT 5.003 hue and 5.001 saturation) for KNX lights.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18641

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
