### PR TITLE
Upgrade Rituals Perfume Genie to quality level "silver"

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/manifest.json
+++ b/homeassistant/components/rituals_perfume_genie/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://www.home-assistant.io/integrations/rituals_perfume_genie",
   "requirements": ["pyrituals==0.0.6"],
   "codeowners": ["@milanmeu"],
+  "quality_scale": "silver",
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
## Proposed change
Upgrade Rituals Perfume Genie to quality level "silver"
https://developers.home-assistant.io/docs/integration_quality_scale_index/

### Checklist:
- [x] Connection/configuration is handled via a component.
    Component? Connection/configuration? 😕 
    Configuration: ConfigFlow
    Connection: pyrituals + Coordinator
    Component: Integration rituals_perfume_genie get devices in async_setup_entry and set up entities in async_setup_platforms

- [x] Set an appropriate SCAN_INTERVAL (if a polling integration)
    https://github.com/home-assistant/core/blob/93899e981f7726f8e4f6d86afe8f578ef64afd20/homeassistant/components/rituals_perfume_genie/__init__.py#L20

    [Quote](https://github.com/home-assistant/core/issues/47321#issuecomment-791387640) from Rituals / Sense Company / InsaneSoftware: 
    > The limit is 30 on each endpoint so basicly you can get the full list 30 times in a minute

    Home Assistant uses 2 request per device per minute. The Rituals Genie App uses 6 request per minute if opened.
    The 30 seconds SCAN_INTERVAL allows 12 devices + 1 opened Rituals Genie App.

    More info is available in https://github.com/home-assistant/core/issues/47321.

- [x] Raise PlatformNotReady if unable to connect during platform setup (if appropriate)
    We don't connect during platform setup but we do during config_entry setup so we raise ConfigEntryNotReady.
    https://github.com/home-assistant/core/blob/93899e981f7726f8e4f6d86afe8f578ef64afd20/homeassistant/components/rituals_perfume_genie/__init__.py#L28-L31
- [x] Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize. (docs)
    No appropriate. You can't revoke an account_hash.
- [x] Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
    Handled by the DataUpdateCoordinator
- [x] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
    Handled by the DataUpdateCoordinator
 - [x] Set available property to False if appropriate (docs)
    Handled, 
    - DataUpdateCoordinator for HA <-> Rituals Cloud
    - Diffuser for Rituals Cloud <-> Device

    https://github.com/home-assistant/core/blob/e037d3a16f868693745003ef44ea5e1383039083/homeassistant/components/rituals_perfume_genie/entity.py#L44-L47
 - [x] Entities have unique ID (if available) (docs)
    Handled
https://github.com/home-assistant/core/blob/e037d3a16f868693745003ef44ea5e1383039083/homeassistant/components/rituals_perfume_genie/entity.py#L35


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/18631

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
