### PR TITLE
Combine some stream test mocks

### DIFF
--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -149,6 +149,7 @@ class FakePyAvBuffer:
         self.segments = []
         self.audio_packets = []
         self.video_packets = []
+        self.memory_file: io.BytesIO | None = None
 
     def add_stream(self, template=None):
         """Create an output buffer that captures packets for test to examine."""
@@ -171,10 +172,13 @@ class FakePyAvBuffer:
         """Capture a packet for tests to examine."""
         # Forward to appropriate FakeStream
         packet.stream.mux(packet)
+        # Make new init/part data available to the worker
+        self.memory_file.write(b"0")
 
     def close(self):
         """Close the buffer."""
-        return
+        # Make the final segment data available to the worker
+        self.memory_file.write(b"0")
 
     def capture_output_segment(self, segment):
         """Capture the output segment for tests to inspect."""
@@ -201,21 +205,9 @@ class MockPyAv:
     def open(self, stream_source, *args, **kwargs):
         """Return a stream or buffer depending on args."""
         if isinstance(stream_source, io.BytesIO):
+            self.capture_buffer.memory_file = stream_source
             return self.capture_buffer
         return self.container
-
-
-class MockFlushPart:
-    """Class to hold a wrapper function for check_flush_part."""
-
-    # Wrap this method with a preceding write so the BytesIO pointer moves
-    check_flush_part = SegmentBuffer.check_flush_part
-
-    @classmethod
-    def wrapped_check_flush_part(cls, segment_buffer, packet):
-        """Wrap check_flush_part to also advance the memory_file pointer."""
-        segment_buffer._memory_file.write(b"0")
-        return cls.check_flush_part(segment_buffer, packet)
 
 
 async def async_decode_stream(hass, packets, py_av=None):
@@ -230,10 +222,6 @@ async def async_decode_stream(hass, packets, py_av=None):
     with patch("av.open", new=py_av.open), patch(
         "homeassistant.components.stream.core.StreamOutput.put",
         side_effect=py_av.capture_buffer.capture_output_segment,
-    ), patch(
-        "homeassistant.components.stream.worker.SegmentBuffer.check_flush_part",
-        side_effect=MockFlushPart.wrapped_check_flush_part,
-        autospec=True,
     ):
         segment_buffer = SegmentBuffer(stream.outputs)
         stream_worker(STREAM_SOURCE, {}, segment_buffer, threading.Event())
@@ -612,11 +600,7 @@ async def test_update_stream_source(hass):
         worker_wake.wait()
         return py_av.open(stream_source, args, kwargs)
 
-    with patch("av.open", new=blocking_open), patch(
-        "homeassistant.components.stream.worker.SegmentBuffer.check_flush_part",
-        side_effect=MockFlushPart.wrapped_check_flush_part,
-        autospec=True,
-    ):
+    with patch("av.open", new=blocking_open):
         stream.start()
         assert worker_open.wait(TIMEOUT)
         assert last_stream_source == STREAM_SOURCE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Combine MockFlushPart with the FakePyAvContainer since the container is
effectively a mock AvOutput. This simulates the behavior of the call to
mux and close that actually write to the memory file.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
