### PR TITLE
Add mixin classes for required keys in EntityDescription

### DIFF
--- a/homeassistant/components/climacell/const.py
+++ b/homeassistant/components/climacell/const.py
@@ -170,9 +170,6 @@ class ClimaCellSensorEntityDescription(SensorEntityDescription):
                 "`unit_imperial` and `unit_metric` both need to be None or both need "
                 "to be defined."
             )
-        if self.name is None:  # pragma: no cover
-            raise TypeError
-        self.name_ = self.name
 
 
 CC_SENSOR_TYPES = (

--- a/homeassistant/components/climacell/sensor.py
+++ b/homeassistant/components/climacell/sensor.py
@@ -65,7 +65,7 @@ class BaseClimaCellSensorEntity(ClimaCellEntity, SensorEntity):
         self._attr_entity_registry_enabled_default = False
         self._attr_name = f"{self._config_entry.data[CONF_NAME]} - {description.name}"
         self._attr_unique_id = (
-            f"{self._config_entry.unique_id}_{slugify(description.name_)}"
+            f"{self._config_entry.unique_id}_{slugify(description.name)}"
         )
         self._attr_extra_state_attributes = {ATTR_ATTRIBUTION: self.attribution}
         self._attr_unit_of_measurement = (

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -22,20 +22,18 @@ from .const import DOMAIN
 
 
 @dataclass
-class MelcloudSensorEntityDescription(SensorEntityDescription):
+class MelcloudRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[Any], float]
+    enabled: Callable[[Any], bool]
+
+
+@dataclass
+class MelcloudSensorEntityDescription(
+    SensorEntityDescription, MelcloudRequiredKeysMixin
+):
     """Describes Melcloud sensor entity."""
-
-    _value_fn: Callable[[Any], float] | None = None
-    _enabled: Callable[[Any], bool] | None = None
-
-    def __post_init__(self) -> None:
-        """Ensure all required fields are set."""
-        if self._value_fn is None:  # pragma: no cover
-            raise TypeError
-        if self._enabled is None:  # pragma: no cover
-            raise TypeError
-        self.value_fn = self._value_fn
-        self.enabled = self._enabled
 
 
 ATA_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
@@ -45,8 +43,8 @@ ATA_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
         icon="mdi:thermometer",
         unit_of_measurement=TEMP_CELSIUS,
         device_class=DEVICE_CLASS_TEMPERATURE,
-        _value_fn=lambda x: x.device.room_temperature,
-        _enabled=lambda x: True,
+        value_fn=lambda x: x.device.room_temperature,
+        enabled=lambda x: True,
     ),
     MelcloudSensorEntityDescription(
         key="energy",
@@ -54,8 +52,8 @@ ATA_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
         icon="mdi:factory",
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
-        _value_fn=lambda x: x.device.total_energy_consumed,
-        _enabled=lambda x: x.device.has_energy_consumed_meter,
+        value_fn=lambda x: x.device.total_energy_consumed,
+        enabled=lambda x: x.device.has_energy_consumed_meter,
     ),
 )
 ATW_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
@@ -65,8 +63,8 @@ ATW_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
         icon="mdi:thermometer",
         unit_of_measurement=TEMP_CELSIUS,
         device_class=DEVICE_CLASS_TEMPERATURE,
-        _value_fn=lambda x: x.device.outside_temperature,
-        _enabled=lambda x: True,
+        value_fn=lambda x: x.device.outside_temperature,
+        enabled=lambda x: True,
     ),
     MelcloudSensorEntityDescription(
         key="tank_temperature",
@@ -74,8 +72,8 @@ ATW_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
         icon="mdi:thermometer",
         unit_of_measurement=TEMP_CELSIUS,
         device_class=DEVICE_CLASS_TEMPERATURE,
-        _value_fn=lambda x: x.device.tank_temperature,
-        _enabled=lambda x: True,
+        value_fn=lambda x: x.device.tank_temperature,
+        enabled=lambda x: True,
     ),
 )
 ATW_ZONE_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
@@ -85,8 +83,8 @@ ATW_ZONE_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
         icon="mdi:thermometer",
         unit_of_measurement=TEMP_CELSIUS,
         device_class=DEVICE_CLASS_TEMPERATURE,
-        _value_fn=lambda zone: zone.room_temperature,
-        _enabled=lambda x: True,
+        value_fn=lambda zone: zone.room_temperature,
+        enabled=lambda x: True,
     ),
     MelcloudSensorEntityDescription(
         key="flow_temperature",
@@ -94,8 +92,8 @@ ATW_ZONE_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
         icon="mdi:thermometer",
         unit_of_measurement=TEMP_CELSIUS,
         device_class=DEVICE_CLASS_TEMPERATURE,
-        _value_fn=lambda zone: zone.flow_temperature,
-        _enabled=lambda x: True,
+        value_fn=lambda zone: zone.flow_temperature,
+        enabled=lambda x: True,
     ),
     MelcloudSensorEntityDescription(
         key="return_temperature",
@@ -103,8 +101,8 @@ ATW_ZONE_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
         icon="mdi:thermometer",
         unit_of_measurement=TEMP_CELSIUS,
         device_class=DEVICE_CLASS_TEMPERATURE,
-        _value_fn=lambda zone: zone.return_temperature,
-        _enabled=lambda x: True,
+        value_fn=lambda zone: zone.return_temperature,
+        enabled=lambda x: True,
     ),
 )
 

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -62,23 +62,22 @@ SUPPORTED_PUBLIC_SENSOR_TYPES: tuple[str, ...] = (
 
 
 @dataclass
-class NetatmoSensorEntityDescription(SensorEntityDescription):
+class NetatmoRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    netatmo_name: str
+
+
+@dataclass
+class NetatmoSensorEntityDescription(SensorEntityDescription, NetatmoRequiredKeysMixin):
     """Describes Netatmo sensor entity."""
-
-    _netatmo_name: str | None = None
-
-    def __post_init__(self) -> None:
-        """Ensure all required attributes are set."""
-        if self._netatmo_name is None:  # pragma: no cover
-            raise TypeError
-        self.netatmo_name = self._netatmo_name
 
 
 SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="temperature",
         name="Temperature",
-        _netatmo_name="Temperature",
+        netatmo_name="Temperature",
         entity_registry_enabled_default=True,
         unit_of_measurement=TEMP_CELSIUS,
         device_class=DEVICE_CLASS_TEMPERATURE,
@@ -86,14 +85,14 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="temp_trend",
         name="Temperature trend",
-        _netatmo_name="temp_trend",
+        netatmo_name="temp_trend",
         entity_registry_enabled_default=False,
         icon="mdi:trending-up",
     ),
     NetatmoSensorEntityDescription(
         key="co2",
         name="CO2",
-        _netatmo_name="CO2",
+        netatmo_name="CO2",
         unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
         entity_registry_enabled_default=True,
         device_class=DEVICE_CLASS_CO2,
@@ -101,7 +100,7 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="pressure",
         name="Pressure",
-        _netatmo_name="Pressure",
+        netatmo_name="Pressure",
         entity_registry_enabled_default=True,
         unit_of_measurement=PRESSURE_MBAR,
         device_class=DEVICE_CLASS_PRESSURE,
@@ -109,14 +108,14 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="pressure_trend",
         name="Pressure trend",
-        _netatmo_name="pressure_trend",
+        netatmo_name="pressure_trend",
         entity_registry_enabled_default=False,
         icon="mdi:trending-up",
     ),
     NetatmoSensorEntityDescription(
         key="noise",
         name="Noise",
-        _netatmo_name="Noise",
+        netatmo_name="Noise",
         entity_registry_enabled_default=True,
         unit_of_measurement=SOUND_PRESSURE_DB,
         icon="mdi:volume-high",
@@ -124,7 +123,7 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="humidity",
         name="Humidity",
-        _netatmo_name="Humidity",
+        netatmo_name="Humidity",
         entity_registry_enabled_default=True,
         unit_of_measurement=PERCENTAGE,
         device_class=DEVICE_CLASS_HUMIDITY,
@@ -132,7 +131,7 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="rain",
         name="Rain",
-        _netatmo_name="Rain",
+        netatmo_name="Rain",
         entity_registry_enabled_default=True,
         unit_of_measurement=LENGTH_MILLIMETERS,
         icon="mdi:weather-rainy",
@@ -140,7 +139,7 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="sum_rain_1",
         name="Rain last hour",
-        _netatmo_name="sum_rain_1",
+        netatmo_name="sum_rain_1",
         entity_registry_enabled_default=False,
         unit_of_measurement=LENGTH_MILLIMETERS,
         icon="mdi:weather-rainy",
@@ -148,7 +147,7 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="sum_rain_24",
         name="Rain today",
-        _netatmo_name="sum_rain_24",
+        netatmo_name="sum_rain_24",
         entity_registry_enabled_default=True,
         unit_of_measurement=LENGTH_MILLIMETERS,
         icon="mdi:weather-rainy",
@@ -156,7 +155,7 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="battery_percent",
         name="Battery Percent",
-        _netatmo_name="battery_percent",
+        netatmo_name="battery_percent",
         entity_registry_enabled_default=True,
         unit_of_measurement=PERCENTAGE,
         device_class=DEVICE_CLASS_BATTERY,
@@ -164,14 +163,14 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="windangle",
         name="Direction",
-        _netatmo_name="WindAngle",
+        netatmo_name="WindAngle",
         entity_registry_enabled_default=True,
         icon="mdi:compass-outline",
     ),
     NetatmoSensorEntityDescription(
         key="windangle_value",
         name="Angle",
-        _netatmo_name="WindAngle",
+        netatmo_name="WindAngle",
         entity_registry_enabled_default=False,
         unit_of_measurement=DEGREE,
         icon="mdi:compass-outline",
@@ -179,7 +178,7 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="windstrength",
         name="Wind Strength",
-        _netatmo_name="WindStrength",
+        netatmo_name="WindStrength",
         entity_registry_enabled_default=True,
         unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
         icon="mdi:weather-windy",
@@ -187,14 +186,14 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="gustangle",
         name="Gust Direction",
-        _netatmo_name="GustAngle",
+        netatmo_name="GustAngle",
         entity_registry_enabled_default=False,
         icon="mdi:compass-outline",
     ),
     NetatmoSensorEntityDescription(
         key="gustangle_value",
         name="Gust Angle",
-        _netatmo_name="GustAngle",
+        netatmo_name="GustAngle",
         entity_registry_enabled_default=False,
         unit_of_measurement=DEGREE,
         icon="mdi:compass-outline",
@@ -202,7 +201,7 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="guststrength",
         name="Gust Strength",
-        _netatmo_name="GustStrength",
+        netatmo_name="GustStrength",
         entity_registry_enabled_default=False,
         unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
         icon="mdi:weather-windy",
@@ -210,21 +209,21 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="reachable",
         name="Reachability",
-        _netatmo_name="reachable",
+        netatmo_name="reachable",
         entity_registry_enabled_default=False,
         icon="mdi:signal",
     ),
     NetatmoSensorEntityDescription(
         key="rf_status",
         name="Radio",
-        _netatmo_name="rf_status",
+        netatmo_name="rf_status",
         entity_registry_enabled_default=False,
         icon="mdi:signal",
     ),
     NetatmoSensorEntityDescription(
         key="rf_status_lvl",
         name="Radio Level",
-        _netatmo_name="rf_status",
+        netatmo_name="rf_status",
         entity_registry_enabled_default=False,
         unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
@@ -232,14 +231,14 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="wifi_status",
         name="Wifi",
-        _netatmo_name="wifi_status",
+        netatmo_name="wifi_status",
         entity_registry_enabled_default=False,
         icon="mdi:wifi",
     ),
     NetatmoSensorEntityDescription(
         key="wifi_status_lvl",
         name="Wifi Level",
-        _netatmo_name="wifi_status",
+        netatmo_name="wifi_status",
         entity_registry_enabled_default=False,
         unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
@@ -247,7 +246,7 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="health_idx",
         name="Health",
-        _netatmo_name="health_idx",
+        netatmo_name="health_idx",
         entity_registry_enabled_default=True,
         icon="mdi:cloud",
     ),

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -79,9 +79,9 @@ def sanitize_path(path: str) -> str:
     return path
 
 
-def slugify(text: str, *, separator: str = "_") -> str:
+def slugify(text: str | None, *, separator: str = "_") -> str:
     """Slugify a given text."""
-    if text == "":
+    if text == "" or text is None:
         return ""
     slug = unicode_slug.slugify(text, separator=separator)
     return "unknown" if slug == "" else slug

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -74,6 +74,7 @@ def test_slugify():
     assert util.slugify("$$$") == "unknown"
     assert util.slugify("$something") == "something"
     assert util.slugify("") == ""
+    assert util.slugify(None) == ""
 
 
 def test_repr_helper():


### PR DESCRIPTION
## Proposed change
Add mixin classes for required keys in the `EntityDescription`.

It's a bit like bending over backwards, but it works 🎉
Some limitations to be aware of:
* The mixin class can only contain **required** keys. If additional optional keys are needed, those need to be defined on the derived class.
* The mixin class **must** be the **last** base class.
* Fields with defaults can't be overwritten. I.e. `name: str | None = None` can't be changed to `name: str` unfortunately.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
