### PR TITLE
Add to the Broadlink integration support for voltage, current, overload and total consumption sensors

### DIFF
--- a/homeassistant/components/broadlink/sensor.py
+++ b/homeassistant/components/broadlink/sensor.py
@@ -6,16 +6,28 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLTAGE,
     PLATFORM_SCHEMA,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import CONF_HOST, PERCENTAGE, POWER_WATT, TEMP_CELSIUS
+from homeassistant.const import (
+    CONF_HOST,
+    ELECTRIC_CURRENT_AMPERE,
+    ELECTRIC_POTENTIAL_VOLT,
+    ENERGY_KILO_WATT_HOUR,
+    PERCENTAGE,
+    POWER_WATT,
+    TEMP_CELSIUS,
+)
 from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN
@@ -58,6 +70,34 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
         state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key="volt",
+        name="Voltage",
+        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key="current",
+        name="Current",
+        native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key="overload",
+        name="Overload",
+        native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key="totalconsum",
+        name="Total consumption",
+        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        device_class=DEVICE_CLASS_ENERGY,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
 )
 

--- a/tests/components/broadlink/__init__.py
+++ b/tests/components/broadlink/__init__.py
@@ -58,6 +58,16 @@ BROADLINK_DEVICES = {
         20025,
         5,
     ),
+    "Dining room": (
+        "192.168.0.16",
+        "34ea34b4fd1c",
+        "SCB1E",
+        "Broadlink",
+        "SP4B",
+        0x5115,
+        57,
+        5,
+    ),
     "Kitchen": (  # Not supported.
         "192.168.0.64",
         "34ea34b61d2c",

--- a/tests/components/broadlink/test_sensors.py
+++ b/tests/components/broadlink/test_sensors.py
@@ -1,10 +1,14 @@
 """Tests for Broadlink sensors."""
+from datetime import timedelta
+
 from homeassistant.components.broadlink.const import DOMAIN, SENSOR_DOMAIN
+from homeassistant.components.broadlink.updater import BroadlinkSP4UpdateManager
 from homeassistant.helpers.entity_registry import async_entries_for_device
+from homeassistant.util import dt
 
 from . import get_device
 
-from tests.common import mock_device_registry, mock_registry
+from tests.common import async_fire_time_changed, mock_device_registry, mock_registry
 
 
 async def test_a1_sensor_setup(hass):
@@ -286,3 +290,107 @@ async def test_rm4_pro_no_sensor(hass):
     entries = async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == SENSOR_DOMAIN}
     assert len(sensors) == 0
+
+
+async def test_scb1e_sensor_setup(hass):
+    """Test a successful SCB1E sensor setup."""
+    device = get_device("Dining room")
+    mock_api = device.get_mock_api()
+    mock_api.get_state.return_value = {
+        "pwr": 1,
+        "indicator": 1,
+        "maxworktime": 0,
+        "power": 255.57,
+        "volt": 121.7,
+        "current": 2.1,
+        "overload": 0,
+        "totalconsum": 1.7,
+        "childlock": 0,
+    }
+
+    device_registry = mock_device_registry(hass)
+    entity_registry = mock_registry(hass)
+
+    mock_setup = await device.setup_entry(hass, mock_api=mock_api)
+
+    assert mock_api.get_state.call_count == 1
+    device_entry = device_registry.async_get_device(
+        {(DOMAIN, mock_setup.entry.unique_id)}
+    )
+    entries = async_entries_for_device(entity_registry, device_entry.id)
+    sensors = [entry for entry in entries if entry.domain == SENSOR_DOMAIN]
+    assert len(sensors) == 5
+
+    sensors_and_states = {
+        (sensor.original_name, hass.states.get(sensor.entity_id).state)
+        for sensor in sensors
+    }
+    assert sensors_and_states == {
+        (f"{device.name} Current power", "255.57"),
+        (f"{device.name} Voltage", "121.7"),
+        (f"{device.name} Current", "2.1"),
+        (f"{device.name} Overload", "0"),
+        (f"{device.name} Total consumption", "1.7"),
+    }
+
+
+async def test_scb1e_sensor_update(hass):
+    """Test a successful SCB1E sensor update."""
+    device = get_device("Dining room")
+    mock_api = device.get_mock_api()
+    mock_api.get_state.return_value = {
+        "pwr": 1,
+        "indicator": 1,
+        "maxworktime": 0,
+        "power": 255.6,
+        "volt": 121.7,
+        "current": 2.1,
+        "overload": 0,
+        "totalconsum": 1.7,
+        "childlock": 0,
+    }
+
+    device_registry = mock_device_registry(hass)
+    entity_registry = mock_registry(hass)
+
+    target_time = (
+        dt.utcnow() + BroadlinkSP4UpdateManager.SCAN_INTERVAL * 3 + timedelta(seconds=1)
+    )
+
+    mock_setup = await device.setup_entry(hass, mock_api=mock_api)
+
+    device_entry = device_registry.async_get_device(
+        {(DOMAIN, mock_setup.entry.unique_id)}
+    )
+    entries = async_entries_for_device(entity_registry, device_entry.id)
+    sensors = [entry for entry in entries if entry.domain == SENSOR_DOMAIN]
+    assert len(sensors) == 5
+
+    mock_setup.api.get_state.return_value = {
+        "pwr": 1,
+        "indicator": 1,
+        "maxworktime": 0,
+        "power": 291.8,
+        "volt": 121.6,
+        "current": 2.4,
+        "overload": 0,
+        "totalconsum": 0.5,
+        "childlock": 0,
+    }
+
+    async_fire_time_changed(hass, target_time)
+    await hass.async_block_till_done()
+
+    assert mock_setup.api.get_state.call_count == 2
+
+    sensors_and_states = {
+        (sensor.original_name, hass.states.get(sensor.entity_id).state)
+        for sensor in sensors
+    }
+    assert sensors_and_states == {
+        (f"{device.name} Current power", "291.8"),
+        (f"{device.name} Voltage", "121.6"),
+        (f"{device.name} Current", "2.4"),
+        (f"{device.name} Overload", "0"),
+        (f"{device.name} Total consumption", "0.5"),
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The SP4 series came with new types of sensors such as voltage, current, overload and power consumption. They are present mainly in SCB1E devices, but they can appear in other devices with the same firmware in the future. This PR brings these sensors to Home Assistant, as entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
