### PR TITLE
Pass through extra dict from TTS to media_player.play_media

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_EXTRA,
     DOMAIN as DOMAIN_MP,
     MEDIA_TYPE_MUSIC,
     SERVICE_PLAY_MEDIA,
@@ -112,6 +113,7 @@ SCHEMA_SERVICE_SAY = vol.Schema(
         vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids,
         vol.Optional(ATTR_LANGUAGE): cv.string,
         vol.Optional(ATTR_OPTIONS): dict,
+        vol.Optional(ATTR_MEDIA_EXTRA, default={}): dict,
     }
 )
 
@@ -180,6 +182,7 @@ async def async_setup(hass, config):
             cache = service.data.get(ATTR_CACHE)
             language = service.data.get(ATTR_LANGUAGE)
             options = service.data.get(ATTR_OPTIONS)
+            extra = service.data.get(ATTR_MEDIA_EXTRA)
 
             try:
                 url = await tts.async_get_url_path(
@@ -197,6 +200,8 @@ async def async_setup(hass, config):
                 ATTR_MEDIA_CONTENT_TYPE: MEDIA_TYPE_MUSIC,
                 ATTR_ENTITY_ID: entity_ids,
             }
+            if extra:
+                data[ATTR_MEDIA_EXTRA] = extra
 
             await hass.services.async_call(
                 DOMAIN_MP,

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -8,6 +8,7 @@ from homeassistant.components.demo.tts import DemoProvider
 from homeassistant.components.media_player.const import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_EXTRA,
     DOMAIN as DOMAIN_MP,
     MEDIA_TYPE_MUSIC,
     SERVICE_PLAY_MEDIA,
@@ -695,7 +696,11 @@ async def test_setup_component_and_web_get_url(hass, hass_client):
     client = await hass_client()
 
     url = "/api/tts_get_url"
-    data = {"platform": "demo", "message": "There is someone at the door."}
+    data = {
+        "platform": "demo",
+        "message": "There is someone at the door.",
+        ATTR_MEDIA_EXTRA: {"volume": 30},
+    }
 
     req = await client.post(url, json=data)
     assert req.status == 200

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -132,6 +132,7 @@ async def test_setup_component_and_test_service(hass, empty_cache_dir):
         {
             "entity_id": "media_player.something",
             tts.ATTR_MESSAGE: "There is someone at the door.",
+            ATTR_MEDIA_EXTRA: {"volume": 30},
         },
         blocking=True,
     )
@@ -142,6 +143,7 @@ async def test_setup_component_and_test_service(hass, empty_cache_dir):
         calls[0].data[ATTR_MEDIA_CONTENT_ID]
         == "http://example.local:8123/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3"
     )
+    assert calls[0].data[ATTR_MEDIA_EXTRA] == {"volume": 30}
     await hass.async_block_till_done()
     assert (
         empty_cache_dir / "42f18378fd4393d18c8dd11d03fa9563c1e54491_en_-_demo.mp3"
@@ -699,7 +701,6 @@ async def test_setup_component_and_web_get_url(hass, hass_client):
     data = {
         "platform": "demo",
         "message": "There is someone at the door.",
-        ATTR_MEDIA_EXTRA: {"volume": 30},
     }
 
     req = await client.post(url, json=data)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When calling `tts.<platform>_say`, extra parameters can be useful in the underlying `media_player.play_media` call. This passes them along as-is.

Example:
```yaml
service: tts.cloud_say
data:
  entity_id: media_player.kitchen
  message: hello friend
  extra:
    volume: 32
```
This is not documented in the TTS `services.yaml` as this dict param is not shown in the base `media_player` service call.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
