### PR TITLE
Add enabled attribute to zwave_js discovery model

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -277,12 +277,6 @@ class ZWaveBooleanBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
             if self.info.primary_value.command_class == CommandClass.BATTERY
             else None
         )
-        # Legacy binary sensors are phased out (replaced by notification sensors)
-        # Disable by default to not confuse users
-        self._attr_entity_registry_enabled_default = bool(
-            self.info.primary_value.command_class != CommandClass.SENSOR_BINARY
-            or self.info.node.device_class.generic.key == 0x20
-        )
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -67,6 +67,8 @@ class ZwaveDiscoveryInfo:
     platform_data: dict[str, Any] | None = None
     # additional values that need to be watched by entity
     additional_value_ids_to_watch: set[str] | None = None
+    # bool to specify whether entity should be enabled by default
+    entity_registry_enabled_default: bool = True
 
 
 @dataclass
@@ -135,6 +137,8 @@ class ZWaveDiscoverySchema:
     allow_multi: bool = False
     # [optional] bool to specify whether state is assumed and events should be fired on value update
     assumed_state: bool = False
+    # [optional] bool to specify whether entity should be enabled by default
+    entity_registry_enabled_default: bool = True
 
 
 def get_config_parameter_discovery_schema(
@@ -161,6 +165,7 @@ def get_config_parameter_discovery_schema(
             property_key_name=property_key_name,
             type={"number"},
         ),
+        entity_registry_enabled_default=False,
         **kwargs,
     )
 
@@ -456,12 +461,18 @@ DISCOVERY_SCHEMAS = [
         platform="sensor",
         hint="string_sensor",
         primary_value=ZWaveValueDiscoverySchema(
-            command_class={
-                CommandClass.SENSOR_ALARM,
-                CommandClass.INDICATOR,
-            },
+            command_class={CommandClass.SENSOR_ALARM},
             type={"string"},
         ),
+    ),
+    ZWaveDiscoverySchema(
+        platform="sensor",
+        hint="string_sensor",
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.INDICATOR},
+            type={"string"},
+        ),
+        entity_registry_enabled_default=False,
     ),
     # generic numeric sensors
     ZWaveDiscoverySchema(
@@ -500,6 +511,7 @@ DISCOVERY_SCHEMAS = [
             type={"number"},
         ),
         allow_multi=True,
+        entity_registry_enabled_default=False,
     ),
     # sensor for basic CC
     ZWaveDiscoverySchema(
@@ -512,6 +524,7 @@ DISCOVERY_SCHEMAS = [
             type={"number"},
             property={"currentValue"},
         ),
+        entity_registry_enabled_default=False,
     ),
     # binary switches
     ZWaveDiscoverySchema(
@@ -697,6 +710,7 @@ def async_discover_values(node: ZwaveNode) -> Generator[ZwaveDiscoveryInfo, None
                 platform_data_template=schema.data_template,
                 platform_data=resolved_data,
                 additional_value_ids_to_watch=additional_value_ids_to_watch,
+                entity_registry_enabled_default=schema.entity_registry_enabled_default,
             )
 
             if not schema.allow_multi:

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -433,12 +433,33 @@ DISCOVERY_SCHEMAS = [
         ],
     ),
     # binary sensors
+    # When CC is Sensor Binary and device class generic is Binary Sensor, entity should
+    # be enabled by default
+    ZWaveDiscoverySchema(
+        platform="binary_sensor",
+        hint="boolean",
+        device_class_generic={"Binary Sensor"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SENSOR_BINARY},
+            type={"boolean"},
+        ),
+    ),
+    # Legacy binary sensors are phased out (replaced by notification sensors)
+    # Disable by default to not confuse users
+    ZWaveDiscoverySchema(
+        platform="binary_sensor",
+        hint="boolean",
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SENSOR_BINARY},
+            type={"boolean"},
+        ),
+        entity_registry_enabled_default=False,
+    ),
     ZWaveDiscoverySchema(
         platform="binary_sensor",
         hint="boolean",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={
-                CommandClass.SENSOR_BINARY,
                 CommandClass.BATTERY,
                 CommandClass.SENSOR_ALARM,
             },
@@ -482,11 +503,19 @@ DISCOVERY_SCHEMAS = [
             command_class={
                 CommandClass.SENSOR_MULTILEVEL,
                 CommandClass.SENSOR_ALARM,
-                CommandClass.INDICATOR,
                 CommandClass.BATTERY,
             },
             type={"number"},
         ),
+    ),
+    ZWaveDiscoverySchema(
+        platform="sensor",
+        hint="numeric_sensor",
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.INDICATOR},
+            type={"number"},
+        ),
+        entity_registry_enabled_default=False,
     ),
     # numeric sensors for Meter CC
     ZWaveDiscoverySchema(

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -46,6 +46,9 @@ class ZWaveBaseEntity(Entity):
         self._attr_unique_id = get_unique_id(
             self.client.driver.controller.home_id, self.info.primary_value.value_id
         )
+        self._attr_entity_registry_enabled_default = (
+            self.info.entity_registry_enabled_default
+        )
         self._attr_assumed_state = self.info.assumed_state
         # device is precreated in main handler
         self._attr_device_info = {

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -106,15 +106,6 @@ class ZwaveSensorBase(ZWaveBaseEntity, SensorEntity):
         self._attr_name = self.generate_name(include_value_name=True)
         self._attr_device_class = self._get_device_class()
         self._attr_state_class = self._get_state_class()
-        self._attr_entity_registry_enabled_default = True
-        # We hide some of the more advanced sensors by default to not overwhelm users
-        if self.info.primary_value.command_class in [
-            CommandClass.BASIC,
-            CommandClass.CONFIGURATION,
-            CommandClass.INDICATOR,
-            CommandClass.NOTIFICATION,
-        ]:
-            self._attr_entity_registry_enabled_default = False
 
     def _get_device_class(self) -> str | None:
         """

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -11,6 +11,8 @@ NOTIFICATION_MOTION_BINARY_SENSOR = (
     "binary_sensor.multisensor_6_home_security_motion_detection"
 )
 NOTIFICATION_MOTION_SENSOR = "sensor.multisensor_6_home_security_motion_sensor_status"
+INDICATOR_SENSOR = "sensor.z_wave_thermostat_indicator_value"
+BASIC_SENSOR = "sensor.livingroomlight_basic"
 PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
     "binary_sensor.august_smart_lock_pro_3rd_gen_the_current_status_of_the_door"
 )

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -14,9 +14,11 @@ from homeassistant.helpers import entity_registry as er
 
 from .common import (
     AIR_TEMPERATURE_SENSOR,
+    BASIC_SENSOR,
     ENERGY_SENSOR,
     HUMIDITY_SENSOR,
     ID_LOCK_CONFIG_PARAMETER_SENSOR,
+    INDICATOR_SENSOR,
     NOTIFICATION_MOTION_SENSOR,
     POWER_SENSOR,
 )
@@ -79,6 +81,28 @@ async def test_disabled_notification_sensor(hass, multisensor_6, integration):
     state = hass.states.get(NOTIFICATION_MOTION_SENSOR)
     assert state.state == "Motion detection"
     assert state.attributes["value"] == 8
+
+
+async def test_disabled_indcator_sensor(
+    hass, climate_radio_thermostat_ct100_plus, integration
+):
+    """Test sensor is created from Indicator CC and is disabled."""
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(INDICATOR_SENSOR)
+
+    assert entity_entry
+    assert entity_entry.disabled
+    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
+
+
+async def test_disabled_basic_sensor(hass, ge_in_wall_dimmer_switch, integration):
+    """Test sensor is created from Basic CC and is disabled."""
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(BASIC_SENSOR)
+
+    assert entity_entry
+    assert entity_entry.disabled
+    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
 
 
 async def test_config_parameter_sensor(hass, lock_id_lock_as_id150, integration):


### PR DESCRIPTION
## Proposed change
Our logic for determining whether an entity should be enabled or not was mixed into the platform logic, which seemed strange. With this change, we've added a property to the discovery schema so that the discovery logic can determine what entities are enabled and disabled by default.

One place where I wasn't able to make this change is for some of the binary sensor types.

~~TODO: Add tests for any of the sensors that are disabled by default that aren't already tested to make sure we didn't introduce a regression.~~


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
