### PR TITLE
Fix unhandled exception with Guardian paired sensor coordinators

### DIFF
--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -297,7 +297,6 @@ class ValveControllerEntity(GuardianEntity):
         return any(
             coordinator.last_update_success
             for coordinator in self.coordinators.values()
-            if coordinator
         )
 
     async def _async_continue_entity_setup(self) -> None:

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_UID,
     DATA_CLIENT,
     DATA_COORDINATOR,
+    DATA_COORDINATOR_PAIRED_SENSOR,
     DATA_PAIRED_SENSOR_MANAGER,
     DATA_UNSUB_DISPATCHER_CONNECT,
     DOMAIN,
@@ -44,6 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         {
             DATA_CLIENT: {},
             DATA_COORDINATOR: {},
+            DATA_COORDINATOR_PAIRED_SENSOR: {},
             DATA_PAIRED_SENSOR_MANAGER: {},
             DATA_UNSUB_DISPATCHER_CONNECT: {},
         },
@@ -51,9 +53,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     client = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id] = Client(
         entry.data[CONF_IP_ADDRESS], port=entry.data[CONF_PORT]
     )
-    hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id] = {
-        API_SENSOR_PAIRED_SENSOR_STATUS: {}
-    }
+    hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id] = {}
+    hass.data[DOMAIN][DATA_COORDINATOR_PAIRED_SENSOR][entry.entry_id] = {}
     hass.data[DOMAIN][DATA_UNSUB_DISPATCHER_CONNECT][entry.entry_id] = []
 
     # The valve controller's UDP-based API can't handle concurrent requests very well,
@@ -113,6 +114,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         hass.data[DOMAIN][DATA_CLIENT].pop(entry.entry_id)
         hass.data[DOMAIN][DATA_COORDINATOR].pop(entry.entry_id)
+        hass.data[DOMAIN][DATA_COORDINATOR_PAIRED_SENSOR].pop(entry.entry_id)
         for unsub in hass.data[DOMAIN][DATA_UNSUB_DISPATCHER_CONNECT][entry.entry_id]:
             unsub()
         hass.data[DOMAIN][DATA_UNSUB_DISPATCHER_CONNECT].pop(entry.entry_id)
@@ -143,8 +145,8 @@ class PairedSensorManager:
 
         self._paired_uids.add(uid)
 
-        coordinator = self._hass.data[DOMAIN][DATA_COORDINATOR][self._entry.entry_id][
-            API_SENSOR_PAIRED_SENSOR_STATUS
+        coordinator = self._hass.data[DOMAIN][DATA_COORDINATOR_PAIRED_SENSOR][
+            self._entry.entry_id
         ][uid] = GuardianDataUpdateCoordinator(
             self._hass,
             client=self._client,
@@ -194,8 +196,8 @@ class PairedSensorManager:
 
         # Clear out objects related to this paired sensor:
         self._paired_uids.remove(uid)
-        self._hass.data[DOMAIN][DATA_COORDINATOR][self._entry.entry_id][
-            API_SENSOR_PAIRED_SENSOR_STATUS
+        self._hass.data[DOMAIN][DATA_COORDINATOR_PAIRED_SENSOR][
+            self._entry.entry_id
         ].pop(uid)
 
         # Remove the paired sensor device from the device registry (which will

--- a/homeassistant/components/guardian/binary_sensor.py
+++ b/homeassistant/components/guardian/binary_sensor.py
@@ -86,7 +86,16 @@ async def async_setup_entry(
         sensors.append(
             ValveControllerBinarySensor(
                 entry,
-                hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id],
+                # ValveControllerEntity objects don't need to know about
+                # DataUpdateCoordinators related to paired sensors, so we make sure to
+                # exclude them from our global storage:
+                {
+                    api: coordinator
+                    for api, coordinator in hass.data[DOMAIN][DATA_COORDINATOR][
+                        entry.entry_id
+                    ].items()
+                    if api != API_SENSOR_PAIRED_SENSOR_STATUS
+                },
                 kind,
                 name,
                 device_class,

--- a/homeassistant/components/guardian/binary_sensor.py
+++ b/homeassistant/components/guardian/binary_sensor.py
@@ -15,11 +15,11 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import PairedSensorEntity, ValveControllerEntity
 from .const import (
-    API_SENSOR_PAIRED_SENSOR_STATUS,
     API_SYSTEM_ONBOARD_SENSOR_STATUS,
     API_WIFI_STATUS,
     CONF_UID,
     DATA_COORDINATOR,
+    DATA_COORDINATOR_PAIRED_SENSOR,
     DATA_UNSUB_DISPATCHER_CONNECT,
     DOMAIN,
     SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED,
@@ -49,9 +49,9 @@ async def async_setup_entry(
     @callback
     def add_new_paired_sensor(uid: str) -> None:
         """Add a new paired sensor."""
-        coordinator = hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][
-            API_SENSOR_PAIRED_SENSOR_STATUS
-        ][uid]
+        coordinator = hass.data[DOMAIN][DATA_COORDINATOR_PAIRED_SENSOR][entry.entry_id][
+            uid
+        ]
 
         entities = []
         for kind in PAIRED_SENSOR_SENSORS:
@@ -86,16 +86,7 @@ async def async_setup_entry(
         sensors.append(
             ValveControllerBinarySensor(
                 entry,
-                # ValveControllerEntity objects don't need to know about
-                # DataUpdateCoordinators related to paired sensors, so we make sure to
-                # exclude them from our global storage:
-                {
-                    api: coordinator
-                    for api, coordinator in hass.data[DOMAIN][DATA_COORDINATOR][
-                        entry.entry_id
-                    ].items()
-                    if api != API_SENSOR_PAIRED_SENSOR_STATUS
-                },
+                hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id],
                 kind,
                 name,
                 device_class,
@@ -104,8 +95,8 @@ async def async_setup_entry(
         )
 
     # Add all paired sensor-specific binary sensors:
-    for coordinator in hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][
-        API_SENSOR_PAIRED_SENSOR_STATUS
+    for coordinator in hass.data[DOMAIN][DATA_COORDINATOR_PAIRED_SENSOR][
+        entry.entry_id
     ].values():
         for kind in PAIRED_SENSOR_SENSORS:
             name, device_class = SENSOR_ATTRS_MAP[kind]

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -16,6 +16,7 @@ CONF_UID = "uid"
 
 DATA_CLIENT = "client"
 DATA_COORDINATOR = "coordinator"
+DATA_COORDINATOR_PAIRED_SENSOR = "coordinator_paired_sensor"
 DATA_PAIRED_SENSOR_MANAGER = "paired_sensor_manager"
 DATA_UNSUB_DISPATCHER_CONNECT = "unsub_dispatcher_connect"
 

--- a/homeassistant/components/guardian/sensor.py
+++ b/homeassistant/components/guardian/sensor.py
@@ -17,11 +17,11 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import PairedSensorEntity, ValveControllerEntity
 from .const import (
-    API_SENSOR_PAIRED_SENSOR_STATUS,
     API_SYSTEM_DIAGNOSTICS,
     API_SYSTEM_ONBOARD_SENSOR_STATUS,
     CONF_UID,
     DATA_COORDINATOR,
+    DATA_COORDINATOR_PAIRED_SENSOR,
     DATA_UNSUB_DISPATCHER_CONNECT,
     DOMAIN,
     SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED,
@@ -54,9 +54,9 @@ async def async_setup_entry(
     @callback
     def add_new_paired_sensor(uid: str) -> None:
         """Add a new paired sensor."""
-        coordinator = hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][
-            API_SENSOR_PAIRED_SENSOR_STATUS
-        ][uid]
+        coordinator = hass.data[DOMAIN][DATA_COORDINATOR_PAIRED_SENSOR][entry.entry_id][
+            uid
+        ]
 
         entities = []
         for kind in PAIRED_SENSOR_SENSORS:
@@ -86,16 +86,7 @@ async def async_setup_entry(
         sensors.append(
             ValveControllerSensor(
                 entry,
-                # ValveControllerEntity objects don't need to know about
-                # DataUpdateCoordinators related to paired sensors, so we make sure to
-                # exclude them from our global storage:
-                {
-                    api: coordinator
-                    for api, coordinator in hass.data[DOMAIN][DATA_COORDINATOR][
-                        entry.entry_id
-                    ].items()
-                    if api != API_SENSOR_PAIRED_SENSOR_STATUS
-                },
+                hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id],
                 kind,
                 name,
                 device_class,
@@ -105,8 +96,8 @@ async def async_setup_entry(
         )
 
     # Add all paired sensor-specific binary sensors:
-    for coordinator in hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][
-        API_SENSOR_PAIRED_SENSOR_STATUS
+    for coordinator in hass.data[DOMAIN][DATA_COORDINATOR_PAIRED_SENSOR][
+        entry.entry_id
     ].values():
         for kind in PAIRED_SENSOR_SENSORS:
             name, device_class, icon, unit = SENSOR_ATTRS_MAP[kind]

--- a/homeassistant/components/guardian/sensor.py
+++ b/homeassistant/components/guardian/sensor.py
@@ -86,7 +86,16 @@ async def async_setup_entry(
         sensors.append(
             ValveControllerSensor(
                 entry,
-                hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id],
+                # ValveControllerEntity objects don't need to know about
+                # DataUpdateCoordinators related to paired sensors, so we make sure to
+                # exclude them from our global storage:
+                {
+                    api: coordinator
+                    for api, coordinator in hass.data[DOMAIN][DATA_COORDINATOR][
+                        entry.entry_id
+                    ].items()
+                    if api != API_SENSOR_PAIRED_SENSOR_STATUS
+                },
                 kind,
                 name,
                 device_class,

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import ValveControllerEntity
 from .const import (
+    API_SENSOR_PAIRED_SENSOR_STATUS,
     API_VALVE_STATUS,
     CONF_UID,
     DATA_CLIENT,
@@ -74,7 +75,16 @@ async def async_setup_entry(
             ValveControllerSwitch(
                 entry,
                 hass.data[DOMAIN][DATA_CLIENT][entry.entry_id],
-                hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id],
+                # ValveControllerEntity objects don't need to know about
+                # DataUpdateCoordinators related to paired sensors, so we make sure to
+                # exclude them from our global storage:
+                {
+                    api: coordinator
+                    for api, coordinator in hass.data[DOMAIN][DATA_COORDINATOR][
+                        entry.entry_id
+                    ].items()
+                    if api != API_SENSOR_PAIRED_SENSOR_STATUS
+                },
             )
         ]
     )

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import ValveControllerEntity
 from .const import (
-    API_SENSOR_PAIRED_SENSOR_STATUS,
     API_VALVE_STATUS,
     CONF_UID,
     DATA_CLIENT,
@@ -75,16 +74,7 @@ async def async_setup_entry(
             ValveControllerSwitch(
                 entry,
                 hass.data[DOMAIN][DATA_CLIENT][entry.entry_id],
-                # ValveControllerEntity objects don't need to know about
-                # DataUpdateCoordinators related to paired sensors, so we make sure to
-                # exclude them from our global storage:
-                {
-                    api: coordinator
-                    for api, coordinator in hass.data[DOMAIN][DATA_COORDINATOR][
-                        entry.entry_id
-                    ].items()
-                    if api != API_SENSOR_PAIRED_SENSOR_STATUS
-                },
+                hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id],
             )
         ]
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Guardian was maintaining a rather unwieldly `dict` of `DataUpdateCoordinator` objects: most keys contained a single coordinator, but one key (related to paired sensor status) contained a `dict` of coordinator objects. This previously went unnoticed because, until recently, the Guardian integration was not strongly typed.

Valve controller entities were looking at their aggregated coordinators to determine their `available` property; the presence of a `dict` could throw an unhandled exception. This PR fixes things by storing paired sensor coordinators separately from the other coordinators.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/53651
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
