### PR TITLE
Add energy support for zwave_js meter CC entities

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -517,10 +517,10 @@ DISCOVERY_SCHEMAS = [
         ),
         entity_registry_enabled_default=False,
     ),
-    # numeric sensors for Meter CC
+    # Meter sensors for Meter CC
     ZWaveDiscoverySchema(
         platform="sensor",
-        hint="numeric_sensor",
+        hint="meter",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={
                 CommandClass.METER,

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -306,7 +306,7 @@ class ZWaveMeterSensor(ZWaveNumericSensor, RestoreEntity):
             options,
         )
         self._attr_last_reset = dt.utcnow()
-        # Notify other meters that may have been reset
+        # Notify meters that may have been reset
         async_dispatcher_send(
             self.hass,
             f"{DOMAIN}_{SERVICE_RESET_METER}",

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -269,6 +269,7 @@ class ZWaveMeterSensor(ZWaveNumericSensor, RestoreEntity):
         """Call when entity is added."""
         await super().async_added_to_hass()
 
+        # Restore the last reset time from stored state
         restored_state = await self.async_get_last_state()
         if restored_state and ATTR_LAST_RESET in restored_state.attributes:
             self._attr_last_reset = dt.parse_datetime(

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -239,30 +239,12 @@ class ZWaveMeterSensor(ZWaveNumericSensor, RestoreEntity):
         super().__init__(config_entry, client, info)
 
         # Entity class attributes
-        self._attr_last_reset = dt.utc_from_timestamp(0)
-
-    def _get_device_class(self) -> str | None:
-        """
-        Get the device class of the sensor.
-
-        This should be run once during initialization so we don't have to calculate
-        this value on every state update.
-        """
+        self._attr_device_class = DEVICE_CLASS_POWER
         if self.info.primary_value.metadata.unit == "kWh":
-            return DEVICE_CLASS_ENERGY
-        return DEVICE_CLASS_POWER
+            self._attr_device_class = DEVICE_CLASS_ENERGY
 
-    def _get_state_class(self) -> str | None:
-        """
-        Get the state class of the sensor.
-
-        This should be run once during initialization so we don't have to calculate
-        this value on every state update.
-        """
-        if self.device_class == DEVICE_CLASS_ENERGY:
-            return STATE_CLASS_MEASUREMENT
-
-        return None
+        self._attr_state_class = STATE_CLASS_MEASUREMENT
+        self._attr_last_reset = dt.utc_from_timestamp(0)
 
     async def async_update_last_reset(
         self, node: ZwaveNode, endpoint: int, meter_type: int | None

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -11,6 +11,7 @@ from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.value import ConfigurationValue
 
 from homeassistant.components.sensor import (
+    ATTR_LAST_RESET,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_ILLUMINANCE,
@@ -28,8 +29,13 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import dt
 
 from .const import ATTR_METER_TYPE, ATTR_VALUE, DATA_CLIENT, DOMAIN, SERVICE_RESET_METER
 from .discovery import ZwaveDiscoveryInfo
@@ -60,6 +66,8 @@ async def async_setup_entry(
             entities.append(ZWaveListSensor(config_entry, client, info))
         elif info.platform_hint == "config_parameter":
             entities.append(ZWaveConfigParameterSensor(config_entry, client, info))
+        elif info.platform_hint == "meter":
+            entities.append(ZWaveMeterSensor(config_entry, client, info))
         else:
             LOGGER.warning(
                 "Sensor not implemented for %s/%s",
@@ -128,10 +136,6 @@ class ZwaveSensorBase(ZWaveBaseEntity, SensorEntity):
         """
         if self.info.primary_value.command_class == CommandClass.BATTERY:
             return DEVICE_CLASS_BATTERY
-        if self.info.primary_value.command_class == CommandClass.METER:
-            if self.info.primary_value.metadata.unit == "kWh":
-                return DEVICE_CLASS_ENERGY
-            return DEVICE_CLASS_POWER
         if isinstance(self.info.primary_value.property_, str):
             property_lower = self.info.primary_value.property_.lower()
             if "humidity" in property_lower:
@@ -221,14 +225,86 @@ class ZWaveNumericSensor(ZwaveSensorBase):
 
         return str(self.info.primary_value.metadata.unit)
 
+
+class ZWaveMeterSensor(ZWaveNumericSensor, RestoreEntity):
+    """Representation of a Z-Wave Meter CC sensor."""
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        client: ZwaveClient,
+        info: ZwaveDiscoveryInfo,
+    ) -> None:
+        """Initialize a ZWaveNumericSensor entity."""
+        super().__init__(config_entry, client, info)
+
+        # Entity class attributes
+        self._attr_last_reset = dt.utc_from_timestamp(0)
+
+    def _get_device_class(self) -> str | None:
+        """
+        Get the device class of the sensor.
+
+        This should be run once during initialization so we don't have to calculate
+        this value on every state update.
+        """
+        if self.info.primary_value.metadata.unit == "kWh":
+            return DEVICE_CLASS_ENERGY
+        return DEVICE_CLASS_POWER
+
+    def _get_state_class(self) -> str | None:
+        """
+        Get the state class of the sensor.
+
+        This should be run once during initialization so we don't have to calculate
+        this value on every state update.
+        """
+        if self.device_class == DEVICE_CLASS_ENERGY:
+            return STATE_CLASS_MEASUREMENT
+
+        return None
+
+    async def async_update_last_reset(
+        self, node: ZwaveNode, endpoint: int, meter_type: int | None
+    ) -> None:
+        """Update last reset."""
+        if self.info.node != node or self.info.primary_value.endpoint != endpoint:
+            return
+        if (
+            meter_type is not None
+            and self.info.primary_value.metadata.cc_specific.get("meterType")
+            != meter_type
+        ):
+            return
+
+        self._attr_last_reset = dt.utcnow()
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity is added."""
+        await super().async_added_to_hass()
+
+        restored_state = await self.async_get_last_state()
+        if restored_state and ATTR_LAST_RESET in restored_state.attributes:
+            self._attr_last_reset = dt.parse_datetime(
+                restored_state.attributes[ATTR_LAST_RESET]
+            )
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_{SERVICE_RESET_METER}",
+                self.async_update_last_reset,
+            )
+        )
+
     async def async_reset_meter(
         self, meter_type: int | None = None, value: int | None = None
     ) -> None:
         """Reset meter(s) on device."""
         node = self.info.node
         primary_value = self.info.primary_value
-        if primary_value.command_class != CommandClass.METER:
-            raise TypeError("Reset only available for Meter sensors")
         options = {}
         if meter_type is not None:
             options["type"] = meter_type
@@ -243,6 +319,15 @@ class ZWaveNumericSensor(ZwaveSensorBase):
             node,
             primary_value.endpoint,
             options,
+        )
+        self._attr_last_reset = dt.utcnow()
+        # Notify other meters that may have been reset
+        async_dispatcher_send(
+            self.hass,
+            f"{DOMAIN}_{SERVICE_RESET_METER}",
+            node,
+            primary_value.endpoint,
+            options.get("type"),
         )
 
 

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -250,8 +250,11 @@ class ZWaveMeterSensor(ZWaveNumericSensor, RestoreEntity):
         self, node: ZwaveNode, endpoint: int, meter_type: int | None
     ) -> None:
         """Update last reset."""
+        # If the signal is not for this node or is for a different endpoint, ignore it
         if self.info.node != node or self.info.primary_value.endpoint != endpoint:
             return
+        # If a meter type was specified and doesn't match this entity's meter type,
+        # ignore it
         if (
             meter_type is not None
             and self.info.primary_value.metadata.cc_specific.get("meterType")

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -229,6 +229,8 @@ class ZWaveNumericSensor(ZwaveSensorBase):
 class ZWaveMeterSensor(ZWaveNumericSensor, RestoreEntity):
     """Representation of a Z-Wave Meter CC sensor."""
 
+    _attr_state_class = STATE_CLASS_MEASUREMENT
+
     def __init__(
         self,
         config_entry: ConfigEntry,
@@ -239,12 +241,10 @@ class ZWaveMeterSensor(ZWaveNumericSensor, RestoreEntity):
         super().__init__(config_entry, client, info)
 
         # Entity class attributes
+        self._attr_last_reset = dt.utc_from_timestamp(0)
         self._attr_device_class = DEVICE_CLASS_POWER
         if self.info.primary_value.metadata.unit == "kWh":
             self._attr_device_class = DEVICE_CLASS_ENERGY
-
-        self._attr_state_class = STATE_CLASS_MEASUREMENT
-        self._attr_last_reset = dt.utc_from_timestamp(0)
 
     async def async_update_last_reset(
         self, node: ZwaveNode, endpoint: int, meter_type: int | None

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -246,7 +246,8 @@ class ZWaveMeterSensor(ZWaveNumericSensor, RestoreEntity):
         if self.info.primary_value.metadata.unit == "kWh":
             self._attr_device_class = DEVICE_CLASS_ENERGY
 
-    async def async_update_last_reset(
+    @callback
+    def async_update_last_reset(
         self, node: ZwaveNode, endpoint: int, meter_type: int | None
     ) -> None:
         """Update last reset."""
@@ -275,7 +276,6 @@ class ZWaveMeterSensor(ZWaveNumericSensor, RestoreEntity):
             self._attr_last_reset = dt.parse_datetime(
                 restored_state.attributes[ATTR_LAST_RESET]
             )
-            self.async_write_ha_state()
 
         self.async_on_remove(
             async_dispatcher_connect(

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -1,4 +1,6 @@
 """Provide common test tools for Z-Wave JS."""
+from datetime import datetime, timezone
+
 AIR_TEMPERATURE_SENSOR = "sensor.multisensor_6_air_temperature"
 HUMIDITY_SENSOR = "sensor.multisensor_6_humidity"
 ENERGY_SENSOR = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_2"
@@ -29,3 +31,7 @@ ID_LOCK_CONFIG_PARAMETER_SENSOR = (
     "sensor.z_wave_module_for_id_lock_150_and_101_config_parameter_door_lock_mode"
 )
 ZEN_31_ENTITY = "light.kitchen_under_cabinet_lights"
+METER_SENSOR = "sensor.smart_switch_6_electric_consumed_v"
+
+DATETIME_ZERO = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+DATETIME_LAST_RESET = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -11,6 +11,11 @@ from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
 from zwave_js_server.version import VersionInfo
 
+from homeassistant.components.sensor import ATTR_LAST_RESET
+from homeassistant.core import State
+
+from .common import DATETIME_LAST_RESET
+
 from tests.common import MockConfigEntry, load_fixture
 
 # Add-on fixtures
@@ -835,3 +840,16 @@ def aeotec_zw164_siren_fixture(client, aeotec_zw164_siren_state):
 def firmware_file_fixture():
     """Return mock firmware file stream."""
     return io.BytesIO(bytes(10))
+
+
+@pytest.fixture(name="restore_last_reset")
+def restore_last_reset_fixture():
+    """Return mock restore last reset."""
+    state = State(
+        "sensor.test", "test", {ATTR_LAST_RESET: DATETIME_LAST_RESET.isoformat()}
+    )
+    with patch(
+        "homeassistant.components.zwave_js.sensor.ZWaveMeterSensor.async_get_last_state",
+        return_value=state,
+    ):
+        yield state


### PR DESCRIPTION
## Proposed change
So the tricky part of adding energy support is that we don't have a way to detect a meter reset from `zwave-js`. Instead, we have to rely on HA service calls to reset meters and to selectively reset the right meters accordingly.

So a couple of things about this PR:
1. When it is first introduced, last reset will be the beginning of time
2. To make last reset more accurate, we will use the `RestoreEntity` mixin to update to the last known reset
3. When the `reset_meter` entity service is called, a signal will be dispatched that all meter CC entities will be listening for since a reset can affect multiple entities.

The main downside with this implementation is that if the meter reset happens outside of HomeAssistant, we have no way to detect it. But that's a Z-Wave protocol limitation more than anything else and I don't think it's something we can address.

CC @MartinHjelmare let me know your thoughts on this approach.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
