### PR TITLE
Add support for BloomSky Storm accessory device

### DIFF
--- a/homeassistant/components/bloomsky/binary_sensor.py
+++ b/homeassistant/components/bloomsky/binary_sensor.py
@@ -16,14 +16,14 @@ SENSOR_TYPES = {
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available BloomSky weather binary sensors."""
     # Default needed in case of discovery
-    if discovery_info is not None:
+    if discovery_info is None:
         return
 
     bloomsky = hass.data[DOMAIN]
 
     for device in bloomsky.devices.values():
         add_entities(
-            (BloomSkySensor(bloomsky, device, sensor) for sensor in SENSOR_TYPES), True
+            BloomSkySensor(bloomsky, device, sensor) for sensor in SENSOR_TYPES
         )
 
 
@@ -38,6 +38,7 @@ class BloomSkySensor(BinarySensorEntity):
         self._attr_name = f"{device['DeviceName']} {sensor_name}"
         self._attr_unique_id = f"{self._device_id}-{sensor_name}"
         self._attr_device_class = SENSOR_TYPES.get(sensor_name)
+        self.update()
 
     def update(self):
         """Request an update from the BloomSky API."""

--- a/homeassistant/components/bloomsky/binary_sensor.py
+++ b/homeassistant/components/bloomsky/binary_sensor.py
@@ -1,25 +1,16 @@
 """Support the binary sensors of a BloomSky weather station."""
-import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOISTURE,
-    PLATFORM_SCHEMA,
     BinarySensorEntity,
 )
-from homeassistant.const import CONF_MONITORED_CONDITIONS
-import homeassistant.helpers.config_validation as cv
 
 from . import DOMAIN
 
-SENSOR_TYPES = {"Rain": DEVICE_CLASS_MOISTURE, "Night": None}
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_TYPES)]
-        )
-    }
-)
+SENSOR_TYPES = {
+    "Rain": DEVICE_CLASS_MOISTURE,
+    "Night": None,
+}
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -28,12 +19,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if discovery_info is not None:
         return
 
-    sensors = config[CONF_MONITORED_CONDITIONS]
     bloomsky = hass.data[DOMAIN]
 
     for device in bloomsky.devices.values():
-        for variable in sensors:
-            add_entities([BloomSkySensor(bloomsky, device, variable)], True)
+        add_entities(
+            (BloomSkySensor(bloomsky, device, sensor) for sensor in SENSOR_TYPES), True
+        )
 
 
 class BloomSkySensor(BinarySensorEntity):

--- a/homeassistant/components/bloomsky/binary_sensor.py
+++ b/homeassistant/components/bloomsky/binary_sensor.py
@@ -21,10 +21,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     bloomsky = hass.data[DOMAIN]
 
+    entities = []
+
     for device in bloomsky.devices.values():
-        add_entities(
+        entities.extend(
             BloomSkySensor(bloomsky, device, sensor) for sensor in SENSOR_TYPES
         )
+    add_entities(entities, True)
 
 
 class BloomSkySensor(BinarySensorEntity):
@@ -38,7 +41,6 @@ class BloomSkySensor(BinarySensorEntity):
         self._attr_name = f"{device['DeviceName']} {sensor_name}"
         self._attr_unique_id = f"{self._device_id}-{sensor_name}"
         self._attr_device_class = SENSOR_TYPES.get(sensor_name)
-        self.update()
 
     def update(self):
         """Request an update from the BloomSky API."""

--- a/homeassistant/components/bloomsky/camera.py
+++ b/homeassistant/components/bloomsky/camera.py
@@ -12,7 +12,7 @@ from . import DOMAIN
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up access to BloomSky cameras."""
-    if discovery_info is not None:
+    if discovery_info is None:
         return
 
     bloomsky = hass.data[DOMAIN]

--- a/homeassistant/components/bloomsky/sensor.py
+++ b/homeassistant/components/bloomsky/sensor.py
@@ -101,20 +101,16 @@ FORMAT_NUMBERS = [
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available BloomSky weather sensors."""
-    # Default needed in case of discovery
-    if discovery_info is not None:
+    if discovery_info is None:  # Only accept discovery
         return
 
     bloomsky = hass.data[DOMAIN]
-    bloomsky.refresh_devices()
 
     for device in bloomsky.devices.values():
-        add_entities(
-            (BloomSkySensor(bloomsky, device, what) for what in SKY_SENSORS), True
-        )
+        add_entities(BloomSkySensor(bloomsky, device, what) for what in SKY_SENSORS)
         if "Storm" in device:
             add_entities(
-                (BloomSkySensor(bloomsky, device, what) for what in STORM_SENSORS), True
+                BloomSkySensor(bloomsky, device, what) for what in STORM_SENSORS
             )
 
 
@@ -135,6 +131,7 @@ class BloomSkySensor(SensorEntity):
             self._attr_native_unit_of_measurement = SENSOR_UNITS_METRIC.get(
                 sensor_name, None
             )
+        self.update()
 
     @property
     def device_class(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Extend the BloomSky platform integration to support BloomSky Storm accessory devices.

The Storm is an accessory that attaches to BloomSky Sky devices, adding rain and wind sensor data.

When a Storm is attached to a Sky, the Storm's data is included in the API's response JSON under the `Storm` object (whereas Sky data is in the `Data` object, see [API documentation](http://weatherlution.com/wp-content/uploads/2016/01/v1.6BloomskyDeviceOwnerAPIDocumentationforBusinessOwners.pdf)).

This PR:
* adds these new sensor types
* Adds and/or corrects the sensor units and device class
* Teaches the update method to parse the Storm response data.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18651

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
