### PR TITLE
Revert the SegmentBuffer class in stream

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -204,14 +204,14 @@ class Stream:
         """Handle consuming streams and restart keepalive streams."""
         # Keep import here so that we can import stream integration without installing reqs
         # pylint: disable=import-outside-toplevel
-        from .worker import SegmentBuffer, stream_worker
+        from .worker import StreamState, stream_worker
 
-        segment_buffer = SegmentBuffer(self.outputs)
+        stream_state = StreamState(self.outputs)
         wait_timeout = 0
         while not self._thread_quit.wait(timeout=wait_timeout):
             start_time = time.time()
-            stream_worker(self.source, self.options, segment_buffer, self._thread_quit)
-            segment_buffer.discontinuity()
+            stream_worker(self.source, self.options, stream_state, self._thread_quit)
+            stream_state.discontinuity()
             if not self.keepalive or self._thread_quit.is_set():
                 if self._fast_restart_once:
                     # The stream source is updated, restart without any delay.

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -30,6 +30,7 @@ class Part:
     has_keyframe: bool = attr.ib()
     # video data (moof+mdat)
     data: bytes = attr.ib()
+    dts: int = attr.ib(default=0)
 
 
 @attr.s(slots=True)
@@ -38,12 +39,13 @@ class Segment:
 
     sequence: int = attr.ib(default=0)
     # the init of the mp4 the segment is based on
-    init: bytes = attr.ib(default=None)
+    init: bytes | None = attr.ib(default=None)
     duration: float = attr.ib(default=0)
     # For detecting discontinuities across stream restarts
     stream_id: int = attr.ib(default=0)
     parts: list[Part] = attr.ib(factory=list)
     start_time: datetime.datetime = attr.ib(factory=datetime.datetime.utcnow)
+    dts: int = attr.ib(default=0)
 
     @property
     def complete(self) -> bool:
@@ -53,6 +55,11 @@ class Segment:
     def get_bytes_without_init(self) -> bytes:
         """Return reconstructed data for all parts as bytes, without init."""
         return b"".join([part.data for part in self.parts])
+
+    @property
+    def current_dts(self) -> int:
+        """Return the most recent dts."""
+        return self.parts[-1].dts if self.parts else self.dts
 
 
 class IdleTimer:

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -39,7 +39,7 @@ class Segment:
 
     sequence: int = attr.ib(default=0)
     # the init of the mp4 the segment is based on
-    init: bytes | None = attr.ib(default=None)
+    init: bytes = attr.ib(default=None)
     duration: float = attr.ib(default=0)
     # For detecting discontinuities across stream restarts
     stream_id: int = attr.ib(default=0)

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -82,7 +82,7 @@ class StreamMuxer:
         self,
         video_stream: av.video.VideoStream,
         audio_stream: av.audio.stream.AudioStream | None,
-    ):
+    ) -> None:
         """Initialize StreamMuxer."""
         self._input_video_stream = video_stream
         self._input_audio_stream = audio_stream


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Revet the SegmentBuffer class in stream, since it makes logic for segmentation more complicated than it needs to be.


Revert back to the old approach of doing more work directly in the for loop, unrolling the member state into local
variables. Part of the existing SegmentBuffer class that holds state across stream restarts is preserved in the SegmentState class. The I/O related logic is preserved in a StreamMuxer class.

**I am not necessarily looking for this PR to be accepted right now, but to get some early feedback if this direction makes sense. In particular, I think we should merge LL HLS first before this is accepted.**


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
