### PR TITLE
Use constants for device_info in Onewire integration

### DIFF
--- a/homeassistant/components/onewire/binary_sensor.py
+++ b/homeassistant/components/onewire/binary_sensor.py
@@ -5,7 +5,13 @@ import os
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_TYPE
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    CONF_TYPE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -113,10 +119,10 @@ def get_entities(onewirehub: OneWireHub) -> list[OneWireBaseEntity]:
         if family not in DEVICE_BINARY_SENSORS:
             continue
         device_info: DeviceInfo = {
-            "identifiers": {(DOMAIN, device_id)},
-            "manufacturer": "Maxim Integrated",
-            "model": device_type,
-            "name": device_id,
+            ATTR_IDENTIFIERS: {(DOMAIN, device_id)},
+            ATTR_MANUFACTURER: "Maxim Integrated",
+            ATTR_MODEL: device_type,
+            ATTR_NAME: device_id,
         }
         for entity_specs in DEVICE_BINARY_SENSORS[family]:
             entity_path = os.path.join(

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -11,7 +11,13 @@ from pi1wire import InvalidCRCException, OneWireInterface, UnsupportResponseExce
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_TYPE
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    CONF_TYPE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -288,10 +294,10 @@ def get_entities(
                 )
                 continue
             device_info: DeviceInfo = {
-                "identifiers": {(DOMAIN, device_id)},
-                "manufacturer": "Maxim Integrated",
-                "model": device_type,
-                "name": device_id,
+                ATTR_IDENTIFIERS: {(DOMAIN, device_id)},
+                ATTR_MANUFACTURER: "Maxim Integrated",
+                ATTR_MODEL: device_type,
+                ATTR_NAME: device_id,
             }
             for entity_specs in get_sensor_types(device_sub_type)[family]:
                 if entity_specs["type"] == SENSOR_TYPE_MOISTURE:
@@ -334,10 +340,10 @@ def get_entities(
                 continue
 
             device_info = {
-                "identifiers": {(DOMAIN, sensor_id)},
-                "manufacturer": "Maxim Integrated",
-                "model": family,
-                "name": sensor_id,
+                ATTR_IDENTIFIERS: {(DOMAIN, sensor_id)},
+                ATTR_MANUFACTURER: "Maxim Integrated",
+                ATTR_MODEL: family,
+                ATTR_NAME: sensor_id,
             }
             device_file = f"/sys/bus/w1/devices/{sensor_id}/w1_slave"
             entities.append(

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -7,7 +7,13 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_TYPE
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    CONF_TYPE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -186,10 +192,10 @@ def get_entities(onewirehub: OneWireHub) -> list[OneWireBaseEntity]:
             continue
 
         device_info: DeviceInfo = {
-            "identifiers": {(DOMAIN, device_id)},
-            "manufacturer": "Maxim Integrated",
-            "model": device_type,
-            "name": device_id,
+            ATTR_IDENTIFIERS: {(DOMAIN, device_id)},
+            ATTR_MANUFACTURER: "Maxim Integrated",
+            ATTR_MODEL: device_type,
+            ATTR_NAME: device_id,
         }
         for entity_specs in DEVICE_SWITCHES[family]:
             entity_path = os.path.join(

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -8,6 +8,10 @@ from homeassistant.components.onewire.const import DOMAIN, PRESSURE_CBAR
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
@@ -24,6 +28,8 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 
+MANUFACTURER = "Maxim Integrated"
+
 MOCK_OWPROXY_DEVICES = {
     "00.111111111111": {
         "inject_reads": [
@@ -36,10 +42,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS2405",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "05.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS2405",
-            "name": "05.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "05.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS2405",
+            ATTR_NAME: "05.111111111111",
         },
         SWITCH_DOMAIN: [
             {
@@ -58,10 +64,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS18S20",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "10.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS18S20",
-            "name": "10.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "10.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS18S20",
+            ATTR_NAME: "10.111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -79,10 +85,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS2406",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "12.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS2406",
-            "name": "12.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "12.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS2406",
+            ATTR_NAME: "12.111111111111",
         },
         BINARY_SENSOR_DOMAIN: [
             {
@@ -168,10 +174,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS2423",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "1D.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS2423",
-            "name": "1D.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "1D.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS2423",
+            ATTR_NAME: "1D.111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -197,10 +203,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS2409",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "1F.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS2409",
-            "name": "1F.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "1F.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS2409",
+            ATTR_NAME: "1F.111111111111",
         },
         "branches": {
             "aux": {},
@@ -210,10 +216,10 @@ MOCK_OWPROXY_DEVICES = {
                         b"DS2423",  # read device type
                     ],
                     "device_info": {
-                        "identifiers": {(DOMAIN, "1D.111111111111")},
-                        "manufacturer": "Maxim Integrated",
-                        "model": "DS2423",
-                        "name": "1D.111111111111",
+                        ATTR_IDENTIFIERS: {(DOMAIN, "1D.111111111111")},
+                        ATTR_MANUFACTURER: MANUFACTURER,
+                        ATTR_MODEL: "DS2423",
+                        ATTR_NAME: "1D.111111111111",
                     },
                     SENSOR_DOMAIN: [
                         {
@@ -244,10 +250,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS1822",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "22.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS1822",
-            "name": "22.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "22.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS1822",
+            ATTR_NAME: "22.111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -265,10 +271,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS2438",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "26.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS2438",
-            "name": "26.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "26.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS2438",
+            ATTR_NAME: "26.111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -376,10 +382,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS18B20",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "28.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS18B20",
-            "name": "28.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "28.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS18B20",
+            ATTR_NAME: "28.111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -397,10 +403,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS2408",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "29.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS2408",
-            "name": "29.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "29.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS2408",
+            ATTR_NAME: "29.111111111111",
         },
         BINARY_SENSOR_DOMAIN: [
             {
@@ -628,10 +634,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS1825",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "3B.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS1825",
-            "name": "3B.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "3B.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS1825",
+            ATTR_NAME: "3B.111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -649,10 +655,10 @@ MOCK_OWPROXY_DEVICES = {
             b"DS28EA00",  # read device type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "42.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "DS28EA00",
-            "name": "42.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "42.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "DS28EA00",
+            ATTR_NAME: "42.111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -670,10 +676,10 @@ MOCK_OWPROXY_DEVICES = {
             b"HobbyBoards_EF",  # read type
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "EF.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "HobbyBoards_EF",
-            "name": "EF.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "EF.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "HobbyBoards_EF",
+            ATTR_NAME: "EF.111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -711,10 +717,10 @@ MOCK_OWPROXY_DEVICES = {
             b"         0",  # read is_leaf_3
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "EF.111111111112")},
-            "manufacturer": "Maxim Integrated",
-            "model": "HB_MOISTURE_METER",
-            "name": "EF.111111111112",
+            ATTR_IDENTIFIERS: {(DOMAIN, "EF.111111111112")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "HB_MOISTURE_METER",
+            ATTR_NAME: "EF.111111111112",
         },
         SENSOR_DOMAIN: [
             {
@@ -757,10 +763,10 @@ MOCK_OWPROXY_DEVICES = {
             b"EDS0068",  # read device_type - note EDS specific
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "7E.111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "EDS",
-            "name": "7E.111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "7E.111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "EDS",
+            ATTR_NAME: "7E.111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -803,10 +809,10 @@ MOCK_OWPROXY_DEVICES = {
             b"EDS0066",  # read device_type - note EDS specific
         ],
         "device_info": {
-            "identifiers": {(DOMAIN, "7E.222222222222")},
-            "manufacturer": "Maxim Integrated",
-            "model": "EDS",
-            "name": "7E.222222222222",
+            ATTR_IDENTIFIERS: {(DOMAIN, "7E.222222222222")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "EDS",
+            ATTR_NAME: "7E.222222222222",
         },
         SENSOR_DOMAIN: [
             {
@@ -833,10 +839,10 @@ MOCK_SYSBUS_DEVICES = {
     "00-111111111111": {SENSOR_DOMAIN: []},
     "10-111111111111": {
         "device_info": {
-            "identifiers": {(DOMAIN, "10-111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "10",
-            "name": "10-111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "10-111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "10",
+            ATTR_NAME: "10-111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -853,10 +859,10 @@ MOCK_SYSBUS_DEVICES = {
     "1D-111111111111": {SENSOR_DOMAIN: []},
     "22-111111111111": {
         "device_info": {
-            "identifiers": {(DOMAIN, "22-111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "22",
-            "name": "22-111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "22-111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "22",
+            ATTR_NAME: "22-111111111111",
         },
         "sensor": [
             {
@@ -872,10 +878,10 @@ MOCK_SYSBUS_DEVICES = {
     "26-111111111111": {SENSOR_DOMAIN: []},
     "28-111111111111": {
         "device_info": {
-            "identifiers": {(DOMAIN, "28-111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "28",
-            "name": "28-111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "28-111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "28",
+            ATTR_NAME: "28-111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -891,10 +897,10 @@ MOCK_SYSBUS_DEVICES = {
     "29-111111111111": {SENSOR_DOMAIN: []},
     "3B-111111111111": {
         "device_info": {
-            "identifiers": {(DOMAIN, "3B-111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "3B",
-            "name": "3B-111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "3B-111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "3B",
+            ATTR_NAME: "3B-111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -909,10 +915,10 @@ MOCK_SYSBUS_DEVICES = {
     },
     "42-111111111111": {
         "device_info": {
-            "identifiers": {(DOMAIN, "42-111111111111")},
-            "manufacturer": "Maxim Integrated",
-            "model": "42",
-            "name": "42-111111111111",
+            ATTR_IDENTIFIERS: {(DOMAIN, "42-111111111111")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "42",
+            ATTR_NAME: "42-111111111111",
         },
         SENSOR_DOMAIN: [
             {
@@ -927,10 +933,10 @@ MOCK_SYSBUS_DEVICES = {
     },
     "42-111111111112": {
         "device_info": {
-            "identifiers": {(DOMAIN, "42-111111111112")},
-            "manufacturer": "Maxim Integrated",
-            "model": "42",
-            "name": "42-111111111112",
+            ATTR_IDENTIFIERS: {(DOMAIN, "42-111111111112")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "42",
+            ATTR_NAME: "42-111111111112",
         },
         SENSOR_DOMAIN: [
             {
@@ -945,10 +951,10 @@ MOCK_SYSBUS_DEVICES = {
     },
     "42-111111111113": {
         "device_info": {
-            "identifiers": {(DOMAIN, "42-111111111113")},
-            "manufacturer": "Maxim Integrated",
-            "model": "42",
-            "name": "42-111111111113",
+            ATTR_IDENTIFIERS: {(DOMAIN, "42-111111111113")},
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL: "42",
+            ATTR_NAME: "42-111111111113",
         },
         SENSOR_DOMAIN: [
             {

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.onewire.const import (
     PLATFORMS,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME
 from homeassistant.setup import async_setup_component
 
 from . import (
@@ -155,9 +156,9 @@ async def test_owserver_setup_valid_device(owproxy, hass, device_id, platform):
         registry_entry = device_registry.async_get_device({(DOMAIN, device_id)})
         assert registry_entry is not None
         assert registry_entry.identifiers == {(DOMAIN, device_id)}
-        assert registry_entry.manufacturer == device_info["manufacturer"]
-        assert registry_entry.name == device_info["name"]
-        assert registry_entry.model == device_info["model"]
+        assert registry_entry.manufacturer == device_info[ATTR_MANUFACTURER]
+        assert registry_entry.name == device_info[ATTR_NAME]
+        assert registry_entry.model == device_info[ATTR_MODEL]
 
     for expected_entity in expected_entities:
         entity_id = expected_entity["entity_id"]
@@ -206,9 +207,9 @@ async def test_onewiredirect_setup_valid_device(hass, device_id):
         registry_entry = device_registry.async_get_device({(DOMAIN, device_id)})
         assert registry_entry is not None
         assert registry_entry.identifiers == {(DOMAIN, device_id)}
-        assert registry_entry.manufacturer == device_info["manufacturer"]
-        assert registry_entry.name == device_info["name"]
-        assert registry_entry.model == device_info["model"]
+        assert registry_entry.manufacturer == device_info[ATTR_MANUFACTURER]
+        assert registry_entry.name == device_info[ATTR_NAME]
+        assert registry_entry.model == device_info[ATTR_MODEL]
 
     for expected_sensor in expected_entities:
         entity_id = expected_sensor["entity_id"]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make use of ATTR_IDENTIFIERS, ATTR_MANUFACTURER, ATTR_MODEL and ATTR_NAME for device information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
