### PR TITLE
Remove YAML configuration from onewire

### DIFF
--- a/homeassistant/components/onewire/config_flow.py
+++ b/homeassistant/components/onewire/config_flow.py
@@ -164,16 +164,3 @@ class OneWireFlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=DATA_SCHEMA_MOUNTDIR,
             errors=errors,
         )
-
-    async def async_step_import(self, platform_config: dict[str, Any]) -> FlowResult:
-        """Handle import configuration from YAML."""
-        # OWServer
-        if platform_config[CONF_TYPE] == CONF_TYPE_OWSERVER:
-            if CONF_PORT not in platform_config:
-                platform_config[CONF_PORT] = DEFAULT_OWSERVER_PORT
-            return await self.async_step_owserver(platform_config)
-
-        # SysBus
-        if CONF_MOUNT_DIR not in platform_config:
-            platform_config[CONF_MOUNT_DIR] = DEFAULT_SYSBUS_MOUNT_DIR
-        return await self.async_step_mount_dir(platform_config)

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -8,24 +8,20 @@ from types import MappingProxyType
 from typing import Any
 
 from pi1wire import InvalidCRCException, OneWireInterface, UnsupportResponseException
-import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TYPE
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import DiscoveryInfoType, StateType
+from homeassistant.helpers.typing import StateType
 
 from .const import (
     CONF_MOUNT_DIR,
     CONF_NAMES,
     CONF_TYPE_OWSERVER,
     CONF_TYPE_SYSBUS,
-    DEFAULT_OWSERVER_PORT,
-    DEFAULT_SYSBUS_MOUNT_DIR,
     DOMAIN,
     SENSOR_TYPE_COUNT,
     SENSOR_TYPE_CURRENT,
@@ -233,16 +229,6 @@ EDS_SENSORS: dict[str, list[DeviceComponentDescription]] = {
 }
 
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_NAMES): {cv.string: cv.string},
-        vol.Optional(CONF_MOUNT_DIR, default=DEFAULT_SYSBUS_MOUNT_DIR): cv.string,
-        vol.Optional(CONF_HOST): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_OWSERVER_PORT): cv.port,
-    }
-)
-
-
 def get_sensor_types(device_sub_type: str) -> dict[str, Any]:
     """Return the proper info array for the device type."""
     if "HobbyBoard" in device_sub_type:
@@ -250,30 +236,6 @@ def get_sensor_types(device_sub_type: str) -> dict[str, Any]:
     if "EDS" in device_sub_type:
         return EDS_SENSORS
     return DEVICE_SENSORS
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: dict[str, Any],
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Old way of setting up 1-Wire platform."""
-    _LOGGER.warning(
-        "Loading 1-Wire via platform setup is deprecated. "
-        "Please remove it from your configuration"
-    )
-
-    if config.get(CONF_HOST):
-        config[CONF_TYPE] = CONF_TYPE_OWSERVER
-    elif config[CONF_MOUNT_DIR] == DEFAULT_SYSBUS_MOUNT_DIR:
-        config[CONF_TYPE] = CONF_TYPE_SYSBUS
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
-    )
 
 
 async def async_setup_entry(

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -30,6 +30,9 @@ async def setup_onewire_sysbus_integration(hass):
         data={
             CONF_TYPE: CONF_TYPE_SYSBUS,
             CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR,
+            "names": {
+                "10-111111111111": "My DS18B20",
+            },
         },
         unique_id=f"{CONF_TYPE_SYSBUS}:{DEFAULT_SYSBUS_MOUNT_DIR}",
         options={},

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -7,11 +7,10 @@ from homeassistant.components.onewire.const import (
     CONF_MOUNT_DIR,
     CONF_TYPE_OWSERVER,
     CONF_TYPE_SYSBUS,
-    DEFAULT_OWSERVER_PORT,
     DEFAULT_SYSBUS_MOUNT_DIR,
     DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
@@ -197,138 +196,6 @@ async def test_user_sysbus_duplicate(hass):
             user_input={CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR},
         )
 
-    assert result["type"] == RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
-    await hass.async_block_till_done()
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import_sysbus(hass):
-    """Test import step."""
-
-    with patch(
-        "homeassistant.components.onewire.onewirehub.os.path.isdir",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.onewire.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={CONF_TYPE: CONF_TYPE_SYSBUS},
-        )
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == DEFAULT_SYSBUS_MOUNT_DIR
-    assert result["data"] == {
-        CONF_TYPE: CONF_TYPE_SYSBUS,
-        CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR,
-    }
-    await hass.async_block_till_done()
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import_sysbus_with_mount_dir(hass):
-    """Test import step."""
-
-    with patch(
-        "homeassistant.components.onewire.onewirehub.os.path.isdir",
-        return_value=True,
-    ), patch(
-        "homeassistant.components.onewire.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={
-                CONF_TYPE: CONF_TYPE_SYSBUS,
-                CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR,
-            },
-        )
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == DEFAULT_SYSBUS_MOUNT_DIR
-    assert result["data"] == {
-        CONF_TYPE: CONF_TYPE_SYSBUS,
-        CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR,
-    }
-    await hass.async_block_till_done()
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import_owserver(hass):
-    """Test import step."""
-
-    with patch("homeassistant.components.onewire.onewirehub.protocol.proxy",), patch(
-        "homeassistant.components.onewire.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={
-                CONF_TYPE: CONF_TYPE_OWSERVER,
-                CONF_HOST: "1.2.3.4",
-            },
-        )
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "1.2.3.4"
-    assert result["data"] == {
-        CONF_TYPE: CONF_TYPE_OWSERVER,
-        CONF_HOST: "1.2.3.4",
-        CONF_PORT: DEFAULT_OWSERVER_PORT,
-    }
-    await hass.async_block_till_done()
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import_owserver_with_port(hass):
-    """Test import step."""
-
-    with patch("homeassistant.components.onewire.onewirehub.protocol.proxy",), patch(
-        "homeassistant.components.onewire.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={
-                CONF_TYPE: CONF_TYPE_OWSERVER,
-                CONF_HOST: "1.2.3.4",
-                CONF_PORT: 1234,
-            },
-        )
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "1.2.3.4"
-    assert result["data"] == {
-        CONF_TYPE: CONF_TYPE_OWSERVER,
-        CONF_HOST: "1.2.3.4",
-        CONF_PORT: 1234,
-    }
-    await hass.async_block_till_done()
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_import_owserver_duplicate(hass):
-    """Test OWServer flow."""
-    # Initialise with single entry
-    with patch(
-        "homeassistant.components.onewire.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        await setup_onewire_owserver_integration(hass)
-        assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-
-    # Import duplicate entry
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={
-            CONF_TYPE: CONF_TYPE_OWSERVER,
-            CONF_HOST: "1.2.3.4",
-            CONF_PORT: 1234,
-        },
-    )
     assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Remove YAML configuration from onewire
Follow up to #50151 (merged into 2021.6.0)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
