### PR TITLE
Fix Xiaomi humidifier name migration

### DIFF
--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -21,7 +21,6 @@ from .const import (
     DOMAIN,
     KEY_COORDINATOR,
     KEY_DEVICE,
-    KEY_MIGRATE_ENTITY_NAME,
     MODELS_AIR_MONITOR,
     MODELS_FAN,
     MODELS_HUMIDIFIER,
@@ -143,8 +142,6 @@ async def async_create_miio_device_and_coordinator(
         KEY_DEVICE: device,
         KEY_COORDINATOR: coordinator,
     }
-    if migrate_entity_name:
-        hass.data[DOMAIN][entry.entry_id][KEY_MIGRATE_ENTITY_NAME] = migrate_entity_name
 
     # Trigger first data fetch
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -112,12 +112,13 @@ async def async_create_miio_device_and_coordinator(
     else:
         device = AirHumidifier(host, token, model=model)
 
-    # Removing fan platform entity for humidifiers and cache the name and entity name for migration
+    # Removing fan platform entity for humidifiers and migrate the name to the config entry for migration
     entity_registry = er.async_get(hass)
     entity_id = entity_registry.async_get_entity_id("fan", DOMAIN, entry.unique_id)
     if entity_id:
         # This check is entities that have a platform migration only and should be removed in the future
         migrate_entity_name = entity_registry.async_get(entity_id).name
+        hass.config_entries.async_update_entry(entry, title=migrate_entity_name)
         entity_registry.async_remove(entity_id)
 
     async def async_update_data():

--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -18,7 +18,6 @@ CONF_CLOUD_SUBDEVICES = "cloud_subdevices"
 # Keys
 KEY_COORDINATOR = "coordinator"
 KEY_DEVICE = "device"
-KEY_MIGRATE_ENTITY_NAME = "migrate_entity_name"
 
 # Attributes
 ATTR_AVAILABLE = "available"

--- a/homeassistant/components/xiaomi_miio/humidifier.py
+++ b/homeassistant/components/xiaomi_miio/humidifier.py
@@ -24,7 +24,6 @@ from .const import (
     DOMAIN,
     KEY_COORDINATOR,
     KEY_DEVICE,
-    KEY_MIGRATE_ENTITY_NAME,
     MODEL_AIRHUMIDIFIER_CA1,
     MODEL_AIRHUMIDIFIER_CA4,
     MODEL_AIRHUMIDIFIER_CB1,
@@ -52,10 +51,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     model = config_entry.data[CONF_MODEL]
     unique_id = config_entry.unique_id
     coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
-    if KEY_MIGRATE_ENTITY_NAME in hass.data[DOMAIN][config_entry.entry_id]:
-        name = hass.data[DOMAIN][config_entry.entry_id][KEY_MIGRATE_ENTITY_NAME]
-    else:
-        name = config_entry.title
+    name = config_entry.title
 
     if model in MODELS_HUMIDIFIER_MIOT:
         air_humidifier = hass.data[DOMAIN][config_entry.entry_id][KEY_DEVICE]

--- a/homeassistant/components/xiaomi_miio/number.py
+++ b/homeassistant/components/xiaomi_miio/number.py
@@ -13,7 +13,6 @@ from .const import (
     FEATURE_SET_MOTOR_SPEED,
     KEY_COORDINATOR,
     KEY_DEVICE,
-    KEY_MIGRATE_ENTITY_NAME,
     MODEL_AIRHUMIDIFIER_CA4,
 )
 from .device import XiaomiCoordinatedMiioEntity
@@ -58,10 +57,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     model = config_entry.data[CONF_MODEL]
     device = hass.data[DOMAIN][config_entry.entry_id][KEY_DEVICE]
     coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
-    if KEY_MIGRATE_ENTITY_NAME in hass.data[DOMAIN][config_entry.entry_id]:
-        name = hass.data[DOMAIN][config_entry.entry_id][KEY_MIGRATE_ENTITY_NAME]
-    else:
-        name = config_entry.title
 
     if model not in [MODEL_AIRHUMIDIFIER_CA4]:
         return
@@ -69,7 +64,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for number in NUMBER_TYPES.values():
         entities.append(
             XiaomiAirHumidifierNumber(
-                f"{name} {number.name}",
+                f"{config_entry.title} {number.name}",
                 device,
                 config_entry,
                 f"{number.short_name}_{config_entry.unique_id}",

--- a/homeassistant/components/xiaomi_miio/select.py
+++ b/homeassistant/components/xiaomi_miio/select.py
@@ -16,7 +16,6 @@ from .const import (
     FEATURE_SET_LED_BRIGHTNESS,
     KEY_COORDINATOR,
     KEY_DEVICE,
-    KEY_MIGRATE_ENTITY_NAME,
     MODEL_AIRHUMIDIFIER_CA1,
     MODEL_AIRHUMIDIFIER_CA4,
     MODEL_AIRHUMIDIFIER_CB1,
@@ -67,10 +66,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     model = config_entry.data[CONF_MODEL]
     device = hass.data[DOMAIN][config_entry.entry_id][KEY_DEVICE]
     coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
-    if KEY_MIGRATE_ENTITY_NAME in hass.data[DOMAIN][config_entry.entry_id]:
-        name = hass.data[DOMAIN][config_entry.entry_id][KEY_MIGRATE_ENTITY_NAME]
-    else:
-        name = config_entry.title
 
     if model in [MODEL_AIRHUMIDIFIER_CA1, MODEL_AIRHUMIDIFIER_CB1]:
         entity_class = XiaomiAirHumidifierSelector
@@ -84,7 +79,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for selector in SELECTOR_TYPES.values():
         entities.append(
             entity_class(
-                f"{name} {selector.name}",
+                f"{config_entry.title} {selector.name}",
                 device,
                 config_entry,
                 f"{selector.short_name}_{config_entry.unique_id}",

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -45,7 +45,6 @@ from .const import (
     DOMAIN,
     KEY_COORDINATOR,
     KEY_DEVICE,
-    KEY_MIGRATE_ENTITY_NAME,
     MODELS_HUMIDIFIER_MIOT,
 )
 from .device import XiaomiCoordinatedMiioEntity, XiaomiMiioEntity
@@ -190,11 +189,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         model = config_entry.data[CONF_MODEL]
         device = None
         sensors = []
-        if KEY_MIGRATE_ENTITY_NAME in hass.data[DOMAIN][config_entry.entry_id]:
-            name = hass.data[DOMAIN][config_entry.entry_id][KEY_MIGRATE_ENTITY_NAME]
-        else:
-            name = config_entry.title
-
         if model in MODELS_HUMIDIFIER_MIOT:
             device = hass.data[DOMAIN][config_entry.entry_id][KEY_DEVICE]
             coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
@@ -205,6 +199,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             sensors = HUMIDIFIER_SENSORS
         else:
             unique_id = config_entry.unique_id
+            name = config_entry.title
             _LOGGER.debug("Initializing with host %s (token %s...)", host, token[:5])
 
             device = AirQualityMonitor(host, token)
@@ -214,7 +209,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for sensor in sensors:
             entities.append(
                 XiaomiGenericSensor(
-                    f"{name} {sensor.replace('_', ' ').title()}",
+                    f"{config_entry.title} {sensor.replace('_', ' ').title()}",
                     device,
                     config_entry,
                     f"{sensor}_{config_entry.unique_id}",

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -41,7 +41,6 @@ from .const import (
     FEATURE_SET_DRY,
     KEY_COORDINATOR,
     KEY_DEVICE,
-    KEY_MIGRATE_ENTITY_NAME,
     MODEL_AIRHUMIDIFIER_CA1,
     MODEL_AIRHUMIDIFIER_CA4,
     MODEL_AIRHUMIDIFIER_CB1,
@@ -235,10 +234,6 @@ async def async_setup_coordinated_entry(hass, config_entry, async_add_entities):
     unique_id = config_entry.unique_id
     device = hass.data[DOMAIN][config_entry.entry_id][KEY_DEVICE]
     coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
-    if KEY_MIGRATE_ENTITY_NAME in hass.data[DOMAIN][config_entry.entry_id]:
-        name = hass.data[DOMAIN][config_entry.entry_id][KEY_MIGRATE_ENTITY_NAME]
-    else:
-        name = config_entry.title
 
     if DATA_KEY not in hass.data:
         hass.data[DATA_KEY] = {}
@@ -256,7 +251,7 @@ async def async_setup_coordinated_entry(hass, config_entry, async_add_entities):
         if feature & device_features:
             entities.append(
                 XiaomiGenericCoordinatedSwitch(
-                    f"{name} {switch.name}",
+                    f"{config_entry.title} {switch.name}",
                     device,
                     config_entry,
                     f"{switch.short_name}_{unique_id}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fix reverts the way the Xiaomi_miio humidifier name is migrated to the new entities from PR #52366.
Instead of passing the previous name to the platforms (which is only happening once now), the config entry name is synced with the old fan entity name. The user can override the name by renaming the device (config flow) or update separate entities.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
