### PR TITLE
Update to iaqualink 0.4.1

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -111,7 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         aiohttp.client_exceptions.ClientConnectorError,
     ) as aio_exception:
         raise ConfigEntryNotReady(
-            f"Errr while attempting login: {aio_exception}"
+            f"Error while attempting login: {aio_exception}"
         ) from aio_exception
 
     try:

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -111,17 +111,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         asyncio.TimeoutError,
         aiohttp.client_exceptions.ClientConnectorError,
     ) as aio_exception:
-        _LOGGER.warning("Exception raised while attempting to login: %s", aio_exception)
-        raise ConfigEntryNotReady from aio_exception
+        raise ConfigEntryNotReady(
+            f"Errr while attempting login: {aio_exception}"
+        ) from aio_exception
 
     try:
         systems = await aqualink.get_systems()
     except AqualinkServiceException as svc_exception:
-        _LOGGER.warning(
-            "Exception raised while attempting to retrieve systems list: %s",
-            svc_exception,
-        )
-        raise ConfigEntryNotReady from svc_exception
+        raise ConfigEntryNotReady(
+            f"Error while attempting to retrieve systems list: {svc_exception}"
+        ) from svc_exception
 
     systems = list(systems.values())
     if not systems:
@@ -132,11 +131,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         devices = await systems[0].get_devices()
     except AqualinkServiceException as svc_exception:
-        _LOGGER.warning(
-            "Exception raised while attempting to retrieve devices list: %s",
-            svc_exception,
-        )
-        raise ConfigEntryNotReady from svc_exception
+        raise ConfigEntryNotReady(
+            f"Error while attempting to retrieve devices list: {svc_exception}"
+        ) from svc_exception
 
     for dev in devices.values():
         if isinstance(dev, AqualinkThermostat):
@@ -215,7 +212,7 @@ async def try_await(awaitable: Awaitable) -> None:
     try:
         await awaitable
     except AqualinkServiceException as svc_exception:
-        raise HomeAssistantError("Aqualink Exception raised") from svc_exception
+        raise HomeAssistantError(f"Aqualink error: {svc_exception}") from svc_exception
 
 
 class AqualinkEntity(Entity):

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable
 from functools import wraps
 import logging
 
@@ -28,7 +27,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
@@ -205,14 +204,6 @@ def refresh_system(func):
         async_dispatcher_send(self.hass, DOMAIN)
 
     return wrapper
-
-
-async def try_await(awaitable: Awaitable) -> None:
-    """Execute API call while catching service exceptions."""
-    try:
-        await awaitable
-    except AqualinkServiceException as svc_exception:
-        raise HomeAssistantError(f"Aqualink error: {svc_exception}") from svc_exception
 
 
 class AqualinkEntity(Entity):

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -212,6 +212,14 @@ def refresh_system(func):
     return wrapper
 
 
+async def safe_exec(awaitable: Awaitable) -> None:
+    """Execute API call while catching service exceptions."""
+    try:
+        await awaitable
+    except AqualinkServiceException as svc_exception:
+        _LOGGER.warning("Aqualink Service Exception raised: %s", svc_exception)
+
+
 class AqualinkEntity(Entity):
     """Abstract class for all Aqualink platforms.
 
@@ -255,13 +263,6 @@ class AqualinkEntity(Entity):
     def available(self) -> bool:
         """Return whether the device is available or not."""
         return self.dev.system.online is True
-
-    async def safe_exec(self, awaitable: Awaitable) -> None:
-        """Execute API call while catching service exceptions."""
-        try:
-            await awaitable
-        except AqualinkServiceException as svc_exception:
-            _LOGGER.warning("Aqualink Service Exception raised: %s", svc_exception)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable
 from functools import wraps
 import logging
-from typing import Awaitable
 
 import aiohttp.client_exceptions
 from iaqualink.client import AqualinkClient

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -170,7 +170,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             await systems[0].update()
         except AqualinkServiceException as svc_exception:
-            _LOGGER.warning("Failed to refresh iAqualink state: %s", svc_exception)
+            if prev is not None:
+                _LOGGER.warning("Failed to refresh iAqualink state: %s", svc_exception)
         else:
             cur = systems[0].online
             if cur is True and prev is not True:

--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -4,18 +4,19 @@ from __future__ import annotations
 import asyncio
 from functools import wraps
 import logging
+from typing import Awaitable
 
 import aiohttp.client_exceptions
-from iaqualink import (
+from iaqualink.client import AqualinkClient
+from iaqualink.device import (
     AqualinkBinarySensor,
-    AqualinkClient,
     AqualinkDevice,
     AqualinkLight,
-    AqualinkLoginException,
     AqualinkSensor,
     AqualinkThermostat,
     AqualinkToggle,
 )
+from iaqualink.exception import AqualinkServiceException
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -78,7 +79,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if conf is not None:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
-                DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=conf
+                DOMAIN,
+                context={"source": config_entries.SOURCE_IMPORT},
+                data=conf,
             )
         )
 
@@ -89,6 +92,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Aqualink from a config entry."""
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
+
+    hass.data.setdefault(DOMAIN, {})
 
     # These will contain the initialized devices
     binary_sensors = hass.data[DOMAIN][BINARY_SENSOR_DOMAIN] = []
@@ -101,7 +106,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     aqualink = AqualinkClient(username, password, session)
     try:
         await aqualink.login()
-    except AqualinkLoginException as login_exception:
+    except AqualinkServiceException as login_exception:
         _LOGGER.error("Failed to login: %s", login_exception)
         return False
     except (
@@ -111,14 +116,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.warning("Exception raised while attempting to login: %s", aio_exception)
         raise ConfigEntryNotReady from aio_exception
 
-    systems = await aqualink.get_systems()
+    try:
+        systems = await aqualink.get_systems()
+    except AqualinkServiceException as svc_exception:
+        _LOGGER.warning(
+            "Exception raised while attempting to retrieve systems list: %s",
+            svc_exception,
+        )
+        raise ConfigEntryNotReady from svc_exception
+
     systems = list(systems.values())
     if not systems:
         _LOGGER.error("No systems detected or supported")
         return False
 
     # Only supporting the first system for now.
-    devices = await systems[0].get_devices()
+    try:
+        devices = await systems[0].get_devices()
+    except AqualinkServiceException as svc_exception:
+        _LOGGER.warning(
+            "Exception raised while attempting to retrieve devices list: %s",
+            svc_exception,
+        )
+        raise ConfigEntryNotReady from svc_exception
 
     for dev in devices.values():
         if isinstance(dev, AqualinkThermostat):
@@ -151,15 +171,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def _async_systems_update(now):
         """Refresh internal state for all systems."""
-        prev = systems[0].last_run_success
+        prev = systems[0].online
 
-        await systems[0].update()
-        success = systems[0].last_run_success
-
-        if not success and prev:
-            _LOGGER.warning("Failed to refresh iAqualink state")
-        elif success and not prev:
-            _LOGGER.warning("Reconnected to iAqualink")
+        try:
+            await systems[0].update()
+            cur = systems[0].online
+        except AqualinkServiceException as svc_exception:
+            _LOGGER.warning("Failed to refresh iAqualink state: %s", svc_exception)
+        else:
+            if cur is True and prev is not True:
+                _LOGGER.warning("Reconnected to iAqualink")
 
         async_dispatcher_send(hass, DOMAIN)
 
@@ -174,7 +195,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         platform for platform in PLATFORMS if platform in hass.data[DOMAIN]
     ]
 
-    hass.data[DOMAIN].clear()
+    del hass.data[DOMAIN]
 
     return await hass.config_entries.async_unload_platforms(entry, platforms_to_unload)
 
@@ -228,12 +249,19 @@ class AqualinkEntity(Entity):
     @property
     def assumed_state(self) -> bool:
         """Return whether the state is based on actual reading from the device."""
-        return not self.dev.system.last_run_success
+        return self.dev.system.online in [False, None]
 
     @property
     def available(self) -> bool:
         """Return whether the device is available or not."""
-        return self.dev.system.online
+        return self.dev.system.online is True
+
+    async def safe_exec(self, awaitable: Awaitable) -> None:
+        """Execute API call while catching service exceptions."""
+        try:
+            await awaitable
+        except AqualinkServiceException as svc_exception:
+            _LOGGER.warning("Aqualink Service Exception raised: %s", svc_exception)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 import logging
 
-from iaqualink import AqualinkHeater, AqualinkPump, AqualinkSensor, AqualinkState
 from iaqualink.const import (
     AQUALINK_TEMP_CELSIUS_HIGH,
     AQUALINK_TEMP_CELSIUS_LOW,
     AQUALINK_TEMP_FAHRENHEIT_HIGH,
     AQUALINK_TEMP_FAHRENHEIT_LOW,
 )
+from iaqualink.device import AqualinkHeater, AqualinkPump, AqualinkSensor, AqualinkState
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
@@ -76,9 +76,9 @@ class HassAqualinkThermostat(AqualinkEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Turn the underlying heater switch on or off."""
         if hvac_mode == HVAC_MODE_HEAT:
-            await self.heater.turn_on()
+            await self.safe_exec(self.heater.turn_on())
         elif hvac_mode == HVAC_MODE_OFF:
-            await self.heater.turn_off()
+            await self.safe_exec(self.heater.turn_off())
         else:
             _LOGGER.warning("Unknown operation mode: %s", hvac_mode)
 
@@ -111,7 +111,7 @@ class HassAqualinkThermostat(AqualinkEntity, ClimateEntity):
     @refresh_system
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
-        await self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE]))
+        await self.safe_exec(self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE])))
 
     @property
     def sensor(self) -> AqualinkSensor:

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -22,8 +22,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant
 
-from . import AqualinkEntity, refresh_system, try_await
+from . import AqualinkEntity, refresh_system
 from .const import CLIMATE_SUPPORTED_MODES, DOMAIN as AQUALINK_DOMAIN
+from .utils import await_or_reraise
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,9 +77,9 @@ class HassAqualinkThermostat(AqualinkEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Turn the underlying heater switch on or off."""
         if hvac_mode == HVAC_MODE_HEAT:
-            await try_await(self.heater.turn_on())
+            await await_or_reraise(self.heater.turn_on())
         elif hvac_mode == HVAC_MODE_OFF:
-            await try_await(self.heater.turn_off())
+            await await_or_reraise(self.heater.turn_off())
         else:
             _LOGGER.warning("Unknown operation mode: %s", hvac_mode)
 
@@ -111,7 +112,7 @@ class HassAqualinkThermostat(AqualinkEntity, ClimateEntity):
     @refresh_system
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
-        await try_await(self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE])))
+        await await_or_reraise(self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE])))
 
     @property
     def sensor(self) -> AqualinkSensor:

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -22,7 +22,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant
 
-from . import AqualinkEntity, refresh_system, safe_exec
+from . import AqualinkEntity, refresh_system, try_await
 from .const import CLIMATE_SUPPORTED_MODES, DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -76,9 +76,9 @@ class HassAqualinkThermostat(AqualinkEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Turn the underlying heater switch on or off."""
         if hvac_mode == HVAC_MODE_HEAT:
-            await safe_exec(self.heater.turn_on())
+            await try_await(self.heater.turn_on())
         elif hvac_mode == HVAC_MODE_OFF:
-            await safe_exec(self.heater.turn_off())
+            await try_await(self.heater.turn_off())
         else:
             _LOGGER.warning("Unknown operation mode: %s", hvac_mode)
 
@@ -111,7 +111,7 @@ class HassAqualinkThermostat(AqualinkEntity, ClimateEntity):
     @refresh_system
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
-        await safe_exec(self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE])))
+        await try_await(self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE])))
 
     @property
     def sensor(self) -> AqualinkSensor:

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -22,7 +22,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant
 
-from . import AqualinkEntity, refresh_system
+from . import AqualinkEntity, refresh_system, safe_exec
 from .const import CLIMATE_SUPPORTED_MODES, DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -76,9 +76,9 @@ class HassAqualinkThermostat(AqualinkEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Turn the underlying heater switch on or off."""
         if hvac_mode == HVAC_MODE_HEAT:
-            await self.safe_exec(self.heater.turn_on())
+            await safe_exec(self.heater.turn_on())
         elif hvac_mode == HVAC_MODE_OFF:
-            await self.safe_exec(self.heater.turn_off())
+            await safe_exec(self.heater.turn_off())
         else:
             _LOGGER.warning("Unknown operation mode: %s", hvac_mode)
 
@@ -111,7 +111,7 @@ class HassAqualinkThermostat(AqualinkEntity, ClimateEntity):
     @refresh_system
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
-        await self.safe_exec(self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE])))
+        await safe_exec(self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE])))
 
     @property
     def sensor(self) -> AqualinkSensor:

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from iaqualink import AqualinkClient, AqualinkLoginException
+from iaqualink.client import AqualinkClient
+from iaqualink.exception import (
+    AqualinkServiceException,
+    AqualinkServiceUnauthorizedException,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -32,16 +36,20 @@ class AqualinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             password = user_input[CONF_PASSWORD]
 
             try:
-                aqualink = AqualinkClient(username, password)
-                await aqualink.login()
-                return self.async_create_entry(title=username, data=user_input)
-            except AqualinkLoginException:
+                async with AqualinkClient(username, password):
+                    return self.async_create_entry(title=username, data=user_input)
+            except AqualinkServiceUnauthorizedException:
+                errors["base"] = "invalid_auth"
+            except AqualinkServiceException:
                 errors["base"] = "cannot_connect"
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
-                {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+                {
+                    vol.Required(CONF_USERNAME): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
             ),
             errors=errors,
         )

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -37,11 +37,13 @@ class AqualinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 async with AqualinkClient(username, password):
-                    return self.async_create_entry(title=username, data=user_input)
+                    pass
             except AqualinkServiceUnauthorizedException:
                 errors["base"] = "invalid_auth"
             except AqualinkServiceException:
                 errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(title=username, data=user_input)
 
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -12,7 +12,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import AqualinkEntity, refresh_system, safe_exec
+from . import AqualinkEntity, refresh_system, try_await
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,18 +52,18 @@ class HassAqualinkLight(AqualinkEntity, LightEntity):
         """
         # For now I'm assuming lights support either effects or brightness.
         if effect_name := kwargs.get(ATTR_EFFECT):
-            await safe_exec(self.dev.set_effect_by_name(effect_name))
+            await try_await(self.dev.set_effect_by_name(effect_name))
         elif brightness := kwargs.get(ATTR_BRIGHTNESS):
             # Aqualink supports percentages in 25% increments.
             pct = int(round(brightness * 4.0 / 255)) * 25
-            await safe_exec(self.dev.set_brightness(pct))
+            await try_await(self.dev.set_brightness(pct))
         else:
-            await safe_exec(self.dev.turn_on())
+            await try_await(self.dev.turn_on())
 
     @refresh_system
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the light."""
-        await safe_exec(self.dev.turn_off())
+        await try_await(self.dev.turn_off())
 
     @property
     def brightness(self) -> int:

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -12,7 +12,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import AqualinkEntity, refresh_system
+from . import AqualinkEntity, refresh_system, safe_exec
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,18 +52,18 @@ class HassAqualinkLight(AqualinkEntity, LightEntity):
         """
         # For now I'm assuming lights support either effects or brightness.
         if effect_name := kwargs.get(ATTR_EFFECT):
-            await self.safe_exec(self.dev.set_effect_by_name(effect_name))
+            await safe_exec(self.dev.set_effect_by_name(effect_name))
         elif brightness := kwargs.get(ATTR_BRIGHTNESS):
             # Aqualink supports percentages in 25% increments.
             pct = int(round(brightness * 4.0 / 255)) * 25
-            await self.safe_exec(self.dev.set_brightness(pct))
+            await safe_exec(self.dev.set_brightness(pct))
         else:
-            await self.safe_exec(self.dev.turn_on())
+            await safe_exec(self.dev.turn_on())
 
     @refresh_system
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the light."""
-        await self.safe_exec(self.dev.turn_off())
+        await safe_exec(self.dev.turn_off())
 
     @property
     def brightness(self) -> int:

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -12,8 +12,9 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import AqualinkEntity, refresh_system, try_await
+from . import AqualinkEntity, refresh_system
 from .const import DOMAIN as AQUALINK_DOMAIN
+from .utils import await_or_reraise
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,18 +53,18 @@ class HassAqualinkLight(AqualinkEntity, LightEntity):
         """
         # For now I'm assuming lights support either effects or brightness.
         if effect_name := kwargs.get(ATTR_EFFECT):
-            await try_await(self.dev.set_effect_by_name(effect_name))
+            await await_or_reraise(self.dev.set_effect_by_name(effect_name))
         elif brightness := kwargs.get(ATTR_BRIGHTNESS):
             # Aqualink supports percentages in 25% increments.
             pct = int(round(brightness * 4.0 / 255)) * 25
-            await try_await(self.dev.set_brightness(pct))
+            await await_or_reraise(self.dev.set_brightness(pct))
         else:
-            await try_await(self.dev.turn_on())
+            await await_or_reraise(self.dev.turn_on())
 
     @refresh_system
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the light."""
-        await try_await(self.dev.turn_off())
+        await await_or_reraise(self.dev.turn_off())
 
     @property
     def brightness(self) -> int:

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -1,5 +1,5 @@
 """Support for Aqualink pool lights."""
-from iaqualink import AqualinkLightEffect
+import logging
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -14,6 +14,8 @@ from homeassistant.core import HomeAssistant
 
 from . import AqualinkEntity, refresh_system
 from .const import DOMAIN as AQUALINK_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
@@ -49,20 +51,19 @@ class HassAqualinkLight(AqualinkEntity, LightEntity):
         them.
         """
         # For now I'm assuming lights support either effects or brightness.
-        if effect := kwargs.get(ATTR_EFFECT):
-            effect = AqualinkLightEffect[effect].value
-            await self.dev.set_effect(effect)
+        if effect_name := kwargs.get(ATTR_EFFECT):
+            await self.safe_exec(self.dev.set_effect_by_name(effect_name))
         elif brightness := kwargs.get(ATTR_BRIGHTNESS):
             # Aqualink supports percentages in 25% increments.
             pct = int(round(brightness * 4.0 / 255)) * 25
-            await self.dev.set_brightness(pct)
+            await self.safe_exec(self.dev.set_brightness(pct))
         else:
-            await self.dev.turn_on()
+            await self.safe_exec(self.dev.turn_on())
 
     @refresh_system
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the light."""
-        await self.dev.turn_off()
+        await self.safe_exec(self.dev.turn_off())
 
     @property
     def brightness(self) -> int:
@@ -75,12 +76,12 @@ class HassAqualinkLight(AqualinkEntity, LightEntity):
     @property
     def effect(self) -> str:
         """Return the current light effect if supported."""
-        return AqualinkLightEffect(self.dev.effect).name
+        return self.dev.effect
 
     @property
     def effect_list(self) -> list:
         """Return supported light effects."""
-        return list(AqualinkLightEffect.__members__)
+        return list(self.dev.supported_light_effects.keys())
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -81,7 +81,7 @@ class HassAqualinkLight(AqualinkEntity, LightEntity):
     @property
     def effect_list(self) -> list:
         """Return supported light effects."""
-        return list(self.dev.supported_light_effects.keys())
+        return list(self.dev.supported_light_effects)
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/iaqualink/manifest.json
+++ b/homeassistant/components/iaqualink/manifest.json
@@ -4,6 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/iaqualink/",
   "codeowners": ["@flz"],
-  "requirements": ["iaqualink==0.3.90"],
+  "requirements": ["iaqualink==0.4.1"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/iaqualink/strings.json
+++ b/homeassistant/components/iaqualink/strings.json
@@ -11,7 +11,8 @@
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -47,9 +47,9 @@ class HassAqualinkSwitch(AqualinkEntity, SwitchEntity):
     @refresh_system
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on the switch."""
-        await self.dev.turn_on()
+        await self.safe_exec(self.dev.turn_on())
 
     @refresh_system
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the switch."""
-        await self.dev.turn_off()
+        await self.safe_exec(self.dev.turn_off())

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -3,7 +3,7 @@ from homeassistant.components.switch import DOMAIN, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import AqualinkEntity, refresh_system, safe_exec
+from . import AqualinkEntity, refresh_system, try_await
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 PARALLEL_UPDATES = 0
@@ -47,9 +47,9 @@ class HassAqualinkSwitch(AqualinkEntity, SwitchEntity):
     @refresh_system
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on the switch."""
-        await safe_exec(self.dev.turn_on())
+        await try_await(self.dev.turn_on())
 
     @refresh_system
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the switch."""
-        await safe_exec(self.dev.turn_off())
+        await try_await(self.dev.turn_off())

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -3,7 +3,7 @@ from homeassistant.components.switch import DOMAIN, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import AqualinkEntity, refresh_system
+from . import AqualinkEntity, refresh_system, safe_exec
 from .const import DOMAIN as AQUALINK_DOMAIN
 
 PARALLEL_UPDATES = 0
@@ -47,9 +47,9 @@ class HassAqualinkSwitch(AqualinkEntity, SwitchEntity):
     @refresh_system
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on the switch."""
-        await self.safe_exec(self.dev.turn_on())
+        await safe_exec(self.dev.turn_on())
 
     @refresh_system
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the switch."""
-        await self.safe_exec(self.dev.turn_off())
+        await safe_exec(self.dev.turn_off())

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -3,8 +3,9 @@ from homeassistant.components.switch import DOMAIN, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import AqualinkEntity, refresh_system, try_await
+from . import AqualinkEntity, refresh_system
 from .const import DOMAIN as AQUALINK_DOMAIN
+from .utils import await_or_reraise
 
 PARALLEL_UPDATES = 0
 
@@ -47,9 +48,9 @@ class HassAqualinkSwitch(AqualinkEntity, SwitchEntity):
     @refresh_system
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on the switch."""
-        await try_await(self.dev.turn_on())
+        await await_or_reraise(self.dev.turn_on())
 
     @refresh_system
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the switch."""
-        await try_await(self.dev.turn_off())
+        await await_or_reraise(self.dev.turn_off())

--- a/homeassistant/components/iaqualink/utils.py
+++ b/homeassistant/components/iaqualink/utils.py
@@ -1,0 +1,16 @@
+"""Utility functions for Aqualink devices."""
+from __future__ import annotations
+
+from collections.abc import Awaitable
+
+from iaqualink.exception import AqualinkServiceException
+
+from homeassistant.exceptions import HomeAssistantError
+
+
+async def await_or_reraise(awaitable: Awaitable) -> None:
+    """Execute API call while catching service exceptions."""
+    try:
+        await awaitable
+    except AqualinkServiceException as svc_exception:
+        raise HomeAssistantError(f"Aqualink error: {svc_exception}") from svc_exception

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -869,7 +869,7 @@ hyperion-py==0.7.4
 iammeter==0.1.7
 
 # homeassistant.components.iaqualink
-iaqualink==0.3.90
+iaqualink==0.4.1
 
 # homeassistant.components.watson_tts
 ibm-watson==5.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -550,7 +550,7 @@ huisbaasje-client==0.1.0
 hyperion-py==0.7.4
 
 # homeassistant.components.iaqualink
-iaqualink==0.3.90
+iaqualink==0.4.1
 
 # homeassistant.components.ping
 icmplib==3.0

--- a/tests/components/iaqualink/conftest.py
+++ b/tests/components/iaqualink/conftest.py
@@ -27,9 +27,10 @@ def async_raises(x):
     return AsyncMock(side_effect=x)
 
 
-def get_aqualink_client():
-    """Create aqualink client."""
-    return AqualinkClient(MOCK_USERNAME, MOCK_PASSWORD)
+@pytest.fixture(name="client")
+def client_fixture():
+    """Create client fixture."""
+    return AqualinkClient(username=MOCK_USERNAME, password=MOCK_PASSWORD)
 
 
 def get_aqualink_system(aqualink, cls=None, data=None):

--- a/tests/components/iaqualink/conftest.py
+++ b/tests/components/iaqualink/conftest.py
@@ -1,0 +1,81 @@
+"""Configuration for iAqualink tests."""
+import random
+from unittest.mock import AsyncMock
+
+from iaqualink.client import AqualinkClient
+from iaqualink.device import AqualinkDevice
+from iaqualink.system import AqualinkSystem
+import pytest
+
+from homeassistant.components.iaqualink import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from tests.common import MockConfigEntry
+
+MOCK_USERNAME = "test@example.com"
+MOCK_PASSWORD = "password"
+MOCK_DATA = {CONF_USERNAME: MOCK_USERNAME, CONF_PASSWORD: MOCK_PASSWORD}
+
+
+def async_returns(x):
+    """Return value-returning async mock."""
+    return AsyncMock(return_value=x)
+
+
+def async_raises(x):
+    """Return exception-raising async mock."""
+    return AsyncMock(side_effect=x)
+
+
+def get_aqualink_client():
+    """Create aqualink client."""
+    return AqualinkClient(MOCK_USERNAME, MOCK_PASSWORD)
+
+
+def get_aqualink_system(aqualink, cls=None, data=None):
+    """Create aqualink system."""
+    if cls is None:
+        cls = AqualinkSystem
+
+    if data is None:
+        data = {}
+
+    num = random.randint(0, 99999)
+    data["serial_number"] = f"SN{num:05}"
+
+    return cls(aqualink=aqualink, data=data)
+
+
+def get_aqualink_device(system, cls=None, data=None):
+    """Create aqualink device."""
+    if cls is None:
+        cls = AqualinkDevice
+
+    if data is None:
+        data = {}
+
+    num = random.randint(0, 999)
+    data["name"] = f"name_{num:03}"
+
+    return cls(system=system, data=data)
+
+
+@pytest.fixture(name="config_data")
+def config_data_fixture():
+    """Create hass config fixture."""
+    return MOCK_DATA
+
+
+@pytest.fixture(name="config")
+def config_fixture():
+    """Create hass config fixture."""
+    return {DOMAIN: MOCK_DATA}
+
+
+@pytest.fixture(name="config_entry")
+def config_entry_fixture():
+    """Create a mock HEOS config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_DATA,
+    )

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -51,7 +51,7 @@ async def test_with_invalid_credentials(hass, config_data, step):
     fname = f"async_step_{step}"
     func = getattr(flow, fname)
     with patch(
-        "iaqualink.client.AqualinkClient.login",
+        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
         side_effect=AqualinkServiceUnauthorizedException,
     ):
         result = await func(config_data)
@@ -70,7 +70,7 @@ async def test_service_exception(hass, config_data, step):
     fname = f"async_step_{step}"
     func = getattr(flow, fname)
     with patch(
-        "iaqualink.client.AqualinkClient.login",
+        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
         side_effect=AqualinkServiceException,
     ):
         result = await func(config_data)
@@ -89,7 +89,10 @@ async def test_with_existing_config(hass, config_data, step):
 
     fname = f"async_step_{step}"
     func = getattr(flow, fname)
-    with patch("iaqualink.client.AqualinkClient.login", return_value=None):
+    with patch(
+        "homeassistant.components.iaqualink.config_flow.AqualinkClient.login",
+        return_value=None,
+    ):
         result = await func(config_data)
 
     assert result["type"] == "create_entry"

--- a/tests/components/iaqualink/test_config_flow.py
+++ b/tests/components/iaqualink/test_config_flow.py
@@ -1,20 +1,19 @@
 """Tests for iAqualink config flow."""
 from unittest.mock import patch
 
-import iaqualink
+from iaqualink.exception import (
+    AqualinkServiceException,
+    AqualinkServiceUnauthorizedException,
+)
 import pytest
 
 from homeassistant.components.iaqualink import config_flow
 
-from tests.common import MockConfigEntry, mock_coro
-
-DATA = {"username": "test@example.com", "password": "pass"}
-
 
 @pytest.mark.parametrize("step", ["import", "user"])
-async def test_already_configured(hass, step):
+async def test_already_configured(hass, config_entry, config_data, step):
     """Test config flow when iaqualink component is already setup."""
-    MockConfigEntry(domain="iaqualink", data=DATA).add_to_hass(hass)
+    config_entry.add_to_hass(hass)
 
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
@@ -22,14 +21,14 @@ async def test_already_configured(hass, step):
 
     fname = f"async_step_{step}"
     func = getattr(flow, fname)
-    result = await func(DATA)
+    result = await func(config_data)
 
     assert result["type"] == "abort"
 
 
 @pytest.mark.parametrize("step", ["import", "user"])
 async def test_without_config(hass, step):
-    """Test with no configuration."""
+    """Test config flow with no configuration."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
     flow.context = {}
@@ -44,7 +43,7 @@ async def test_without_config(hass, step):
 
 
 @pytest.mark.parametrize("step", ["import", "user"])
-async def test_with_invalid_credentials(hass, step):
+async def test_with_invalid_credentials(hass, config_data, step):
     """Test config flow with invalid username and/or password."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
@@ -52,9 +51,29 @@ async def test_with_invalid_credentials(hass, step):
     fname = f"async_step_{step}"
     func = getattr(flow, fname)
     with patch(
-        "iaqualink.AqualinkClient.login", side_effect=iaqualink.AqualinkLoginException
+        "iaqualink.client.AqualinkClient.login",
+        side_effect=AqualinkServiceUnauthorizedException,
     ):
-        result = await func(DATA)
+        result = await func(config_data)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+@pytest.mark.parametrize("step", ["import", "user"])
+async def test_service_exception(hass, config_data, step):
+    """Test config flow encountering service exception."""
+    flow = config_flow.AqualinkFlowHandler()
+    flow.hass = hass
+
+    fname = f"async_step_{step}"
+    func = getattr(flow, fname)
+    with patch(
+        "iaqualink.client.AqualinkClient.login",
+        side_effect=AqualinkServiceException,
+    ):
+        result = await func(config_data)
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
@@ -62,17 +81,17 @@ async def test_with_invalid_credentials(hass, step):
 
 
 @pytest.mark.parametrize("step", ["import", "user"])
-async def test_with_existing_config(hass, step):
-    """Test with existing configuration."""
+async def test_with_existing_config(hass, config_data, step):
+    """Test config flow with existing configuration."""
     flow = config_flow.AqualinkFlowHandler()
     flow.hass = hass
     flow.context = {}
 
     fname = f"async_step_{step}"
     func = getattr(flow, fname)
-    with patch("iaqualink.AqualinkClient.login", return_value=mock_coro(None)):
-        result = await func(DATA)
+    with patch("iaqualink.client.AqualinkClient.login", return_value=None):
+        result = await func(config_data)
 
     assert result["type"] == "create_entry"
-    assert result["title"] == DATA["username"]
-    assert result["data"] == DATA
+    assert result["title"] == config_data["username"]
+    assert result["data"] == config_data

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -45,7 +45,7 @@ async def test_setup_login_exception(hass, config_entry):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_setup_login_timeout(hass, config_entry):
@@ -59,7 +59,7 @@ async def test_setup_login_timeout(hass, config_entry):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_systems_exception(hass, config_entry):
@@ -75,7 +75,7 @@ async def test_setup_systems_exception(hass, config_entry):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_no_systems_recognized(hass, config_entry):
@@ -91,7 +91,7 @@ async def test_setup_no_systems_recognized(hass, config_entry):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_setup_devices_exception(hass, config_entry, client):
@@ -113,7 +113,7 @@ async def test_setup_devices_exception(hass, config_entry, client):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_all_good_no_recognized_devices(hass, config_entry, client):
@@ -138,7 +138,7 @@ async def test_setup_all_good_no_recognized_devices(hass, config_entry, client):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 0
     assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 0
@@ -149,7 +149,7 @@ async def test_setup_all_good_no_recognized_devices(hass, config_entry, client):
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_setup_all_good_all_device_types(hass, config_entry, client):
@@ -179,7 +179,7 @@ async def test_setup_all_good_all_device_types(hass, config_entry, client):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 1
     assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 1
@@ -190,7 +190,7 @@ async def test_setup_all_good_all_device_types(hass, config_entry, client):
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_multiple_updates(hass, config_entry, caplog, client):
@@ -213,7 +213,7 @@ async def test_multiple_updates(hass, config_entry, caplog, client):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     def set_online_to_true():
         system.online = True
@@ -293,7 +293,7 @@ async def test_multiple_updates(hass, config_entry, caplog, client):
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_entity_assumed_and_available(hass, config_entry, client):

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -15,7 +15,12 @@ from iaqualink.exception import AqualinkServiceException
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.components.iaqualink import DOMAIN, UPDATE_INTERVAL, AqualinkEntity
+from homeassistant.components.iaqualink import (
+    DOMAIN,
+    UPDATE_INTERVAL,
+    AqualinkEntity,
+    safe_exec,
+)
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -319,17 +324,12 @@ async def test_entity_assumed_and_available(hass):
 
 async def test_safe_exec(hass):
     """Test assumed_state and_available properties for all values of online."""
-    client = get_aqualink_client()
-    system = get_aqualink_system(client)
-    light = get_aqualink_device(system, AqualinkLightToggle)
-    ha_light = AqualinkEntity(light)
-
     with patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
         async_noop = async_returns(None)
-        await ha_light.safe_exec(async_noop())
+        await safe_exec(async_noop())
         mock_warn.assert_not_called()
 
     with patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
         async_ex = async_raises(AqualinkServiceException)
-        await ha_light.safe_exec(async_ex())
+        await safe_exec(async_ex())
         mock_warn.assert_called_once()

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -16,20 +16,22 @@ from iaqualink.exception import AqualinkServiceException
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.components.iaqualink import UPDATE_INTERVAL, AqualinkEntity
+from homeassistant.components.iaqualink.const import UPDATE_INTERVAL
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_ASSUMED_STATE, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 from tests.components.iaqualink.conftest import get_aqualink_device, get_aqualink_system
 
 
-def _ffwd_next_update_interval(hass):
+async def _ffwd_next_update_interval(hass):
     now = dt_util.utcnow()
     async_fire_time_changed(hass, now + UPDATE_INTERVAL)
+    await hass.async_block_till_done()
 
 
 async def test_setup_login_exception(hass, config_entry):
@@ -158,7 +160,6 @@ async def test_setup_all_good_all_device_types(hass, config_entry, client):
     systems = {system.serial: system}
 
     devices = [
-        get_aqualink_device(system, AqualinkDevice),
         get_aqualink_device(system, AqualinkAuxToggle),
         get_aqualink_device(system, AqualinkBinarySensor),
         get_aqualink_device(system, AqualinkLightToggle),
@@ -226,24 +227,21 @@ async def test_multiple_updates(hass, config_entry, caplog, client):
     system.online = True
     caplog.clear()
     system.update.side_effect = set_online_to_true
-    _ffwd_next_update_interval(hass)
-    await hass.async_block_till_done()
+    await _ffwd_next_update_interval(hass)
     assert len(caplog.records) == 0
 
     # True -> False
     system.online = True
     caplog.clear()
     system.update.side_effect = set_online_to_false
-    _ffwd_next_update_interval(hass)
-    await hass.async_block_till_done()
+    await _ffwd_next_update_interval(hass)
     assert len(caplog.records) == 0
 
     # True -> None / ServiceException
     system.online = True
     caplog.clear()
     system.update.side_effect = AqualinkServiceException
-    _ffwd_next_update_interval(hass)
-    await hass.async_block_till_done()
+    await _ffwd_next_update_interval(hass)
     assert len(caplog.records) == 1
     assert "Failed" in caplog.text
 
@@ -251,17 +249,14 @@ async def test_multiple_updates(hass, config_entry, caplog, client):
     system.online = False
     caplog.clear()
     system.update.side_effect = set_online_to_false
-    _ffwd_next_update_interval(hass)
-    await hass.async_block_till_done()
-    print(caplog.records)
+    await _ffwd_next_update_interval(hass)
     assert len(caplog.records) == 0
 
     # False -> True
     system.online = False
     caplog.clear()
     system.update.side_effect = set_online_to_true
-    _ffwd_next_update_interval(hass)
-    await hass.async_block_till_done()
+    await _ffwd_next_update_interval(hass)
     assert len(caplog.records) == 1
     assert "Reconnected" in caplog.text
 
@@ -269,8 +264,7 @@ async def test_multiple_updates(hass, config_entry, caplog, client):
     system.online = False
     caplog.clear()
     system.update.side_effect = AqualinkServiceException
-    _ffwd_next_update_interval(hass)
-    await hass.async_block_till_done()
+    await _ffwd_next_update_interval(hass)
     assert len(caplog.records) == 1
     assert "Failed" in caplog.text
 
@@ -278,16 +272,14 @@ async def test_multiple_updates(hass, config_entry, caplog, client):
     system.online = None
     caplog.clear()
     system.update.side_effect = AqualinkServiceException
-    _ffwd_next_update_interval(hass)
-    await hass.async_block_till_done()
+    await _ffwd_next_update_interval(hass)
     assert len(caplog.records) == 0
 
     # None -> True
     system.online = None
     caplog.clear()
     system.update.side_effect = set_online_to_true
-    _ffwd_next_update_interval(hass)
-    await hass.async_block_till_done()
+    await _ffwd_next_update_interval(hass)
     assert len(caplog.records) == 1
     assert "Reconnected" in caplog.text
 
@@ -295,8 +287,7 @@ async def test_multiple_updates(hass, config_entry, caplog, client):
     system.online = None
     caplog.clear()
     system.update.side_effect = set_online_to_false
-    _ffwd_next_update_interval(hass)
-    await hass.async_block_till_done()
+    await _ffwd_next_update_interval(hass)
     assert len(caplog.records) == 0
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
@@ -305,21 +296,46 @@ async def test_multiple_updates(hass, config_entry, caplog, client):
     assert config_entry.state == ConfigEntryState.NOT_LOADED
 
 
-async def test_entity_assumed_and_available(hass, client):
+async def test_entity_assumed_and_available(hass, config_entry, client):
     """Test assumed_state and_available properties for all values of online."""
+    config_entry.add_to_hass(hass)
+
     system = get_aqualink_system(client)
-    light = get_aqualink_device(system, AqualinkLightToggle)
-    ha_light = AqualinkEntity(light)
+    systems = {system.serial: system}
+
+    light = get_aqualink_device(system, AqualinkLightToggle, data={"state": "1"})
+    devices = {d.name: d for d in [light]}
+    system.get_devices = AsyncMock(return_value=devices)
+    system.update = AsyncMock()
+
+    with patch(
+        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+    ), patch(
+        "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+        return_value=systems,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(hass.states.async_entity_ids(LIGHT_DOMAIN)) == 1
+
+    name = f"{LIGHT_DOMAIN}.{light.name}"
 
     # None means maybe.
     light.system.online = None
-    assert ha_light.assumed_state is True
-    assert ha_light.available is False
+    await _ffwd_next_update_interval(hass)
+    state = hass.states.get(name)
+    assert state.state == STATE_UNAVAILABLE
+    assert state.attributes.get(ATTR_ASSUMED_STATE) is True
 
     light.system.online = False
-    assert ha_light.assumed_state is True
-    assert ha_light.available is False
+    await _ffwd_next_update_interval(hass)
+    state = hass.states.get(name)
+    assert state.state == STATE_UNAVAILABLE
+    assert state.attributes.get(ATTR_ASSUMED_STATE) is True
 
     light.system.online = True
-    assert ha_light.assumed_state is False
-    assert ha_light.available is True
+    await _ffwd_next_update_interval(hass)
+    state = hass.states.get(name)
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_ASSUMED_STATE) is None

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -1,0 +1,335 @@
+"""Tests for iAqualink integration."""
+
+import asyncio
+from unittest.mock import patch
+
+from iaqualink.device import (
+    AqualinkAuxToggle,
+    AqualinkBinarySensor,
+    AqualinkDevice,
+    AqualinkLightToggle,
+    AqualinkSensor,
+    AqualinkThermostat,
+)
+from iaqualink.exception import AqualinkServiceException
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.iaqualink import DOMAIN, UPDATE_INTERVAL, AqualinkEntity
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed
+from tests.components.iaqualink.conftest import (
+    async_raises,
+    async_returns,
+    get_aqualink_client,
+    get_aqualink_device,
+    get_aqualink_system,
+)
+
+
+def _ffwd_next_update_interval(hass):
+    now = dt_util.utcnow()
+    async_fire_time_changed(hass, now + UPDATE_INTERVAL)
+
+
+async def test_setup_login_exception(hass, config_entry):
+    """Test setup encountering a login exception."""
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "iaqualink.client.AqualinkClient.login",
+        side_effect=AqualinkServiceException,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_login_timeout(hass, config_entry):
+    """Test setup encountering a timeout while logging in."""
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "iaqualink.client.AqualinkClient.login",
+        side_effect=asyncio.TimeoutError,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_systems_exception(hass, config_entry):
+    """Test setup encountering an exception while retrieving systems."""
+    config_entry.add_to_hass(hass)
+
+    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
+        "iaqualink.client.AqualinkClient.get_systems",
+        side_effect=AqualinkServiceException,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_no_systems_recognized(hass, config_entry):
+    """Test setup ending in no systems recognized."""
+    config_entry.add_to_hass(hass)
+
+    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
+        "iaqualink.client.AqualinkClient.get_systems",
+        return_value={},
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_devices_exception(hass, config_entry):
+    """Test setup encountering an exception while retrieving devices."""
+    config_entry.add_to_hass(hass)
+
+    client = get_aqualink_client()
+    system = get_aqualink_system(client)
+    systems = {system.serial: system}
+
+    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
+        "iaqualink.client.AqualinkClient.get_systems", return_value=systems
+    ), patch(
+        "iaqualink.system.AqualinkSystem.get_devices",
+        side_effect=AqualinkServiceException,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_all_good_no_recognized_devices(hass, config_entry):
+    """Test setup ending in no devices recognized."""
+    config_entry.add_to_hass(hass)
+
+    client = get_aqualink_client()
+    system = get_aqualink_system(client)
+    systems = {system.serial: system}
+    device = get_aqualink_device(system, AqualinkDevice)
+    devices = {device.name: device}
+
+    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
+        "iaqualink.client.AqualinkClient.get_systems", return_value=systems
+    ), patch("iaqualink.system.AqualinkSystem.get_devices", return_value=devices):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    assert hass.data[DOMAIN][BINARY_SENSOR_DOMAIN] == []
+    assert hass.data[DOMAIN][CLIMATE_DOMAIN] == []
+    assert hass.data[DOMAIN][LIGHT_DOMAIN] == []
+    assert hass.data[DOMAIN][SENSOR_DOMAIN] == []
+    assert hass.data[DOMAIN][SWITCH_DOMAIN] == []
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert DOMAIN not in hass.data
+
+
+async def test_setup_all_good_all_device_types(hass, config_entry):
+    """Test setup ending in one device of each type recognized."""
+    config_entry.add_to_hass(hass)
+
+    client = get_aqualink_client()
+    system = get_aqualink_system(client)
+    systems = {system.serial: system}
+    devices = [
+        get_aqualink_device(system, AqualinkDevice),
+        get_aqualink_device(system, AqualinkAuxToggle),
+        get_aqualink_device(system, AqualinkBinarySensor),
+        get_aqualink_device(system, AqualinkLightToggle),
+        get_aqualink_device(system, AqualinkSensor),
+        get_aqualink_device(system, AqualinkThermostat),
+    ]
+    devices = {d.name: d for d in devices}
+
+    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
+        "iaqualink.client.AqualinkClient.get_systems", return_value=systems
+    ), patch("iaqualink.system.AqualinkSystem.get_devices", return_value=devices):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    assert len(hass.data[DOMAIN][BINARY_SENSOR_DOMAIN]) == 1
+    assert len(hass.data[DOMAIN][CLIMATE_DOMAIN]) == 1
+    assert len(hass.data[DOMAIN][LIGHT_DOMAIN]) == 1
+    assert len(hass.data[DOMAIN][SENSOR_DOMAIN]) == 1
+    assert len(hass.data[DOMAIN][SWITCH_DOMAIN]) == 1
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert DOMAIN not in hass.data
+
+
+async def test_multiple_updates(hass, config_entry):
+    """Test all possible results of online status transition after update."""
+    config_entry.add_to_hass(hass)
+
+    client = get_aqualink_client()
+    system = get_aqualink_system(client)
+    systems = {system.serial: system}
+
+    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
+        "iaqualink.client.AqualinkClient.get_systems", return_value=systems
+    ), patch("iaqualink.system.AqualinkSystem.get_devices", return_value={}):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    def set_online_to_true():
+        system.online = True
+
+    def set_online_to_false():
+        system.online = False
+
+    # True -> True
+    system.online = True
+    with patch(
+        "iaqualink.system.AqualinkSystem.update", side_effect=set_online_to_true
+    ), patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+        _ffwd_next_update_interval(hass)
+        await hass.async_block_till_done()
+        mock_warn.assert_not_called()
+
+    # True -> False
+    system.online = True
+    with patch(
+        "iaqualink.system.AqualinkSystem.update", side_effect=set_online_to_false
+    ), patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+        _ffwd_next_update_interval(hass)
+        await hass.async_block_till_done()
+        mock_warn.assert_not_called()
+
+    # True -> None / ServiceException
+    system.online = True
+    with patch(
+        "iaqualink.system.AqualinkSystem.update",
+        side_effect=AqualinkServiceException,
+    ), patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+        _ffwd_next_update_interval(hass)
+        await hass.async_block_till_done()
+        mock_warn.assert_called_once()
+
+    # False -> False
+    system.online = False
+    with patch(
+        "iaqualink.system.AqualinkSystem.update", side_effect=set_online_to_false
+    ), patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+        _ffwd_next_update_interval(hass)
+        await hass.async_block_till_done()
+        mock_warn.assert_not_called()
+
+    # False -> True
+    system.online = False
+    with patch(
+        "iaqualink.system.AqualinkSystem.update", side_effect=set_online_to_true
+    ), patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+        _ffwd_next_update_interval(hass)
+        await hass.async_block_till_done()
+        mock_warn.assert_called_once()
+
+    # False -> None / ServiceException
+    system.online = False
+    with patch(
+        "iaqualink.system.AqualinkSystem.update",
+        side_effect=AqualinkServiceException,
+    ), patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+        _ffwd_next_update_interval(hass)
+        await hass.async_block_till_done()
+        mock_warn.assert_called_once()
+
+    # None -> None / ServiceException
+    system.online = None
+    with patch(
+        "iaqualink.system.AqualinkSystem.update",
+        side_effect=AqualinkServiceException,
+    ), patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+        _ffwd_next_update_interval(hass)
+        await hass.async_block_till_done()
+        mock_warn.assert_called_once()
+
+    # None -> True
+    system.online = None
+    with patch(
+        "iaqualink.system.AqualinkSystem.update", side_effect=set_online_to_true
+    ), patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+
+        _ffwd_next_update_interval(hass)
+        await hass.async_block_till_done()
+        mock_warn.assert_called_once()
+
+    # None -> False
+    system.online = None
+    with patch(
+        "iaqualink.system.AqualinkSystem.update", side_effect=set_online_to_false
+    ), patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+        _ffwd_next_update_interval(hass)
+        await hass.async_block_till_done()
+        mock_warn.assert_not_called()
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert DOMAIN not in hass.data
+
+
+async def test_entity_assumed_and_available(hass):
+    """Test assumed_state and_available properties for all values of online."""
+    client = get_aqualink_client()
+    system = get_aqualink_system(client)
+    light = get_aqualink_device(system, AqualinkLightToggle)
+    ha_light = AqualinkEntity(light)
+
+    # None means maybe.
+    light.system.online = None
+    assert ha_light.assumed_state is True
+    assert ha_light.available is False
+
+    light.system.online = False
+    assert ha_light.assumed_state is True
+    assert ha_light.available is False
+
+    light.system.online = True
+    assert ha_light.assumed_state is False
+    assert ha_light.available is True
+
+
+async def test_safe_exec(hass):
+    """Test assumed_state and_available properties for all values of online."""
+    client = get_aqualink_client()
+    system = get_aqualink_system(client)
+    light = get_aqualink_device(system, AqualinkLightToggle)
+    ha_light = AqualinkEntity(light)
+
+    with patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+        async_noop = async_returns(None)
+        await ha_light.safe_exec(async_noop())
+        mock_warn.assert_not_called()
+
+    with patch("homeassistant.components.iaqualink._LOGGER.warning") as mock_warn:
+        async_ex = async_raises(AqualinkServiceException)
+        await ha_light.safe_exec(async_ex())
+        mock_warn.assert_called_once()

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -12,27 +12,18 @@ from iaqualink.device import (
     AqualinkThermostat,
 )
 from iaqualink.exception import AqualinkServiceException
-import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.components.iaqualink import (
-    DOMAIN,
-    UPDATE_INTERVAL,
-    AqualinkEntity,
-    try_await,
-)
+from homeassistant.components.iaqualink import UPDATE_INTERVAL, AqualinkEntity
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 from tests.components.iaqualink.conftest import (
-    async_raises,
-    async_returns,
     get_aqualink_client,
     get_aqualink_device,
     get_aqualink_system,
@@ -150,17 +141,16 @@ async def test_setup_all_good_no_recognized_devices(hass, config_entry):
 
     assert config_entry.state == ConfigEntryState.LOADED
 
-    assert hass.data[DOMAIN][BINARY_SENSOR_DOMAIN] == []
-    assert hass.data[DOMAIN][CLIMATE_DOMAIN] == []
-    assert hass.data[DOMAIN][LIGHT_DOMAIN] == []
-    assert hass.data[DOMAIN][SENSOR_DOMAIN] == []
-    assert hass.data[DOMAIN][SWITCH_DOMAIN] == []
+    assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 0
+    assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 0
+    assert len(hass.states.async_entity_ids(LIGHT_DOMAIN)) == 0
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert config_entry.state == ConfigEntryState.NOT_LOADED
-    assert DOMAIN not in hass.data
 
 
 async def test_setup_all_good_all_device_types(hass, config_entry):
@@ -193,17 +183,16 @@ async def test_setup_all_good_all_device_types(hass, config_entry):
 
     assert config_entry.state == ConfigEntryState.LOADED
 
-    assert len(hass.data[DOMAIN][BINARY_SENSOR_DOMAIN]) == 1
-    assert len(hass.data[DOMAIN][CLIMATE_DOMAIN]) == 1
-    assert len(hass.data[DOMAIN][LIGHT_DOMAIN]) == 1
-    assert len(hass.data[DOMAIN][SENSOR_DOMAIN]) == 1
-    assert len(hass.data[DOMAIN][SWITCH_DOMAIN]) == 1
+    assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(LIGHT_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert config_entry.state == ConfigEntryState.NOT_LOADED
-    assert DOMAIN not in hass.data
 
 
 async def test_multiple_updates(hass, config_entry):
@@ -322,7 +311,6 @@ async def test_multiple_updates(hass, config_entry):
     await hass.async_block_till_done()
 
     assert config_entry.state == ConfigEntryState.NOT_LOADED
-    assert DOMAIN not in hass.data
 
 
 async def test_entity_assumed_and_available(hass):
@@ -344,17 +332,3 @@ async def test_entity_assumed_and_available(hass):
     light.system.online = True
     assert ha_light.assumed_state is False
     assert ha_light.available is True
-
-
-async def test_try_await(hass):
-    """Test try_await for all values of awaitable."""
-    async_noop = async_returns(None)
-    await try_await(async_noop())
-
-    with pytest.raises(Exception):
-        async_ex = async_raises(Exception)
-        await try_await(async_ex())
-
-    with pytest.raises(HomeAssistantError):
-        async_ex = async_raises(AqualinkServiceException)
-        await try_await(async_ex())

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -49,7 +49,7 @@ async def test_setup_login_exception(hass, config_entry):
     config_entry.add_to_hass(hass)
 
     with patch(
-        "iaqualink.client.AqualinkClient.login",
+        "homeassistant.components.iaqualink.AqualinkClient.login",
         side_effect=AqualinkServiceException,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -63,7 +63,7 @@ async def test_setup_login_timeout(hass, config_entry):
     config_entry.add_to_hass(hass)
 
     with patch(
-        "iaqualink.client.AqualinkClient.login",
+        "homeassistant.components.iaqualink.AqualinkClient.login",
         side_effect=asyncio.TimeoutError,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -76,8 +76,10 @@ async def test_setup_systems_exception(hass, config_entry):
     """Test setup encountering an exception while retrieving systems."""
     config_entry.add_to_hass(hass)
 
-    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
-        "iaqualink.client.AqualinkClient.get_systems",
+    with patch(
+        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+    ), patch(
+        "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         side_effect=AqualinkServiceException,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -90,8 +92,10 @@ async def test_setup_no_systems_recognized(hass, config_entry):
     """Test setup ending in no systems recognized."""
     config_entry.add_to_hass(hass)
 
-    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
-        "iaqualink.client.AqualinkClient.get_systems",
+    with patch(
+        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+    ), patch(
+        "homeassistant.components.iaqualink.AqualinkClient.get_systems",
         return_value={},
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -108,8 +112,11 @@ async def test_setup_devices_exception(hass, config_entry):
     system = get_aqualink_system(client)
     systems = {system.serial: system}
 
-    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
-        "iaqualink.client.AqualinkClient.get_systems", return_value=systems
+    with patch(
+        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+    ), patch(
+        "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+        return_value=systems,
     ), patch(
         "iaqualink.system.AqualinkSystem.get_devices",
         side_effect=AqualinkServiceException,
@@ -130,9 +137,14 @@ async def test_setup_all_good_no_recognized_devices(hass, config_entry):
     device = get_aqualink_device(system, AqualinkDevice)
     devices = {device.name: device}
 
-    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
-        "iaqualink.client.AqualinkClient.get_systems", return_value=systems
-    ), patch("iaqualink.system.AqualinkSystem.get_devices", return_value=devices):
+    with patch(
+        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+    ), patch(
+        "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+        return_value=systems,
+    ), patch(
+        "iaqualink.system.AqualinkSystem.get_devices", return_value=devices
+    ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -168,9 +180,14 @@ async def test_setup_all_good_all_device_types(hass, config_entry):
     ]
     devices = {d.name: d for d in devices}
 
-    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
-        "iaqualink.client.AqualinkClient.get_systems", return_value=systems
-    ), patch("iaqualink.system.AqualinkSystem.get_devices", return_value=devices):
+    with patch(
+        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+    ), patch(
+        "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+        return_value=systems,
+    ), patch(
+        "iaqualink.system.AqualinkSystem.get_devices", return_value=devices
+    ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -197,9 +214,14 @@ async def test_multiple_updates(hass, config_entry):
     system = get_aqualink_system(client)
     systems = {system.serial: system}
 
-    with patch("iaqualink.client.AqualinkClient.login", return_value=None), patch(
-        "iaqualink.client.AqualinkClient.get_systems", return_value=systems
-    ), patch("iaqualink.system.AqualinkSystem.get_devices", return_value={}):
+    with patch(
+        "homeassistant.components.iaqualink.AqualinkClient.login", return_value=None
+    ), patch(
+        "homeassistant.components.iaqualink.AqualinkClient.get_systems",
+        return_value=systems,
+    ), patch(
+        "iaqualink.system.AqualinkSystem.get_devices", return_value={}
+    ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/iaqualink/test_utils.py
+++ b/tests/components/iaqualink/test_utils.py
@@ -1,0 +1,23 @@
+"""Tests for iAqualink integration utility functions."""
+
+from iaqualink.exception import AqualinkServiceException
+import pytest
+
+from homeassistant.components.iaqualink.utils import await_or_reraise
+from homeassistant.exceptions import HomeAssistantError
+
+from tests.components.iaqualink.conftest import async_raises, async_returns
+
+
+async def test_await_or_reraise(hass):
+    """Test await_or_reraise for all values of awaitable."""
+    async_noop = async_returns(None)
+    await await_or_reraise(async_noop())
+
+    with pytest.raises(Exception):
+        async_ex = async_raises(Exception)
+        await await_or_reraise(async_ex())
+
+    with pytest.raises(HomeAssistantError):
+        async_ex = async_raises(AqualinkServiceException)
+        await await_or_reraise(async_ex())


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Update dependent library. See [link](https://github.com/flz/iaqualink-py/compare/v0.3.4...v0.4.1) for full changes.
* Catch service exceptions with new safe_exec() method.
* Cover __init__.py in tests to make CI checks happy.
 
Thanks to @SteveOnorato for some proposed changes to the light platform (see [link](https://github.com/SteveOnorato/core/commit/b84328c7c3eae62cca248f96abdd5c77a8476bb4)).

Note: This is take 2 of home-assistant/core#48137. Previous comments by @bdraco have been addressed in this version.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#39279
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
