### PR TITLE
Cost sensor handle consumption sensor in Wh

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -196,6 +196,12 @@ class EnergyCostSensor(SensorEntity):
                 energy_price = float(energy_price_state.state)
             except ValueError:
                 return
+
+            if energy_price_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT, "").endswith(
+                f"/{ENERGY_WATT_HOUR}"
+            ):
+                energy_price *= 1000.0
+
         else:
             energy_price_state = None
             energy_price = cast(float, self._flow["number_energy_price"])

--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import partial
+import logging
 from typing import Any, Final, Literal, TypeVar, cast
 
 from homeassistant.components.sensor import (
@@ -10,6 +11,11 @@ from homeassistant.components.sensor import (
     DEVICE_CLASS_MONETARY,
     STATE_CLASS_MEASUREMENT,
     SensorEntity,
+)
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    ENERGY_KILO_WATT_HOUR,
+    ENERGY_WATT_HOUR,
 )
 from homeassistant.core import HomeAssistant, State, callback, split_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,6 +25,8 @@ import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
 from .data import EnergyManager, async_get_manager
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_platform(
@@ -195,6 +203,16 @@ class EnergyCostSensor(SensorEntity):
         if self._last_energy_sensor_state is None:
             # Initialize as it's the first time all required entities are in place.
             self._reset(energy_state)
+            return
+
+        energy_unit = energy_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+
+        if energy_unit == ENERGY_WATT_HOUR:
+            energy_price /= 1000
+        elif energy_unit != ENERGY_KILO_WATT_HOUR:
+            _LOGGER.warning(
+                "Found unexpected unit %s for %s", energy_unit, energy_state.entity_id
+            )
             return
 
         if (

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -16,6 +16,8 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
     DEVICE_CLASS_MONETARY,
+    ENERGY_KILO_WATT_HOUR,
+    ENERGY_WATT_HOUR,
 )
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -133,7 +135,9 @@ async def test_cost_sensor_price_entity(
     # Optionally initialize dependent entities
     if initial_energy is not None:
         hass.states.async_set(
-            usage_sensor_entity_id, initial_energy, {"last_reset": last_reset}
+            usage_sensor_entity_id,
+            initial_energy,
+            {"last_reset": last_reset, ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR},
         )
     hass.states.async_set("sensor.energy_price", "1")
 
@@ -152,7 +156,12 @@ async def test_cost_sensor_price_entity(
     if initial_energy is None:
         with patch("homeassistant.util.dt.utcnow", return_value=now):
             hass.states.async_set(
-                usage_sensor_entity_id, "0", {"last_reset": last_reset}
+                usage_sensor_entity_id,
+                "0",
+                {
+                    "last_reset": last_reset,
+                    ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+                },
             )
             await hass.async_block_till_done()
 
@@ -169,7 +178,11 @@ async def test_cost_sensor_price_entity(
     # # assert entry.unique_id == "energy_energy_consumption cost"
 
     # Energy use bumped to 10 kWh
-    hass.states.async_set(usage_sensor_entity_id, "10", {"last_reset": last_reset})
+    hass.states.async_set(
+        usage_sensor_entity_id,
+        "10",
+        {"last_reset": last_reset, ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR},
+    )
     await hass.async_block_till_done()
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "10.0"  # 0 EUR + (10-0) kWh * 1 EUR/kWh = 10 EUR
@@ -189,7 +202,11 @@ async def test_cost_sensor_price_entity(
     assert state.state == "10.0"  # 10 EUR + (10-10) kWh * 2 EUR/kWh = 10 EUR
 
     # Additional consumption is using the new price
-    hass.states.async_set(usage_sensor_entity_id, "14.5", {"last_reset": last_reset})
+    hass.states.async_set(
+        usage_sensor_entity_id,
+        "14.5",
+        {"last_reset": last_reset, ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR},
+    )
     await hass.async_block_till_done()
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "19.0"  # 10 EUR + (14.5-10) kWh * 2 EUR/kWh = 19 EUR
@@ -202,13 +219,21 @@ async def test_cost_sensor_price_entity(
 
     # Energy sensor is reset, with start point at 4kWh
     last_reset = (now + timedelta(seconds=1)).isoformat()
-    hass.states.async_set(usage_sensor_entity_id, "4", {"last_reset": last_reset})
+    hass.states.async_set(
+        usage_sensor_entity_id,
+        "4",
+        {"last_reset": last_reset, ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR},
+    )
     await hass.async_block_till_done()
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "0.0"  # 0 EUR + (4-4) kWh * 2 EUR/kWh = 0 EUR
 
     # Energy use bumped to 10 kWh
-    hass.states.async_set(usage_sensor_entity_id, "10", {"last_reset": last_reset})
+    hass.states.async_set(
+        usage_sensor_entity_id,
+        "10",
+        {"last_reset": last_reset, ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR},
+    )
     await hass.async_block_till_done()
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "12.0"  # 0 EUR + (10-4) kWh * 2 EUR/kWh = 12 EUR
@@ -218,3 +243,55 @@ async def test_cost_sensor_price_entity(
     statistics = await hass.loop.run_in_executor(None, _compile_statistics, hass)
     assert cost_sensor_entity_id in statistics
     assert statistics[cost_sensor_entity_id]["stat"]["sum"] == 31.0
+
+
+async def test_cost_sensor_handle_wh(hass, hass_storage) -> None:
+    """Test energy cost price from sensor entity."""
+    energy_data = data.EnergyManager.default_preferences()
+    energy_data["energy_sources"].append(
+        {
+            "type": "grid",
+            "flow_from": [
+                {
+                    "stat_energy_from": "sensor.energy_consumption",
+                    "entity_energy_from": "sensor.energy_consumption",
+                    "stat_cost": None,
+                    "entity_energy_price": None,
+                    "number_energy_price": 0.5,
+                }
+            ],
+            "flow_to": [],
+            "cost_adjustment_day": 0,
+        }
+    )
+
+    hass_storage[data.STORAGE_KEY] = {
+        "version": 1,
+        "data": energy_data,
+    }
+
+    now = dt_util.utcnow()
+    last_reset = dt_util.utc_from_timestamp(0).isoformat()
+
+    hass.states.async_set(
+        "sensor.energy_consumption",
+        10000,
+        {"last_reset": last_reset, "unit_of_measurement": ENERGY_WATT_HOUR},
+    )
+
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        await setup_integration(hass)
+
+    state = hass.states.get("sensor.energy_consumption_cost")
+    assert state.state == "0.0"
+
+    # Energy use bumped to 10 kWh
+    hass.states.async_set(
+        "sensor.energy_consumption",
+        20000,
+        {"last_reset": last_reset, "unit_of_measurement": ENERGY_WATT_HOUR},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.energy_consumption_cost")
+    assert state.state == "5.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix cost sensor always expecting consumption entities being in kWh while they could also could be Wh.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
