### PR TITLE
Fix Xiaomi Miio humidifier mode change

### DIFF
--- a/homeassistant/components/xiaomi_miio/humidifier.py
+++ b/homeassistant/components/xiaomi_miio/humidifier.py
@@ -232,7 +232,7 @@ class XiaomiAirHumidifier(XiaomiGenericHumidifier, HumidifierEntity):
         """Return the target humidity."""
         return (
             self._target_humidity
-            if self._mode == AirhumidifierOperationMode.Auto.name
+            if self._mode == AirhumidifierOperationMode.Auto.value
             or AirhumidifierOperationMode.Auto.name not in self.available_modes
             else None
         )
@@ -264,7 +264,7 @@ class XiaomiAirHumidifier(XiaomiGenericHumidifier, HumidifierEntity):
             self._device.set_mode,
             AirhumidifierOperationMode.Auto,
         ):
-            self._mode = AirhumidifierOperationMode.Auto.name
+            self._mode = AirhumidifierOperationMode.Auto.value
             self.async_write_ha_state()
 
     async def async_set_mode(self, mode: str) -> None:
@@ -280,9 +280,9 @@ class XiaomiAirHumidifier(XiaomiGenericHumidifier, HumidifierEntity):
         if await self._try_command(
             "Setting operation mode of the miio device failed.",
             self._device.set_mode,
-            AirhumidifierOperationMode[mode.title()],
+            AirhumidifierOperationMode[mode],
         ):
-            self._mode = mode.title()
+            self._mode = mode.lower()
             self.async_write_ha_state()
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Changing mode of the humidifier sometimes causes `ValueError`. This is because `self._mode` sometimes uses mode name (e.g. `Auto`) and sometimes mode value (e.g. `auto`). This PR fixes this.

```
2021-07-30 15:38:18 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140717990923616] 'Medium' is not a valid OperationMode
Traceback (most recent call last):
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/websocket_api/commands.py", line 185, in handle_call_service
    await hass.services.async_call(
  File "/home/maciek/develop/home-assistant-core/homeassistant/core.py", line 1491, in async_call
    task.result()
  File "/home/maciek/develop/home-assistant-core/homeassistant/core.py", line 1526, in _execute_service
    await handler.job.target(service_call)
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity_component.py", line 213, in handle_service
    await self.hass.helpers.service.entity_service_call(
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/service.py", line 658, in entity_service_call
    future.result()  # pop exception if have
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 856, in async_request_call
    await coro
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/service.py", line 695, in _handle_entity_call
    await result
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/xiaomi_miio/humidifier.py", line 286, in async_set_mode
    self.async_write_ha_state()
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 464, in async_write_ha_state
    self._async_write_ha_state()
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 500, in _async_write_ha_state
    attr.update(self.state_attributes or {})
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/humidifier/__init__.py", line 145, in state_attributes
    data[ATTR_MODE] = self.mode
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/xiaomi_miio/humidifier.py", line 228, in mode
    return AirhumidifierOperationMode(self._mode).name
  File "/usr/local/lib/python3.9/enum.py", line 360, in __call__
    return cls.__new__(cls, value)
  File "/usr/local/lib/python3.9/enum.py", line 677, in __new__
    raise ve_exc
ValueError: 'Medium' is not a valid OperationMode
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
