### PR TITLE
Add "stop watering" service to rachio

### DIFF
--- a/homeassistant/components/rachio/const.py
+++ b/homeassistant/components/rachio/const.py
@@ -54,6 +54,7 @@ SCHEDULE_TYPE_FIXED = "FIXED"
 SCHEDULE_TYPE_FLEX = "FLEX"
 SERVICE_PAUSE_WATERING = "pause_watering"
 SERVICE_RESUME_WATERING = "resume_watering"
+SERVICE_STOP_WATERING = "stop_watering"
 SERVICE_SET_ZONE_MOISTURE = "set_zone_moisture_percent"
 SERVICE_START_MULTIPLE_ZONES = "start_multiple_zone_schedule"
 

--- a/homeassistant/components/rachio/device.py
+++ b/homeassistant/components/rachio/device.py
@@ -26,6 +26,7 @@ from .const import (
     MODEL_GENERATION_1,
     SERVICE_PAUSE_WATERING,
     SERVICE_RESUME_WATERING,
+    SERVICE_STOP_WATERING,
 )
 from .webhooks import LISTEN_EVENT_TYPES, WEBHOOK_CONST_ID
 
@@ -43,6 +44,8 @@ PAUSE_SERVICE_SCHEMA = vol.Schema(
 )
 
 RESUME_SERVICE_SCHEMA = vol.Schema({vol.Optional(ATTR_DEVICES): cv.string})
+
+STOP_SERVICE_SCHEMA = vol.Schema({vol.Optional(ATTR_DEVICES): cv.string})
 
 
 class RachioPerson:
@@ -87,6 +90,13 @@ class RachioPerson:
                 if iro.name in devices:
                     iro.resume_watering()
 
+        def stop_water(service):
+            """Service to stop watering on all or specific controllers."""
+            devices = service.data.get(ATTR_DEVICES, all_devices)
+            for iro in self._controllers:
+                if iro.name in devices:
+                    iro.stop_watering()
+
         hass.services.async_register(
             DOMAIN,
             SERVICE_PAUSE_WATERING,
@@ -99,6 +109,13 @@ class RachioPerson:
             SERVICE_RESUME_WATERING,
             resume_water,
             schema=RESUME_SERVICE_SCHEMA,
+        )
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_STOP_WATERING,
+            stop_water,
+            schema=STOP_SERVICE_SCHEMA,
         )
 
     def _setup(self, hass):

--- a/homeassistant/components/rachio/services.yaml
+++ b/homeassistant/components/rachio/services.yaml
@@ -65,7 +65,7 @@ stop_watering:
   fields:
     devices:
       name: Devices
-      description: Name of controllers to pause. Defaults to all controllers on the account if not provided.
+      description: Name of controllers to stop. Defaults to all controllers on the account if not provided.
       example: "Main House"
       selector:
         text:

--- a/homeassistant/components/rachio/services.yaml
+++ b/homeassistant/components/rachio/services.yaml
@@ -59,3 +59,13 @@ resume_watering:
       example: "Main House"
       selector:
         text:
+stop_watering:
+  name: Stop watering
+  description: Stop any currently running zones or schedules.
+  fields:
+    devices:
+      name: Devices
+      description: Name of controllers to pause. Defaults to all controllers on the account if not provided.
+      example: "Main House"
+      selector:
+        text:


### PR DESCRIPTION
Mirrors the existing pause & resume services. Each Rachio schedule is modeled as a switch, but schedules may change over time. This service allows you to quickly stop ALL watering on any schedule.

## Proposed change

Adds a new "stop_watering" service to Rachio that will stop all watering.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#18668

## Checklist

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
