### PR TITLE
Improve light scene support for white mode

### DIFF
--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -132,6 +132,12 @@ async def _async_reproduce_state(
     if deprecated_attrs:
         _LOGGER.warning(DEPRECATION_WARNING, deprecated_attrs)
 
+    if ATTR_WHITE in state.attributes and ATTR_COLOR_MODE not in state.attributes:
+        state_dict = state.as_dict()
+        state_dict["attributes"][ATTR_BRIGHTNESS] = state.attributes[ATTR_WHITE]
+        state_dict["attributes"][ATTR_COLOR_MODE] = COLOR_MODE_WHITE
+        state = State.from_dict(state_dict)
+
     # Return if we are already at the right state.
     if (
         cur_state.state == state.state

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -20,6 +20,8 @@ VALID_PROFILE = {"profile": "relax"}
 VALID_RGB_COLOR = {"rgb_color": (255, 63, 111)}
 VALID_RGBW_COLOR = {"rgbw_color": (255, 63, 111, 10)}
 VALID_RGBWW_COLOR = {"rgbww_color": (255, 63, 111, 10, 20)}
+VALID_WHITE = {"white": 220}  # Specified in a scene
+VALID_WHITE_STATE = {"color_mode": "white", "brightness": 220}  # The light's state
 VALID_XY_COLOR = {"xy_color": (0.59, 0.274)}
 
 
@@ -27,7 +29,7 @@ async def test_reproducing_states(hass, caplog):
     """Test reproducing Light states."""
     hass.states.async_set("light.entity_off", "off", {})
     hass.states.async_set("light.entity_bright", "on", VALID_BRIGHTNESS)
-    hass.states.async_set("light.entity_white", "on", VALID_WHITE_VALUE)
+    hass.states.async_set("light.entity_white_value", "on", VALID_WHITE_VALUE)
     hass.states.async_set("light.entity_flash", "on", VALID_FLASH)
     hass.states.async_set("light.entity_effect", "on", VALID_EFFECT)
     hass.states.async_set("light.entity_trans", "on", VALID_TRANSITION)
@@ -37,6 +39,7 @@ async def test_reproducing_states(hass, caplog):
     hass.states.async_set("light.entity_kelvin", "on", VALID_KELVIN)
     hass.states.async_set("light.entity_profile", "on", VALID_PROFILE)
     hass.states.async_set("light.entity_rgb", "on", VALID_RGB_COLOR)
+    hass.states.async_set("light.entity_white", "on", VALID_WHITE_STATE)
     hass.states.async_set("light.entity_xy", "on", VALID_XY_COLOR)
 
     turn_on_calls = async_mock_service(hass, "light", "turn_on")
@@ -47,7 +50,7 @@ async def test_reproducing_states(hass, caplog):
         [
             State("light.entity_off", "off"),
             State("light.entity_bright", "on", VALID_BRIGHTNESS),
-            State("light.entity_white", "on", VALID_WHITE_VALUE),
+            State("light.entity_white_value", "on", VALID_WHITE_VALUE),
             State("light.entity_flash", "on", VALID_FLASH),
             State("light.entity_effect", "on", VALID_EFFECT),
             State("light.entity_trans", "on", VALID_TRANSITION),
@@ -57,6 +60,7 @@ async def test_reproducing_states(hass, caplog):
             State("light.entity_kelvin", "on", VALID_KELVIN),
             State("light.entity_profile", "on", VALID_PROFILE),
             State("light.entity_rgb", "on", VALID_RGB_COLOR),
+            State("light.entity_white", "on", VALID_WHITE),
             State("light.entity_xy", "on", VALID_XY_COLOR),
         ]
     )
@@ -79,7 +83,7 @@ async def test_reproducing_states(hass, caplog):
             State("light.entity_xy", "off"),
             State("light.entity_off", "on", VALID_BRIGHTNESS),
             State("light.entity_bright", "on", VALID_WHITE_VALUE),
-            State("light.entity_white", "on", VALID_FLASH),
+            State("light.entity_white_value", "on", VALID_FLASH),
             State("light.entity_flash", "on", VALID_EFFECT),
             State("light.entity_effect", "on", VALID_TRANSITION),
             State("light.entity_trans", "on", VALID_COLOR_NAME),
@@ -88,11 +92,12 @@ async def test_reproducing_states(hass, caplog):
             State("light.entity_hs", "on", VALID_KELVIN),
             State("light.entity_kelvin", "on", VALID_PROFILE),
             State("light.entity_profile", "on", VALID_RGB_COLOR),
-            State("light.entity_rgb", "on", VALID_XY_COLOR),
+            State("light.entity_rgb", "on", VALID_WHITE),
+            State("light.entity_white", "on", VALID_XY_COLOR),
         ],
     )
 
-    assert len(turn_on_calls) == 12
+    assert len(turn_on_calls) == 13
 
     expected_calls = []
 
@@ -104,9 +109,9 @@ async def test_reproducing_states(hass, caplog):
     expected_bright["entity_id"] = "light.entity_bright"
     expected_calls.append(expected_bright)
 
-    expected_white = dict(VALID_FLASH)
-    expected_white["entity_id"] = "light.entity_white"
-    expected_calls.append(expected_white)
+    expected_white_value = dict(VALID_FLASH)
+    expected_white_value["entity_id"] = "light.entity_white_value"
+    expected_calls.append(expected_white_value)
 
     expected_flash = dict(VALID_EFFECT)
     expected_flash["entity_id"] = "light.entity_flash"
@@ -140,9 +145,14 @@ async def test_reproducing_states(hass, caplog):
     expected_profile["entity_id"] = "light.entity_profile"
     expected_calls.append(expected_profile)
 
-    expected_rgb = dict(VALID_XY_COLOR)
+    expected_rgb = dict(VALID_WHITE)
     expected_rgb["entity_id"] = "light.entity_rgb"
+    expected_rgb["brightness"] = expected_rgb["white"]
     expected_calls.append(expected_rgb)
+
+    expected_white = dict(VALID_XY_COLOR)
+    expected_white["entity_id"] = "light.entity_white"
+    expected_calls.append(expected_white)
 
     for call in turn_on_calls:
         assert call.domain == "light"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `white` service call parameter is exceptional because it doesn't have a direct mapping to a state attribute, it instead translates to color_mode `white` + a brightness. This is highly confusing for hand edited scenes.
This PR improves light scene support for `white` mode by allowing setting the light to white mode using the same syntax as in a service call.

Example:
```yaml
    entities:
      light.ceiling:
        state: "on"
        white: 200
```

The above example will now be translated to the corresponding state:
```yaml
    entities:
      light.ceiling:
        state: "on"
        color_mode: "white"
        brightness: 200
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
