### PR TITLE
Do not block setup of TP-Link when device unreachable

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -99,7 +99,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up TPLink from a config entry."""
     config_data = hass.data[DOMAIN].get(ATTR_CONFIG)
-    if config_data is None and entry.data is not None:
+    if config_data is None and entry.data:
         config_data = entry.data
     elif config_data is not None:
         hass.config_entries.async_update_entry(entry, data=config_data)

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 import logging
 import time
+from typing import Any
 
 from pyHS100.smartdevice import SmartDevice, SmartDeviceException
 from pyHS100.smartplug import SmartPlug
@@ -22,9 +23,9 @@ from homeassistant.const import (
     CONF_STATE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.dt import utc_from_timestamp
@@ -44,6 +45,9 @@ from .const import (
     CONF_SWITCH,
     COORDINATORS,
     PLATFORMS,
+    UNAVAILABLE_DEVICES,
+    UNAVAILABLE_REMOVE_LISTENER,
+    UNAVAILABLE_RETRY_DELAY,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -96,16 +100,23 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up TPLink from a config entry."""
     config_data = hass.data[DOMAIN].get(ATTR_CONFIG)
+    if config_data is None and entry.data is not None:
+        config_data = entry.data
+    elif config_data is not None:
+        hass.config_entries.async_update_entry(entry, data=config_data)
 
     device_registry = dr.async_get(hass)
     tplink_devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
     device_count = len(tplink_devices)
+    hass_data: dict[str, Any] = hass.data[DOMAIN]
 
     # These will contain the initialized devices
-    hass.data[DOMAIN][CONF_LIGHT] = []
-    hass.data[DOMAIN][CONF_SWITCH] = []
-    lights: list[SmartDevice] = hass.data[DOMAIN][CONF_LIGHT]
-    switches: list[SmartPlug] = hass.data[DOMAIN][CONF_SWITCH]
+    hass_data[CONF_LIGHT] = []
+    hass_data[CONF_SWITCH] = []
+    hass_data[UNAVAILABLE_DEVICES] = []
+    lights: list[SmartDevice] = hass_data[CONF_LIGHT]
+    switches: list[SmartPlug] = hass_data[CONF_SWITCH]
+    unavailable_devices: list[SmartDevice] = hass_data[UNAVAILABLE_DEVICES]
 
     # Add static devices
     static_devices = SmartDevices()
@@ -136,21 +147,52 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ", ".join(d.host for d in switches),
         )
 
+    async def async_retry_devices(self) -> None:
+        """Retry unavailable devices."""
+        unavailable_devices: list[SmartDevice] = hass_data[UNAVAILABLE_DEVICES]
+        _LOGGER.debug(
+            "retry during setup unavailable devices: %s",
+            [d.host for d in unavailable_devices],
+        )
+
+        for device in unavailable_devices:
+            try:
+                device.get_sysinfo()
+            except SmartDeviceException:
+                continue
+            _LOGGER.debug(
+                "at least one device is available again, so reload integration"
+            )
+            await hass.config_entries.async_reload(entry.entry_id)
+
     # prepare DataUpdateCoordinators
-    hass.data[DOMAIN][COORDINATORS] = {}
+    hass_data[COORDINATORS] = {}
     for switch in switches:
 
         try:
             await hass.async_add_executor_job(switch.get_sysinfo)
-        except SmartDeviceException as ex:
-            _LOGGER.debug(ex)
-            raise ConfigEntryNotReady from ex
+        except SmartDeviceException:
+            _LOGGER.warning(
+                "Device at '%s' not reachable during setup, will retry later",
+                switch.host,
+            )
+            unavailable_devices.append(switch)
+            continue
 
-        hass.data[DOMAIN][COORDINATORS][
+        hass_data[COORDINATORS][
             switch.mac
         ] = coordinator = SmartPlugDataUpdateCoordinator(hass, switch)
 
         await coordinator.async_config_entry_first_refresh()
+
+    if unavailable_devices:
+        hass_data[UNAVAILABLE_REMOVE_LISTENER] = async_track_time_interval(
+            hass, async_retry_devices, UNAVAILABLE_RETRY_DELAY
+        )
+        unavailable_devices_hosts = [d.host for d in unavailable_devices]
+        hass_data[CONF_SWITCH] = [
+            s for s in switches if s.host not in unavailable_devices_hosts
+        ]
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
@@ -159,10 +201,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    platforms = [platform for platform in PLATFORMS if hass.data[DOMAIN].get(platform)]
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, platforms)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    hass_data: dict[str, Any] = hass.data[DOMAIN]
+    if callable(hass_data.get(UNAVAILABLE_REMOVE_LISTENER)):
+        hass_data[UNAVAILABLE_REMOVE_LISTENER]()
     if unload_ok:
-        hass.data[DOMAIN].clear()
+        hass_data.clear()
 
     return unload_ok
 

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -7,7 +7,6 @@ DOMAIN = "tplink"
 COORDINATORS = "coordinators"
 UNAVAILABLE_DEVICES = "unavailable_devices"
 UNAVAILABLE_RETRY_DELAY = datetime.timedelta(seconds=300)
-UNAVAILABLE_REMOVE_LISTENER = "unavailable_remove_listener"
 
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=8)
 MAX_DISCOVERY_RETRIES = 4

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -5,6 +5,9 @@ import datetime
 
 DOMAIN = "tplink"
 COORDINATORS = "coordinators"
+UNAVAILABLE_DEVICES = "unavailable_devices"
+UNAVAILABLE_RETRY_DELAY = datetime.timedelta(seconds=300)
+UNAVAILABLE_REMOVE_LISTENER = "unavailable_remove_listener"
 
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=8)
 MAX_DISCOVERY_RETRIES = 4

--- a/tests/components/tplink/consts.py
+++ b/tests/components/tplink/consts.py
@@ -1,6 +1,6 @@
 """Constants for the TP-Link component tests."""
 
-SMARTPLUGSWITCH_DATA = {
+SMARTPLUG_HS110_DATA = {
     "sysinfo": {
         "sw_ver": "1.0.4 Build 191111 Rel.143500",
         "hw_ver": "4.0",
@@ -33,6 +33,33 @@ SMARTPLUGSWITCH_DATA = {
         "total_wh": 1793,
         "err_code": 0,
     },
+}
+SMARTPLUG_HS100_DATA = {
+    "sysinfo": {
+        "sw_ver": "1.0.4 Build 191111 Rel.143500",
+        "hw_ver": "4.0",
+        "model": "HS100(EU)",
+        "deviceId": "4C56447B395BB7A2FAC68C9DFEE2E84163222581",
+        "oemId": "40F54B43071E9436B6395611E9D91CEA",
+        "hwId": "A6C77E4FDD238B53D824AC8DA361F043",
+        "rssi": -24,
+        "longitude_i": 130793,
+        "latitude_i": 480582,
+        "alias": "SmartPlug",
+        "status": "new",
+        "mic_type": "IOT.SMARTPLUGSWITCH",
+        "feature": "TIM:",
+        "mac": "A9:F4:3D:A4:E3:47",
+        "updating": 0,
+        "led_off": 0,
+        "relay_state": 0,
+        "on_time": 0,
+        "active_mode": "none",
+        "icon_hash": "",
+        "dev_name": "Smart Wi-Fi Plug",
+        "next_action": {"type": -1},
+        "err_code": 0,
+    }
 }
 SMARTSTRIPWITCH_DATA = {
     "sysinfo": {

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -11,6 +11,8 @@ import pytest
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import tplink
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.tplink.common import SmartDevices
 from homeassistant.components.tplink.const import (
     CONF_DIMMER,
@@ -19,16 +21,21 @@ from homeassistant.components.tplink.const import (
     CONF_SW_VERSION,
     CONF_SWITCH,
     COORDINATORS,
+    UNAVAILABLE_RETRY_DELAY,
 )
 from homeassistant.components.tplink.sensor import ENERGY_SENSORS
 from homeassistant.const import CONF_ALIAS, CONF_DEVICE_ID, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
-from homeassistant.util import slugify
+from homeassistant.util import dt, slugify
 
-from tests.common import MockConfigEntry, mock_coro
-from tests.components.tplink.consts import SMARTPLUGSWITCH_DATA, SMARTSTRIPWITCH_DATA
+from tests.common import MockConfigEntry, async_fire_time_changed, mock_coro
+from tests.components.tplink.consts import (
+    SMARTPLUG_HS100_DATA,
+    SMARTPLUG_HS110_DATA,
+    SMARTSTRIPWITCH_DATA,
+)
 
 
 async def test_creating_entry_tries_discover(hass):
@@ -220,9 +227,9 @@ async def test_platforms_are_initialized(hass: HomeAssistant):
 
         light = SmartBulb("123.123.123.123")
         switch = SmartPlug("321.321.321.321")
-        switch.get_sysinfo = MagicMock(return_value=SMARTPLUGSWITCH_DATA["sysinfo"])
+        switch.get_sysinfo = MagicMock(return_value=SMARTPLUG_HS110_DATA["sysinfo"])
         switch.get_emeter_realtime = MagicMock(
-            return_value=EmeterStatus(SMARTPLUGSWITCH_DATA["realtime"])
+            return_value=EmeterStatus(SMARTPLUG_HS110_DATA["realtime"])
         )
         switch.get_emeter_daily = MagicMock(
             return_value={int(time.strftime("%e")): 1.123}
@@ -271,24 +278,21 @@ async def test_smartplug_without_consumption_sensors(hass: HomeAssistant):
         "homeassistant.components.tplink.light.async_setup_entry",
         return_value=mock_coro(True),
     ), patch(
-        "homeassistant.components.tplink.switch.async_setup_entry",
-        return_value=mock_coro(True),
-    ), patch(
         "homeassistant.components.tplink.common.SmartPlug.is_dimmable", False
     ):
 
         switch = SmartPlug("321.321.321.321")
-        switch.get_sysinfo = MagicMock(return_value=SMARTPLUGSWITCH_DATA["sysinfo"])
+        switch.get_sysinfo = MagicMock(return_value=SMARTPLUG_HS100_DATA["sysinfo"])
         get_static_devices.return_value = SmartDevices([], [switch])
 
         await async_setup_component(hass, tplink.DOMAIN, config)
         await hass.async_block_till_done()
 
-        for description in ENERGY_SENSORS:
-            state = hass.states.get(
-                f"sensor.{switch.alias}_{slugify(description.name)}"
-            )
-            assert state is None
+        entities = hass.states.async_entity_ids(SWITCH_DOMAIN)
+        assert len(entities) == 1
+
+        entities = hass.states.async_entity_ids(SENSOR_DOMAIN)
+        assert len(entities) == 0
 
 
 async def test_smartstrip_device(hass: HomeAssistant):
@@ -363,9 +367,6 @@ async def test_not_available_at_startup(hass: HomeAssistant):
         "homeassistant.components.tplink.light.async_setup_entry",
         return_value=mock_coro(True),
     ), patch(
-        "homeassistant.components.tplink.switch.async_setup_entry",
-        return_value=mock_coro(True),
-    ), patch(
         "homeassistant.components.tplink.common.SmartPlug.is_dimmable", False
     ):
 
@@ -373,6 +374,7 @@ async def test_not_available_at_startup(hass: HomeAssistant):
         switch.get_sysinfo = MagicMock(side_effect=SmartDeviceException())
         get_static_devices.return_value = SmartDevices([], [switch])
 
+        # run setup while device unreachable
         await async_setup_component(hass, tplink.DOMAIN, config)
         await hass.async_block_till_done()
 
@@ -380,8 +382,31 @@ async def test_not_available_at_startup(hass: HomeAssistant):
         assert len(entries) == 1
         assert entries[0].state is config_entries.ConfigEntryState.LOADED
 
-        entities = hass.states.async_entity_ids(tplink.DOMAIN)
+        entities = hass.states.async_entity_ids(SWITCH_DOMAIN)
         assert len(entities) == 0
+
+        # retrying with still unreachable device
+        async_fire_time_changed(hass, dt.utcnow() + UNAVAILABLE_RETRY_DELAY)
+        await hass.async_block_till_done()
+
+        entries = hass.config_entries.async_entries(tplink.DOMAIN)
+        assert len(entries) == 1
+        assert entries[0].state is config_entries.ConfigEntryState.LOADED
+
+        entities = hass.states.async_entity_ids(SWITCH_DOMAIN)
+        assert len(entities) == 0
+
+        # retrying with now reachable device
+        switch.get_sysinfo = MagicMock(return_value=SMARTPLUG_HS100_DATA["sysinfo"])
+        async_fire_time_changed(hass, dt.utcnow() + UNAVAILABLE_RETRY_DELAY)
+        await hass.async_block_till_done()
+
+        entries = hass.config_entries.async_entries(tplink.DOMAIN)
+        assert len(entries) == 1
+        assert entries[0].state is config_entries.ConfigEntryState.LOADED
+
+        entities = hass.states.async_entity_ids(SWITCH_DOMAIN)
+        assert len(entities) == 1
 
 
 @pytest.mark.parametrize("platform", ["switch", "light"])
@@ -408,9 +433,9 @@ async def test_unload(hass, platform):
 
         light = SmartBulb("123.123.123.123")
         switch = SmartPlug("321.321.321.321")
-        switch.get_sysinfo = MagicMock(return_value=SMARTPLUGSWITCH_DATA["sysinfo"])
+        switch.get_sysinfo = MagicMock(return_value=SMARTPLUG_HS110_DATA["sysinfo"])
         switch.get_emeter_realtime = MagicMock(
-            return_value=EmeterStatus(SMARTPLUGSWITCH_DATA["realtime"])
+            return_value=EmeterStatus(SMARTPLUG_HS110_DATA["realtime"])
         )
         if platform == "light":
             get_static_devices.return_value = SmartDevices([light], [])

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -346,8 +346,8 @@ async def test_no_config_creates_no_entry(hass):
     assert mock_setup.call_count == 0
 
 
-async def test_not_ready(hass: HomeAssistant):
-    """Test for not ready when configured devices are not available."""
+async def test_not_available_at_startup(hass: HomeAssistant):
+    """Test when configured devices are not available."""
     config = {
         tplink.DOMAIN: {
             CONF_DISCOVERY: False,
@@ -377,9 +377,11 @@ async def test_not_ready(hass: HomeAssistant):
         await hass.async_block_till_done()
 
         entries = hass.config_entries.async_entries(tplink.DOMAIN)
-
         assert len(entries) == 1
-        assert entries[0].state is config_entries.ConfigEntryState.SETUP_RETRY
+        assert entries[0].state is config_entries.ConfigEntryState.LOADED
+
+        entities = hass.states.async_entity_ids(tplink.DOMAIN)
+        assert len(entities) == 0
 
 
 @pytest.mark.parametrize("platform", ["switch", "light"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With this, setup of `tplink` integration is not blocked by `ConfigEntryNotReady`, when a configured switch device is unreachable.
Furthermore every 300s it is checked, if former unreachable devices meanwhile becomes available and if so, integration will be reloaded.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53755
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
