### PR TITLE
ForecastSolar -  power production now   w not k w

### DIFF
--- a/homeassistant/components/forecast_solar/const.py
+++ b/homeassistant/components/forecast_solar/const.py
@@ -61,8 +61,7 @@ SENSORS: tuple[ForecastSolarSensorEntityDescription, ...] = (
         key="power_production_next_hour",
         state=lambda estimate: estimate.power_production_at_time(
             estimate.now() + timedelta(hours=1)
-        )
-        / 1000,
+        ),
         name="Estimated Power Production - Next Hour",
         device_class=DEVICE_CLASS_POWER,
         entity_registry_enabled_default=False,
@@ -72,8 +71,7 @@ SENSORS: tuple[ForecastSolarSensorEntityDescription, ...] = (
         key="power_production_next_12hours",
         state=lambda estimate: estimate.power_production_at_time(
             estimate.now() + timedelta(hours=12)
-        )
-        / 1000,
+        ),
         name="Estimated Power Production - Next 12 Hours",
         device_class=DEVICE_CLASS_POWER,
         entity_registry_enabled_default=False,
@@ -83,8 +81,7 @@ SENSORS: tuple[ForecastSolarSensorEntityDescription, ...] = (
         key="power_production_next_24hours",
         state=lambda estimate: estimate.power_production_at_time(
             estimate.now() + timedelta(hours=24)
-        )
-        / 1000,
+        ),
         name="Estimated Power Production - Next 24 Hours",
         device_class=DEVICE_CLASS_POWER,
         entity_registry_enabled_default=False,

--- a/homeassistant/components/forecast_solar/const.py
+++ b/homeassistant/components/forecast_solar/const.py
@@ -53,7 +53,7 @@ SENSORS: tuple[ForecastSolarSensorEntityDescription, ...] = (
         key="power_production_now",
         name="Estimated Power Production - Now",
         device_class=DEVICE_CLASS_POWER,
-        state=lambda estimate: estimate.power_production_now / 1000,
+        state=lambda estimate: estimate.power_production_now,
         state_class=STATE_CLASS_MEASUREMENT,
         unit_of_measurement=POWER_WATT,
     ),

--- a/tests/components/forecast_solar/test_sensor.py
+++ b/tests/components/forecast_solar/test_sensor.py
@@ -175,17 +175,17 @@ async def test_disabled_by_default(
         (
             "power_production_next_12hours",
             "Estimated Power Production - Next 12 Hours",
-            "600.0",
+            "600000",
         ),
         (
             "power_production_next_24hours",
             "Estimated Power Production - Next 24 Hours",
-            "700.0",
+            "700000",
         ),
         (
             "power_production_next_hour",
             "Estimated Power Production - Next Hour",
-            "400.0",
+            "400000",
         ),
     ],
 )

--- a/tests/components/forecast_solar/test_sensor.py
+++ b/tests/components/forecast_solar/test_sensor.py
@@ -96,7 +96,7 @@ async def test_sensors(
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_power_production_now"
-    assert state.state == "300.0"
+    assert state.state == "300000"
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME) == "Estimated Power Production - Now"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Forecast Solar is showing data in Watts but the figure is being divided by 1000 in error due to an upstream change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53789
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
