### PR TITLE
Convert modbus call configuration to a simpler structure

### DIFF
--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -1,5 +1,4 @@
 """Constants used in modbus integration."""
-
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate.const import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
@@ -110,18 +109,8 @@ DEFAULT_HUB = "modbus_hub"
 DEFAULT_SCAN_INTERVAL = 15  # seconds
 DEFAULT_SLAVE = 1
 DEFAULT_STRUCTURE_PREFIX = ">f"
-DEFAULT_STRUCT_FORMAT = {
-    DATA_TYPE_INT16: ["h", 1],
-    DATA_TYPE_INT32: ["i", 2],
-    DATA_TYPE_INT64: ["q", 4],
-    DATA_TYPE_UINT16: ["H", 1],
-    DATA_TYPE_UINT32: ["I", 2],
-    DATA_TYPE_UINT64: ["Q", 4],
-    DATA_TYPE_FLOAT16: ["e", 1],
-    DATA_TYPE_FLOAT32: ["f", 2],
-    DATA_TYPE_FLOAT64: ["d", 4],
-    DATA_TYPE_STRING: ["s", 1],
-}
+
+
 DEFAULT_TEMP_UNIT = "C"
 MODBUS_DOMAIN = "modbus"
 

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -1,6 +1,6 @@
 """Support for Modbus."""
 import asyncio
-from copy import deepcopy
+from collections import namedtuple
 import logging
 
 from pymodbus.client.sync import ModbusSerialClient, ModbusTcpClient, ModbusUdpClient
@@ -54,54 +54,52 @@ from .const import (
     SERVICE_WRITE_REGISTER,
 )
 
-ENTRY_FUNC = "func"
-ENTRY_ATTR = "attr"
-ENTRY_NAME = "name"
-
 _LOGGER = logging.getLogger(__name__)
 
-PYMODBUS_CALL = {
-    CALL_TYPE_COIL: {
-        ENTRY_ATTR: "bits",
-        ENTRY_NAME: "read_coils",
-        ENTRY_FUNC: None,
-    },
-    CALL_TYPE_DISCRETE: {
-        ENTRY_ATTR: "bits",
-        ENTRY_NAME: "read_discrete_inputs",
-        ENTRY_FUNC: None,
-    },
-    CALL_TYPE_REGISTER_HOLDING: {
-        ENTRY_ATTR: "registers",
-        ENTRY_NAME: "read_holding_registers",
-        ENTRY_FUNC: None,
-    },
-    CALL_TYPE_REGISTER_INPUT: {
-        ENTRY_ATTR: "registers",
-        ENTRY_NAME: "read_input_registers",
-        ENTRY_FUNC: None,
-    },
-    CALL_TYPE_WRITE_COIL: {
-        ENTRY_ATTR: "value",
-        ENTRY_NAME: "write_coil",
-        ENTRY_FUNC: None,
-    },
-    CALL_TYPE_WRITE_COILS: {
-        ENTRY_ATTR: "count",
-        ENTRY_NAME: "write_coils",
-        ENTRY_FUNC: None,
-    },
-    CALL_TYPE_WRITE_REGISTER: {
-        ENTRY_ATTR: "value",
-        ENTRY_NAME: "write_register",
-        ENTRY_FUNC: None,
-    },
-    CALL_TYPE_WRITE_REGISTERS: {
-        ENTRY_ATTR: "count",
-        ENTRY_NAME: "write_registers",
-        ENTRY_FUNC: None,
-    },
-}
+ConfEntry = namedtuple("ConfEntry", "call_type attr func_name")
+RunEntry = namedtuple("RunEntry", "attr func")
+PYMODBUS_CALL = [
+    ConfEntry(
+        CALL_TYPE_COIL,
+        "bits",
+        "read_coils",
+    ),
+    ConfEntry(
+        CALL_TYPE_DISCRETE,
+        "bits",
+        "read_discrete_inputs",
+    ),
+    ConfEntry(
+        CALL_TYPE_REGISTER_HOLDING,
+        "registers",
+        "read_holding_registers",
+    ),
+    ConfEntry(
+        CALL_TYPE_REGISTER_INPUT,
+        "registers",
+        "read_input_registers",
+    ),
+    ConfEntry(
+        CALL_TYPE_WRITE_COIL,
+        "value",
+        "write_coil",
+    ),
+    ConfEntry(
+        CALL_TYPE_WRITE_COILS,
+        "count",
+        "write_coils",
+    ),
+    ConfEntry(
+        CALL_TYPE_WRITE_REGISTER,
+        "value",
+        "write_register",
+    ),
+    ConfEntry(
+        CALL_TYPE_WRITE_REGISTERS,
+        "count",
+        "write_registers",
+    ),
+]
 
 
 async def async_modbus_setup(
@@ -197,7 +195,7 @@ class ModbusHub:
         self._config_name = client_config[CONF_NAME]
         self._config_type = client_config[CONF_TYPE]
         self._config_delay = client_config[CONF_DELAY]
-        self._pb_call = deepcopy(PYMODBUS_CALL)
+        self._pb_call = {}
         self._pb_class = {
             CONF_SERIAL: ModbusSerialClient,
             CONF_TCP: ModbusTcpClient,
@@ -246,8 +244,9 @@ class ModbusHub:
             self._log_error(str(exception_error), error_state=False)
             return False
 
-        for entry in self._pb_call.values():
-            entry[ENTRY_FUNC] = getattr(self._client, entry[ENTRY_NAME])
+        for entry in PYMODBUS_CALL:
+            func = getattr(self._client, entry.func_name)
+            self._pb_call[entry.call_type] = RunEntry(entry.attr, func)
 
         await self.async_connect_task()
         return True
@@ -301,12 +300,13 @@ class ModbusHub:
     def _pymodbus_call(self, unit, address, value, use_call):
         """Call sync. pymodbus."""
         kwargs = {"unit": unit} if unit else {}
+        entry = self._pb_call[use_call]
         try:
-            result = self._pb_call[use_call][ENTRY_FUNC](address, value, **kwargs)
+            result = entry.func(address, value, **kwargs)
         except ModbusException as exception_error:
             self._log_error(str(exception_error))
             return None
-        if not hasattr(result, self._pb_call[use_call][ENTRY_ATTR]):
+        if not hasattr(result, entry.attr):
             self._log_error(str(result))
             return None
         self._in_error = False

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -1,6 +1,7 @@
 """Validate Modbus configuration."""
 from __future__ import annotations
 
+from collections import namedtuple
 import logging
 import struct
 from typing import Any
@@ -29,12 +30,12 @@ from .const import (
     DATA_TYPE_INT16,
     DATA_TYPE_INT32,
     DATA_TYPE_INT64,
+    DATA_TYPE_STRING,
     DATA_TYPE_UINT,
     DATA_TYPE_UINT16,
     DATA_TYPE_UINT32,
     DATA_TYPE_UINT64,
     DEFAULT_SCAN_INTERVAL,
-    DEFAULT_STRUCT_FORMAT,
     PLATFORMS,
 )
 
@@ -56,6 +57,19 @@ OLD_DATA_TYPES = {
         2: DATA_TYPE_FLOAT32,
         4: DATA_TYPE_FLOAT64,
     },
+}
+ENTRY = namedtuple("ENTRY", ["struct_id", "register_count"])
+DEFAULT_STRUCT_FORMAT = {
+    DATA_TYPE_INT16: ENTRY("h", 1),
+    DATA_TYPE_INT32: ENTRY("i", 2),
+    DATA_TYPE_INT64: ENTRY("q", 4),
+    DATA_TYPE_UINT16: ENTRY("H", 1),
+    DATA_TYPE_UINT32: ENTRY("I", 2),
+    DATA_TYPE_UINT64: ENTRY("Q", 4),
+    DATA_TYPE_FLOAT16: ENTRY("e", 1),
+    DATA_TYPE_FLOAT32: ENTRY("f", 2),
+    DATA_TYPE_FLOAT64: ENTRY("d", 4),
+    DATA_TYPE_STRING: ENTRY("s", 1),
 }
 
 
@@ -79,9 +93,9 @@ def struct_validator(config):
         if structure:
             error = f"{name}  structure: cannot be mixed with {data_type}"
             raise vol.Invalid(error)
-        structure = f">{DEFAULT_STRUCT_FORMAT[data_type][0]}"
+        structure = f">{DEFAULT_STRUCT_FORMAT[data_type].struct_id}"
         if CONF_COUNT not in config:
-            config[CONF_COUNT] = DEFAULT_STRUCT_FORMAT[data_type][1]
+            config[CONF_COUNT] = DEFAULT_STRUCT_FORMAT[data_type].register_count
     else:
         if not structure:
             error = (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Solve pylint "code_style" issue and at the same time, simplify the pymodbus interface structure.

Setup is now stored in an array of NamedTuples (PYMODBUS_CALL) which during integration load is translated into a dict (to allow indexing with a string) with NamedTuples consisting of a reference to the pymodbus function as well as the the type of attribute to test for. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
