### PR TITLE
Fix crash when AVM FRITZ!SmartHome devices are unreachable

### DIFF
--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -146,7 +146,7 @@ class FritzBoxEntity(CoordinatorEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success and self.device.present
+        return super().available and self.device.present
 
     @property
     def device(self) -> FritzhomeDevice:

--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -144,6 +144,11 @@ class FritzBoxEntity(CoordinatorEntity):
         self._attr_state_class = entity_info[ATTR_STATE_CLASS]
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.device.present
+
+    @property
     def device(self) -> FritzhomeDevice:
         """Return device object from coordinator."""
         return self.coordinator.data[self.ain]

--- a/homeassistant/components/fritzbox/binary_sensor.py
+++ b/homeassistant/components/fritzbox/binary_sensor.py
@@ -54,6 +54,4 @@ class FritzboxBinarySensor(FritzBoxEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if sensor is on."""
-        if not self.device.present:
-            return False
         return self.device.alert_state  # type: ignore [no-any-return]

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -94,11 +94,6 @@ class FritzboxThermostat(FritzBoxEntity, ClimateEntity):
         return SUPPORT_FLAGS
 
     @property
-    def available(self) -> bool:
-        """Return if thermostat is available."""
-        return self.device.present  # type: ignore [no-any-return]
-
-    @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement that is used."""
         return TEMP_CELSIUS

--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -121,7 +121,7 @@ class FritzBoxPowerSensor(FritzBoxEntity, SensorEntity):
     @property
     def state(self) -> float | None:
         """Return the state of the sensor."""
-        return self.device.power / 1000  # type: ignore [no-any-return]
+        return (self.device.power or 0.0) / 1000
 
 
 class FritzBoxEnergySensor(FritzBoxEntity, SensorEntity):

--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -121,7 +121,9 @@ class FritzBoxPowerSensor(FritzBoxEntity, SensorEntity):
     @property
     def state(self) -> float | None:
         """Return the state of the sensor."""
-        return (self.device.power or 0.0) / 1000
+        if power := self.device.power:
+            return power / 1000  # type: ignore [no-any-return]
+        return 0.0
 
 
 class FritzBoxEnergySensor(FritzBoxEntity, SensorEntity):
@@ -130,7 +132,9 @@ class FritzBoxEnergySensor(FritzBoxEntity, SensorEntity):
     @property
     def state(self) -> float | None:
         """Return the state of the sensor."""
-        return (self.device.energy or 0.0) / 1000
+        if energy := self.device.energy:
+            return energy / 1000  # type: ignore [no-any-return]
+        return 0.0
 
     @property
     def last_reset(self) -> datetime:

--- a/homeassistant/components/fritzbox/switch.py
+++ b/homeassistant/components/fritzbox/switch.py
@@ -57,11 +57,6 @@ class FritzboxSwitch(FritzBoxEntity, SwitchEntity):
     """The switch class for FRITZ!SmartHome switches."""
 
     @property
-    def available(self) -> bool:
-        """Return if switch is available."""
-        return self.device.present  # type: ignore [no-any-return]
-
-    @property
     def is_on(self) -> bool:
         """Return true if the switch is on."""
         return self.device.switch_state  # type: ignore [no-any-return]

--- a/tests/components/fritzbox/test_binary_sensor.py
+++ b/tests/components/fritzbox/test_binary_sensor.py
@@ -14,8 +14,8 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_DEVICES,
     PERCENTAGE,
-    STATE_OFF,
     STATE_ON,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
@@ -60,7 +60,7 @@ async def test_is_off(hass: HomeAssistant, fritz: Mock):
 
     state = hass.states.get(ENTITY_ID)
     assert state
-    assert state.state == STATE_OFF
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_update(hass: HomeAssistant, fritz: Mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will set entity unavailable, when `device.present` is `False`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53747
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
