### PR TITLE
Convert base_config_test in modbus to existing Pytest.fixture

### DIFF
--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -39,9 +39,16 @@ def mock_pymodbus():
         yield mock_pb
 
 
-@pytest.fixture
-async def mock_modbus(hass, do_config):
+@pytest.fixture(
+    scope="function",
+    params=[
+        {"testLoad": True},
+    ],
+)
+async def mock_modbus(hass, caplog, request, do_config):
     """Load integration modbus using mocked pymodbus."""
+
+    caplog.set_level(logging.WARNING)
     config = {
         DOMAIN: [
             {
@@ -56,7 +63,10 @@ async def mock_modbus(hass, do_config):
     with mock.patch(
         "homeassistant.components.modbus.modbus.ModbusTcpClient", autospec=True
     ) as mock_pb:
-        assert await async_setup_component(hass, DOMAIN, config) is True
+        if request.param["testLoad"]:
+            assert await async_setup_component(hass, DOMAIN, config) is True
+        else:
+            await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
         yield mock_pb
 
@@ -88,7 +98,6 @@ async def base_test(
     register_words,
     expected,
     method_discovery=False,
-    check_config_only=False,
     config_modbus=None,
     scan_interval=None,
     expect_init_to_fail=False,
@@ -173,8 +182,6 @@ async def base_test(
                 assert device is None
             elif device is None:
                 pytest.fail("CONFIG failed, see output")
-        if check_config_only:
-            return
 
         # Trigger update call with time_changed event
         now = now + timedelta(seconds=scan_interval + 60)
@@ -185,37 +192,6 @@ async def base_test(
         # Check state
         entity_id = f"{entity_domain}.{device_name}"
         return hass.states.get(entity_id).state
-
-
-async def base_config_test(
-    hass,
-    config_device,
-    device_name,
-    entity_domain,
-    array_name_discovery,
-    array_name_old_config,
-    method_discovery=False,
-    config_modbus=None,
-    expect_init_to_fail=False,
-    expect_setup_to_fail=False,
-):
-    """Check config of device for given config."""
-
-    await base_test(
-        hass,
-        config_device,
-        device_name,
-        entity_domain,
-        array_name_discovery,
-        array_name_old_config,
-        None,
-        None,
-        method_discovery=method_discovery,
-        check_config_only=True,
-        config_modbus=config_modbus,
-        expect_init_to_fail=expect_init_to_fail,
-        expect_setup_to_fail=expect_setup_to_fail,
-    )
 
 
 async def prepare_service_update(hass, config):

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -40,7 +40,6 @@ def mock_pymodbus():
 
 
 @pytest.fixture(
-    scope="function",
     params=[
         {"testLoad": True},
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With the old configuration gone, there are no need for the complicated test harness in conftest.py, it can be replaced by pytest.fixtures that are already available (but need to be modified).

Removing base_config_test is the first step, this involved the challenge of using caplog across fixture and test function.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
