### PR TITLE
Fix some homekit_controller entities getting wrong (duplicate) unique id

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -189,11 +189,16 @@ class CharacteristicEntity(HomeKitEntity):
     the service entity.
     """
 
+    def __init__(self, accessory, devinfo, char):
+        """Initialise a generic single characteristic HomeKit entity."""
+        self._char = char
+        super().__init__(accessory, devinfo)
+
     @property
     def unique_id(self) -> str:
         """Return the ID of this device."""
         serial = self.accessory_info.value(CharacteristicsTypes.SERIAL_NUMBER)
-        return f"homekit-{serial}-aid:{self._aid}-sid:{self._iid}-cid:{self._iid}"
+        return f"homekit-{serial}-aid:{self._aid}-sid:{self._char.service.iid}-cid:{self._char.iid}"
 
 
 async def async_setup_entry(hass, entry):

--- a/homeassistant/components/homekit_controller/number.py
+++ b/homeassistant/components/homekit_controller/number.py
@@ -53,9 +53,8 @@ class HomeKitNumber(CharacteristicEntity, NumberEntity):
         self._device_class = device_class
         self._icon = icon
         self._name = name
-        self._char = char
 
-        super().__init__(conn, info)
+        super().__init__(conn, info, char)
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity is tracking."""

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -254,9 +254,8 @@ class SimpleSensor(CharacteristicEntity, SensorEntity):
         self._unit = unit
         self._icon = icon
         self._name = name
-        self._char = char
 
-        super().__init__(conn, info)
+        super().__init__(conn, info, char)
 
     def get_characteristic_types(self):
         """Define the homekit characteristics the entity is tracking."""

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -60,7 +60,7 @@ async def test_ecobee3_setup(hass):
     assert climate_state.attributes["max_humidity"] == 50
 
     climate_sensor = entity_registry.async_get("sensor.homew_current_temperature")
-    assert climate_sensor.unique_id == "homekit-123456789012-aid:1-sid:16-cid:16"
+    assert climate_sensor.unique_id == "homekit-123456789012-aid:1-sid:16-cid:19"
 
     occ1 = entity_registry.async_get("binary_sensor.kitchen")
     assert occ1.unique_id == "homekit-AB1C-56"

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
@@ -37,7 +37,7 @@ async def test_koogeek_p1eu_setup(hass):
 
     # Assert the power sensor is detected
     entry = entity_registry.async_get("sensor.koogeek_p1_a00aa0_real_time_energy")
-    assert entry.unique_id == "homekit-EUCP03190xxxxx48-aid:1-sid:21-cid:21"
+    assert entry.unique_id == "homekit-EUCP03190xxxxx48-aid:1-sid:21-cid:22"
 
     helper = Helper(
         hass,

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
@@ -45,7 +45,7 @@ async def test_koogeek_ls1_setup(hass):
 
     # Assert that the power sensor entity is correctly added to the entity registry
     entry = entity_registry.async_get("sensor.koogeek_sw2_187a91_real_time_energy")
-    assert entry.unique_id == "homekit-CNNT061751001372-aid:1-sid:14-cid:14"
+    assert entry.unique_id == "homekit-CNNT061751001372-aid:1-sid:14-cid:18"
 
     helper = Helper(
         hass,

--- a/tests/components/homekit_controller/specific_devices/test_mysa_living.py
+++ b/tests/components/homekit_controller/specific_devices/test_mysa_living.py
@@ -1,0 +1,91 @@
+"""Make sure that Mysa Living is enumerated properly."""
+
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.components.homekit_controller.common import (
+    Helper,
+    setup_accessories_from_file,
+    setup_test_accessories,
+)
+
+
+async def test_mysa_living_setup(hass):
+    """Test that the accessory can be correctly setup in HA."""
+    accessories = await setup_accessories_from_file(hass, "mysa_living.json")
+    config_entry, pairing = await setup_test_accessories(hass, accessories)
+
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    # Check that the switch entity is handled correctly
+
+    entry = entity_registry.async_get("sensor.mysa_85dda9_current_humidity")
+    assert entry.unique_id == "homekit-AAAAAAA000-aid:1-sid:20-cid:27"
+
+    helper = Helper(
+        hass,
+        "sensor.mysa_85dda9_current_humidity",
+        pairing,
+        accessories[0],
+        config_entry,
+    )
+    state = await helper.poll_and_get_state()
+    assert state.attributes["friendly_name"] == "Mysa-85dda9 - Current Humidity"
+
+    device = device_registry.async_get(entry.device_id)
+    assert device.manufacturer == "Empowered Homes Inc."
+    assert device.name == "Mysa-85dda9"
+    assert device.model == "v1"
+    assert device.sw_version == "2.8.1"
+    assert device.via_device_id is None
+
+    # Assert the humidifier is detected
+    entry = entity_registry.async_get("sensor.mysa_85dda9_current_temperature")
+    assert entry.unique_id == "homekit-AAAAAAA000-aid:1-sid:20-cid:25"
+
+    helper = Helper(
+        hass,
+        "sensor.mysa_85dda9_current_temperature",
+        pairing,
+        accessories[0],
+        config_entry,
+    )
+    state = await helper.poll_and_get_state()
+    assert state.attributes["friendly_name"] == "Mysa-85dda9 - Current Temperature"
+
+    # The sensor should be part of the same device
+    assert entry.device_id == device.id
+
+    # Assert the light is detected
+    entry = entity_registry.async_get("light.mysa_85dda9")
+    assert entry.unique_id == "homekit-AAAAAAA000-40"
+
+    helper = Helper(
+        hass,
+        "light.mysa_85dda9",
+        pairing,
+        accessories[0],
+        config_entry,
+    )
+    state = await helper.poll_and_get_state()
+    assert state.attributes["friendly_name"] == "Mysa-85dda9"
+
+    # The light should be part of the same device
+    assert entry.device_id == device.id
+
+    # Assert the climate entity is detected
+    entry = entity_registry.async_get("climate.mysa_85dda9")
+    assert entry.unique_id == "homekit-AAAAAAA000-20"
+
+    helper = Helper(
+        hass,
+        "climate.mysa_85dda9",
+        pairing,
+        accessories[0],
+        config_entry,
+    )
+    state = await helper.poll_and_get_state()
+    assert state.attributes["friendly_name"] == "Mysa-85dda9"
+
+    # The light should be part of the same device
+    assert entry.device_id == device.id

--- a/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
+++ b/tests/components/homekit_controller/specific_devices/test_vocolinc_flowerbud.py
@@ -20,7 +20,7 @@ async def test_vocolinc_flowerbud_setup(hass):
     # Check that the switch entity is handled correctly
 
     entry = entity_registry.async_get("number.vocolinc_flowerbud_0d324b")
-    assert entry.unique_id == "homekit-AM01121849000327-aid:1-sid:30-cid:30"
+    assert entry.unique_id == "homekit-AM01121849000327-aid:1-sid:30-cid:38"
 
     helper = Helper(
         hass, "number.vocolinc_flowerbud_0d324b", pairing, accessories[0], config_entry
@@ -73,7 +73,7 @@ async def test_vocolinc_flowerbud_setup(hass):
     entry = entity_registry.async_get(
         "sensor.vocolinc_flowerbud_0d324b_current_humidity"
     )
-    assert entry.unique_id == "homekit-AM01121849000327-aid:1-sid:30-cid:30"
+    assert entry.unique_id == "homekit-AM01121849000327-aid:1-sid:30-cid:33"
 
     helper = Helper(
         hass,

--- a/tests/fixtures/homekit_controller/mysa_living.json
+++ b/tests/fixtures/homekit_controller/mysa_living.json
@@ -1,0 +1,250 @@
+[
+    {
+        "aid": 1,
+        "primary": true,
+        "services": [
+            {
+                "type": "0000004A-0000-1000-8000-0026BB765291",
+                "primary": true,
+                "iid": 20,
+                "characteristics": [
+                    {
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "Thermostat",
+                        "perms": [
+                            "pr"
+                        ],
+                        "iid": 24
+                    },
+                    {
+                        "type": "00000010-0000-1000-8000-0026BB765291",
+                        "format": "float",
+                        "minValue": 0,
+                        "maxValue": 100,
+                        "stepValue": 1,
+                        "value": 40,
+                        "iid": 27,
+                        "unit": "percentage",
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ]
+                    },
+                    {
+                        "type": "0000000F-0000-1000-8000-0026BB765291",
+                        "value": 0,
+                        "minValue": 0,
+                        "maxValue": 2,
+                        "stepValue": 1,
+                        "format": "uint8",
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "iid": 21
+                    },
+                    {
+                        "type": "00000033-0000-1000-8000-0026BB765291",
+                        "value": 0,
+                        "minValue": 0,
+                        "maxValue": 3,
+                        "stepValue": 1,
+                        "format": "uint8",
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "iid": 22
+                    },
+                    {
+                        "type": "00000011-0000-1000-8000-0026BB765291",
+                        "value": 24.1,
+                        "minValue": 0,
+                        "maxValue": 100,
+                        "stepValue": 0.1,
+                        "unit": "celsius",
+                        "format": "float",
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "iid": 25
+                    },
+                    {
+                        "type": "00000035-0000-1000-8000-0026BB765291",
+                        "value": 22,
+                        "minValue": 5,
+                        "maxValue": 30,
+                        "stepValue": 0.1,
+                        "unit": "celsius",
+                        "format": "float",
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "iid": 23
+                    },
+                    {
+                        "type": "00000036-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "minValue": 0,
+                        "maxValue": 1,
+                        "stepValue": 1,
+                        "value": 0,
+                        "iid": 26,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ]
+                    }
+                ]
+            },
+            {
+                "type": "0000003E-0000-1000-8000-0026BB765291",
+                "iid": 1,
+                "characteristics": [
+                    {
+                        "type": "00000014-0000-1000-8000-0026BB765291",
+                        "perms": [
+                            "pw"
+                        ],
+                        "iid": 2,
+                        "format": "bool"
+                    },
+                    {
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "Empowered Homes Inc.",
+                        "perms": [
+                            "pr"
+                        ],
+                        "iid": 3
+                    },
+                    {
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "v1",
+                        "perms": [
+                            "pr"
+                        ],
+                        "iid": 4
+                    },
+                    {
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "Mysa-85dda9",
+                        "perms": [
+                            "pr"
+                        ],
+                        "iid": 5
+                    },
+                    {
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "AAAAAAA000",
+                        "perms": [
+                            "pr"
+                        ],
+                        "iid": 6
+                    },
+                    {
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "2.8.1",
+                        "perms": [
+                            "pr"
+                        ],
+                        "iid": 7
+                    },
+                    {
+                        "hidden": true,
+                        "type": "22280E2C-9B79-43BD-8370-5A8F67777B29",
+                        "format": "string",
+                        "value": "b4e62d85dda9",
+                        "perms": [
+                            "pr"
+                        ],
+                        "iid": 8
+                    }
+                ]
+            },
+            {
+                "type": "000000A2-0000-1000-8000-0026BB765291",
+                "iid": 10,
+                "characteristics": [
+                    {
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "1.1.0",
+                        "perms": [
+                            "pr"
+                        ],
+                        "iid": 11
+                    }
+                ]
+            },
+            {
+                "type": "00000043-0000-1000-8000-0026BB765291",
+                "iid": 40,
+                "characteristics": [
+                    {
+                        "type": "00000025-0000-1000-8000-0026BB765291",
+                        "format": "bool",
+                        "value": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "iid": 42
+                    },
+                    {
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "Display",
+                        "perms": [
+                            "pr"
+                        ],
+                        "iid": 41
+                    },
+                    {
+                        "type": "00000008-0000-1000-8000-0026BB765291",
+                        "format": "int",
+                        "minValue": 0,
+                        "maxValue": 100,
+                        "stepValue": 1,
+                        "value": 0,
+                        "iid": 43,
+                        "unit": "percentage",
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ]
+                    }
+                ]
+            },
+            {
+                "type": "3354EC82-AF38-4755-B4A4-4DB8E418F555",
+                "iid": 50,
+                "characteristics": [
+                    {
+                        "hidden": true,
+                        "type": "E71D8348-BB33-4C34-8C50-A64B1136EDD2",
+                        "format": "bool",
+                        "value": 0,
+                        "perms": [
+                            "pr",
+                            "pw"
+                        ],
+                        "iid": 51
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Breaking change

homekit_controller was using the wrong id to track some sensors. The following are effected:

* Koogeek or Eve power sensors (added in [Jan 2021](https://github.com/home-assistant/core/pull/44013))
* The temperature sensor added alongside homekit climate devices (added in [Jul 2021](https://github.com/home-assistant/core/pull/52194), the climate entity itself is not affected)

If you have one of these you may need to remove a stale entity registry entry and you may need to fix the names of these entities as customisations may be lost.

## Proposed change

Fix "secondary" entities getting assigned an incorrect unique id. The ID was supposed to contain the service iid and characteristic iid, but instead contained the service iid twice. Unfortunately this can lead to duplicates.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53844  #53700
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
