### PR TITLE
Support device triggers in HomeKit

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -640,7 +640,7 @@ class HomeKit:
         return None
 
     def add_bridge_triggers_accessory(self, device, device_triggers):
-        """Try trigger accessory to th ebridge."""
+        """Add device automation triggers to the bridge."""
         # The bridge itself counts as an accessory
         if len(self.bridge.accessories) + 1 >= MAX_DEVICES:
             _LOGGER.warning(

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -8,7 +8,7 @@ from aiohttp import web
 from pyhap.const import STANDALONE_AID
 import voluptuous as vol
 
-from homeassistant.components import network, zeroconf
+from homeassistant.components import device_automation, network, zeroconf
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_BATTERY_CHARGING,
     DEVICE_CLASS_MOTION,
@@ -28,6 +28,7 @@ from homeassistant.const import (
     ATTR_MANUFACTURER,
     ATTR_MODEL,
     ATTR_SW_VERSION,
+    CONF_DEVICES,
     CONF_IP_ADDRESS,
     CONF_NAME,
     CONF_PORT,
@@ -99,6 +100,7 @@ from .const import (
     SERVICE_HOMEKIT_UNPAIR,
     SHUTDOWN_TIMEOUT,
 )
+from .type_triggers import DeviceTriggerAccessory
 from .util import (
     accessory_friendly_name,
     dismiss_setup_message,
@@ -158,6 +160,7 @@ BRIDGE_SCHEMA = vol.All(
             vol.Optional(CONF_FILTER, default={}): BASE_FILTER_SCHEMA,
             vol.Optional(CONF_ENTITY_CONFIG, default={}): validate_entity_config,
             vol.Optional(CONF_ZEROCONF_DEFAULT_INTERFACE): cv.boolean,
+            vol.Optional(CONF_DEVICES): cv.ensure_list,
         },
         extra=vol.ALLOW_EXTRA,
     ),
@@ -237,8 +240,9 @@ def _async_update_config_entry_if_from_yaml(hass, entries_by_name, conf):
         data = conf.copy()
         options = {}
         for key in CONFIG_OPTIONS:
-            options[key] = data[key]
-            del data[key]
+            if key in data:
+                options[key] = data[key]
+                del data[key]
 
         hass.config_entries.async_update_entry(entry, data=data, options=options)
         return True
@@ -277,6 +281,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entity_config = options.get(CONF_ENTITY_CONFIG, {}).copy()
     auto_start = options.get(CONF_AUTO_START, DEFAULT_AUTO_START)
     entity_filter = FILTER_SCHEMA(options.get(CONF_FILTER, {}))
+    devices = options.get(CONF_DEVICES, [])
 
     homekit = HomeKit(
         hass,
@@ -290,6 +295,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         advertise_ip,
         entry.entry_id,
         entry.title,
+        devices=devices,
     )
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
@@ -492,6 +498,7 @@ class HomeKit:
         advertise_ip=None,
         entry_id=None,
         entry_title=None,
+        devices=None,
     ):
         """Initialize a HomeKit object."""
         self.hass = hass
@@ -505,6 +512,7 @@ class HomeKit:
         self._entry_id = entry_id
         self._entry_title = entry_title
         self._homekit_mode = homekit_mode
+        self._devices = devices or []
         self.aid_storage = None
         self.status = STATUS_READY
 
@@ -630,6 +638,52 @@ class HomeKit:
                 "Failed to create a HomeKit accessory for %s", state.entity_id
             )
         return None
+
+    def add_bridge_triggers_accessory(self, device, device_triggers):
+        """Try trigger accessory to th ebridge."""
+        # The bridge itself counts as an accessory
+        if len(self.bridge.accessories) + 1 >= MAX_DEVICES:
+            _LOGGER.warning(
+                "Cannot add %s as this would exceed the %d device limit. Consider using the filter option",
+                device.name,
+                MAX_DEVICES,
+            )
+            return
+
+        aid = self.aid_storage.get_or_allocate_aid(device.id, device.id)
+        # If an accessory cannot be created or added due to an exception
+        # of any kind (usually in pyhap) it should not prevent
+        # the rest of the accessories from being created
+        config = {}
+        if device.manufacturer:
+            config[ATTR_MANUFACTURER] = device.manufacturer
+        if device.model:
+            config[ATTR_MODEL] = device.model
+        if device.config_entries:
+            first_entry = list(device.config_entries)[0]
+            if entry := self.hass.config_entries.async_get_entry(first_entry):
+                config[ATTR_INTEGRATION] = entry.domain
+
+        try:
+            acc = DeviceTriggerAccessory(
+                self.hass,
+                self.driver,
+                device.name,
+                None,
+                aid,
+                config,
+                device_id=device.id,
+                device_triggers=device_triggers,
+            )
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Failed to create a HomeKit accessory for %s (%s)",
+                device.name,
+                device.id,
+            )
+            return
+
+        self.bridge.add_accessory(acc)
 
     def remove_bridge_accessory(self, aid):
         """Try adding accessory to bridge if configured beforehand."""
@@ -778,12 +832,26 @@ class HomeKit:
             )
         return acc
 
-    @callback
-    def _async_create_bridge_accessory(self, entity_states):
+    async def _async_create_bridge_accessory(self, entity_states):
         """Create a HomeKit bridge with accessories. (bridge mode)."""
         self.bridge = HomeBridge(self.hass, self.driver, self._name)
         for state in entity_states:
             self.add_bridge_accessory(state)
+        dev_reg = device_registry.async_get(self.hass)
+        if self._devices:
+            triggers = await device_automation.async_get_device_automations(
+                self.hass, "trigger", self._devices
+            )
+            for device_id, device_triggers in triggers.items():
+                device = dev_reg.async_get(device_id)
+                if not device:
+                    _LOGGER.warning(
+                        "HomeKit %s cannot add device %s because it is missing from the device registry",
+                        self._name,
+                        device_id,
+                    )
+                    continue
+                self.add_bridge_triggers_accessory(device, device_triggers)
         return self.bridge
 
     async def _async_create_accessories(self):
@@ -792,7 +860,7 @@ class HomeKit:
         if self._homekit_mode == HOMEKIT_MODE_ACCESSORY:
             acc = self._async_create_single_accessory(entity_states)
         else:
-            acc = self._async_create_bridge_accessory(entity_states)
+            acc = await self._async_create_bridge_accessory(entity_states)
 
         if acc is None:
             return False

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -224,6 +224,7 @@ class HomeAccessory(Accessory):
         config,
         *args,
         category=CATEGORY_OTHER,
+        device_id=None,
         **kwargs,
     ):
         """Initialize a Accessory object."""
@@ -231,7 +232,12 @@ class HomeAccessory(Accessory):
             driver=driver, display_name=name[:MAX_NAME_LENGTH], aid=aid, *args, **kwargs
         )
         self.config = config or {}
-        domain = split_entity_id(entity_id)[0].replace("_", " ")
+        if device_id:
+            self.device_id = device_id
+            domain = None
+        else:
+            self.device_id = None
+            domain = split_entity_id(entity_id)[0].replace("_", " ")
 
         if self.config.get(ATTR_MANUFACTURER) is not None:
             manufacturer = self.config[ATTR_MANUFACTURER]
@@ -260,6 +266,10 @@ class HomeAccessory(Accessory):
         self.entity_id = entity_id
         self.hass = hass
         self._subscriptions = []
+
+        if device_id:
+            return
+
         self._char_battery = None
         self._char_charging = None
         self._char_low_battery = None

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -234,21 +234,27 @@ class HomeAccessory(Accessory):
         self.config = config or {}
         if device_id:
             self.device_id = device_id
+            serial_number = device_id
             domain = None
         else:
             self.device_id = None
+            serial_number = entity_id
             domain = split_entity_id(entity_id)[0].replace("_", " ")
 
         if self.config.get(ATTR_MANUFACTURER) is not None:
             manufacturer = self.config[ATTR_MANUFACTURER]
         elif self.config.get(ATTR_INTEGRATION) is not None:
             manufacturer = self.config[ATTR_INTEGRATION].replace("_", " ").title()
-        else:
+        elif domain:
             manufacturer = f"{MANUFACTURER} {domain}".title()
+        else:
+            manufacturer = MANUFACTURER
         if self.config.get(ATTR_MODEL) is not None:
             model = self.config[ATTR_MODEL]
-        else:
+        elif domain:
             model = domain.title()
+        else:
+            model = MANUFACTURER
         sw_version = None
         if self.config.get(ATTR_SW_VERSION) is not None:
             sw_version = format_sw_version(self.config[ATTR_SW_VERSION])
@@ -258,7 +264,7 @@ class HomeAccessory(Accessory):
         self.set_info_service(
             manufacturer=manufacturer[:MAX_MANUFACTURER_LENGTH],
             model=model[:MAX_MODEL_LENGTH],
-            serial_number=entity_id[:MAX_SERIAL_LENGTH],
+            serial_number=serial_number[:MAX_SERIAL_LENGTH],
             firmware_revision=sw_version[:MAX_VERSION_LENGTH],
         )
 

--- a/homeassistant/components/homekit/aidmanager.py
+++ b/homeassistant/components/homekit/aidmanager.py
@@ -94,12 +94,12 @@ class AccessoryAidStorage:
         """Generate a stable aid for an entity id."""
         entity = self._entity_registry.async_get(entity_id)
         if not entity:
-            return self._get_or_allocate_aid(None, entity_id)
+            return self.get_or_allocate_aid(None, entity_id)
 
         sys_unique_id = get_system_unique_id(entity)
-        return self._get_or_allocate_aid(sys_unique_id, entity_id)
+        return self.get_or_allocate_aid(sys_unique_id, entity_id)
 
-    def _get_or_allocate_aid(self, unique_id: str, entity_id: str):
+    def get_or_allocate_aid(self, unique_id: str, entity_id: str):
         """Allocate (and return) a new aid for an accessory."""
         if unique_id and unique_id in self.allocations:
             return self.allocations[unique_id]

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -415,7 +415,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     self.included_cameras = set()
 
             self.hk_options[CONF_FILTER] = entity_filter
-            if self.hk_options[CONF_HOMEKIT_MODE] == HOMEKIT_MODE_BRIDGE:
+            if (
+                self.show_advanced_options
+                and self.hk_options[CONF_HOMEKIT_MODE] == HOMEKIT_MODE_BRIDGE
+            ):
                 self.hk_options[CONF_DEVICES] = user_input[CONF_DEVICES]
 
             if self.included_cameras:
@@ -448,7 +451,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             all_supported_entities
         )
 
-        if self.hk_options[CONF_HOMEKIT_MODE] == HOMEKIT_MODE_BRIDGE:
+        if (
+            self.show_advanced_options
+            and self.hk_options[CONF_HOMEKIT_MODE] == HOMEKIT_MODE_BRIDGE
+        ):
             all_supported_devices = await _async_get_supported_devices(self.hass)
             devices = self.hk_options.get(CONF_DEVICES, [])
             data_schema[vol.Optional(CONF_DEVICES, default=devices)] = cv.multi_select(

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -9,6 +9,7 @@ import string
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components import device_automation
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
@@ -16,6 +17,7 @@ from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
+    CONF_DEVICES,
     CONF_DOMAINS,
     CONF_ENTITIES,
     CONF_ENTITY_ID,
@@ -23,6 +25,7 @@ from homeassistant.const import (
     CONF_PORT,
 )
 from homeassistant.core import HomeAssistant, callback, split_entity_id
+from homeassistant.helpers import device_registry
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entityfilter import (
     CONF_EXCLUDE_DOMAINS,
@@ -412,6 +415,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     self.included_cameras = set()
 
             self.hk_options[CONF_FILTER] = entity_filter
+            if self.hk_options[CONF_HOMEKIT_MODE] == HOMEKIT_MODE_BRIDGE:
+                self.hk_options[CONF_DEVICES] = user_input[CONF_DEVICES]
 
             if self.included_cameras:
                 return await self.async_step_cameras()
@@ -442,6 +447,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         data_schema[vol.Optional(CONF_ENTITIES, default=entities)] = entity_schema(
             all_supported_entities
         )
+
+        if self.hk_options[CONF_HOMEKIT_MODE] == HOMEKIT_MODE_BRIDGE:
+            all_supported_devices = await _async_get_supported_devices(self.hass)
+            devices = self.hk_options.get(CONF_DEVICES, [])
+            data_schema[vol.Optional(CONF_DEVICES, default=devices)] = cv.multi_select(
+                all_supported_devices
+            )
 
         return self.async_show_form(
             step_id="include_exclude", data_schema=vol.Schema(data_schema)
@@ -479,6 +491,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 }
             ),
         )
+
+
+async def _async_get_supported_devices(hass):
+    """Return all supported devices."""
+    results = await device_automation.async_get_device_automations(hass, "trigger")
+    dev_reg = device_registry.async_get(hass)
+    unsorted = {device_id: dev_reg.async_get(device_id).name for device_id in results}
+    return dict(sorted(unsorted.items(), key=lambda item: item[1]))
 
 
 def _async_get_matching_entities(hass, domains=None):

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -1,5 +1,7 @@
 """Constants used be the HomeKit component."""
 
+from homeassistant.const import CONF_DEVICES
+
 # #### Misc ####
 DEBOUNCE_TIMEOUT = 0.5
 DEVICE_PRECISION_LEEWAY = 6
@@ -136,6 +138,7 @@ SERV_MOTION_SENSOR = "MotionSensor"
 SERV_OCCUPANCY_SENSOR = "OccupancySensor"
 SERV_OUTLET = "Outlet"
 SERV_SECURITY_SYSTEM = "SecuritySystem"
+SERV_SERVICE_LABEL = "ServiceLabel"
 SERV_SMOKE_SENSOR = "SmokeSensor"
 SERV_SPEAKER = "Speaker"
 SERV_STATELESS_PROGRAMMABLE_SWITCH = "StatelessProgrammableSwitch"
@@ -205,6 +208,8 @@ CHAR_ROTATION_DIRECTION = "RotationDirection"
 CHAR_ROTATION_SPEED = "RotationSpeed"
 CHAR_SATURATION = "Saturation"
 CHAR_SERIAL_NUMBER = "SerialNumber"
+CHAR_SERVICE_LABEL_INDEX = "ServiceLabelIndex"
+CHAR_SERVICE_LABEL_NAMESPACE = "ServiceLabelNamespace"
 CHAR_SLEEP_DISCOVER_MODE = "SleepDiscoveryMode"
 CHAR_SMOKE_DETECTED = "SmokeDetected"
 CHAR_STATUS_LOW_BATTERY = "StatusLowBattery"
@@ -292,6 +297,7 @@ CONFIG_OPTIONS = [
     CONF_SAFE_MODE,
     CONF_ENTITY_CONFIG,
     CONF_HOMEKIT_MODE,
+    CONF_DEVICES,
 ]
 
 # ### Maximum Lengths ###

--- a/homeassistant/components/homekit/strings.json
+++ b/homeassistant/components/homekit/strings.json
@@ -30,8 +30,8 @@
             },
             "advanced": {
                 "data": {
-                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)",
-                    "devices": "Devices (Triggers)"
+                    "devices": "Devices (Triggers)",
+                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)"
                 },
                 "description": "Programmable switches are created for each selected device. When a device trigger fires, HomeKit can be configured to run an automation or scene.",
                 "title": "Advanced Configuration"

--- a/homeassistant/components/homekit/strings.json
+++ b/homeassistant/components/homekit/strings.json
@@ -16,8 +16,7 @@
             "include_exclude": {
                 "data": {
                     "mode": "[%key:common::config_flow::data::mode%]",
-                    "entities": "Entities",
-                    "devices": "Devices"
+                    "entities": "Entities"
                 },
                 "description": "Choose the entities to be included. In accessory mode, only a single entity is included. In bridge include mode, all entities in the domain will be included unless specific entities are selected. In bridge exclude mode, all entities in the domain will be included except for the excluded entities. For best performance, a separate HomeKit accessory will be created for each tv media player, activity based remote, lock, and camera.",
                 "title": "Select entities to be included"
@@ -31,9 +30,10 @@
             },
             "advanced": {
                 "data": {
-                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)"
+                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)",
+                    "devices": "Devices (Triggers)"
                 },
-                "description": "These settings only need to be adjusted if HomeKit is not functional.",
+                "description": "Programmable switches are created for each selected device. When a device trigger fires, HomeKit can be configured to run an automation or scene.",
                 "title": "Advanced Configuration"
             }
         }

--- a/homeassistant/components/homekit/strings.json
+++ b/homeassistant/components/homekit/strings.json
@@ -16,7 +16,8 @@
             "include_exclude": {
                 "data": {
                     "mode": "[%key:common::config_flow::data::mode%]",
-                    "entities": "Entities"
+                    "entities": "Entities",
+                    "devices": "Devices"
                 },
                 "description": "Choose the entities to be included. In accessory mode, only a single entity is included. In bridge include mode, all entities in the domain will be included unless specific entities are selected. In bridge exclude mode, all entities in the domain will be included except for the excluded entities. For best performance, a separate HomeKit accessory will be created for each tv media player, activity based remote, lock, and camera.",
                 "title": "Select entities to be included"

--- a/homeassistant/components/homekit/translations/en.json
+++ b/homeassistant/components/homekit/translations/en.json
@@ -35,6 +35,7 @@
             },
             "include_exclude": {
                 "data": {
+                    "devices": "Devices",
                     "entities": "Entities",
                     "mode": "Mode"
                 },

--- a/homeassistant/components/homekit/translations/en.json
+++ b/homeassistant/components/homekit/translations/en.json
@@ -21,9 +21,10 @@
         "step": {
             "advanced": {
                 "data": {
-                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)"
+                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)",
+                    "devices": "Devices (Triggers)"
                 },
-                "description": "These settings only need to be adjusted if HomeKit is not functional.",
+                "description": "Programmable switches are created for each selected device. When a device trigger fires, HomeKit can be configured to run an automation or scene.",
                 "title": "Advanced Configuration"
             },
             "cameras": {
@@ -35,7 +36,6 @@
             },
             "include_exclude": {
                 "data": {
-                    "devices": "Devices (Triggers Only)",
                     "entities": "Entities",
                     "mode": "Mode"
                 },

--- a/homeassistant/components/homekit/translations/en.json
+++ b/homeassistant/components/homekit/translations/en.json
@@ -35,7 +35,7 @@
             },
             "include_exclude": {
                 "data": {
-                    "devices": "Devices",
+                    "devices": "Devices (Triggers Only)",
                     "entities": "Entities",
                     "mode": "Mode"
                 },

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -1,7 +1,7 @@
 """Class to hold all sensor accessories."""
 import logging
 
-from pyhap.const import CATEGORY_SWITCH
+from pyhap.const import CATEGORY_SENSOR
 
 from homeassistant.helpers.trigger import async_initialize_triggers
 
@@ -24,7 +24,7 @@ class DeviceTriggerAccessory(HomeAccessory):
 
     def __init__(self, *args, device_triggers=None, device_id=None):
         """Initialize a Programmable switch accessory object."""
-        super().__init__(*args, category=CATEGORY_SWITCH, device_id=device_id)
+        super().__init__(*args, category=CATEGORY_SENSOR, device_id=device_id)
         self._device_triggers = device_triggers
         self._remove_triggers = None
         self.triggers = []

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -46,11 +46,10 @@ class DeviceTriggerAccessory(HomeAccessory):
                 )
             )
             serv_stateless_switch.configure_char(CHAR_NAME, value=trigger_name)
-            serv_stateless_switch.configure_char(
-                CHAR_SERVICE_LABEL_INDEX, value=idx + 1
-            )
+            serv_stateless_switch.configure_char(CHAR_SERVICE_LABEL_INDEX, value=idx)
             serv_service_label = self.add_preload_service(SERV_SERVICE_LABEL)
             serv_service_label.configure_char(CHAR_SERVICE_LABEL_NAMESPACE, value=1)
+            serv_stateless_switch.add_linked_service(serv_service_label)
 
     async def async_trigger(self, run_variables, context=None, skip_condition=False):
         """Trigger button press.

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -44,7 +44,9 @@ class DeviceTriggerAccessory(HomeAccessory):
                 )
             )
             serv_stateless_switch.configure_char(CHAR_NAME, value=trigger_name)
-            serv_stateless_switch.configure_char(CHAR_SERVICE_LABEL_INDEX, value=idx)
+            serv_stateless_switch.configure_char(
+                CHAR_SERVICE_LABEL_INDEX, value=idx + 1
+            )
             serv_service_label = self.add_preload_service(
                 SERV_SERVICE_LABEL, [CHAR_NAME]
             )

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -32,11 +32,6 @@ class DeviceTriggerAccessory(HomeAccessory):
             type_ = trigger.get("type")
             subtype = trigger.get("subtype")
             trigger_name = f"{type_} {subtype}" if subtype else type_
-            serv_service_label = self.add_preload_service(
-                SERV_SERVICE_LABEL, [CHAR_NAME]
-            )
-            serv_service_label.configure_char(CHAR_SERVICE_LABEL_NAMESPACE, value=1)
-            serv_service_label.configure_char(CHAR_NAME, value=trigger_name)
             serv_stateless_switch = self.add_preload_service(
                 SERV_STATELESS_PROGRAMMABLE_SWITCH,
                 [CHAR_NAME, CHAR_SERVICE_LABEL_INDEX],
@@ -45,11 +40,16 @@ class DeviceTriggerAccessory(HomeAccessory):
                 serv_stateless_switch.configure_char(
                     CHAR_PROGRAMMABLE_SWITCH_EVENT,
                     value=0,
-                    valid_values={"Press": 0},
+                    valid_values={"SinglePress": 0},
                 )
             )
             serv_stateless_switch.configure_char(CHAR_NAME, value=trigger_name)
             serv_stateless_switch.configure_char(CHAR_SERVICE_LABEL_INDEX, value=idx)
+            serv_service_label = self.add_preload_service(
+                SERV_SERVICE_LABEL, [CHAR_NAME]
+            )
+            serv_service_label.configure_char(CHAR_SERVICE_LABEL_NAMESPACE, value=1)
+            serv_service_label.configure_char(CHAR_NAME, value=trigger_name)
 
     async def async_trigger(self, run_variables, context=None, skip_condition=False):
         """Trigger button press.

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -23,13 +23,12 @@ class DeviceTriggerAccessory(HomeAccessory):
     """Generate a Programmable switch."""
 
     def __init__(self, *args, device_triggers=None, device_id=None):
-        """Initialize a TemperatureSensor accessory object."""
+        """Initialize a Programmable switch accessory object."""
         super().__init__(*args, category=CATEGORY_SWITCH, device_id=device_id)
         self._device_triggers = device_triggers
         self._remove_triggers = None
         self._triggers = []
         for idx, trigger in enumerate(device_triggers):
-            _LOGGER.warning("Set up up trigger: %s", trigger)
             type_ = trigger.get("type")
             subtype = trigger.get("subtype")
             trigger_name = f"{type_} {subtype}" if subtype else type_

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -31,7 +31,9 @@ class DeviceTriggerAccessory(HomeAccessory):
         for idx, trigger in enumerate(device_triggers):
             type_ = trigger.get("type")
             subtype = trigger.get("subtype")
-            trigger_name = f"{type_} {subtype}" if subtype else type_
+            trigger_name = (
+                f"{type_.title()} {subtype.title()}" if subtype else type_.title()
+            )
             serv_stateless_switch = self.add_preload_service(
                 SERV_STATELESS_PROGRAMMABLE_SWITCH,
                 [CHAR_NAME, CHAR_SERVICE_LABEL_INDEX],
@@ -40,7 +42,7 @@ class DeviceTriggerAccessory(HomeAccessory):
                 serv_stateless_switch.configure_char(
                     CHAR_PROGRAMMABLE_SWITCH_EVENT,
                     value=0,
-                    valid_values={"SinglePress": 0},
+                    valid_values={"Trigger": 0},
                 )
             )
             serv_stateless_switch.configure_char(CHAR_NAME, value=trigger_name)

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -46,7 +46,9 @@ class DeviceTriggerAccessory(HomeAccessory):
                 )
             )
             serv_stateless_switch.configure_char(CHAR_NAME, value=trigger_name)
-            serv_stateless_switch.configure_char(CHAR_SERVICE_LABEL_INDEX, value=idx)
+            serv_stateless_switch.configure_char(
+                CHAR_SERVICE_LABEL_INDEX, value=idx + 1
+            )
             serv_service_label = self.add_preload_service(SERV_SERVICE_LABEL)
             serv_service_label.configure_char(CHAR_SERVICE_LABEL_NAMESPACE, value=1)
             serv_stateless_switch.add_linked_service(serv_service_label)

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -27,7 +27,7 @@ class DeviceTriggerAccessory(HomeAccessory):
         super().__init__(*args, category=CATEGORY_SWITCH, device_id=device_id)
         self._device_triggers = device_triggers
         self._remove_triggers = None
-        self._triggers = []
+        self.triggers = []
         for idx, trigger in enumerate(device_triggers):
             type_ = trigger.get("type")
             subtype = trigger.get("subtype")
@@ -41,7 +41,7 @@ class DeviceTriggerAccessory(HomeAccessory):
                 SERV_STATELESS_PROGRAMMABLE_SWITCH,
                 [CHAR_NAME, CHAR_SERVICE_LABEL_INDEX],
             )
-            self._triggers.append(
+            self.triggers.append(
                 serv_stateless_switch.configure_char(
                     CHAR_PROGRAMMABLE_SWITCH_EVENT,
                     value=0,
@@ -61,7 +61,7 @@ class DeviceTriggerAccessory(HomeAccessory):
             reason = f' by {run_variables["trigger"]["description"]}'
         _LOGGER.debug("Button triggered%s - %s", reason, run_variables)
         idx = int(run_variables["trigger"]["idx"])
-        self._triggers[idx].set_value(0)
+        self.triggers[idx].set_value(0)
 
     # Attach the trigger using the helper in async run
     # and detach it in async stop

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -47,11 +47,8 @@ class DeviceTriggerAccessory(HomeAccessory):
             serv_stateless_switch.configure_char(
                 CHAR_SERVICE_LABEL_INDEX, value=idx + 1
             )
-            serv_service_label = self.add_preload_service(
-                SERV_SERVICE_LABEL, [CHAR_NAME]
-            )
+            serv_service_label = self.add_preload_service(SERV_SERVICE_LABEL)
             serv_service_label.configure_char(CHAR_SERVICE_LABEL_NAMESPACE, value=1)
-            serv_service_label.configure_char(CHAR_NAME, value=trigger_name)
 
     async def async_trigger(self, run_variables, context=None, skip_condition=False):
         """Trigger button press.

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -1,0 +1,88 @@
+"""Class to hold all sensor accessories."""
+import logging
+
+from pyhap.const import CATEGORY_SWITCH
+
+from homeassistant.helpers.trigger import async_initialize_triggers
+
+from .accessories import TYPES, HomeAccessory
+from .const import (
+    CHAR_NAME,
+    CHAR_PROGRAMMABLE_SWITCH_EVENT,
+    CHAR_SERVICE_LABEL_INDEX,
+    CHAR_SERVICE_LABEL_NAMESPACE,
+    SERV_SERVICE_LABEL,
+    SERV_STATELESS_PROGRAMMABLE_SWITCH,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@TYPES.register("DeviceTriggerAccessory")
+class DeviceTriggerAccessory(HomeAccessory):
+    """Generate a Programmable switch."""
+
+    def __init__(self, *args, device_triggers=None, device_id=None):
+        """Initialize a TemperatureSensor accessory object."""
+        super().__init__(*args, category=CATEGORY_SWITCH, device_id=device_id)
+        self._device_triggers = device_triggers
+        self._remove_triggers = None
+        self._triggers = []
+        for idx, trigger in enumerate(device_triggers):
+            _LOGGER.warning("Set up up trigger: %s", trigger)
+            type_ = trigger.get("type")
+            subtype = trigger.get("subtype")
+            trigger_name = f"{type_} {subtype}" if subtype else type_
+            serv_service_label = self.add_preload_service(
+                SERV_SERVICE_LABEL, [CHAR_NAME]
+            )
+            serv_service_label.configure_char(CHAR_SERVICE_LABEL_NAMESPACE, value=1)
+            serv_service_label.configure_char(CHAR_NAME, value=trigger_name)
+            serv_stateless_switch = self.add_preload_service(
+                SERV_STATELESS_PROGRAMMABLE_SWITCH,
+                [CHAR_NAME, CHAR_SERVICE_LABEL_INDEX],
+            )
+            self._triggers.append(
+                serv_stateless_switch.configure_char(
+                    CHAR_PROGRAMMABLE_SWITCH_EVENT,
+                    value=0,
+                    valid_values={"Press": 0},
+                )
+            )
+            serv_stateless_switch.configure_char(CHAR_NAME, value=trigger_name)
+            serv_stateless_switch.configure_char(CHAR_SERVICE_LABEL_INDEX, value=idx)
+
+    async def async_trigger(self, run_variables, context=None, skip_condition=False):
+        """Trigger button press.
+
+        This method is a coroutine.
+        """
+        reason = ""
+        if "trigger" in run_variables and "description" in run_variables["trigger"]:
+            reason = f' by {run_variables["trigger"]["description"]}'
+        _LOGGER.debug("Button triggered%s - %s", reason, run_variables)
+        idx = int(run_variables["trigger"]["idx"])
+        self._triggers[idx].set_value(0)
+
+    # Attach the trigger using the helper in async run
+    # and detach it in async stop
+    async def run(self):
+        """Handle accessory driver started event."""
+        self._remove_triggers = await async_initialize_triggers(
+            self.hass,
+            self._device_triggers,
+            self.async_trigger,
+            "homekit",
+            self.display_name,
+            _LOGGER.log,
+        )
+
+    async def stop(self):
+        """Handle accessory driver stop event."""
+        if self._remove_triggers:
+            self._remove_triggers()
+
+    @property
+    def available(self):
+        """Return available."""
+        return True

--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -1,9 +1,12 @@
 """HomeKit session fixtures."""
+from contextlib import suppress
+import os
 from unittest.mock import patch
 
 from pyhap.accessory_driver import AccessoryDriver
 import pytest
 
+from homeassistant.components.device_tracker.legacy import YAML_DEVICES
 from homeassistant.components.homekit.const import EVENT_HOMEKIT_CHANGED
 
 from tests.common import async_capture_events, mock_device_registry, mock_registry
@@ -59,3 +62,11 @@ def device_reg_fixture(hass):
 def entity_reg_fixture(hass):
     """Return an empty, loaded, registry."""
     return mock_registry(hass)
+
+
+@pytest.fixture
+def demo_cleanup(hass):
+    """Clean up device tracker demo file."""
+    yield
+    with suppress(FileNotFoundError):
+        os.remove(hass.config.path(YAML_DEVICES))

--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components.homekit.const import EVENT_HOMEKIT_CHANGED
 
-from tests.common import async_capture_events
+from tests.common import async_capture_events, mock_device_registry, mock_registry
 
 
 @pytest.fixture
@@ -25,6 +25,37 @@ def hk_driver(loop):
 
 
 @pytest.fixture
+def mock_hap(loop, mock_zeroconf):
+    """Return a custom AccessoryDriver instance for HomeKit accessory init."""
+    with patch("pyhap.accessory_driver.AsyncZeroconf"), patch(
+        "pyhap.accessory_driver.AccessoryEncoder"
+    ), patch("pyhap.accessory_driver.HAPServer.async_stop"), patch(
+        "pyhap.accessory_driver.HAPServer.async_start"
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.publish"
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.async_stop"
+    ), patch(
+        "pyhap.accessory_driver.AccessoryDriver.persist"
+    ):
+        yield AccessoryDriver(pincode=b"123-45-678", address="127.0.0.1", loop=loop)
+
+
+@pytest.fixture
 def events(hass):
     """Yield caught homekit_changed events."""
     return async_capture_events(hass, EVENT_HOMEKIT_CHANGED)
+
+
+@pytest.fixture(name="device_reg")
+def device_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture(name="entity_reg")
+def entity_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -407,7 +407,6 @@ async def test_options_flow_devices(
         result["flow_id"],
         user_input={
             "entities": ["climate.old"],
-            "devices": [device_id],
             "include_exclude_mode": "exclude",
         },
     )
@@ -415,7 +414,7 @@ async def test_options_flow_devices(
     with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
         result3 = await hass.config_entries.options.async_configure(
             result2["flow_id"],
-            user_input={"auto_start": True},
+            user_input={"auto_start": True, "devices": [device_id]},
         )
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -368,7 +368,9 @@ async def test_options_flow_exclude_mode_basic(hass):
     }
 
 
-async def test_options_flow_devices(mock_hap, hass, device_reg, entity_reg):
+async def test_options_flow_devices(
+    mock_hap, hass, demo_cleanup, device_reg, entity_reg
+):
     """Test devices can be bridged."""
 
     config_entry = _mock_config_entry_with_options_populated()

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -314,6 +314,7 @@ async def test_options_flow_exclude_mode_advanced(auto_start, hass):
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": auto_start,
+        "devices": [],
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -355,6 +356,7 @@ async def test_options_flow_exclude_mode_basic(hass):
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
+        "devices": [],
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -398,6 +400,7 @@ async def test_options_flow_include_mode_basic(hass):
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
+        "devices": [],
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -454,6 +457,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass):
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
+        "devices": [],
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -500,6 +504,7 @@ async def test_options_flow_exclude_mode_with_cameras(hass):
 
     assert config_entry.options == {
         "auto_start": True,
+        "devices": [],
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -542,6 +547,7 @@ async def test_options_flow_include_mode_with_cameras(hass):
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
+            "devices": [],
             "entities": ["camera.native_h264", "camera.transcode_h264"],
             "include_exclude_mode": "include",
         },
@@ -557,6 +563,7 @@ async def test_options_flow_include_mode_with_cameras(hass):
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
+        "devices": [],
         "mode": "bridge",
         "filter": {
             "exclude_domains": [],
@@ -598,6 +605,7 @@ async def test_options_flow_include_mode_with_cameras(hass):
     assert result["data_schema"]({}) == {
         "entities": ["camera.native_h264", "camera.transcode_h264"],
         "include_exclude_mode": "include",
+        "devices": [],
     }
     schema = result["data_schema"].schema
     assert _get_schema_default(schema, "entities") == [
@@ -627,6 +635,7 @@ async def test_options_flow_include_mode_with_cameras(hass):
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
         "auto_start": True,
+        "devices": [],
         "entity_config": {"camera.native_h264": {}},
         "filter": {
             "exclude_domains": [],
@@ -646,6 +655,7 @@ async def test_options_flow_blocked_when_from_yaml(hass):
         data={CONF_NAME: "mock_name", CONF_PORT: 12345},
         options={
             "auto_start": True,
+            "devices": [],
             "filter": {
                 "include_domains": [
                     "fan",

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1168,6 +1168,7 @@ async def test_homekit_finds_linked_batteries(
             "manufacturer": "Tesla",
             "model": "Powerwall 2",
             "sw_version": "0.16.0",
+            "platform": "test",
             "linked_battery_charging_sensor": "binary_sensor.powerwall_battery_charging",
             "linked_battery_sensor": "sensor.powerwall_battery",
         },
@@ -1444,6 +1445,7 @@ async def test_homekit_finds_linked_motion_sensors(
         {
             "manufacturer": "Ubq",
             "model": "Camera Server",
+            "platform": "test",
             "sw_version": "0.16.0",
             "linked_motion_sensor": "binary_sensor.camera_motion_sensor",
         },
@@ -1508,6 +1510,7 @@ async def test_homekit_finds_linked_humidity_sensors(
         {
             "manufacturer": "Home Assistant",
             "model": "Smart Brainy Clever Humidifier",
+            "platform": "test",
             "sw_version": "0.16.1",
             "linked_humidity_sensor": "sensor.humidifier_humidity_sensor",
         },

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -178,6 +178,7 @@ async def test_setup_min(hass, mock_zeroconf):
         None,
         entry.entry_id,
         entry.title,
+        devices=[],
     )
 
     # Test auto start enabled
@@ -214,6 +215,7 @@ async def test_setup_auto_start_disabled(hass, mock_zeroconf):
         None,
         entry.entry_id,
         entry.title,
+        devices=[],
     )
 
     # Test auto_start disabled
@@ -1250,6 +1252,7 @@ async def test_yaml_updates_update_config_entry_for_name(hass, mock_zeroconf):
         None,
         entry.entry_id,
         entry.title,
+        devices=[],
     )
 
     # Test auto start enabled
@@ -1518,6 +1521,7 @@ async def test_reload(hass, mock_zeroconf):
         None,
         entry.entry_id,
         entry.title,
+        devices=[],
     )
     yaml_path = os.path.join(
         _get_fixtures_base_path(),
@@ -1556,6 +1560,7 @@ async def test_reload(hass, mock_zeroconf):
         None,
         entry.entry_id,
         entry.title,
+        devices=[],
     )
 
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -70,7 +70,7 @@ from homeassistant.util import json as json_util
 
 from .util import PATH_HOMEKIT, async_init_entry, async_init_integration
 
-from tests.common import MockConfigEntry, mock_device_registry, mock_registry
+from tests.common import MockConfigEntry
 
 IP_ADDRESS = "127.0.0.1"
 
@@ -99,18 +99,6 @@ def generate_filter(
 @pytest.fixture(autouse=True)
 def always_patch_driver(hk_driver):
     """Load the hk_driver fixture."""
-
-
-@pytest.fixture(name="device_reg")
-def device_reg_fixture(hass):
-    """Return an empty, loaded, registry."""
-    return mock_device_registry(hass)
-
-
-@pytest.fixture(name="entity_reg")
-def entity_reg_fixture(hass):
-    """Return an empty, loaded, registry."""
-    return mock_registry(hass)
 
 
 def _mock_homekit(hass, entry, homekit_mode, entity_filter=None):

--- a/tests/components/homekit/test_type_triggers.py
+++ b/tests/components/homekit/test_type_triggers.py
@@ -10,7 +10,7 @@ from tests.common import MockConfigEntry, async_get_device_automations
 
 
 async def test_programmable_switch_button_fires_on_trigger(
-    hass, hk_driver, events, device_reg, entity_reg
+    hass, hk_driver, events, demo_cleanup, device_reg, entity_reg
 ):
     """Test that DeviceTriggerAccessory fires the programmable switch event on trigger."""
     hk_driver.publish = MagicMock()

--- a/tests/components/homekit/test_type_triggers.py
+++ b/tests/components/homekit/test_type_triggers.py
@@ -1,0 +1,57 @@
+"""Test different accessory types: Triggers (Programmable Switches)."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.homekit.type_triggers import DeviceTriggerAccessory
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry, async_get_device_automations
+
+
+async def test_programmable_switch_button_fires_on_trigger(
+    hass, hk_driver, events, device_reg, entity_reg
+):
+    """Test that DeviceTriggerAccessory fires the programmable switch event on trigger."""
+    hk_driver.publish = MagicMock()
+
+    demo_config_entry = MockConfigEntry(domain="domain")
+    demo_config_entry.add_to_hass(hass)
+    assert await async_setup_component(hass, "demo", {"demo": {}})
+    await hass.async_block_till_done()
+    hass.states.async_set("light.ceiling_lights", STATE_OFF)
+    await hass.async_block_till_done()
+
+    entry = entity_reg.async_get("light.ceiling_lights")
+    assert entry is not None
+    device_id = entry.device_id
+
+    device_triggers = await async_get_device_automations(hass, "trigger", device_id)
+    acc = DeviceTriggerAccessory(
+        hass,
+        hk_driver,
+        "DeviceTriggerAccessory",
+        None,
+        1,
+        None,
+        device_id=device_id,
+        device_triggers=device_triggers,
+    )
+    await acc.run()
+    await hass.async_block_till_done()
+
+    assert acc.entity_id is None
+    assert acc.device_id is device_id
+    assert acc.available is True
+
+    hk_driver.publish.reset_mock()
+    hass.states.async_set("light.ceiling_lights", STATE_ON)
+    await hass.async_block_till_done()
+    hk_driver.publish.assert_called_once()
+
+    hk_driver.publish.reset_mock()
+    hass.states.async_set("light.ceiling_lights", STATE_OFF)
+    await hass.async_block_till_done()
+    hk_driver.publish.assert_called_once()
+
+    await acc.stop()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bridged device triggers are represented as a single press button on stateless programmable switches. This allows a HomeKit automation to run when a device trigger fires.
Closes #50609

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18913

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
