### PR TITLE
Fix watts unit for homekit_controller power sensors

### DIFF
--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     DEVICE_CLASS_TEMPERATURE,
     LIGHT_LUX,
     PERCENTAGE,
+    POWER_WATT,
     TEMP_CELSIUS,
 )
 from homeassistant.core import callback
@@ -29,19 +30,19 @@ SIMPLE_SENSOR = {
         "name": "Real Time Energy",
         "device_class": DEVICE_CLASS_POWER,
         "state_class": STATE_CLASS_MEASUREMENT,
-        "unit": "watts",
+        "unit": POWER_WATT,
     },
     CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY: {
         "name": "Real Time Energy",
         "device_class": DEVICE_CLASS_POWER,
         "state_class": STATE_CLASS_MEASUREMENT,
-        "unit": "watts",
+        "unit": POWER_WATT,
     },
     CharacteristicsTypes.Vendor.KOOGEEK_REALTIME_ENERGY_2: {
         "name": "Real Time Energy",
         "device_class": DEVICE_CLASS_POWER,
         "state_class": STATE_CLASS_MEASUREMENT,
-        "unit": "watts",
+        "unit": POWER_WATT,
     },
     CharacteristicsTypes.get_uuid(CharacteristicsTypes.TEMPERATURE_CURRENT): {
         "name": "Current Temperature",

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
@@ -1,5 +1,6 @@
 """Make sure that existing Koogeek P1EU support isn't broken."""
 
+from homeassistant.const import POWER_WATT
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.homekit_controller.common import (
@@ -48,6 +49,7 @@ async def test_koogeek_p1eu_setup(hass):
     )
     state = await helper.poll_and_get_state()
     assert state.attributes["friendly_name"] == "Koogeek-P1-A00AA0 - Real Time Energy"
+    assert state.attributes["unit_of_measurement"] == POWER_WATT
 
     # The sensor and switch should be part of the same device
     assert entry.device_id == device.id

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_sw2.py
@@ -6,6 +6,7 @@ This Koogeek device has a custom power sensor that extra handling.
 It should have 2 entities - the actual switch and a sensor for power usage.
 """
 
+from homeassistant.const import POWER_WATT
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.homekit_controller.common import (
@@ -58,6 +59,7 @@ async def test_koogeek_ls1_setup(hass):
 
     # Assert that the friendly name is detected correctly
     assert state.attributes["friendly_name"] == "Koogeek-SW2-187A91 - Real Time Energy"
+    assert state.attributes["unit_of_measurement"] == POWER_WATT
 
     device_registry = dr.async_get(hass)
 


### PR DESCRIPTION
## Breaking change

If you have a power sensor for a Eve Energy or Koogeek P1EU/SW2, the units for that sensor has changed from `watts` to `W` to properly follow Home Assistant standards.

## Proposed change

We weren't using the `POWER_WATTS` constant, and as a result were wrong/inconsistent with other sensors in HA.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
