### PR TITLE
Add user to homeassistant system health

### DIFF
--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -4,6 +4,7 @@
       "arch": "CPU Architecture",
       "dev": "Development",
       "docker": "Docker",
+      "user": "User",
       "hassio": "Supervisor",
       "installation_type": "Installation Type",
       "os_name": "Operating System Family",

--- a/homeassistant/components/homeassistant/system_health.py
+++ b/homeassistant/components/homeassistant/system_health.py
@@ -22,6 +22,7 @@ async def system_health_info(hass):
         "dev": info.get("dev"),
         "hassio": info.get("hassio"),
         "docker": info.get("docker"),
+        "user": info.get("user"),
         "virtualenv": info.get("virtualenv"),
         "python_version": info.get("python_version"),
         "os_name": info.get("os_name"),

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -1,6 +1,7 @@
 """Helper to gather system info."""
 from __future__ import annotations
 
+from getpass import getuser
 import os
 import platform
 from typing import Any
@@ -22,6 +23,7 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
         "virtualenv": is_virtual_env(),
         "python_version": platform.python_version(),
         "docker": False,
+        "user": getuser(),
         "arch": platform.machine(),
         "timezone": str(hass.config.time_zone),
         "os_name": platform.system(),
@@ -36,7 +38,7 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
         info_object["docker"] = os.path.isfile("/.dockerenv")
 
     # Determine installation type on current data
-    if info_object["docker"]:
+    if info_object["docker"] and info_object["user"] == "root":
         info_object["installation_type"] = "Home Assistant Container"
     elif is_virtual_env():
         info_object["installation_type"] = "Home Assistant Core"

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -38,8 +38,9 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
         info_object["docker"] = os.path.isfile("/.dockerenv")
 
     # Determine installation type on current data
-    if info_object["docker"] and info_object["user"] == "root":
-        info_object["installation_type"] = "Home Assistant Container"
+    if info_object["docker"]:
+        if info_object["user"] == "root":
+            info_object["installation_type"] = "Home Assistant Container"
     elif is_virtual_env():
         info_object["installation_type"] = "Home Assistant Core"
 

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -1,5 +1,6 @@
 """Tests for the system info helper."""
 import json
+from unittest.mock import patch
 
 from homeassistant.const import __version__ as current_version
 
@@ -9,4 +10,20 @@ async def test_get_system_info(hass):
     info = await hass.helpers.system_info.async_get_system_info()
     assert isinstance(info, dict)
     assert info["version"] == current_version
+    assert info["user"] is not None
     assert json.dumps(info) is not None
+
+
+async def test_container_installationtype(hass):
+    """Test container installation type."""
+    with patch("platform.system", return_value="Linux"), patch(
+        "os.path.isfile", return_value=True
+    ):
+        info = await hass.helpers.system_info.async_get_system_info()
+        assert info["installation_type"] == "Home Assistant Container"
+
+    with patch("platform.system", return_value="Linux"), patch(
+        "os.path.isfile", return_value=True
+    ), patch("homeassistant.helpers.system_info.getuser", return_value="user"):
+        info = await hass.helpers.system_info.async_get_system_info()
+        assert info["installation_type"] == "Unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Add "user" to homeassistant system health information
- Require this to be "root" to set the installation type to "Home Assistant Container" as noted in the ADR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
