### PR TITLE
Use `SelectEntityDescription` for Xiaomi Miio integration

### DIFF
--- a/homeassistant/components/xiaomi_miio/select.py
+++ b/homeassistant/components/xiaomi_miio/select.py
@@ -47,7 +47,7 @@ SELECTOR_TYPES = {
         name="Led Brightness",
         icon="mdi:brightness-6",
         device_class="xiaomi_miio__led_brightness",
-        options=("Bright", "Dim", "Off"),
+        options=("bright", "dim", "off"),
     ),
 }
 
@@ -122,7 +122,7 @@ class XiaomiAirHumidifierSelector(XiaomiSelector):
     @property
     def current_option(self):
         """Return the current option."""
-        return self.led_brightness
+        return self.led_brightness.lower()
 
     async def async_select_option(self, option: str) -> None:
         """Set an option of the miio device."""
@@ -130,7 +130,7 @@ class XiaomiAirHumidifierSelector(XiaomiSelector):
             raise ValueError(
                 f"Selection '{option}' is not a valid {self.entity_description.name}"
             )
-        await self.async_set_led_brightness(option)
+        await self.async_set_led_brightness(option.title())
 
     @property
     def led_brightness(self):

--- a/homeassistant/components/xiaomi_miio/select.py
+++ b/homeassistant/components/xiaomi_miio/select.py
@@ -20,7 +20,6 @@ from .const import (
     KEY_DEVICE,
     MODELS_HUMIDIFIER_MIIO,
     MODELS_HUMIDIFIER_MIOT,
-    SERVICE_SET_LED_BRIGHTNESS,
 )
 from .device import XiaomiCoordinatedMiioEntity
 
@@ -50,7 +49,6 @@ SELECTOR_TYPES = {
         icon="mdi:brightness-6",
         device_class="xiaomi_miio__led_brightness",
         options=("Bright", "Dim", "Off"),
-        service=SERVICE_SET_LED_BRIGHTNESS,
     ),
 }
 

--- a/homeassistant/components/xiaomi_miio/select.py
+++ b/homeassistant/components/xiaomi_miio/select.py
@@ -39,7 +39,6 @@ class XiaomiMiioSelectDescription(SelectEntityDescription):
     """A class that describes select entities."""
 
     options: tuple = ()
-    service: str | None = None
 
 
 SELECTOR_TYPES = {

--- a/homeassistant/components/xiaomi_miio/select.py
+++ b/homeassistant/components/xiaomi_miio/select.py
@@ -44,7 +44,7 @@ class XiaomiMiioSelectDescription(SelectEntityDescription):
 SELECTOR_TYPES = {
     FEATURE_SET_LED_BRIGHTNESS: XiaomiMiioSelectDescription(
         key=ATTR_LED_BRIGHTNESS,
-        name="Led brightness",
+        name="Led Brightness",
         icon="mdi:brightness-6",
         device_class="xiaomi_miio__led_brightness",
         options=("Bright", "Dim", "Off"),

--- a/homeassistant/components/xiaomi_miio/select.py
+++ b/homeassistant/components/xiaomi_miio/select.py
@@ -1,11 +1,13 @@
 """Support led_brightness for Mi Air Humidifier."""
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 
 from miio.airhumidifier import LedBrightness as AirhumidifierLedBrightness
 from miio.airhumidifier_miot import LedBrightness as AirhumidifierMiotLedBrightness
 
-from homeassistant.components.select import SelectEntity
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import callback
 
 from .const import (
@@ -34,22 +36,20 @@ LED_BRIGHTNESS_REVERSE_MAP_MIOT = {
 
 
 @dataclass
-class SelectorType:
-    """Class that holds device specific info for a xiaomi aqara or humidifier selectors."""
+class XiaomiMiioSelectDescription(SelectEntityDescription):
+    """A class that describes select entities."""
 
-    name: str = None
-    icon: str = None
-    short_name: str = None
-    options: list = None
-    service: str = None
+    options: tuple = ()
+    service: str | None = None
 
 
 SELECTOR_TYPES = {
-    FEATURE_SET_LED_BRIGHTNESS: SelectorType(
+    FEATURE_SET_LED_BRIGHTNESS: XiaomiMiioSelectDescription(
+        key=ATTR_LED_BRIGHTNESS,
         name="Led brightness",
         icon="mdi:brightness-6",
-        short_name=ATTR_LED_BRIGHTNESS,
-        options=["Bright", "Dim", "Off"],
+        device_class="xiaomi_miio__led_brightness",
+        options=("Bright", "Dim", "Off"),
         service=SERVICE_SET_LED_BRIGHTNESS,
     ),
 }
@@ -71,15 +71,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     else:
         return
 
-    selector = SELECTOR_TYPES[FEATURE_SET_LED_BRIGHTNESS]
+    description = SELECTOR_TYPES[FEATURE_SET_LED_BRIGHTNESS]
     entities.append(
         entity_class(
-            f"{config_entry.title} {selector.name}",
+            f"{config_entry.title} {description.name}",
             device,
             config_entry,
-            f"{selector.short_name}_{config_entry.unique_id}",
-            selector,
+            f"{description.key}_{config_entry.unique_id}",
             hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR],
+            description,
         )
     )
 
@@ -89,12 +89,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class XiaomiSelector(XiaomiCoordinatedMiioEntity, SelectEntity):
     """Representation of a generic Xiaomi attribute selector."""
 
-    def __init__(self, name, device, entry, unique_id, selector, coordinator):
+    def __init__(self, name, device, entry, unique_id, coordinator, description):
         """Initialize the generic Xiaomi attribute selector."""
         super().__init__(name, device, entry, unique_id, coordinator)
-        self._attr_icon = selector.icon
-        self._controller = selector
-        self._attr_options = self._controller.options
+        self._attr_options = list(description.options)
+        self.entity_description = description
 
     @staticmethod
     def _extract_value_from_attribute(state, attribute):
@@ -108,18 +107,18 @@ class XiaomiSelector(XiaomiCoordinatedMiioEntity, SelectEntity):
 class XiaomiAirHumidifierSelector(XiaomiSelector):
     """Representation of a Xiaomi Air Humidifier selector."""
 
-    def __init__(self, name, device, entry, unique_id, controller, coordinator):
+    def __init__(self, name, device, entry, unique_id, coordinator, description):
         """Initialize the plug switch."""
-        super().__init__(name, device, entry, unique_id, controller, coordinator)
+        super().__init__(name, device, entry, unique_id, coordinator, description)
         self._current_led_brightness = self._extract_value_from_attribute(
-            self.coordinator.data, self._controller.short_name
+            self.coordinator.data, self.entity_description.key
         )
 
     @callback
     def _handle_coordinator_update(self):
         """Fetch state from the device."""
         self._current_led_brightness = self._extract_value_from_attribute(
-            self.coordinator.data, self._controller.short_name
+            self.coordinator.data, self.entity_description.key
         )
         self.async_write_ha_state()
 
@@ -132,7 +131,7 @@ class XiaomiAirHumidifierSelector(XiaomiSelector):
         """Set an option of the miio device."""
         if option not in self.options:
             raise ValueError(
-                f"Selection '{option}' is not a valid {self._controller.name}"
+                f"Selection '{option}' is not a valid {self.entity_description.name}"
             )
         await self.async_set_led_brightness(option)
 

--- a/homeassistant/components/xiaomi_miio/strings.select.json
+++ b/homeassistant/components/xiaomi_miio/strings.select.json
@@ -1,9 +1,9 @@
 {
     "state": {
       "xiaomi_miio__led_brightness": {
-        "Bright": "Bright",
-        "Dim": "Dim",
-        "Off": "Off"
+        "bright": "Bright",
+        "dim": "Dim",
+        "off": "Off"
       }
     }
   }

--- a/homeassistant/components/xiaomi_miio/strings.select.json
+++ b/homeassistant/components/xiaomi_miio/strings.select.json
@@ -1,0 +1,9 @@
+{
+    "state": {
+      "xiaomi_miio__led_brightness": {
+        "Bright": "Bright",
+        "Dim": "Dim",
+        "Off": "Off"
+      }
+    }
+  }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates `select` platform to use `SelectEntityDescription` class and adds the ability to translate `led brightness` states.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
