### PR TITLE
Convert last properties in modbus to _attr_variable

### DIFF
--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     CONF_STRUCTURE,
     STATE_ON,
 )
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import Entity, ToggleEntity
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -120,48 +120,46 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
         registers = self._swap_registers(registers)
         byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
         if self._data_type == DATA_TYPE_STRING:
-            self._value = byte_string.decode()
-        else:
-            val = struct.unpack(self._structure, byte_string)
+            return byte_string.decode()
 
-            # Issue: https://github.com/home-assistant/core/issues/41944
-            # If unpack() returns a tuple greater than 1, don't try to process the value.
-            # Instead, return the values of unpack(...) separated by commas.
-            if len(val) > 1:
-                # Apply scale and precision to floats and ints
-                v_result = []
-                for entry in val:
-                    v_temp = self._scale * entry + self._offset
-
-                    # We could convert int to float, and the code would still work; however
-                    # we lose some precision, and unit tests will fail. Therefore, we do
-                    # the conversion only when it's absolutely necessary.
-                    if isinstance(v_temp, int) and self._precision == 0:
-                        v_result.append(str(v_temp))
-                    else:
-                        v_result.append(f"{float(v_temp):.{self._precision}f}")
-                self._value = ",".join(map(str, v_result))
-            else:
-                # Apply scale and precision to floats and ints
-                val = self._scale * val[0] + self._offset
+        val = struct.unpack(self._structure, byte_string)
+        # Issue: https://github.com/home-assistant/core/issues/41944
+        # If unpack() returns a tuple greater than 1, don't try to process the value.
+        # Instead, return the values of unpack(...) separated by commas.
+        if len(val) > 1:
+            # Apply scale and precision to floats and ints
+            v_result = []
+            for entry in val:
+                v_temp = self._scale * entry + self._offset
 
                 # We could convert int to float, and the code would still work; however
                 # we lose some precision, and unit tests will fail. Therefore, we do
                 # the conversion only when it's absolutely necessary.
-                if isinstance(val, int) and self._precision == 0:
-                    self._value = str(val)
+                if isinstance(v_temp, int) and self._precision == 0:
+                    v_result.append(str(v_temp))
                 else:
-                    self._value = f"{float(val):.{self._precision}f}"
+                    v_result.append(f"{float(v_temp):.{self._precision}f}")
+            return ",".join(map(str, v_result))
+
+        # Apply scale and precision to floats and ints
+        val = self._scale * val[0] + self._offset
+
+        # We could convert int to float, and the code would still work; however
+        # we lose some precision, and unit tests will fail. Therefore, we do
+        # the conversion only when it's absolutely necessary.
+        if isinstance(val, int) and self._precision == 0:
+            return str(val)
+        return f"{float(val):.{self._precision}f}"
 
 
-class BaseSwitch(BasePlatform, RestoreEntity):
+class BaseSwitch(BasePlatform, ToggleEntity, RestoreEntity):
     """Base class representing a Modbus switch."""
 
     def __init__(self, hub: ModbusHub, config: dict) -> None:
         """Initialize the switch."""
         config[CONF_INPUT_TYPE] = ""
         super().__init__(hub, config)
-        self._is_on = None
+        self._attr_is_on = False
         convert = {
             CALL_TYPE_REGISTER_HOLDING: (
                 CALL_TYPE_REGISTER_HOLDING,
@@ -198,12 +196,7 @@ class BaseSwitch(BasePlatform, RestoreEntity):
         await self.async_base_added_to_hass()
         state = await self.async_get_last_state()
         if state:
-            self._is_on = state.state == STATE_ON
-
-    @property
-    def is_on(self):
-        """Return true if switch is on."""
-        return self._is_on
+            self._attr_is_on = state.state == STATE_ON
 
     async def async_turn(self, command):
         """Evaluate switch result."""
@@ -217,7 +210,7 @@ class BaseSwitch(BasePlatform, RestoreEntity):
 
         self._attr_available = True
         if not self._verify_active:
-            self._is_on = command == self.command_on
+            self._attr_is_on = command == self.command_on
             self.async_write_ha_state()
             return
 
@@ -254,13 +247,13 @@ class BaseSwitch(BasePlatform, RestoreEntity):
 
         self._attr_available = True
         if self._verify_type == CALL_TYPE_COIL:
-            self._is_on = bool(result.bits[0] & 1)
+            self._attr_is_on = bool(result.bits[0] & 1)
         else:
             value = int(result.registers[0])
             if value == self._state_on:
-                self._is_on = True
+                self._attr_is_on = True
             elif value == self._state_off:
-                self._is_on = False
+                self._attr_is_on = False
             elif value is not None:
                 _LOGGER.error(
                     "Unexpected response from modbus device slave %s register %s, got 0x%2x",

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -43,14 +43,7 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
         await self.async_base_added_to_hass()
         state = await self.async_get_last_state()
         if state:
-            self._value = state.state == STATE_ON
-        else:
-            self._value = None
-
-    @property
-    def is_on(self):
-        """Return the state of the sensor."""
-        return self._value
+            self._attr_is_on = state.state == STATE_ON
 
     async def async_update(self, now=None):
         """Update the state of the sensor."""
@@ -68,6 +61,6 @@ class ModbusBinarySensor(BasePlatform, RestoreEntity, BinarySensorEntity):
             self.async_write_ha_state()
             return
 
-        self._value = result.bits[0] & 1
+        self._attr_is_on = result.bits[0] & 1
         self._attr_available = True
         self.async_write_ha_state()

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -165,8 +165,7 @@ class ModbusThermostat(BaseStructPlatform, RestoreEntity, ClimateEntity):
             self._attr_available = False
             return -1
 
-        self.unpack_structure_result(result.registers)
-
+        self._value = self.unpack_structure_result(result.registers)
         self._attr_available = True
 
         if self._value is None:

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -109,22 +109,13 @@ class ModbusCover(BasePlatform, CoverEntity, RestoreEntity):
                 STATE_UNAVAILABLE: None,
                 STATE_UNKNOWN: None,
             }
-            self._value = convert[state.state]
+            self._set_attr_state(convert[state.state])
 
-    @property
-    def is_opening(self):
-        """Return if the cover is opening or not."""
-        return self._value == self._state_opening
-
-    @property
-    def is_closing(self):
-        """Return if the cover is closing or not."""
-        return self._value == self._state_closing
-
-    @property
-    def is_closed(self):
-        """Return if the cover is closed or not."""
-        return self._value == self._state_closed
+    def _set_attr_state(self, value):
+        """Convert received value to HA state."""
+        self._attr_is_opening = value == self._state_opening
+        self._attr_is_closing = value == self._state_closing
+        self._attr_is_closed = value == self._state_closed
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""
@@ -160,7 +151,7 @@ class ModbusCover(BasePlatform, CoverEntity, RestoreEntity):
             return None
         self._attr_available = True
         if self._input_type == CALL_TYPE_COIL:
-            self._value = bool(result.bits[0] & 1)
+            self._set_attr_state(bool(result.bits[0] & 1))
         else:
-            self._value = int(result.registers[0])
+            self._set_attr_state(int(result.registers[0]))
         self.async_write_ha_state()

--- a/homeassistant/components/modbus/fan.py
+++ b/homeassistant/components/modbus/fan.py
@@ -42,3 +42,11 @@ class ModbusFan(BaseSwitch, FanEntity):
     ) -> None:
         """Set fan on."""
         await self.async_turn(self.command_on)
+
+    @property
+    def is_on(self):
+        """Return true if fan is on.
+
+        This is needed due to the ongoing conversion of fan.
+        """
+        return self._attr_is_on

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -54,12 +54,7 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreEntity, SensorEntity):
         await self.async_base_added_to_hass()
         state = await self.async_get_last_state()
         if state:
-            self._value = state.state
-
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._value
+            self._attr_state = state.state
 
     async def async_update(self, now=None):
         """Update the state of the sensor."""
@@ -73,6 +68,6 @@ class ModbusRegisterSensor(BaseStructPlatform, RestoreEntity, SensorEntity):
             self.async_write_ha_state()
             return
 
-        self.unpack_structure_result(result.registers)
+        self._attr_state = self.unpack_structure_result(result.registers)
         self._attr_available = True
         self.async_write_ha_state()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Last set of @property with one exception, the fan entity needs the is_on property, seems to be because the fan entity itself is being transformed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
