### PR TITLE
Limit zwave_js meter sensor last reset

### DIFF
--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -33,7 +33,8 @@ ID_LOCK_CONFIG_PARAMETER_SENSOR = (
     "sensor.z_wave_module_for_id_lock_150_and_101_config_parameter_door_lock_mode"
 )
 ZEN_31_ENTITY = "light.kitchen_under_cabinet_lights"
-METER_SENSOR = "sensor.smart_switch_6_electric_consumed_v"
+METER_ENERGY_SENSOR = "sensor.smart_switch_6_electric_consumed_kwh"
+METER_VOLTAGE_SENSOR = "sensor.smart_switch_6_electric_consumed_v"
 
 DATETIME_ZERO = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 DATETIME_LAST_RESET = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -203,7 +203,7 @@ async def test_reset_meter(
     client.async_send_command.return_value = {}
     client.async_send_command_no_wait.return_value = {}
 
-    # Validate that non accumulating meters does not have a last reset attribute
+    # Validate that non accumulating meter does not have a last reset attribute
 
     assert ATTR_LAST_RESET not in hass.states.get(METER_VOLTAGE_SENSOR).attributes
 
@@ -237,7 +237,7 @@ async def test_reset_meter(
     assert args["endpoint"] == 0
     assert args["args"] == []
 
-    # Validate that non accumulating meters does not have a last reset attribute
+    # Validate that non accumulating meter does not have a last reset attribute
 
     assert ATTR_LAST_RESET not in hass.states.get(METER_VOLTAGE_SENSOR).attributes
 
@@ -262,7 +262,7 @@ async def test_reset_meter(
     assert args["endpoint"] == 0
     assert args["args"] == [{"type": 1, "targetValue": 2}]
 
-    # Validate that non accumulating meters does not have a last reset attribute
+    # Validate that non accumulating meter does not have a last reset attribute
 
     assert ATTR_LAST_RESET not in hass.states.get(METER_VOLTAGE_SENSOR).attributes
 
@@ -282,6 +282,6 @@ async def test_restore_last_reset(
         == DATETIME_LAST_RESET.isoformat()
     )
 
-    # Validate that non accumulating meters does not have a last reset attribute
+    # Validate that non accumulating meter does not have a last reset attribute
 
     assert ATTR_LAST_RESET not in hass.states.get(METER_VOLTAGE_SENSOR).attributes

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -36,7 +36,8 @@ from .common import (
     HUMIDITY_SENSOR,
     ID_LOCK_CONFIG_PARAMETER_SENSOR,
     INDICATOR_SENSOR,
-    METER_SENSOR,
+    METER_ENERGY_SENSOR,
+    METER_VOLTAGE_SENSOR,
     NOTIFICATION_MOTION_SENSOR,
     POWER_SENSOR,
     VOLTAGE_SENSOR,
@@ -202,9 +203,13 @@ async def test_reset_meter(
     client.async_send_command.return_value = {}
     client.async_send_command_no_wait.return_value = {}
 
+    # Validate that non accumulating meters does not have a last reset attribute
+
+    assert ATTR_LAST_RESET not in hass.states.get(METER_VOLTAGE_SENSOR).attributes
+
     # Validate that the sensor last reset is starting from nothing
     assert (
-        hass.states.get(METER_SENSOR).attributes[ATTR_LAST_RESET]
+        hass.states.get(METER_ENERGY_SENSOR).attributes[ATTR_LAST_RESET]
         == DATETIME_ZERO.isoformat()
     )
 
@@ -215,13 +220,13 @@ async def test_reset_meter(
             DOMAIN,
             SERVICE_RESET_METER,
             {
-                ATTR_ENTITY_ID: METER_SENSOR,
+                ATTR_ENTITY_ID: METER_ENERGY_SENSOR,
             },
             blocking=True,
         )
 
     assert (
-        hass.states.get(METER_SENSOR).attributes[ATTR_LAST_RESET]
+        hass.states.get(METER_ENERGY_SENSOR).attributes[ATTR_LAST_RESET]
         == DATETIME_LAST_RESET.isoformat()
     )
 
@@ -232,6 +237,10 @@ async def test_reset_meter(
     assert args["endpoint"] == 0
     assert args["args"] == []
 
+    # Validate that non accumulating meters does not have a last reset attribute
+
+    assert ATTR_LAST_RESET not in hass.states.get(METER_VOLTAGE_SENSOR).attributes
+
     client.async_send_command_no_wait.reset_mock()
 
     # Test successful meter reset call with options
@@ -239,7 +248,7 @@ async def test_reset_meter(
         DOMAIN,
         SERVICE_RESET_METER,
         {
-            ATTR_ENTITY_ID: METER_SENSOR,
+            ATTR_ENTITY_ID: METER_ENERGY_SENSOR,
             ATTR_METER_TYPE: 1,
             ATTR_VALUE: 2,
         },
@@ -253,6 +262,10 @@ async def test_reset_meter(
     assert args["endpoint"] == 0
     assert args["args"] == [{"type": 1, "targetValue": 2}]
 
+    # Validate that non accumulating meters does not have a last reset attribute
+
+    assert ATTR_LAST_RESET not in hass.states.get(METER_VOLTAGE_SENSOR).attributes
+
     client.async_send_command_no_wait.reset_mock()
 
 
@@ -265,6 +278,10 @@ async def test_restore_last_reset(
 ):
     """Test restoring last_reset on setup."""
     assert (
-        hass.states.get(METER_SENSOR).attributes[ATTR_LAST_RESET]
+        hass.states.get(METER_ENERGY_SENSOR).attributes[ATTR_LAST_RESET]
         == DATETIME_LAST_RESET.isoformat()
     )
+
+    # Validate that non accumulating meters does not have a last reset attribute
+
+    assert ATTR_LAST_RESET not in hass.states.get(METER_VOLTAGE_SENSOR).attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We only want to set last_reset attribute for accumulating meter types. Fix this for now by targeting energy sensors specifically. A follow up should be done to include the remaining accumulating types according to Z-Wave specs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
