### PR TITLE
Always mock SubscriptionRegistry & DiscoveryResponder for wemo tests

### DIFF
--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -43,9 +43,8 @@ async def async_pywemo_registry_fixture():
 @pytest.fixture(name="pywemo_discovery_responder", autouse=True)
 def pywemo_discovery_responder_fixture():
     """Fixture for the DiscoveryResponder instance."""
-    discovery_responder = create_autospec(pywemo.ssdp.DiscoveryResponder, instance=True)
-    with patch("pywemo.ssdp.DiscoveryResponder", return_value=discovery_responder):
-        yield discovery_responder
+    with patch("pywemo.ssdp.DiscoveryResponder", autospec=True):
+        yield
 
 
 @pytest.fixture(name="pywemo_device")

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -22,8 +22,8 @@ def pywemo_model_fixture():
     return "LightSwitch"
 
 
-@pytest.fixture(name="pywemo_registry")
-def pywemo_registry_fixture():
+@pytest.fixture(name="pywemo_registry", autouse=True)
+async def async_pywemo_registry_fixture():
     """Fixture for SubscriptionRegistry instances."""
     registry = create_autospec(pywemo.SubscriptionRegistry, instance=True)
 
@@ -38,6 +38,14 @@ def pywemo_registry_fixture():
 
     with patch("pywemo.SubscriptionRegistry", return_value=registry):
         yield registry
+
+
+@pytest.fixture(name="pywemo_discovery_responder", autouse=True)
+def pywemo_discovery_responder_fixture():
+    """Fixture for the DiscoveryResponder instance."""
+    discovery_responder = create_autospec(pywemo.ssdp.DiscoveryResponder, instance=True)
+    with patch("pywemo.ssdp.DiscoveryResponder", return_value=discovery_responder):
+        yield discovery_responder
 
 
 @pytest.fixture(name="pywemo_device")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
Always use mocks for the pyWeMo SubscriptionRegistry & DiscoveryResponder instances in the wemo tests. This fixes a performance issue when running the tests.

`pytest tests/components/wemo --durations=10`

**Before**
```
========================================================= slowest 10 durations ==========================================================
1.10s teardown tests/components/wemo/test_init.py::test_static_config_with_port[pyloop]
1.09s teardown tests/components/wemo/test_init.py::test_config_no_static[pyloop]
1.09s teardown tests/components/wemo/test_wemo_device.py::test_async_register_device_longpress_fails[pyloop]
1.09s teardown tests/components/wemo/test_binary_sensor.py::test_binary_sensor_update_entity[pyloop]
1.09s teardown tests/components/wemo/test_switch.py::test_switch_registry_state_callback[pyloop]
1.09s teardown tests/components/wemo/test_light_bridge.py::test_async_update_with_timeout_and_recovery[pyloop]
1.09s teardown tests/components/wemo/test_init.py::test_static_config_without_port[pyloop]
1.08s teardown tests/components/wemo/test_init.py::test_static_duplicate_static_entry[pyloop]
1.08s teardown tests/components/wemo/test_light_dimmer.py::test_async_locked_update_with_exception[pyloop]
1.08s teardown tests/components/wemo/test_switch.py::test_async_update_locked_callback_and_update[pyloop]
```

**After**
```
========================================================= slowest 10 durations ==========================================================
0.19s setup    tests/components/wemo/test_binary_sensor.py::test_async_update_locked_callback_and_update[pyloop]
0.12s setup    tests/components/wemo/test_fan.py::test_fan_set_humidity_service[pyloop-50-1]
0.12s setup    tests/components/wemo/test_light_bridge.py::test_async_locked_update_with_exception[pyloop]
0.12s setup    tests/components/wemo/test_light_dimmer.py::test_async_update_locked_multiple_updates[pyloop]
0.12s setup    tests/components/wemo/test_sensor.py::TestInsightTodayEnergy::test_async_update_locked_multiple_callbacks[pyloop]
0.12s setup    tests/components/wemo/test_sensor.py::TestInsightCurrentPower::test_async_update_locked_multiple_updates[pyloop]
0.12s setup    tests/components/wemo/test_light_bridge.py::test_async_update_locked_multiple_updates[pyloop]
0.12s setup    tests/components/wemo/test_fan.py::test_fan_set_humidity_service[pyloop-100-4]
0.12s teardown tests/components/wemo/test_fan.py::test_async_update_locked_multiple_callbacks[pyloop]
0.12s setup    tests/components/wemo/test_light_bridge.py::test_async_update_with_timeout_and_recovery[pyloop]
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53879
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
