### PR TITLE
Sonos add bass & treble EQ option

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -126,6 +126,7 @@ ATTR_SPEECH_ENHANCE = "speech_enhance"
 ATTR_QUEUE_POSITION = "queue_position"
 ATTR_STATUS_LIGHT = "status_light"
 ATTR_EQ_BASS = "bass_level"
+ATTR_EQ_TREBLE = "treble_level"
 
 
 async def async_setup_entry(
@@ -237,6 +238,9 @@ async def async_setup_entry(
             vol.Optional(ATTR_SPEECH_ENHANCE): cv.boolean,
             vol.Optional(ATTR_STATUS_LIGHT): cv.boolean,
             vol.Optional(ATTR_EQ_BASS): vol.All(
+                vol.Coerce(int), vol.Range(min=-10, max=10)
+            ),
+            vol.Optional(ATTR_EQ_TREBLE): vol.All(
                 vol.Coerce(int), vol.Range(min=-10, max=10)
             ),
         },
@@ -619,6 +623,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         speech_enhance: bool | None = None,
         status_light: bool | None = None,
         bass_level: int | None = None,
+        treble_level: int | None = None,
     ) -> None:
         """Modify playback options."""
         if buttons_enabled is not None:
@@ -639,6 +644,9 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         if bass_level is not None:
             self.soco.bass = bass_level
 
+        if treble_level is not None:
+            self.soco.treble = treble_level
+
     @soco_error()
     def play_queue(self, queue_position: int = 0) -> None:
         """Start playing the queue."""
@@ -658,6 +666,9 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
 
         if self.speaker.bass_level is not None:
             attributes[ATTR_EQ_BASS] = self.speaker.bass_level
+
+        if self.speaker.treble_level is not None:
+            attributes[ATTR_EQ_TREBLE] = self.speaker.treble_level
 
         if self.speaker.night_mode is not None:
             attributes[ATTR_NIGHT_SOUND] = self.speaker.night_mode

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -125,6 +125,7 @@ ATTR_NIGHT_SOUND = "night_sound"
 ATTR_SPEECH_ENHANCE = "speech_enhance"
 ATTR_QUEUE_POSITION = "queue_position"
 ATTR_STATUS_LIGHT = "status_light"
+ATTR_EQ_BASS = "bass_level"
 
 
 async def async_setup_entry(
@@ -221,7 +222,6 @@ async def async_setup_entry(
         {
             vol.Required(ATTR_ALARM_ID): cv.positive_int,
             vol.Optional(ATTR_TIME): cv.time,
-            vol.Optional(ATTR_VOLUME): cv.small_float,
             vol.Optional(ATTR_ENABLED): cv.boolean,
             vol.Optional(ATTR_INCLUDE_LINKED_ZONES): cv.boolean,
         },
@@ -236,6 +236,9 @@ async def async_setup_entry(
             vol.Optional(ATTR_NIGHT_SOUND): cv.boolean,
             vol.Optional(ATTR_SPEECH_ENHANCE): cv.boolean,
             vol.Optional(ATTR_STATUS_LIGHT): cv.boolean,
+            vol.Optional(ATTR_EQ_BASS): vol.All(
+                vol.Coerce(int), vol.Range(min=-10, max=10)
+            ),
         },
         "set_option",
     )
@@ -615,6 +618,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         night_sound: bool | None = None,
         speech_enhance: bool | None = None,
         status_light: bool | None = None,
+        bass_level: int | None = None,
     ) -> None:
         """Modify playback options."""
         if buttons_enabled is not None:
@@ -632,6 +636,9 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         if status_light is not None:
             self.soco.status_light = status_light
 
+        if bass_level is not None:
+            self.soco.bass = bass_level
+
     @soco_error()
     def play_queue(self, queue_position: int = 0) -> None:
         """Start playing the queue."""
@@ -648,6 +655,9 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         attributes: dict[str, Any] = {
             ATTR_SONOS_GROUP: self.speaker.sonos_group_entities
         }
+
+        if self.speaker.bass_level is not None:
+            attributes[ATTR_EQ_BASS] = self.speaker.bass_level
 
         if self.speaker.night_mode is not None:
             attributes[ATTR_NIGHT_SOUND] = self.speaker.night_mode

--- a/homeassistant/components/sonos/services.yaml
+++ b/homeassistant/components/sonos/services.yaml
@@ -121,6 +121,14 @@ set_option:
       description: Enable Status (LED) Light
       selector:
         boolean:
+    bass_level:
+      name: Bass Level
+      description: Bass level for EQ.
+      selector:
+        number:
+          min: -10
+          max: 10
+          mode: box
 
 play_queue:
   name: Play queue

--- a/homeassistant/components/sonos/services.yaml
+++ b/homeassistant/components/sonos/services.yaml
@@ -129,6 +129,14 @@ set_option:
           min: -10
           max: 10
           mode: box
+    treble_level:
+      name: Treble Level
+      description: Treble level for EQ.
+      selector:
+        number:
+          min: -10
+          max: 10
+          mode: box
 
 play_queue:
   name: Play queue

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -189,6 +189,7 @@ class SonosSpeaker:
         self.muted: bool | None = None
         self.night_mode: bool | None = None
         self.dialog_mode: bool | None = None
+        self.bass_level: int | None = None
 
         # Grouping
         self.coordinator: SonosSpeaker | None = None
@@ -448,6 +449,9 @@ class SonosSpeaker:
 
         if "dialog_level" in variables:
             self.dialog_mode = variables["dialog_level"] == "1"
+
+        if "bass_level" in variables:
+            self.bass_level = variables["bass_level"]
 
         self.async_write_entity_states()
 
@@ -931,6 +935,7 @@ class SonosSpeaker:
         self.muted = self.soco.mute
         self.night_mode = self.soco.night_mode
         self.dialog_mode = self.soco.dialog_mode
+        self.bass_level = self.soco.bass
 
     def update_media(self, event: SonosEvent | None = None) -> None:
         """Update information about currently playing media."""

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -190,6 +190,7 @@ class SonosSpeaker:
         self.night_mode: bool | None = None
         self.dialog_mode: bool | None = None
         self.bass_level: int | None = None
+        self.treble_level: int | None = None
 
         # Grouping
         self.coordinator: SonosSpeaker | None = None
@@ -452,6 +453,9 @@ class SonosSpeaker:
 
         if "bass_level" in variables:
             self.bass_level = variables["bass_level"]
+
+        if "treble_level" in variables:
+            self.treble_level = variables["treble_level"]
 
         self.async_write_entity_states()
 
@@ -936,6 +940,7 @@ class SonosSpeaker:
         self.night_mode = self.soco.night_mode
         self.dialog_mode = self.soco.dialog_mode
         self.bass_level = self.soco.bass
+        self.treble_level = self.soco.treble
 
     def update_media(self, event: SonosEvent | None = None) -> None:
         """Update information about currently playing media."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add a bass and treble option to the Sonos devices


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
