### PR TITLE
Bump pyuptimerobot to 21.8.1

### DIFF
--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -24,7 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             response = await uptime_robot_api.async_get_monitors()
         except UptimeRobotException as exception:
-            raise UpdateFailed(exception)
+            raise UpdateFailed(exception) from exception
         else:
             if response.status == API_ATTR_OK:
                 monitors: list[UptimeRobotMonitor] = response.data

--- a/homeassistant/components/uptimerobot/__init__.py
+++ b/homeassistant/components/uptimerobot/__init__.py
@@ -1,44 +1,35 @@
 """The Uptime Robot integration."""
 from __future__ import annotations
 
-import async_timeout
-from pyuptimerobot import UptimeRobot
+from pyuptimerobot import UptimeRobot, UptimeRobotException, UptimeRobotMonitor
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    API_ATTR_MONITORS,
-    API_ATTR_OK,
-    API_ATTR_STAT,
-    CONNECTION_ERROR,
-    COORDINATOR_UPDATE_INTERVAL,
-    DOMAIN,
-    LOGGER,
-    PLATFORMS,
-    MonitorData,
-)
+from .const import API_ATTR_OK, COORDINATOR_UPDATE_INTERVAL, DOMAIN, LOGGER, PLATFORMS
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Uptime Robot from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    uptime_robot_api = UptimeRobot()
+    uptime_robot_api = UptimeRobot(
+        entry.data[CONF_API_KEY], async_get_clientsession(hass)
+    )
 
-    async def async_update_data() -> list[MonitorData]:
+    async def async_update_data() -> list[UptimeRobotMonitor]:
         """Fetch data from API UptimeRobot API."""
-        async with async_timeout.timeout(10):
-            monitors = await hass.async_add_executor_job(
-                uptime_robot_api.getMonitors, entry.data[CONF_API_KEY]
-            )
-            if not monitors or monitors.get(API_ATTR_STAT) != API_ATTR_OK:
-                raise UpdateFailed(CONNECTION_ERROR)
-            return [
-                MonitorData.from_dict(monitor)
-                for monitor in monitors.get(API_ATTR_MONITORS, [])
-            ]
+        try:
+            response = await uptime_robot_api.async_get_monitors()
+        except UptimeRobotException as exception:
+            raise UpdateFailed(exception)
+        else:
+            if response.status == API_ATTR_OK:
+                monitors: list[UptimeRobotMonitor] = response.data
+                return monitors
+            raise UpdateFailed(response.error.message)
 
     hass.data[DOMAIN][entry.entry_id] = coordinator = DataUpdateCoordinator(
         hass,

--- a/homeassistant/components/uptimerobot/binary_sensor.py
+++ b/homeassistant/components/uptimerobot/binary_sensor.py
@@ -50,7 +50,7 @@ async def async_setup_entry(
                 coordinator,
                 BinarySensorEntityDescription(
                     key=str(monitor.id),
-                    name=monitor.name,
+                    name=monitor.friendly_name,
                     device_class=DEVICE_CLASS_CONNECTIVITY,
                 ),
                 target=monitor.url,

--- a/homeassistant/components/uptimerobot/config_flow.py
+++ b/homeassistant/components/uptimerobot/config_flow.py
@@ -24,7 +24,7 @@ async def validate_input(hass: HomeAssistant, data: ConfigType) -> UptimeRobotAc
     try:
         response = await uptime_robot_api.async_get_account_details()
     except UptimeRobotException as exception:
-        raise CannotConnect(exception)
+        raise CannotConnect(exception) from exception
     else:
         if response.status == API_ATTR_OK:
             return response.data

--- a/homeassistant/components/uptimerobot/config_flow.py
+++ b/homeassistant/components/uptimerobot/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Uptime Robot integration."""
 from __future__ import annotations
 
-from pyuptimerobot import UptimeRobot
+from pyuptimerobot import UptimeRobot, UptimeRobotAccount, UptimeRobotException
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -9,24 +9,26 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .const import API_ATTR_OK, API_ATTR_STAT, DOMAIN, LOGGER
+from .const import API_ATTR_OK, DOMAIN, LOGGER
 
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
 
 
-async def validate_input(hass: HomeAssistant, data: ConfigType) -> None:
+async def validate_input(hass: HomeAssistant, data: ConfigType) -> UptimeRobotAccount:
     """Validate the user input allows us to connect."""
+    uptime_robot_api = UptimeRobot(data[CONF_API_KEY], async_get_clientsession(hass))
 
-    uptime_robot_api = UptimeRobot()
-
-    monitors = await hass.async_add_executor_job(
-        uptime_robot_api.getMonitors, data[CONF_API_KEY]
-    )
-
-    if not monitors or monitors.get(API_ATTR_STAT) != API_ATTR_OK:
-        raise CannotConnect("Error communicating with Uptime Robot API")
+    try:
+        response = await uptime_robot_api.async_get_account_details()
+    except UptimeRobotException as exception:
+        raise CannotConnect(exception)
+    else:
+        if response.status == API_ATTR_OK:
+            return response.data
+        raise CannotConnect(response.error.message)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -43,14 +45,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         try:
-            await validate_input(self.hass, user_input)
+            account = await validate_input(self.hass, user_input)
         except CannotConnect:
             errors["base"] = "cannot_connect"
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
-            return self.async_create_entry(title="", data=user_input)
+            return self.async_create_entry(title=account.email, data=user_input)
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
@@ -65,9 +67,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 return self.async_abort(reason="already_configured")
 
-        return self.async_create_entry(
-            title="", data={CONF_API_KEY: import_config[CONF_API_KEY]}
-        )
+        imported_config = {CONF_API_KEY: import_config[CONF_API_KEY]}
+
+        account = await validate_input(self.hass, imported_config)
+        return self.async_create_entry(title=account.email, data=imported_config)
 
 
 class CannotConnect(HomeAssistantError):

--- a/homeassistant/components/uptimerobot/const.py
+++ b/homeassistant/components/uptimerobot/const.py
@@ -1,9 +1,7 @@
 """Constants for the Uptime Robot integration."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import timedelta
-from enum import Enum
 from logging import Logger, getLogger
 from typing import Final
 
@@ -14,42 +12,8 @@ COORDINATOR_UPDATE_INTERVAL: timedelta = timedelta(seconds=60)
 DOMAIN: Final = "uptimerobot"
 PLATFORMS: Final = ["binary_sensor"]
 
-CONNECTION_ERROR: Final = "Error connecting to the Uptime Robot API"
-
 ATTRIBUTION: Final = "Data provided by Uptime Robot"
 
 ATTR_TARGET: Final = "target"
 
-API_ATTR_STAT: Final = "stat"
 API_ATTR_OK: Final = "ok"
-API_ATTR_MONITORS: Final = "monitors"
-
-
-class MonitorType(Enum):
-    """Monitors type."""
-
-    HTTP = 1
-    keyword = 2
-    ping = 3
-
-
-@dataclass
-class MonitorData:
-    """Dataclass for monitors."""
-
-    id: int
-    status: int
-    url: str
-    name: str
-    type: MonitorType
-
-    @staticmethod
-    def from_dict(monitor: dict) -> MonitorData:
-        """Create a new monitor from a dict."""
-        return MonitorData(
-            id=monitor["id"],
-            status=monitor["status"],
-            url=monitor["url"],
-            name=monitor["friendly_name"],
-            type=MonitorType(monitor["type"]),
-        )

--- a/homeassistant/components/uptimerobot/entity.py
+++ b/homeassistant/components/uptimerobot/entity.py
@@ -1,6 +1,8 @@
 """Base UptimeRobot entity."""
 from __future__ import annotations
 
+from pyuptimerobot import UptimeRobotMonitor
+
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 from homeassistant.helpers.update_coordinator import (
@@ -8,7 +10,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import ATTR_TARGET, ATTRIBUTION, DOMAIN, MonitorData
+from .const import ATTR_TARGET, ATTRIBUTION, DOMAIN
 
 
 class UptimeRobotEntity(CoordinatorEntity):
@@ -48,12 +50,12 @@ class UptimeRobotEntity(CoordinatorEntity):
         return {}
 
     @property
-    def monitors(self) -> list[MonitorData]:
+    def monitors(self) -> list[UptimeRobotMonitor]:
         """Return all monitors."""
         return self.coordinator.data or []
 
     @property
-    def monitor(self) -> MonitorData | None:
+    def monitor(self) -> UptimeRobotMonitor | None:
         """Return the monitor for this entity."""
         return next(
             (
@@ -67,7 +69,8 @@ class UptimeRobotEntity(CoordinatorEntity):
     @property
     def monitor_available(self) -> bool:
         """Returtn if the monitor is available."""
-        return self.monitor.status == 2 if self.monitor else False
+        status: bool = self.monitor.status == 2 if self.monitor else False
+        return status
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/uptimerobot/manifest.json
+++ b/homeassistant/components/uptimerobot/manifest.json
@@ -3,7 +3,7 @@
   "name": "Uptime Robot",
   "documentation": "https://www.home-assistant.io/integrations/uptimerobot",
   "requirements": [
-    "pyuptimerobot==0.0.5"
+    "pyuptimerobot==21.08.0"
   ],
   "codeowners": [
     "@ludeeus"

--- a/homeassistant/components/uptimerobot/manifest.json
+++ b/homeassistant/components/uptimerobot/manifest.json
@@ -3,7 +3,7 @@
   "name": "Uptime Robot",
   "documentation": "https://www.home-assistant.io/integrations/uptimerobot",
   "requirements": [
-    "pyuptimerobot==21.08.0"
+    "pyuptimerobot==21.8.1"
   ],
   "codeowners": [
     "@ludeeus"

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -12,7 +12,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "Account already configured"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }
   }
 }

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -12,7 +12,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "Account already configured"
     }
   }
 }

--- a/homeassistant/components/uptimerobot/translations/en.json
+++ b/homeassistant/components/uptimerobot/translations/en.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Account already configured"
         },
         "error": {
             "cannot_connect": "Failed to connect",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1948,7 +1948,7 @@ pytradfri[async]==7.0.6
 pytrafikverket==0.1.6.2
 
 # homeassistant.components.uptimerobot
-pyuptimerobot==0.0.5
+pyuptimerobot==21.08.0
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1948,7 +1948,7 @@ pytradfri[async]==7.0.6
 pytrafikverket==0.1.6.2
 
 # homeassistant.components.uptimerobot
-pyuptimerobot==21.08.0
+pyuptimerobot==21.8.1
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1077,7 +1077,7 @@ pytraccar==0.9.0
 pytradfri[async]==7.0.6
 
 # homeassistant.components.uptimerobot
-pyuptimerobot==21.08.0
+pyuptimerobot==21.8.1
 
 # homeassistant.components.vera
 pyvera==0.3.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1077,7 +1077,7 @@ pytraccar==0.9.0
 pytradfri[async]==7.0.6
 
 # homeassistant.components.uptimerobot
-pyuptimerobot==0.0.5
+pyuptimerobot==21.08.0
 
 # homeassistant.components.vera
 pyvera==0.3.13

--- a/tests/components/uptimerobot/test_config_flow.py
+++ b/tests/components/uptimerobot/test_config_flow.py
@@ -1,13 +1,10 @@
 """Test the Uptime Robot config flow."""
 from unittest.mock import patch
 
+from pyuptimerobot import UptimeRobotApiResponse
+
 from homeassistant import config_entries, setup
-from homeassistant.components.uptimerobot.const import (
-    API_ATTR_MONITORS,
-    API_ATTR_OK,
-    API_ATTR_STAT,
-    DOMAIN,
-)
+from homeassistant.components.uptimerobot.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
@@ -26,8 +23,13 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     with patch(
-        "pyuptimerobot.UptimeRobot.getMonitors",
-        return_value={API_ATTR_STAT: API_ATTR_OK, API_ATTR_MONITORS: []},
+        "pyuptimerobot.UptimeRobot.async_get_account_details",
+        return_value=UptimeRobotApiResponse.from_dict(
+            {
+                "stat": "ok",
+                "account": {"email": "test@test.test"},
+            }
+        ),
     ), patch(
         "homeassistant.components.uptimerobot.async_setup_entry",
         return_value=True,
@@ -39,7 +41,7 @@ async def test_form(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == ""
+    assert result2["title"] == "test@test.test"
     assert result2["data"] == {"api_key": "1234"}
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -50,7 +52,10 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch("pyuptimerobot.UptimeRobot.getMonitors", return_value=None):
+    with patch(
+        "pyuptimerobot.UptimeRobot.async_get_account_details",
+        return_value=UptimeRobotApiResponse.from_dict({"stat": "fail", "error": {}}),
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"api_key": "1234"},
@@ -63,8 +68,13 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
 async def test_flow_import(hass):
     """Test an import flow."""
     with patch(
-        "pyuptimerobot.UptimeRobot.getMonitors",
-        return_value={API_ATTR_STAT: API_ATTR_OK, API_ATTR_MONITORS: []},
+        "pyuptimerobot.UptimeRobot.async_get_account_details",
+        return_value=UptimeRobotApiResponse.from_dict(
+            {
+                "stat": "ok",
+                "account": {"email": "test@test.test"},
+            }
+        ),
     ), patch(
         "homeassistant.components.uptimerobot.async_setup_entry",
         return_value=True,
@@ -81,8 +91,8 @@ async def test_flow_import(hass):
         assert result["data"] == {"api_key": "1234"}
 
     with patch(
-        "pyuptimerobot.UptimeRobot.getMonitors",
-        return_value={API_ATTR_STAT: API_ATTR_OK, API_ATTR_MONITORS: []},
+        "pyuptimerobot.UptimeRobot.async_get_account_details",
+        return_value=UptimeRobotApiResponse.from_dict({"stat": "ok", "monitors": []}),
     ), patch(
         "homeassistant.components.uptimerobot.async_setup_entry",
         return_value=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Bump `pyuptimerobot` to 21.8.1
Diff: <https://github.com/ludeeus/pyuptimerobot/compare/6b415ae5bb7c45f2d84b83bf9b9ce2720f913ed6...21.08.1>

Bigger bump PR than usual because of full rewrite in the lib with move to async

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
