### PR TITLE
Add `state_class` for KNX sensors

### DIFF
--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -17,6 +17,10 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES as BINARY_SENSOR_DEVICE_CLASSES,
 )
 from homeassistant.components.cover import DEVICE_CLASSES as COVER_DEVICE_CLASSES
+from homeassistant.components.sensor import (
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASSES_SCHEMA,
+)
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_ENTITY_ID,
@@ -148,6 +152,20 @@ def sensor_type_validator(value: Any) -> str | int:
     if isinstance(value, (str, int)) and DPTBase.parse_transcoder(value) is not None:
         return value
     raise vol.Invalid(f"value '{value}' is not a valid sensor type.")
+
+
+def sensor_type_sub_validator(entity_config: OrderedDict) -> OrderedDict:
+    """Validate a sensor entity options configuration."""
+    # validate that value is parsable as sensor type
+    sensor_type = entity_config[CONF_TYPE]
+    dpt_class = DPTBase.parse_transcoder(sensor_type)
+    if dpt_class is None:
+        raise vol.Invalid(f"value '{sensor_type}' is not a valid sensor type.")
+    # string sensors may not have a state_class
+    if dpt_class.value_type == "string":
+        entity_config[SensorSchema.CONF_STATE_CLASS] = None
+
+    return entity_config
 
 
 sync_state_validator = vol.Any(
@@ -724,17 +742,24 @@ class SensorSchema(KNXPlatformSchema):
 
     CONF_ALWAYS_CALLBACK = "always_callback"
     CONF_STATE_ADDRESS = CONF_STATE_ADDRESS
+    CONF_STATE_CLASS = "state_class"
     CONF_SYNC_STATE = CONF_SYNC_STATE
     DEFAULT_NAME = "KNX Sensor"
 
-    ENTITY_SCHEMA = vol.Schema(
-        {
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-            vol.Optional(CONF_SYNC_STATE, default=True): sync_state_validator,
-            vol.Optional(CONF_ALWAYS_CALLBACK, default=False): cv.boolean,
-            vol.Required(CONF_TYPE): sensor_type_validator,
-            vol.Required(CONF_STATE_ADDRESS): ga_list_validator,
-        }
+    ENTITY_SCHEMA = vol.All(
+        vol.Schema(
+            {
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                vol.Optional(CONF_SYNC_STATE, default=True): sync_state_validator,
+                vol.Optional(CONF_ALWAYS_CALLBACK, default=False): cv.boolean,
+                vol.Optional(
+                    CONF_STATE_CLASS, default=STATE_CLASS_MEASUREMENT
+                ): vol.Maybe(STATE_CLASSES_SCHEMA),
+                vol.Required(CONF_TYPE): vol.Any(str, int),
+                vol.Required(CONF_STATE_ADDRESS): ga_list_validator,
+            }
+        ),
+        sensor_type_sub_validator,
     )
 
 

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -63,7 +63,7 @@ class KNXSensor(KnxEntity, SensorEntity):
         self._attr_force_update = self._device.always_callback
         self._attr_unique_id = str(self._device.sensor_value.group_address_state)
         self._attr_unit_of_measurement = self._device.unit_of_measurement()
-        self._attr_state_class = config[SensorSchema.CONF_STATE_CLASS]
+        self._attr_state_class = config.get(SensorSchema.CONF_STATE_CLASS)
 
     @property
     def state(self) -> StateType:

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -63,6 +63,7 @@ class KNXSensor(KnxEntity, SensorEntity):
         self._attr_force_update = self._device.always_callback
         self._attr_unique_id = str(self._device.sensor_value.group_address_state)
         self._attr_unit_of_measurement = self._device.unit_of_measurement()
+        self._attr_state_class = config[SensorSchema.CONF_STATE_CLASS]
 
     @property
     def state(self) -> StateType:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enable long term statistics for KNX sensors.

As most KNX sensors represent measurements (temperature, power, energy, illumination, etc) we default to `state_class: measurement`. 
If a user wants to opt out it can be set to `None` like
```yaml
knx:
  sensor:
    - name: "Non measurement"
      type: temperature
      state_address: "1/2/3"
      state_class:
```
or to different values as they are implemented.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18782

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
