### PR TITLE
Add powerwall import and export sensors

### DIFF
--- a/homeassistant/components/powerwall/const.py
+++ b/homeassistant/components/powerwall/const.py
@@ -9,8 +9,6 @@ POWERWALL_API_CHANGED = "api_changed"
 UPDATE_INTERVAL = 30
 
 ATTR_FREQUENCY = "frequency"
-ATTR_ENERGY_EXPORTED = "energy_exported_(in_kW)"
-ATTR_ENERGY_IMPORTED = "energy_imported_(in_kW)"
 ATTR_INSTANT_AVERAGE_VOLTAGE = "instant_average_voltage"
 ATTR_INSTANT_TOTAL_CURRENT = "instant_total_current"
 ATTR_IS_ACTIVE = "is_active"

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -181,7 +181,7 @@ class PowerWallEnergyDirectionSensor(PowerWallEntity, SensorEntity):
 
     @property
     def state(self):
-        """Get the current value in kW."""
+        """Get the current value in kWh."""
         meter = self.coordinator.data[POWERWALL_API_METERS].get_meter(self._meter)
         if self._meter_direction == _METER_DIRECTION_EXPORT:
             return meter.get_energy_exported()

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_POWER,
+    ENERGY_KILO_WATT_HOUR,
     PERCENTAGE,
     POWER_KILO_WATT,
 )
@@ -151,7 +152,7 @@ class PowerWallEnergyDirectionSensor(PowerWallEntity, SensorEntity):
     """Representation of an Powerwall Direction Energy sensor."""
 
     _attr_state_class = STATE_CLASS_MEASUREMENT
-    _attr_unit_of_measurement = POWER_KILO_WATT
+    _attr_unit_of_measurement = ENERGY_KILO_WATT_HOUR
     _attr_device_class = DEVICE_CLASS_ENERGY
     _attr_last_reset = dt_util.utc_from_timestamp(0)
 

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -14,8 +14,6 @@ from homeassistant.const import (
 import homeassistant.util.dt as dt_util
 
 from .const import (
-    ATTR_ENERGY_EXPORTED,
-    ATTR_ENERGY_IMPORTED,
     ATTR_FREQUENCY,
     ATTR_INSTANT_AVERAGE_VOLTAGE,
     ATTR_INSTANT_TOTAL_CURRENT,
@@ -143,8 +141,6 @@ class PowerWallEnergySensor(PowerWallEntity, SensorEntity):
         meter = self.coordinator.data[POWERWALL_API_METERS].get_meter(self._meter)
         return {
             ATTR_FREQUENCY: round(meter.frequency, 1),
-            ATTR_ENERGY_EXPORTED: meter.get_energy_exported(),
-            ATTR_ENERGY_IMPORTED: meter.get_energy_imported(),
             ATTR_INSTANT_AVERAGE_VOLTAGE: round(meter.average_voltage, 1),
             ATTR_INSTANT_TOTAL_CURRENT: meter.get_instant_total_current(),
             ATTR_IS_ACTIVE: meter.is_active(),

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -53,6 +53,9 @@ async def test_sensors(hass):
     assert float(hass.states.get("sensor.powerwall_site_export").state) == 10429.5
     assert float(hass.states.get("sensor.powerwall_site_import").state) == 4824.2
 
+    export_attributes = hass.states.get("sensor.powerwall_site_export").attributes
+    assert export_attributes["unit_of_measurement"] == "kWh"
+
     state = hass.states.get("sensor.powerwall_load_now")
     assert state.state == "1.971"
     expected_attributes = {

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -39,8 +39,6 @@ async def test_sensors(hass):
     assert state.state == "0.032"
     expected_attributes = {
         "frequency": 60,
-        "energy_exported_(in_kW)": 10429.5,
-        "energy_imported_(in_kW)": 4824.2,
         "instant_average_voltage": 120.7,
         "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Site Now",
@@ -52,12 +50,13 @@ async def test_sensors(hass):
     for key, value in expected_attributes.items():
         assert state.attributes[key] == value
 
+    assert float(hass.states.get("sensor.powerwall_site_export").state) == 10429.5
+    assert float(hass.states.get("sensor.powerwall_site_import").state) == 4824.2
+
     state = hass.states.get("sensor.powerwall_load_now")
     assert state.state == "1.971"
     expected_attributes = {
         "frequency": 60,
-        "energy_exported_(in_kW)": 1056.8,
-        "energy_imported_(in_kW)": 4693.0,
         "instant_average_voltage": 120.7,
         "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Load Now",
@@ -69,12 +68,13 @@ async def test_sensors(hass):
     for key, value in expected_attributes.items():
         assert state.attributes[key] == value
 
+    assert float(hass.states.get("sensor.powerwall_load_export").state) == 1056.8
+    assert float(hass.states.get("sensor.powerwall_load_import").state) == 4693.0
+
     state = hass.states.get("sensor.powerwall_battery_now")
     assert state.state == "-8.55"
     expected_attributes = {
         "frequency": 60.0,
-        "energy_exported_(in_kW)": 3620.0,
-        "energy_imported_(in_kW)": 4216.2,
         "instant_average_voltage": 240.6,
         "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Battery Now",
@@ -86,12 +86,13 @@ async def test_sensors(hass):
     for key, value in expected_attributes.items():
         assert state.attributes[key] == value
 
+    assert float(hass.states.get("sensor.powerwall_battery_export").state) == 3620.0
+    assert float(hass.states.get("sensor.powerwall_battery_import").state) == 4216.2
+
     state = hass.states.get("sensor.powerwall_solar_now")
     assert state.state == "10.49"
     expected_attributes = {
         "frequency": 60,
-        "energy_exported_(in_kW)": 9864.2,
-        "energy_imported_(in_kW)": 28.2,
         "instant_average_voltage": 120.7,
         "unit_of_measurement": "kW",
         "friendly_name": "Powerwall Solar Now",
@@ -102,6 +103,9 @@ async def test_sensors(hass):
     # HA changes the implementation and a new one appears
     for key, value in expected_attributes.items():
         assert state.attributes[key] == value
+
+    assert float(hass.states.get("sensor.powerwall_solar_export").state) == 9864.2
+    assert float(hass.states.get("sensor.powerwall_solar_import").state) == 28.2
 
     state = hass.states.get("sensor.powerwall_charge")
     assert state.state == "47"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The powerwall attributes for `energy_exported_(in_kW)` and `energy_imported_(in_kW)` have been converted to energy sensors.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Closes #53986


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
