### PR TITLE
Switch velbus from python-velbus to velbusaio

### DIFF
--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -51,31 +51,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = controller
     await controller.connect()
 
-    # add the controller as a device
-    device_registry = await hass.helpers.device_registry.async_get_registry()
-    device_registry.async_get_or_create(
-        name=f"{entry.title}-interface",
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, entry.data[CONF_PORT])},
-        connections={(CONF_PORT, entry.data[CONF_PORT])},
-    )
-
-    # setup the platforms
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     if hass.services.has_service(DOMAIN, "scan"):
         return True
 
     async def get_entry_id(interface: str):
-        device_registry = dr.async_get(hass)
-        device_entry = device_registry.async_get(interface)
-        if device_entry is None:
-            _LOGGER.warning("Missing device: %s", device_id)
-            return None
         for entry in hass.config_entries.async_entries(DOMAIN):
-            if entry.entry_id in device_entry.config_entries:
+            if "port" in entry.data and entry.data["port"] == interface:
                 return entry.entry_id
-        _LOGGER.warning("Can not find the entry: %s", entry.entry_id)
+        _LOGGER.warning("Can not find the config entry for: %s", interface)
         return None
 
     async def scan(call):

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -19,7 +19,6 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 PLATFORMS = ["switch", "sensor", "binary_sensor", "cover", "climate", "light"]
-PLATFORMS = ["switch", "sensor", "binary_sensor", "cover"]
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 PLATFORMS = ["switch", "sensor", "binary_sensor", "cover", "climate", "light"]
-PLATFORMS = ["switch", "binary_sensor", "cover"]
+PLATFORMS = ["switch", "sensor", "binary_sensor", "cover"]
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -106,11 +106,12 @@ class VelbusEntity(Entity):
     @property
     def unique_id(self):
         """Get unique ID."""
-        return "{}.{}.{}".format(
-            self._channel.get_module_type(),
-            self._channel.get_module_address(),
-            self._channel.get_channel_number(),
-        )
+        serial = 0
+        if self._channel.get_module_serial() == 0:
+            serial = self._channel.get_module_address()
+        else:
+            serial = self._channel.get_module_serial()
+        return f"{serial}-{self._channel.get_channel_number()}"
 
     @property
     def name(self):

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -89,7 +89,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Remove the velbus connection."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    await hass.data[DOMAIN][entry.entry_id]["cntrl"].stop()
+    await hass.data[DOMAIN][entry.entry_id].stop()
     hass.data[DOMAIN].pop(entry.entry_id)
     if not hass.data[DOMAIN]:
         hass.data.pop(DOMAIN)

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -29,18 +29,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = controller
     await controller.connect()
 
-    for platform in PLATFORMS:
-        hass.add_job(hass.config_entries.async_forward_entry_setup(entry, platform))
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     async def scan(self, service=None):
         await controller.scan()
 
-    hass.services.async_register(DOMAIN, "scan", scan, schema=vol.Schema({}))
+    hass.services.async_register(DOMAIN, "scan", scan)
 
     async def syn_clock(self, service=None):
         await controller.sync_clock()
 
-    hass.services.async_register(DOMAIN, "sync_clock", syn_clock, schema=vol.Schema({}))
+    hass.services.async_register(DOMAIN, "sync_clock", syn_clock)
 
     def set_memo_text(service):
         """Handle Memo Text service call."""
@@ -107,7 +106,7 @@ class VelbusEntity(Entity):
         self._channel.on_status_update(self._on_update)
 
     async def _on_update(self):
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     @property
     def device_info(self):

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -29,7 +29,6 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 PLATFORMS = ["switch", "sensor", "binary_sensor", "cover", "climate", "light"]
-PLATFORMS = ["switch"]
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -69,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Remove the velbus connection."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    hass.data[DOMAIN][entry.entry_id]["cntrl"].stop()
+    await hass.data[DOMAIN][entry.entry_id]["cntrl"].stop()
     hass.data[DOMAIN].pop(entry.entry_id)
     if not hass.data[DOMAIN]:
         hass.data.pop(DOMAIN)
@@ -106,8 +106,8 @@ class VelbusEntity(Entity):
         """Add listener for state changes."""
         self._channel.on_status_update(self._on_update)
 
-    def _on_update(self, state):
-        self.schedule_update_ha_state()
+    async def _on_update(self):
+        self.async_schedule_update_ha_state()
 
     @property
     def device_info(self):

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -7,7 +7,6 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
@@ -99,10 +98,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def set_memo_text(call):
         """Handle Memo Text service call."""
-        cntrl_id = await get_entry_id(call.data["interface"])
-        if not cntrl_id:
+        entry_id = await get_entry_id(call.data["interface"])
+        if not entry_id:
             return
-        memo_text = service.data[CONF_MEMO_TEXT]
+        memo_text = call.data[CONF_MEMO_TEXT]
         memo_text.hass = hass
         await hass.data[DOMAIN][entry_id].get_module(
             call.data[CONF_ADDRESS]

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -6,7 +6,6 @@ import logging
 from velbusaio.controller import Velbus
 import voluptuous as vol
 
-from homeassistant.components import persistent_notification
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -56,17 +55,7 @@ async def velbus_connect_task(
     controller: Velbus, hass: HomeAssistant, entry_id: str
 ) -> None:
     """Task to offload the long running connect."""
-    # create notification
-    persistent_notification.async_create(
-        hass,
-        "Velbus is scanning the bus, this can take some time.",
-        "Velbus Starting",
-        f"{DOMAIN}-{entry_id}",
-    )
-    # connect
     await controller.connect()
-    # clear notification
-    persistent_notification.async_dismiss(hass, f"{DOMAIN}-{entry_id}")
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -110,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DOMAIN,
         SERVICE_SCAN,
         scan,
-        vol.Schema({vol.Required(CONF_INTERFACE): vol.All(check_entry_id, cv.string)}),
+        vol.Schema({vol.Required(CONF_INTERFACE): vol.All(cv.string, check_entry_id)}),
     )
 
     async def syn_clock(call):
@@ -123,7 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DOMAIN,
         SERVICE_SYNC,
         syn_clock,
-        vol.Schema({vol.Required(CONF_INTERFACE): vol.All(check_entry_id, cv.string)}),
+        vol.Schema({vol.Required(CONF_INTERFACE): vol.All(cv.string, check_entry_id)}),
     )
 
     async def set_memo_text(call):
@@ -143,7 +132,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         set_memo_text,
         vol.Schema(
             {
-                vol.Required(CONF_INTERFACE): vol.All(check_entry_id, cv.string),
+                vol.Required(CONF_INTERFACE): vol.All(cv.string, check_entry_id),
                 vol.Required(CONF_ADDRESS): vol.All(
                     vol.Coerce(int), vol.Range(min=0, max=255)
                 ),

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -112,15 +112,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ),
     )
 
-    def set_memo_text(call):
+    async def set_memo_text(call):
         """Handle Memo Text service call."""
         cntrl_id = await get_entry_id(call.data["interface"])
         if not cntrl_id:
             return
-        # TODO get the module address from call.data[CONF_ADDRESS]
         memo_text = service.data[CONF_MEMO_TEXT]
         memo_text.hass = hass
-        controller.get_module(module_address).set_memo_text(memo_text.async_render())
+        await hass.data[DOMAIN][entry_id].get_module(
+            call.data[CONF_ADDRESS]
+        ).set_memo_text(memo_text.async_render())
 
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -27,7 +27,7 @@ async def async_setup(hass, config):
     if DOMAIN not in config:
         return True
 
-    _LOGGER.warning("Loading VELBUS via platform config is deprecated")
+    _LOGGER.warning("Loading VELBUS via configuration.yaml is deprecated")
 
     port = config[DOMAIN].get(CONF_PORT)
     data = {}

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -4,8 +4,8 @@ import logging
 from velbusaio.controller import Velbus
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ADDRESS, CONF_PORT
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -19,6 +19,27 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 PLATFORMS = ["switch", "sensor", "binary_sensor", "cover", "climate", "light"]
+
+
+async def async_setup(hass, config):
+    """Set up the Velbus platform."""
+    # Import from the configuration file if needed
+    if DOMAIN not in config:
+        return True
+
+    _LOGGER.warning("Loading VELBUS via platform config is deprecated")
+
+    port = config[DOMAIN].get(CONF_PORT)
+    data = {}
+
+    if port:
+        data = {CONF_PORT: port, CONF_NAME: "Velbus import"}
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=data
+        )
+    )
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -151,7 +151,7 @@ class VelbusEntity(Entity):
     @property
     def unique_id(self):
         """Get unique ID."""
-        if serial := self._channel.get_module_serial():
+        if (serial := self._channel.get_module_serial()) == 0:
             serial = self._channel.get_module_address()
         return f"{serial}-{self._channel.get_channel_number()}"
 

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -4,8 +4,8 @@ import logging
 from velbusaio.controller import Velbus
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_PORT
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -19,25 +19,6 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 PLATFORMS = ["switch", "sensor", "binary_sensor", "cover", "climate", "light"]
-
-
-async def async_setup(hass, config):
-    """Set up the Velbus platform."""
-    # Import from the configuration file if needed
-    if DOMAIN not in config:
-        return True
-    port = config[DOMAIN].get(CONF_PORT)
-    data = {}
-
-    if port:
-        data = {CONF_PORT: port, CONF_NAME: "Velbus import"}
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=data
-        )
-    )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -56,8 +37,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.services.async_register(DOMAIN, "scan", scan, schema=vol.Schema({}))
 
-    def syn_clock(self, service=None):
-        controller.sync_clock()
+    async def syn_clock(self, service=None):
+        await controller.sync_clock()
 
     hass.services.async_register(DOMAIN, "sync_clock", syn_clock, schema=vol.Schema({}))
 

--- a/homeassistant/components/velbus/binary_sensor.py
+++ b/homeassistant/components/velbus/binary_sensor.py
@@ -19,6 +19,6 @@ class VelbusBinarySensor(VelbusEntity, BinarySensorEntity):
     """Representation of a Velbus Binary Sensor."""
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if the sensor is on."""
         return self._channel.is_closed()

--- a/homeassistant/components/velbus/binary_sensor.py
+++ b/homeassistant/components/velbus/binary_sensor.py
@@ -7,7 +7,8 @@ from .const import DOMAIN
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Velbus switch based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    await hass.data[DOMAIN][entry.entry_id]["tsk"]
+    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
     entities = []
     for channel in cntrl.get_all("binary_sensor"):
         entities.append(VelbusBinarySensor(channel))

--- a/homeassistant/components/velbus/binary_sensor.py
+++ b/homeassistant/components/velbus/binary_sensor.py
@@ -6,13 +6,11 @@ from .const import DOMAIN
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up Velbus binary sensor based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
-    modules_data = hass.data[DOMAIN][entry.entry_id]["binary_sensor"]
+    """Set up Velbus switch based on config_entry."""
+    cntrl = hass.data[DOMAIN][entry.entry_id]
     entities = []
-    for address, channel in modules_data:
-        module = cntrl.get_module(address)
-        entities.append(VelbusBinarySensor(module, channel))
+    for channel in cntrl.get_all("binary_sensor"):
+        entities.append(VelbusBinarySensor(channel))
     async_add_entities(entities)
 
 
@@ -22,4 +20,4 @@ class VelbusBinarySensor(VelbusEntity, BinarySensorEntity):
     @property
     def is_on(self):
         """Return true if the sensor is on."""
-        return self._module.is_closed(self._channel)
+        return self._channel.is_closed()

--- a/homeassistant/components/velbus/climate.py
+++ b/homeassistant/components/velbus/climate.py
@@ -16,7 +16,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Velbus switch based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    await hass.data[DOMAIN][entry.entry_id]["tsk"]
+    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
     entities = []
     for channel in cntrl.get_all("climate"):
         entities.append(VelbusClimate(channel))

--- a/homeassistant/components/velbus/climate.py
+++ b/homeassistant/components/velbus/climate.py
@@ -20,7 +20,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
     for channel in cntrl.get_all("climate"):
         entities.append(VelbusClimate(channel))
-        async_add_entities(entities)
+    async_add_entities(entities)
 
 
 class VelbusClimate(VelbusEntity, ClimateEntity):

--- a/homeassistant/components/velbus/climate.py
+++ b/homeassistant/components/velbus/climate.py
@@ -1,14 +1,12 @@
 """Support for Velbus thermostat."""
 import logging
 
-from velbus.util import VelbusException
-
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT,
     SUPPORT_TARGET_TEMPERATURE,
 )
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 
 from . import VelbusEntity
 from .const import DOMAIN
@@ -17,14 +15,12 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up Velbus binary sensor based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
-    modules_data = hass.data[DOMAIN][entry.entry_id]["climate"]
+    """Set up Velbus switch based on config_entry."""
+    cntrl = hass.data[DOMAIN][entry.entry_id]
     entities = []
-    for address, channel in modules_data:
-        module = cntrl.get_module(address)
-        entities.append(VelbusClimate(module, channel))
-    async_add_entities(entities)
+    for channel in cntrl.get_all("climate"):
+        entities.append(VelbusClimate(channel))
+        async_add_entities(entities)
 
 
 class VelbusClimate(VelbusEntity, ClimateEntity):
@@ -37,15 +33,13 @@ class VelbusClimate(VelbusEntity, ClimateEntity):
 
     @property
     def temperature_unit(self):
-        """Return the unit this state is expressed in."""
-        if self._module.get_unit(self._channel) == TEMP_CELSIUS:
-            return TEMP_CELSIUS
-        return TEMP_FAHRENHEIT
+        """Return the unit."""
+        return TEMP_CELSIUS
 
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self._module.get_state(self._channel)
+        return self._channel.get_state()
 
     @property
     def hvac_mode(self):
@@ -66,18 +60,14 @@ class VelbusClimate(VelbusEntity, ClimateEntity):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self._module.get_climate_target()
+        return self._channel.get_climate_target()
 
     def set_temperature(self, **kwargs):
         """Set new target temperatures."""
         temp = kwargs.get(ATTR_TEMPERATURE)
         if temp is None:
             return
-        try:
-            self._module.set_temp(temp)
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
-            return
+        self._channel.set_temp(temp)
         self.schedule_update_ha_state()
 
     def set_hvac_mode(self, hvac_mode):

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -35,12 +35,12 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _test_connection(self, prt):
         """Try to connect to the velbus with the port specified."""
-        try:
-            controller = velbus.Controller(prt)
-        except Exception:  # pylint: disable=broad-except
-            self._errors[CONF_PORT] = "cannot_connect"
-            return False
-        controller.stop()
+        # try:
+        #    controller = velbus.Controller(prt)
+        # except Exception:  # pylint: disable=broad-except
+        #    self._errors[CONF_PORT] = "cannot_connect"
+        #    return False
+        # controller.stop()
         return True
 
     def _prt_in_configuration_exists(self, prt: str) -> bool:

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Velbus platform."""
 from __future__ import annotations
 
-import velbus
+from velbusaio.controller import Velbus
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -35,12 +35,12 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _test_connection(self, prt):
         """Try to connect to the velbus with the port specified."""
-        # try:
-        #    controller = velbus.Controller(prt)
-        # except Exception:  # pylint: disable=broad-except
-        #    self._errors[CONF_PORT] = "cannot_connect"
-        #    return False
-        # controller.stop()
+        try:
+            controller = Velbus(prt, True)
+            controller.stop()
+        except Exception:  # pylint: disable=broad-except
+            self._errors[CONF_PORT] = "cannot_connect"
+            return False
         return True
 
     def _prt_in_configuration_exists(self, prt: str) -> bool:

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import velbusaio
-from velbusaio.exceptions import VelbuConnectionFailed
+from velbusaio.exceptions import VelbusConnectionFailed
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -40,7 +40,7 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             controller = velbusaio.controller.Velbus(prt)
             await controller.connect(True)
             await controller.stop()
-        except VelbuConnectionFailed:
+        except VelbusConnectionFailed:
             self._errors[CONF_PORT] = "cannot_connect"
             return False
         return True

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -77,3 +77,13 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             errors=self._errors,
         )
+
+    async def async_step_import(self, user_input=None):
+        """Import a config entry."""
+        user_input[CONF_NAME] = "Velbus Import"
+        prt = user_input[CONF_PORT]
+        if self._prt_in_configuration_exists(prt):
+            # if the velbus import is already in the config
+            # we should not proceed the import
+            return self.async_abort(reason="already_configured")
+        return await self.async_step_user(user_input)

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import velbusaio
+from velbusaio.exceptions import VelbuConnectionFailed
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -39,7 +40,7 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             controller = velbusaio.controller.Velbus(prt)
             await controller.connect(True)
             await controller.stop()
-        except Exception:  # pylint: disable=broad-except
+        except VelbuConnectionFailed:
             self._errors[CONF_PORT] = "cannot_connect"
             return False
         return True

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -35,16 +35,14 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _test_connection(self, prt):
         """Try to connect to the velbus with the port specified."""
-        print(prt)
         try:
             controller = Velbus(prt)
             await controller.connect(True)
-            controller.stop()
-        except Exception:  # pylint: disable=broad-except
+            await controller.stop()
+        except Exception as excep:  # pylint: disable=broad-except
             self._errors[CONF_PORT] = "cannot_connect"
-            print("HERE")
+            print(excep)
             return False
-        print("HERE2")
         return True
 
     def _prt_in_configuration_exists(self, prt: str) -> bool:

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Velbus platform."""
 from __future__ import annotations
 
-from velbusaio.controller import Velbus
+import velbusaio
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -36,7 +36,7 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _test_connection(self, prt):
         """Try to connect to the velbus with the port specified."""
         try:
-            controller = Velbus(prt)
+            controller = velbusaio.controller.Velbus(prt)
             await controller.connect(True)
             await controller.stop()
         except Exception as excep:  # pylint: disable=broad-except

--- a/homeassistant/components/velbus/config_flow.py
+++ b/homeassistant/components/velbus/config_flow.py
@@ -39,9 +39,8 @@ class VelbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             controller = velbusaio.controller.Velbus(prt)
             await controller.connect(True)
             await controller.stop()
-        except Exception as excep:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             self._errors[CONF_PORT] = "cannot_connect"
-            print(excep)
             return False
         return True
 

--- a/homeassistant/components/velbus/const.py
+++ b/homeassistant/components/velbus/const.py
@@ -2,6 +2,9 @@
 
 DOMAIN = "velbus"
 
+CONF_INTERFACE = "interface"
 CONF_MEMO_TEXT = "memo_text"
 
+SERVICE_SCAN = "scan"
+SERVICE_SYNC = "sync_clock"
 SERVICE_SET_MEMO_TEXT = "set_memo_text"

--- a/homeassistant/components/velbus/cover.py
+++ b/homeassistant/components/velbus/cover.py
@@ -38,9 +38,7 @@ class VelbusCover(VelbusEntity, CoverEntity):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        if self._channel.get_position() == 100:
-            return True
-        return False
+        return self._channel.is_closed()
 
     @property
     def current_cover_position(self):

--- a/homeassistant/components/velbus/cover.py
+++ b/homeassistant/components/velbus/cover.py
@@ -18,7 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Velbus switch based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    await hass.data[DOMAIN][entry.entry_id]["tsk"]
+    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
     entities = []
     for channel in cntrl.get_all("cover"):
         entities.append(VelbusCover(channel))

--- a/homeassistant/components/velbus/cover.py
+++ b/homeassistant/components/velbus/cover.py
@@ -1,8 +1,6 @@
 """Support for Velbus covers."""
 import logging
 
-from velbus.util import VelbusException
-
 from homeassistant.components.cover import (
     ATTR_POSITION,
     SUPPORT_CLOSE,
@@ -19,13 +17,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up Velbus cover based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
-    modules_data = hass.data[DOMAIN][entry.entry_id]["cover"]
+    """Set up Velbus switch based on config_entry."""
+    cntrl = hass.data[DOMAIN][entry.entry_id]
     entities = []
-    for address, channel in modules_data:
-        module = cntrl.get_module(address)
-        entities.append(VelbusCover(module, channel))
+    for channel in cntrl.get_all("cover"):
+        entities.append(VelbusCover(channel))
     async_add_entities(entities)
 
 
@@ -35,14 +31,14 @@ class VelbusCover(VelbusEntity, CoverEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        if self._module.support_position():
+        if self._channel.support_position():
             return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION
         return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP
 
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        if self._module.get_position(self._channel) == 100:
+        if self._channel.get_position() == 100:
             return True
         return False
 
@@ -53,33 +49,21 @@ class VelbusCover(VelbusEntity, CoverEntity):
         None is unknown, 0 is closed, 100 is fully open
         Velbus: 100 = closed, 0 = open
         """
-        pos = self._module.get_position(self._channel)
+        pos = self._channel.get_position()
         return 100 - pos
 
-    def open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        try:
-            self._module.open(self._channel)
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
+        await self._channel.open()
 
-    def close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        try:
-            self._module.close(self._channel)
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
+        await self._channel.close()
 
-    def stop_cover(self, **kwargs):
+    async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
-        try:
-            self._module.stop(self._channel)
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
+        await self._channel.stop()
 
-    def set_cover_position(self, **kwargs):
+    async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        try:
-            self._module.set(self._channel, (100 - kwargs[ATTR_POSITION]))
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
+        self._channel.set_position(100 - kwargs[ATTR_POSITION])

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -34,8 +34,8 @@ class VelbusLight(VelbusEntity, LightEntity):
     @property
     def name(self):
         """Return the display name of this entity."""
-        # if self._module.light_is_buttonled(self._channel):
-        #    return f"LED {self._module.get_name(self._channel)}"
+        if self._channel.light_is_buttonled():
+            return f"LED {self._channel.get_name()}"
         return self._channel.get_name()
 
     @property
@@ -64,7 +64,7 @@ class VelbusLight(VelbusEntity, LightEntity):
 
     def turn_on(self, **kwargs):
         """Instruct the Velbus light to turn on."""
-        if self._module.light_is_buttonled(self._channel):
+        if self._channel.light_is_buttonled(self._channel):
             if ATTR_FLASH in kwargs:
                 if kwargs[ATTR_FLASH] == FLASH_LONG:
                     attr, *args = "set_led_state", self._channel, "slow"

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -21,7 +21,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Velbus switch based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    await hass.data[DOMAIN][entry.entry_id]["tsk"]
+    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
     entities = []
     for channel in cntrl.get_all("light"):
         entities.append(VelbusLight(channel, False))

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -100,7 +100,6 @@ class VelbusLight(VelbusEntity, LightEntity):
         else:
             attr, *args = (
                 "set_dimmer_state",
-                self._channel,
                 0,
                 kwargs.get(ATTR_TRANSITION, 0),
             )

--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -1,8 +1,6 @@
 """Support for Velbus light."""
 import logging
 
-from velbus.util import VelbusException
-
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_FLASH,
@@ -22,13 +20,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up Velbus light based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
-    modules_data = hass.data[DOMAIN][entry.entry_id]["light"]
+    """Set up Velbus switch based on config_entry."""
+    cntrl = hass.data[DOMAIN][entry.entry_id]
     entities = []
-    for address, channel in modules_data:
-        module = cntrl.get_module(address)
-        entities.append(VelbusLight(module, channel))
+    for channel in cntrl.get_all("climate"):
+        entities.append(VelbusLight(channel))
     async_add_entities(entities)
 
 
@@ -38,33 +34,33 @@ class VelbusLight(VelbusEntity, LightEntity):
     @property
     def name(self):
         """Return the display name of this entity."""
-        if self._module.light_is_buttonled(self._channel):
-            return f"LED {self._module.get_name(self._channel)}"
-        return self._module.get_name(self._channel)
+        # if self._module.light_is_buttonled(self._channel):
+        #    return f"LED {self._module.get_name(self._channel)}"
+        return self._channel.get_name()
 
     @property
     def supported_features(self):
         """Flag supported features."""
-        if self._module.light_is_buttonled(self._channel):
+        if self._channel.light_is_buttonled():
             return SUPPORT_FLASH
         return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
 
     @property
     def entity_registry_enabled_default(self):
         """Disable Button LEDs by default."""
-        if self._module.light_is_buttonled(self._channel):
+        if self._channel.light_is_buttonled():
             return False
         return True
 
     @property
     def is_on(self):
         """Return true if the light is on."""
-        return self._module.is_on(self._channel)
+        return self._channel.is_on()
 
     @property
     def brightness(self):
         """Return the brightness of the light."""
-        return int((self._module.get_dimmer_state(self._channel) * 255) / 100)
+        return int((self._channel.get_dimmer_state() * 255) / 100)
 
     def turn_on(self, **kwargs):
         """Instruct the Velbus light to turn on."""
@@ -97,14 +93,11 @@ class VelbusLight(VelbusEntity, LightEntity):
                     self._channel,
                     kwargs.get(ATTR_TRANSITION, 0),
                 )
-        try:
-            getattr(self._module, attr)(*args)
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
+        getattr(self._channel, attr)(*args)
 
     def turn_off(self, **kwargs):
         """Instruct the velbus light to turn off."""
-        if self._module.light_is_buttonled(self._channel):
+        if self._channel.light_is_buttonled():
             attr, *args = "set_led_state", self._channel, "off"
         else:
             attr, *args = (
@@ -113,7 +106,4 @@ class VelbusLight(VelbusEntity, LightEntity):
                 0,
                 kwargs.get(ATTR_TRANSITION, 0),
             )
-        try:
-            getattr(self._module, attr)(*args)
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
+        getattr(self._channel, attr)(*args)

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.0"],
+  "requirements": ["velbus-aio==2021.8.1"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push",

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.6"],
+  "requirements": ["velbus-aio==2021.8.7"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push",

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.4"],
+  "requirements": ["velbus-aio==2021.8.5"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push",

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.5"],
+  "requirements": ["velbus-aio==2021.8.6"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push",

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,8 +2,9 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["python-velbus==2.1.2"],
+  "requirements": ["velbus-aio==2021.8.0"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
-  "iot_class": "local_push"
+  "iot_class": "local_push",
+  "quality_scale": "platinum"
 }

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.1"],
+  "requirements": ["velbus-aio==2021.8.2"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push",

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.2"],
+  "requirements": ["velbus-aio==2021.8.3"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push",

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.3"],
+  "requirements": ["velbus-aio==2021.8.4"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push",

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.9"],
+  "requirements": ["velbus-aio==2021.8.10"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.11"],
+  "requirements": ["velbus-aio==2021.9.1"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -6,5 +6,5 @@
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push",
-  "quality_scale": "platinum"
+  "quality_scale": "gold"
 }

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.8"],
+  "requirements": ["velbus-aio==2021.8.9"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -5,6 +5,5 @@
   "requirements": ["velbus-aio==2021.8.7"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
-  "iot_class": "local_push",
-  "quality_scale": "gold"
+  "iot_class": "local_push"
 }

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.7"],
+  "requirements": ["velbus-aio==2021.8.8"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.8.10"],
+  "requirements": ["velbus-aio==2021.8.11"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 from datetime import datetime
 
 from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
-from homeassistant.const import DEVICE_CLASS_ENERGY, DEVICE_CLASS_POWER
+from homeassistant.const import (
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE,
+)
 from homeassistant.util.dt import utc_from_timestamp
 
 from . import VelbusEntity
@@ -53,6 +57,8 @@ class VelbusSensor(VelbusEntity, SensorEntity):
             return DEVICE_CLASS_ENERGY
         if self._channel.is_counter_channel():
             return DEVICE_CLASS_POWER
+        if self._channel.is_temperature():
+            return DEVICE_CLASS_TEMPERATURE
         return None
 
     @property

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -90,3 +90,13 @@ class VelbusSensor(VelbusEntity, SensorEntity):
         if self._is_counter:
             return STATE_CLASS_TOTAL_INCREASING
         return STATE_CLASS_MEASUREMENT
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the sun."""
+        if self._channel.is_temperature():
+            return {
+                "Max": self._channel.get_max(),
+                "Min": self._channel.get_min(),
+            }
+        return {}

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -12,6 +12,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
     for channel in cntrl.get_all("sensor"):
         entities.append(VelbusSensor(channel))
+        if channel.get_class() == "counter":
+            entities.append(VelbusSensor(channel, True))
     async_add_entities(entities)
 
 
@@ -35,7 +37,7 @@ class VelbusSensor(VelbusEntity, SensorEntity):
     def device_class(self):
         """Return the device class of the sensor."""
         if self._channel.get_class() == "counter" and not self._is_counter:
-            if self._channel.get_counter_unit() == ENERGY_KILO_WATT_HOUR:
+            if self._channel.get_unit() == ENERGY_KILO_WATT_HOUR:
                 return DEVICE_CLASS_POWER
             return None
         return self._channel.get_class()
@@ -50,8 +52,6 @@ class VelbusSensor(VelbusEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the unit this state is expressed in."""
-        if self._is_counter:
-            return self._channel.get_counter_unit()
         return self._channel.get_unit()
 
     @property

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -18,7 +18,8 @@ from .const import DOMAIN
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Velbus switch based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    await hass.data[DOMAIN][entry.entry_id]["tsk"]
+    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
     entities = []
     for channel in cntrl.get_all("sensor"):
         entities.append(VelbusSensor(channel))

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -90,13 +90,3 @@ class VelbusSensor(VelbusEntity, SensorEntity):
         if self._is_counter:
             return STATE_CLASS_TOTAL_INCREASING
         return STATE_CLASS_MEASUREMENT
-
-    @property
-    def extra_state_attributes(self):
-        """Return the state attributes of the sun."""
-        if self._channel.is_temperature():
-            return {
-                "Max": self._channel.get_max(),
-                "Min": self._channel.get_min(),
-            }
-        return {}

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -1,5 +1,5 @@
 """Support for Velbus sensors."""
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
 from homeassistant.const import DEVICE_CLASS_ENERGY, DEVICE_CLASS_POWER
 
 from . import VelbusEntity
@@ -46,7 +46,7 @@ class VelbusSensor(VelbusEntity, SensorEntity):
         """Return the device class of the sensor."""
         if self._is_counter:
             return DEVICE_CLASS_POWER
-        elif self._channel.is_counter_channel():
+        if self._channel.is_counter_channel():
             return DEVICE_CLASS_ENERGY
         return None
 
@@ -70,3 +70,8 @@ class VelbusSensor(VelbusEntity, SensorEntity):
         if self._is_counter:
             return "mdi:counter"
         return None
+
+    @property
+    def state_class(self):
+        """Return the state class of this device."""
+        return STATE_CLASS_MEASUREMENT

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -1,15 +1,16 @@
 """Support for Velbus sensors."""
 from __future__ import annotations
 
-from datetime import datetime
-
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
+from homeassistant.components.sensor import (
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+    SensorEntity,
+)
 from homeassistant.const import (
     DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
 )
-from homeassistant.util.dt import utc_from_timestamp
 
 from . import VelbusEntity
 from .const import DOMAIN
@@ -85,11 +86,6 @@ class VelbusSensor(VelbusEntity, SensorEntity):
     @property
     def state_class(self):
         """Return the state class of this device."""
-        return STATE_CLASS_MEASUREMENT
-
-    @property
-    def last_reset(self) -> datetime | None:
-        """Return the last reset date of this sensor."""
         if self._is_counter:
-            return utc_from_timestamp(0)
-        return None
+            return STATE_CLASS_TOTAL_INCREASING
+        return STATE_CLASS_MEASUREMENT

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -1,6 +1,11 @@
 """Support for Velbus sensors."""
+from __future__ import annotations
+
+from datetime import datetime
+
 from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
 from homeassistant.const import DEVICE_CLASS_ENERGY, DEVICE_CLASS_POWER
+from homeassistant.util.dt import utc_from_timestamp
 
 from . import VelbusEntity
 from .const import DOMAIN
@@ -45,9 +50,9 @@ class VelbusSensor(VelbusEntity, SensorEntity):
     def device_class(self):
         """Return the device class of the sensor."""
         if self._is_counter:
-            return DEVICE_CLASS_POWER
-        if self._channel.is_counter_channel():
             return DEVICE_CLASS_ENERGY
+        if self._channel.is_counter_channel():
+            return DEVICE_CLASS_POWER
         return None
 
     @property
@@ -75,3 +80,10 @@ class VelbusSensor(VelbusEntity, SensorEntity):
     def state_class(self):
         """Return the state class of this device."""
         return STATE_CLASS_MEASUREMENT
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the last reset date of this sensor."""
+        if self._is_counter:
+            return utc_from_timestamp(0)
+        return None

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -1,6 +1,6 @@
 """Support for Velbus sensors."""
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import DEVICE_CLASS_POWER, ENERGY_KILO_WATT_HOUR
+from homeassistant.const import DEVICE_CLASS_ENERGY, DEVICE_CLASS_POWER
 
 from . import VelbusEntity
 from .const import DOMAIN
@@ -12,7 +12,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
     for channel in cntrl.get_all("sensor"):
         entities.append(VelbusSensor(channel))
-        if channel.get_class() == "counter":
+        if channel.is_counter_channel():
             entities.append(VelbusSensor(channel, True))
     async_add_entities(entities)
 
@@ -34,13 +34,21 @@ class VelbusSensor(VelbusEntity, SensorEntity):
         return unique_id
 
     @property
+    def name(self):
+        """Return the name for the sensor."""
+        name = super().name
+        if self._is_counter:
+            name = f"{name}-counter"
+        return name
+
+    @property
     def device_class(self):
         """Return the device class of the sensor."""
-        if self._channel.get_class() == "counter" and not self._is_counter:
-            if self._channel.get_unit() == ENERGY_KILO_WATT_HOUR:
-                return DEVICE_CLASS_POWER
-            return None
-        return self._channel.get_class()
+        if self._is_counter:
+            return DEVICE_CLASS_POWER
+        elif self._channel.is_counter_channel():
+            return DEVICE_CLASS_ENERGY
+        return None
 
     @property
     def native_value(self):
@@ -52,6 +60,8 @@ class VelbusSensor(VelbusEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the unit this state is expressed in."""
+        if self._is_counter:
+            return self._channel.get_counter_unit()
         return self._channel.get_unit()
 
     @property

--- a/homeassistant/components/velbus/services.yaml
+++ b/homeassistant/components/velbus/services.yaml
@@ -4,11 +4,12 @@ sync_clock:
   fields:
     interface:
       name: Interface
-      description: The velbus interface to send the command to
+      description: The velbus interface to send the command to, this will be the same value as used during configuration
       required: true
+      example: "192.168.1.5:27015"
+      default: ''
       selector:
-        device:
-          integration: velbus
+        text:
 
 scan:
   name: Scan
@@ -16,11 +17,12 @@ scan:
   fields:
     interface:
       name: Interface
-      description: The velbus interface to send the command to
+      description: The velbus interface to send the command to, this will be the same value as used during configuration
       required: true
+      example: "192.168.1.5:27015"
+      default: ''
       selector:
-        device:
-          integration: velbus
+        text:
 
 set_memo_text:
   name: Set memo text
@@ -30,18 +32,22 @@ set_memo_text:
   fields:
     interface:
       name: Interface
-      description: The velbus interface to send the command to
+      description: The velbus interface to send the command to, this will be the same value as used during configuration
       required: true
+      example: "192.168.1.5:27015"
+      default: ''
       selector:
-        device:
-          integration: velbus
+        text:
     address:
-      name: Module
-      description: The module to send the memotext to
+      name: Address
+      description: >
+        The module address in decimal format.
+        The decimal addresses are displayed in front of the modules listed at the integration page.
       required: true
       selector:
-        device:
-          integration: velbus
+        number:
+          min: 1
+          max: 254
     memo_text:
       name: Memo text
       description: >

--- a/homeassistant/components/velbus/services.yaml
+++ b/homeassistant/components/velbus/services.yaml
@@ -1,6 +1,26 @@
 sync_clock:
   name: Sync clock
   description: Sync the velbus modules clock to the Home Assistant clock, this is the same as the 'sync clock' from VelbusLink
+  fields:
+    interface:
+      name: Interface
+      description: The velbus interface to send the command to
+      required: true
+      selector:
+        device:
+          integration: velbus
+
+scan:
+  name: Scan
+  description: Scan the velbus modules, this will be need if you see unknown module warnings in the logs, or when you added new modules
+  fields:
+    interface:
+      name: Interface
+      description: The velbus interface to send the command to
+      required: true
+      selector:
+        device:
+          integration: velbus
 
 set_memo_text:
   name: Set memo text
@@ -8,16 +28,20 @@ set_memo_text:
     Set the memo text to the display of modules like VMBGPO, VMBGPOD
     Be sure the page(s) of the module is configured to display the memo text.
   fields:
-    address:
-      name: Address
-      description: >
-        The module address in decimal format.
-        The decimal addresses are displayed in front of the modules listed at the integration page.
+    interface:
+      name: Interface
+      description: The velbus interface to send the command to
       required: true
       selector:
-        number:
-          min: 0
-          max: 255
+        device:
+          integration: velbus
+    address:
+      name: Module
+      description: The module to send the memotext to
+      required: true
+      selector:
+        device:
+          integration: velbus
     memo_text:
       name: Memo text
       description: >

--- a/homeassistant/components/velbus/switch.py
+++ b/homeassistant/components/velbus/switch.py
@@ -28,10 +28,19 @@ class VelbusSwitch(VelbusEntity, SwitchEntity):
         """Return true if the switch is on."""
         return self._channel.is_on()
 
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return the state attributes of the sun."""
+        return {
+            "Forced on": self._channel.is_forced_on(),
+            "Inhibit": self._channel.is_inhibit(),
+            "Disabled": self._channel.is_disabled(),
+        }
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the switch to turn on."""
         await self._channel.turn_on()
 
-    async def async_turn_off(self, **kwargs: any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the switch to turn off."""
         await self._channel.turn_off()

--- a/homeassistant/components/velbus/switch.py
+++ b/homeassistant/components/velbus/switch.py
@@ -12,7 +12,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Velbus switch based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]
+    await hass.data[DOMAIN][entry.entry_id]["tsk"]
+    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
     entities = []
     for channel in cntrl.get_all("switch"):
         entities.append(VelbusSwitch(channel))

--- a/homeassistant/components/velbus/switch.py
+++ b/homeassistant/components/velbus/switch.py
@@ -1,7 +1,6 @@
 """Support for Velbus switches."""
 import logging
-
-from velbus.util import VelbusException
+from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 
@@ -13,12 +12,10 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Velbus switch based on config_entry."""
-    cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
-    modules_data = hass.data[DOMAIN][entry.entry_id]["switch"]
+    cntrl = hass.data[DOMAIN][entry.entry_id]
     entities = []
-    for address, channel in modules_data:
-        module = cntrl.get_module(address)
-        entities.append(VelbusSwitch(module, channel))
+    for channel in cntrl.get_all("switch"):
+        entities.append(VelbusSwitch(channel))
     async_add_entities(entities)
 
 
@@ -26,20 +23,14 @@ class VelbusSwitch(VelbusEntity, SwitchEntity):
     """Representation of a switch."""
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if the switch is on."""
-        return self._module.is_on(self._channel)
+        return self._channel.is_on()
 
-    def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the switch to turn on."""
-        try:
-            self._module.turn_on(self._channel)
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
+        await self._channel.turn_on()
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs: any) -> None:
         """Instruct the switch to turn off."""
-        try:
-            self._module.turn_off(self._channel)
-        except VelbusException as err:
-            _LOGGER.error("A Velbus error occurred: %s", err)
+        await self._channel.turn_off()

--- a/homeassistant/components/velbus/switch.py
+++ b/homeassistant/components/velbus/switch.py
@@ -28,15 +28,6 @@ class VelbusSwitch(VelbusEntity, SwitchEntity):
         """Return true if the switch is on."""
         return self._channel.is_on()
 
-    @property
-    def extra_state_attributes(self) -> dict:
-        """Return the state attributes of the sun."""
-        return {
-            "Forced on": self._channel.is_forced_on(),
-            "Inhibit": self._channel.is_inhibit(),
-            "Disabled": self._channel.is_disabled(),
-        }
-
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the switch to turn on."""
         await self._channel.turn_on()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.11
+velbus-aio==2021.9.1
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.1
+velbus-aio==2021.8.2
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.3
+velbus-aio==2021.8.4
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.8
+velbus-aio==2021.8.9
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.0
+velbus-aio==2021.8.1
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1924,9 +1924,6 @@ python-telnet-vlc==2.0.1
 # homeassistant.components.twitch
 python-twitch-client==0.6.0
 
-# homeassistant.components.velbus
-python-velbus==2.1.2
-
 # homeassistant.components.vlc
 python-vlc==1.1.2
 
@@ -2355,6 +2352,9 @@ uvcclient==0.11.0
 
 # homeassistant.components.vallox
 vallox-websocket-api==2.8.1
+
+# homeassistant.components.velbus
+velbus-aio==2021.8.0
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.9
+velbus-aio==2021.8.10
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.7
+velbus-aio==2021.8.8
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.10
+velbus-aio==2021.8.11
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.6
+velbus-aio==2021.8.7
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.4
+velbus-aio==2021.8.5
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.5
+velbus-aio==2021.8.6
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2354,7 +2354,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.2
+velbus-aio==2021.8.3
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.1
+velbus-aio==2021.8.2
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.5
+velbus-aio==2021.8.6
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.7
+velbus-aio==2021.8.8
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.3
+velbus-aio==2021.8.4
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1090,9 +1090,6 @@ python-tado==0.10.0
 # homeassistant.components.twitch
 python-twitch-client==0.6.0
 
-# homeassistant.components.velbus
-python-velbus==2.1.2
-
 # homeassistant.components.awair
 python_awair==0.2.1
 
@@ -1314,6 +1311,9 @@ url-normalize==1.4.1
 
 # homeassistant.components.uvc
 uvcclient==0.11.0
+
+# homeassistant.components.velbus
+velbus-aio==2021.8.0
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.9
+velbus-aio==2021.8.10
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.11
+velbus-aio==2021.9.1
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.10
+velbus-aio==2021.8.11
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.4
+velbus-aio==2021.8.5
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.6
+velbus-aio==2021.8.7
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.0
+velbus-aio==2021.8.1
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.2
+velbus-aio==2021.8.3
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1313,7 +1313,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.8.8
+velbus-aio==2021.8.9
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -16,7 +16,7 @@ PORT_TCP = "127.0.1.0.1:3788"
 @pytest.fixture(name="controller_assert")
 def mock_controller_assert():
     """Mock the velbus controller with an assert."""
-    with patch("velbus.Controller", side_effect=Exception()):
+    with patch("velbusaio.Velbus", side_effect=Exception()):
         yield
 
 
@@ -24,7 +24,7 @@ def mock_controller_assert():
 def mock_controller():
     """Mock a successful velbus controller."""
     controller = Mock()
-    with patch("velbus.Controller", return_value=controller):
+    with patch("velbusaio.Velbus", return_value=controller):
         yield controller
 
 

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -2,6 +2,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from velbusaio.exceptions import VelbusConnectionFailed
 
 from homeassistant import data_entry_flow
 from homeassistant.components.velbus import config_flow
@@ -16,7 +17,7 @@ PORT_TCP = "127.0.1.0.1:3788"
 @pytest.fixture(name="controller_assert")
 def mock_controller_assert():
     """Mock the velbus controller with an assert."""
-    with patch("velbusaio.controller.Velbus", side_effect=Exception()):
+    with patch("velbusaio.controller.Velbus", side_effect=VelbusConnectionFailed()):
         yield
 
 

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -76,12 +76,27 @@ async def test_user_fail(hass, controller_assert):
     assert result["errors"] == {CONF_PORT: "cannot_connect"}
 
 
+async def test_import(hass, controller):
+    """Test import step."""
+    flow = init_config_flow(hass)
+
+    result = await flow.async_step_import({CONF_PORT: PORT_TCP})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "velbus_import"
+
+
 async def test_abort_if_already_setup(hass):
     """Test we abort if Daikin is already setup."""
     flow = init_config_flow(hass)
     MockConfigEntry(
         domain="velbus", data={CONF_PORT: PORT_TCP, CONF_NAME: "velbus home"}
     ).add_to_hass(hass)
+
+    result = await flow.async_step_import(
+        {CONF_PORT: PORT_TCP, CONF_NAME: "velbus import test"}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
 
     result = await flow.async_step_user(
         {CONF_PORT: PORT_TCP, CONF_NAME: "velbus import test"}

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -1,5 +1,5 @@
 """Tests for the Velbus config flow."""
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -23,9 +23,8 @@ def mock_controller_assert():
 @pytest.fixture(name="controller")
 def mock_controller():
     """Mock a successful velbus controller."""
-    controller = Mock()
+    controller = AsyncMock()
     with patch("velbusaio.controller.Velbus", return_value=controller):
-        controller.return_value.connect = Mock(side_effect=Exception)
         yield controller
 
 


### PR DESCRIPTION
## Breaking change

- The configuration.yaml config option is deprecated
- The velbus services call will now need an `interface` parameter, to allow support for multiple velbus connections.

## Proposed change
Switch the velbus component from python-velbus to velbusaio lib. Both modules are compatible and support the same features. velbusaio is just an asyncio implementation for python-velbus.
https://github.com/Cereal2nd/velbus-aio

The velbusaio lib has has the following advantages
- asyncio
- uses a json protocol description generated from the velbus protocol desciption. This will result in more supported modules and les maintenance
- add caching, the velbus scan can take up to 10 minuts, this is verry long and  until its finished HASS does not know the velbus entities. The velbusaio has a caching mechanisme, so the startup only takes about 20 seconds.
- fix the power sensors so they are useable in the energy dashboard
- Deprecate the platform setup via the config file
- Fix some errors in the velbus packet parsing (made the component break in some cases)

## Additional information
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19309

## Type of change
- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone
