### PR TITLE
Add unique_id to Uptime Robot config_flow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1112,6 +1112,7 @@ omit =
     homeassistant/components/upcloud/switch.py
     homeassistant/components/upnp/*
     homeassistant/components/upc_connect/*
+    homeassistant/components/uptimerobot/__init__.py
     homeassistant/components/uptimerobot/binary_sensor.py
     homeassistant/components/uptimerobot/const.py
     homeassistant/components/uptimerobot/entity.py

--- a/homeassistant/components/uptimerobot/config_flow.py
+++ b/homeassistant/components/uptimerobot/config_flow.py
@@ -42,7 +42,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             LOGGER.error(exception)
             errors["base"] = "cannot_connect"
         except Exception as exception:  # pylint: disable=broad-except
-            LOGGER.error(exception)
+            LOGGER.exception(exception)
             errors["base"] = "unknown"
         else:
             if response.status != API_ATTR_OK:

--- a/homeassistant/components/uptimerobot/config_flow.py
+++ b/homeassistant/components/uptimerobot/config_flow.py
@@ -1,14 +1,18 @@
 """Config flow for Uptime Robot integration."""
 from __future__ import annotations
 
-from pyuptimerobot import UptimeRobot, UptimeRobotAccount, UptimeRobotException
+from pyuptimerobot import (
+    UptimeRobot,
+    UptimeRobotAccount,
+    UptimeRobotApiError,
+    UptimeRobotApiResponse,
+    UptimeRobotException,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY
-from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
@@ -17,41 +21,61 @@ from .const import API_ATTR_OK, DOMAIN, LOGGER
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_API_KEY): str})
 
 
-async def validate_input(hass: HomeAssistant, data: ConfigType) -> UptimeRobotAccount:
-    """Validate the user input allows us to connect."""
-    uptime_robot_api = UptimeRobot(data[CONF_API_KEY], async_get_clientsession(hass))
-
-    try:
-        response = await uptime_robot_api.async_get_account_details()
-    except UptimeRobotException as exception:
-        raise CannotConnect(exception) from exception
-    else:
-        if response.status == API_ATTR_OK:
-            return response.data
-        raise CannotConnect(response.error.message)
-
-
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Uptime Robot."""
 
     VERSION = 1
+
+    async def _validate_input(
+        self, data: ConfigType
+    ) -> tuple[dict[str, str], UptimeRobotAccount | None]:
+        """Validate the user input allows us to connect."""
+        errors: dict[str, str] = {}
+        response: UptimeRobotApiResponse | UptimeRobotApiError | None = None
+        uptime_robot_api = UptimeRobot(
+            data[CONF_API_KEY], async_get_clientsession(self.hass)
+        )
+
+        try:
+            response = await uptime_robot_api.async_get_account_details()
+        except UptimeRobotException as exception:
+            LOGGER.error(exception)
+            errors["base"] = "cannot_connect"
+        except Exception as exception:  # pylint: disable=broad-except
+            LOGGER.error(exception)
+            errors["base"] = "unknown"
+        else:
+            if response.status != API_ATTR_OK:
+                if response.error.message in (
+                    "api_key not found.",
+                    "api_key is invalid.",
+                ):
+                    errors["base"] = "invalid_api_key"
+                else:
+                    errors["base"] = "unknown"
+                    LOGGER.error(response.error.message)
+
+        account: UptimeRobotAccount | None = (
+            response.data
+            if response and response.data and response.data.email
+            else None
+        )
+        if account:
+            await self.async_set_unique_id(str(account.user_id))
+            self._abort_if_unique_id_configured()
+
+        return errors, account
 
     async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is None:
             return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
 
-        try:
-            account = await validate_input(self.hass, user_input)
-        except CannotConnect:
-            errors["base"] = "cannot_connect"
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.exception("Unexpected exception")
-            errors["base"] = "unknown"
-        else:
+        errors, account = await self._validate_input(user_input)
+        if account:
             return self.async_create_entry(title=account.email, data=user_input)
 
         return self.async_show_form(
@@ -69,9 +93,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         imported_config = {CONF_API_KEY: import_config[CONF_API_KEY]}
 
-        account = await validate_input(self.hass, imported_config)
-        return self.async_create_entry(title=account.email, data=imported_config)
-
-
-class CannotConnect(HomeAssistantError):
-    """Error to indicate we cannot connect."""
+        _, account = await self._validate_input(imported_config)
+        if account:
+            return self.async_create_entry(title=account.email, data=imported_config)
+        return self.async_abort(reason="unknown")

--- a/homeassistant/components/uptimerobot/manifest.json
+++ b/homeassistant/components/uptimerobot/manifest.json
@@ -3,7 +3,7 @@
   "name": "Uptime Robot",
   "documentation": "https://www.home-assistant.io/integrations/uptimerobot",
   "requirements": [
-    "pyuptimerobot==21.8.1"
+    "pyuptimerobot==21.8.2"
   ],
   "codeowners": [
     "@ludeeus"

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -9,10 +9,12 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   }
 }

--- a/homeassistant/components/uptimerobot/translations/en.json
+++ b/homeassistant/components/uptimerobot/translations/en.json
@@ -1,10 +1,12 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Account already configured"
+            "already_configured": "Account already configured",
+            "unknown": "Unexpected error"
         },
         "error": {
             "cannot_connect": "Failed to connect",
+            "invalid_api_key": "Invalid API key",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1948,7 +1948,7 @@ pytradfri[async]==7.0.6
 pytrafikverket==0.1.6.2
 
 # homeassistant.components.uptimerobot
-pyuptimerobot==21.8.1
+pyuptimerobot==21.8.2
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1077,7 +1077,7 @@ pytraccar==0.9.0
 pytradfri[async]==7.0.6
 
 # homeassistant.components.uptimerobot
-pyuptimerobot==21.8.1
+pyuptimerobot==21.8.2
 
 # homeassistant.components.vera
 pyvera==0.3.13


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Add `unique_id` to the Config Flow

To better handle API key issues `pyuptimerobot` was bumped to 21.8.2
https://github.com/ludeeus/pyuptimerobot/releases/tag/21.8.2

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
