### PR TITLE
Force an attempted subscribe on speaker reboot

### DIFF
--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -454,7 +454,7 @@ class SonosSpeaker:
     #
     # Speaker availability methods
     #
-    async def async_seen(self, soco: SoCo | None = None, force_was_unavailable: bool = False) -> None:
+    async def async_seen(self, soco: SoCo | None = None) -> None:
         """Record that this speaker was seen right now."""
         if soco is not None:
             self.soco = soco
@@ -468,7 +468,7 @@ class SonosSpeaker:
             SEEN_EXPIRE_TIME.total_seconds(), self.async_unseen
         )
 
-        if not force_was_unavailable and was_available:
+        if was_available:
             self.async_write_entity_states()
             return
 
@@ -497,7 +497,7 @@ class SonosSpeaker:
         self.async_write_entity_states()
 
     async def async_unseen(
-        self, now: datetime.datetime | None = None, will_reconnect: bool = False
+        self, now: datetime.datetime | None = None
     ) -> None:
         """Make this player unavailable when it was not seen recently."""
         if self._seen_timer:
@@ -527,9 +527,8 @@ class SonosSpeaker:
 
         await self.async_unsubscribe()
 
-        if not will_reconnect:
-            self.hass.data[DATA_SONOS].discovery_known.discard(self.soco.uid)
-            self.async_write_entity_states()
+        self.hass.data[DATA_SONOS].discovery_known.discard(self.soco.uid)
+        self.async_write_entity_states()
 
     async def async_rebooted(self, soco: SoCo) -> None:
         """Handle a detected speaker reboot."""
@@ -538,8 +537,25 @@ class SonosSpeaker:
             self.zone_name,
             soco,
         )
-        await self.async_unseen(will_reconnect=True)
-        await self.async_seen(soco, force_was_unavailable=True)
+        await self.async_unsubscribe()
+        self.soco = soco
+        await self.async_subscribe()
+        if self._seen_timer:
+            self._seen_timer()
+        self._seen_timer = self.hass.helpers.event.async_call_later(
+            SEEN_EXPIRE_TIME.total_seconds(), self.async_unseen
+        )
+        if self._poll_timer:
+            self._poll_timer()
+        self._poll_timer = self.hass.helpers.event.async_track_time_interval(
+            partial(
+                async_dispatcher_send,
+                self.hass,
+                f"{SONOS_POLL_UPDATE}-{self.soco.uid}",
+            ),
+            SCAN_INTERVAL,
+        )
+        self.async_write_entity_states()
 
     #
     # Battery management

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -496,9 +496,7 @@ class SonosSpeaker:
 
         self.async_write_entity_states()
 
-    async def async_unseen(
-        self, now: datetime.datetime | None = None
-    ) -> None:
+    async def async_unseen(self, now: datetime.datetime | None = None) -> None:
         """Make this player unavailable when it was not seen recently."""
         if self._seen_timer:
             self._seen_timer()

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -545,16 +545,15 @@ class SonosSpeaker:
         self._seen_timer = self.hass.helpers.event.async_call_later(
             SEEN_EXPIRE_TIME.total_seconds(), self.async_unseen
         )
-        if self._poll_timer:
-            self._poll_timer()
-        self._poll_timer = self.hass.helpers.event.async_track_time_interval(
-            partial(
-                async_dispatcher_send,
-                self.hass,
-                f"{SONOS_POLL_UPDATE}-{self.soco.uid}",
-            ),
-            SCAN_INTERVAL,
-        )
+        if not self._poll_timer:
+            self._poll_timer = self.hass.helpers.event.async_track_time_interval(
+                partial(
+                    async_dispatcher_send,
+                    self.hass,
+                    f"{SONOS_POLL_UPDATE}-{self.soco.uid}",
+                ),
+                SCAN_INTERVAL,
+            )
         self.async_write_entity_states()
 
     #

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -454,7 +454,7 @@ class SonosSpeaker:
     #
     # Speaker availability methods
     #
-    async def async_seen(self, soco: SoCo | None = None) -> None:
+    async def async_seen(self, soco: SoCo | None = None, force_was_unavailable: bool = False) -> None:
         """Record that this speaker was seen right now."""
         if soco is not None:
             self.soco = soco
@@ -468,7 +468,7 @@ class SonosSpeaker:
             SEEN_EXPIRE_TIME.total_seconds(), self.async_unseen
         )
 
-        if was_available:
+        if not force_was_unavailable and was_available:
             self.async_write_entity_states()
             return
 
@@ -539,7 +539,7 @@ class SonosSpeaker:
             soco,
         )
         await self.async_unseen(will_reconnect=True)
-        await self.async_seen(soco)
+        await self.async_seen(soco, force_was_unavailable=True)
 
     #
     # Battery management


### PR DESCRIPTION
## Proposed change

Bug

on 2021.7.4:

- when a Sonos speaker is powered off (I power off the whole room overnight).
- After 3.5 mins the sonos component unsubscribes from events from the speaker
- Powering the speaker back on, the sonos component logs a warning "<speaker name> rebooted or lost connectivity, reconnecting with <SoCo object...>
- The state of the speaker is incorrect, if it was playing music when powered off it it shown as still playing that song
- The speaker does not respond correctly. e.g trying to pause it logs "Error code 701 ignored in call to media_pause"

My understanding of the issue:

The recent addition of zeroconf to the sonos speaker has broken the reboot procedure. As zeroconf (in the call to `async_unseen`) finds the speaker on the network, it sets the `_seen_timer` which causes the speaker to be "available" in the subsequent call to `async_seen`, this means we do not resubscribe to the speaker and thus do not obtain its correct state.

The fix:

When we know we are processing a speaker reboot, force the `async_seen` call to treat the speaker as having been unavailable (it was powered off after all).

Caveats:

There is a likely a nicer way to achieve this but that would require more time to familiarise myself with the code, this change fixes the issue in what I think is a low risk way.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
None

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
