### PR TITLE
Handle software version being None when setting up HomeKit accessories 

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -238,6 +238,7 @@ class HomeAccessory(Accessory):
             model = self.config[ATTR_MODEL]
         else:
             model = domain.title()
+        sw_version = None
         if self.config.get(ATTR_SW_VERSION) is not None:
             sw_version = format_sw_version(self.config[ATTR_SW_VERSION])
         if sw_version is None:

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -240,7 +240,7 @@ class HomeAccessory(Accessory):
             model = domain.title()
         if self.config.get(ATTR_SW_VERSION) is not None:
             sw_version = format_sw_version(self.config[ATTR_SW_VERSION])
-        else:
+        if sw_version is None:
             sw_version = __version__
 
         self.set_info_service(

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -245,10 +245,10 @@ class HomeAccessory(Accessory):
             sw_version = __version__
 
         self.set_info_service(
-            manufacturer=f"{manufacturer}"[:MAX_MANUFACTURER_LENGTH],
-            model=f"{model}"[:MAX_MODEL_LENGTH],
-            serial_number=f"{entity_id}"[:MAX_SERIAL_LENGTH],
-            firmware_revision=f"{sw_version}"[:MAX_VERSION_LENGTH],
+            manufacturer=manufacturer[:MAX_MANUFACTURER_LENGTH],
+            model=model[:MAX_MODEL_LENGTH],
+            serial_number=entity_id[:MAX_SERIAL_LENGTH],
+            firmware_revision=sw_version[:MAX_VERSION_LENGTH],
         )
 
         self.category = category

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -244,10 +244,10 @@ class HomeAccessory(Accessory):
             sw_version = __version__
 
         self.set_info_service(
-            manufacturer=manufacturer[:MAX_MANUFACTURER_LENGTH],
-            model=model[:MAX_MODEL_LENGTH],
-            serial_number=entity_id[:MAX_SERIAL_LENGTH],
-            firmware_revision=sw_version[:MAX_VERSION_LENGTH],
+            manufacturer=f"{manufacturer}"[:MAX_MANUFACTURER_LENGTH],
+            model=f"{model}"[:MAX_MODEL_LENGTH],
+            serial_number=f"{entity_id}"[:MAX_SERIAL_LENGTH],
+            firmware_revision=f"{sw_version}"[:MAX_VERSION_LENGTH],
         )
 
         self.category = category

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -143,7 +143,7 @@ async def test_home_accessory(hass, hk_driver):
         {
             ATTR_MODEL: "Awesome Model that exceeds the maximum maximum maximum maximum maximum maximum length",
             ATTR_MANUFACTURER: "Lux Brands that exceeds the maximum maximum maximum maximum maximum maximum length",
-            ATTR_SW_VERSION: 4,
+            ATTR_SW_VERSION: "will_not_match_regex",
             ATTR_INTEGRATION: "luxe that exceeds the maximum maximum maximum maximum maximum maximum length",
         },
     )

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -132,6 +132,41 @@ async def test_home_accessory(hass, hk_driver):
         == "light.accessory_that_exceeds_the_maximum_maximum_maximum_maximum"
     )
     assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == "0.4.3"
+    
+    
+    acc4 = HomeAccessory(
+        hass,
+        hk_driver,
+        "Home Accessory that exceeds the maximum maximum maximum maximum maximum maximum length",
+        entity_id2,
+        3,
+        {
+            ATTR_MODEL: "Awesome Model that exceeds the maximum maximum maximum maximum maximum maximum length",
+            ATTR_MANUFACTURER: "Lux Brands that exceeds the maximum maximum maximum maximum maximum maximum length",
+            ATTR_SW_VERSION: 4,
+            ATTR_INTEGRATION: "luxe that exceeds the maximum maximum maximum maximum maximum maximum length",
+        },
+    )
+    assert acc4.available is False
+    serv = acc4.services[0]  # SERV_ACCESSORY_INFO
+    assert (
+        serv.get_characteristic(CHAR_NAME).value
+        == "Home Accessory that exceeds the maximum maximum maximum maximum "
+    )
+    assert (
+        serv.get_characteristic(CHAR_MANUFACTURER).value
+        == "Lux Brands that exceeds the maximum maximum maximum maximum maxi"
+    )
+    assert (
+        serv.get_characteristic(CHAR_MODEL).value
+        == "Awesome Model that exceeds the maximum maximum maximum maximum m"
+    )
+    assert (
+        serv.get_characteristic(CHAR_SERIAL_NUMBER).value
+        == "light.accessory_that_exceeds_the_maximum_maximum_maximum_maximum"
+    )
+    assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == "4"
+    
 
     hass.states.async_set(entity_id, "on")
     await hass.async_block_till_done()

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -132,8 +132,7 @@ async def test_home_accessory(hass, hk_driver):
         == "light.accessory_that_exceeds_the_maximum_maximum_maximum_maximum"
     )
     assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == "0.4.3"
-    
-    
+
     acc4 = HomeAccessory(
         hass,
         hk_driver,
@@ -165,8 +164,7 @@ async def test_home_accessory(hass, hk_driver):
         serv.get_characteristic(CHAR_SERIAL_NUMBER).value
         == "light.accessory_that_exceeds_the_maximum_maximum_maximum_maximum"
     )
-    assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == "4"
-    
+    assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == hass_version
 
     hass.states.async_set(entity_id, "on")
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes issue with some accessories no longer loading in HomeKit when they have non-string based model names.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54124

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
