### PR TITLE
Fix Squeezebox dhcp discovery

### DIFF
--- a/homeassistant/components/squeezebox/browse_media.py
+++ b/homeassistant/components/squeezebox/browse_media.py
@@ -137,7 +137,6 @@ async def build_item_response(entity, player, payload):
 
 async def library_payload(player):
     """Create response payload to describe contents of library."""
-
     library_info = {
         "title": "Music Library",
         "media_class": MEDIA_CLASS_DIRECTORY,

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -199,12 +199,12 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         _LOGGER.debug("Configuring dhcp player with unique id: %s", self.unique_id)
 
-        er = async_get(self.hass)
+        registry = async_get(self.hass)
 
         # if we have detected this player, do nothing. if not, there must be a server out there for us to configure, so start the normal user flow (which tries to autodetect server)
-        if er.async_get_entity_id(MP_DOMAIN, DOMAIN, self.unique_id) is not None:
+        if registry.async_get_entity_id(MP_DOMAIN, DOMAIN, self.unique_id) is not None:
             # this player is already known, so do nothing other than mark as configured
             raise data_entry_flow.AbortFlow("already_configured")
-        else:
-            # if the player is unknown, then we likely need to configure its server
-            return await self.async_step_user()
+
+        # if the player is unknown, then we likely need to configure its server
+        return await self.async_step_user()

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -5,8 +5,9 @@ import logging
 from pysqueezebox import Server, async_discover
 import voluptuous as vol
 
-from homeassistant import config_entries
-from homeassistant.components.dhcp import IP_ADDRESS, MAC_ADDRESS
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.dhcp import MAC_ADDRESS
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -15,6 +16,8 @@ from homeassistant.const import (
     HTTP_UNAUTHORIZED,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.entity_registry import async_get
 
 from .const import DEFAULT_PORT, DOMAIN
 
@@ -166,28 +169,18 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason=error)
         return self.async_create_entry(title=config[CONF_HOST], data=config)
 
-    async def async_step_discovery(self, discovery_info):
-        """Handle discovery."""
-        _LOGGER.debug("Reached discovery flow with info: %s", discovery_info)
+    async def async_step_integration_discovery(self, discovery_info):
+        """Handle discovery of a server."""
+        _LOGGER.debug("Reached server discovery flow with info: %s", discovery_info)
         if "uuid" in discovery_info:
             await self.async_set_unique_id(discovery_info.pop("uuid"))
             self._abort_if_unique_id_configured()
         else:
             # attempt to connect to server and determine uuid. will fail if
             # password required
-
-            if CONF_HOST not in discovery_info and IP_ADDRESS in discovery_info:
-                discovery_info[CONF_HOST] = discovery_info[IP_ADDRESS]
-
-            if CONF_PORT not in discovery_info:
-                discovery_info[CONF_PORT] = DEFAULT_PORT
-
             error = await self._validate_input(discovery_info)
             if error:
-                if MAC_ADDRESS in discovery_info:
-                    await self.async_set_unique_id(discovery_info[MAC_ADDRESS])
-                else:
-                    await self._async_handle_discovery_without_unique_id()
+                await self._async_handle_discovery_without_unique_id()
 
         # update schema with suggested values from discovery
         self.data_schema = _base_schema(discovery_info)
@@ -195,3 +188,23 @@ class SqueezeboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.context.update({"title_placeholders": {"host": discovery_info[CONF_HOST]}})
 
         return await self.async_step_edit()
+
+    async def async_step_dhcp(self, discovery_info):
+        """Handle dhcp discovery of a Squeezebox player."""
+        _LOGGER.debug(
+            "Reached dhcp discovery of a player with info: %s", discovery_info
+        )
+        await self.async_set_unique_id(format_mac(discovery_info[MAC_ADDRESS]))
+        self._abort_if_unique_id_configured()
+
+        _LOGGER.debug("Configuring dhcp player with unique id: %s", self.unique_id)
+
+        er = async_get(self.hass)
+
+        # if we have detected this player, do nothing. if not, there must be a server out there for us to configure, so start the normal user flow (which tries to autodetect server)
+        if er.async_get_entity_id(MP_DOMAIN, DOMAIN, self.unique_id) is not None:
+            # this player is already known, so do nothing other than mark as configured
+            raise data_entry_flow.AbortFlow("already_configured")
+        else:
+            # if the player is unknown, then we likely need to configure its server
+            return await self.async_step_user()

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -27,7 +27,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
 )
-from homeassistant.config_entries import SOURCE_DISCOVERY
+from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY
 from homeassistant.const import (
     ATTR_COMMAND,
     CONF_HOST,
@@ -43,6 +43,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -127,7 +128,7 @@ async def start_server_discovery(hass):
         asyncio.create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
-                context={"source": SOURCE_DISCOVERY},
+                context={"source": SOURCE_INTEGRATION_DISCOVERY},
                 data={
                     CONF_HOST: server.host,
                     CONF_PORT: int(server.port),
@@ -146,7 +147,6 @@ async def start_server_discovery(hass):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up squeezebox platform from platform entry in configuration.yaml (deprecated)."""
-
     if config:
         await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config
@@ -283,7 +283,7 @@ class SqueezeBoxEntity(MediaPlayerEntity):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return self._player.player_id
+        return format_mac(self._player.player_id)
 
     @property
     def available(self):
@@ -573,7 +573,6 @@ class SqueezeBoxEntity(MediaPlayerEntity):
 
     async def async_browse_media(self, media_content_type=None, media_content_id=None):
         """Implement the websocket media browsing helper."""
-
         _LOGGER.debug(
             "Reached async_browse_media with content_type %s and content_id %s",
             media_content_type,

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -178,7 +178,7 @@ async def test_discovery(hass):
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            context={"source": config_entries.SOURCE_DISCOVERY},
+            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
             data={CONF_HOST: HOST, CONF_PORT: PORT, "uuid": UUID},
         )
         assert result["type"] == RESULT_TYPE_FORM
@@ -190,7 +190,7 @@ async def test_discovery_no_uuid(hass):
     with patch("pysqueezebox.Server.async_query", new=patch_async_query_unauthorized):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            context={"source": config_entries.SOURCE_DISCOVERY},
+            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
             data={CONF_HOST: HOST, CONF_PORT: PORT},
         )
         assert result["type"] == RESULT_TYPE_FORM
@@ -199,9 +199,8 @@ async def test_discovery_no_uuid(hass):
 
 async def test_dhcp_discovery(hass):
     """Test we can process discovery from dhcp."""
-    with patch(
-        "pysqueezebox.Server.async_query",
-        return_value={"uuid": UUID},
+    with patch("pysqueezebox.Server.async_query", return_value={"uuid": UUID},), patch(
+        "homeassistant.components.squeezebox.config_flow.async_discover", mock_discover
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -216,9 +215,12 @@ async def test_dhcp_discovery(hass):
         assert result["step_id"] == "edit"
 
 
-async def test_dhcp_discovery_no_connection(hass):
-    """Test we can process discovery from dhcp without connecting to squeezebox server."""
-    with patch("pysqueezebox.Server.async_query", new=patch_async_query_unauthorized):
+async def test_dhcp_discovery_no_server_found(hass):
+    """Test we can handle dhcp discovery when no server is found."""
+    with patch(
+        "homeassistant.components.squeezebox.config_flow.async_discover",
+        mock_failed_discover,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
@@ -229,7 +231,7 @@ async def test_dhcp_discovery_no_connection(hass):
             },
         )
         assert result["type"] == RESULT_TYPE_FORM
-        assert result["step_id"] == "edit"
+        assert result["step_id"] == "user"
 
 
 async def test_import(hass):

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -234,6 +234,24 @@ async def test_dhcp_discovery_no_server_found(hass):
         assert result["step_id"] == "user"
 
 
+async def test_dhcp_discovery_existing_player(hass):
+    """Test that we properly ignore known players during dhcp discover."""
+    with patch(
+        "homeassistant.helpers.entity_registry.EntityRegistry.async_get_entity_id",
+        return_value="test_entity",
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data={
+                IP_ADDRESS: "1.1.1.1",
+                MAC_ADDRESS: "AA:BB:CC:DD:EE:FF",
+                HOSTNAME: "any",
+            },
+        )
+        assert result["type"] == RESULT_TYPE_ABORT
+
+
 async def test_import(hass):
     """Test handling of configuration imported."""
     with patch("pysqueezebox.Server.async_query", return_value={"uuid": UUID},), patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Squeezebox integration does not properly implement DHCP discovery. As a stopgap, it was using the deprecated discovery configuration flow. However, that configuration flow expected to process discovered Squeezebox servers. The DHCP integration, however, discovers Squeezebox players. In addition, a bug in the configuration flow meant that we weren't respecting a user's choice to ignore these discovered players. See #53388 and #51677.

The proposed change properly handles DHCP discovery by first checking if the discovered player is new or not. If it is new, we start a configuration flow looking for a Squeezebox server (which should be on the network if there is a player). If it isn't new, we abort the configuration flow, so that the user doesn't have to manually ignore it.

This fix also removes the deprecated `discovery` configuration flow, refactoring it into `dhcp` and `integration_discovery` flows.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53388 and #51677
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
