### PR TITLE
Fetch interface index from network integration instead of socket in zeroconf

### DIFF
--- a/homeassistant/components/network/models.py
+++ b/homeassistant/components/network/models.py
@@ -24,6 +24,7 @@ class Adapter(TypedDict):
     """Configured network adapters."""
 
     name: str
+    index: int
     enabled: bool
     auto: bool
     default: bool

--- a/homeassistant/components/network/util.py
+++ b/homeassistant/components/network/util.py
@@ -116,6 +116,7 @@ def _ifaddr_adapter_to_ha(
 
     return {
         "name": adapter.nice_name,
+        "index": adapter.index,
         "enabled": False,
         "auto": auto,
         "default": default,

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -155,9 +155,8 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
                     for ipv4 in ipv4s
                     if not ipaddress.ip_address(ipv4["address"]).is_loopback
                 )
-            if adapter["ipv6"]:
-                ifi = socket.if_nametoindex(adapter["name"])
-                interfaces.append(ifi)
+            if adapter["ipv6"] and adapter["index"] not in interfaces:
+                interfaces.append(adapter["index"])
 
     ipv6 = True
     if not any(adapter["enabled"] and adapter["ipv6"] for adapter in adapters):

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -21,15 +21,19 @@ def _generate_mock_adapters():
     mock_lo0 = Mock(spec=ifaddr.Adapter)
     mock_lo0.nice_name = "lo0"
     mock_lo0.ips = [ifaddr.IP("127.0.0.1", 8, "lo0")]
+    mock_lo0.index = 0
     mock_eth0 = Mock(spec=ifaddr.Adapter)
     mock_eth0.nice_name = "eth0"
     mock_eth0.ips = [ifaddr.IP(("2001:db8::", 1, 1), 8, "eth0")]
+    mock_eth0.index = 1
     mock_eth1 = Mock(spec=ifaddr.Adapter)
     mock_eth1.nice_name = "eth1"
     mock_eth1.ips = [ifaddr.IP("192.168.1.5", 23, "eth1")]
+    mock_eth1.index = 2
     mock_vtun0 = Mock(spec=ifaddr.Adapter)
     mock_vtun0.nice_name = "vtun0"
     mock_vtun0.ips = [ifaddr.IP("169.254.3.2", 16, "vtun0")]
+    mock_vtun0.index = 3
     return [mock_eth0, mock_lo0, mock_eth1, mock_vtun0]
 
 
@@ -51,6 +55,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_sto
     assert network_obj.adapters == [
         {
             "auto": False,
+            "index": 1,
             "default": False,
             "enabled": False,
             "ipv4": [],
@@ -65,6 +70,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_sto
             "name": "eth0",
         },
         {
+            "index": 0,
             "auto": False,
             "default": False,
             "enabled": False,
@@ -73,6 +79,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_sto
             "name": "lo0",
         },
         {
+            "index": 2,
             "auto": True,
             "default": True,
             "enabled": True,
@@ -81,6 +88,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_sto
             "name": "eth1",
         },
         {
+            "index": 3,
             "auto": False,
             "default": False,
             "enabled": False,
@@ -107,6 +115,7 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage
     assert network_obj.configured_adapters == []
     assert network_obj.adapters == [
         {
+            "index": 1,
             "auto": True,
             "default": False,
             "enabled": True,
@@ -122,6 +131,7 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage
             "name": "eth0",
         },
         {
+            "index": 0,
             "auto": False,
             "default": True,
             "enabled": False,
@@ -130,6 +140,7 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage
             "name": "lo0",
         },
         {
+            "index": 2,
             "auto": True,
             "default": False,
             "enabled": True,
@@ -138,6 +149,7 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage
             "name": "eth1",
         },
         {
+            "index": 3,
             "auto": False,
             "default": False,
             "enabled": False,
@@ -165,6 +177,7 @@ async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
     assert network_obj.adapters == [
         {
             "auto": True,
+            "index": 1,
             "default": False,
             "enabled": True,
             "ipv4": [],
@@ -180,6 +193,7 @@ async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 0,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
@@ -188,6 +202,7 @@ async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
         },
         {
             "auto": True,
+            "index": 2,
             "default": False,
             "enabled": True,
             "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -196,6 +211,7 @@ async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 3,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
@@ -222,6 +238,7 @@ async def test_async_detect_interfaces_setting_exception(hass, hass_storage):
     assert network_obj.adapters == [
         {
             "auto": True,
+            "index": 1,
             "default": False,
             "enabled": True,
             "ipv4": [],
@@ -237,6 +254,7 @@ async def test_async_detect_interfaces_setting_exception(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 0,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
@@ -245,6 +263,7 @@ async def test_async_detect_interfaces_setting_exception(hass, hass_storage):
         },
         {
             "auto": True,
+            "index": 2,
             "default": False,
             "enabled": True,
             "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -253,6 +272,7 @@ async def test_async_detect_interfaces_setting_exception(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 3,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
@@ -285,6 +305,7 @@ async def test_interfaces_configured_from_storage(hass, hass_storage):
     assert network_obj.adapters == [
         {
             "auto": False,
+            "index": 1,
             "default": False,
             "enabled": True,
             "ipv4": [],
@@ -300,6 +321,7 @@ async def test_interfaces_configured_from_storage(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 0,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
@@ -308,6 +330,7 @@ async def test_interfaces_configured_from_storage(hass, hass_storage):
         },
         {
             "auto": True,
+            "index": 2,
             "default": True,
             "enabled": True,
             "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -316,6 +339,7 @@ async def test_interfaces_configured_from_storage(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 3,
             "default": False,
             "enabled": True,
             "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
@@ -356,6 +380,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
     assert response["result"][ATTR_ADAPTERS] == [
         {
             "auto": False,
+            "index": 1,
             "default": False,
             "enabled": True,
             "ipv4": [],
@@ -371,6 +396,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": False,
+            "index": 0,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
@@ -379,6 +405,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": True,
+            "index": 2,
             "default": True,
             "enabled": True,
             "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -387,6 +414,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": False,
+            "index": 3,
             "default": False,
             "enabled": True,
             "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
@@ -407,6 +435,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
     assert response["result"][ATTR_ADAPTERS] == [
         {
             "auto": False,
+            "index": 1,
             "default": False,
             "enabled": False,
             "ipv4": [],
@@ -422,6 +451,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": False,
+            "index": 0,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
@@ -430,6 +460,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": True,
+            "index": 2,
             "default": True,
             "enabled": True,
             "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -438,6 +469,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": False,
+            "index": 3,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -725,6 +725,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(
 _ADAPTERS_WITH_MANUAL_CONFIG = [
     {
         "auto": True,
+        "index": 1,
         "default": False,
         "enabled": True,
         "ipv4": [],
@@ -746,6 +747,7 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
     },
     {
         "auto": True,
+        "index": 2,
         "default": False,
         "enabled": True,
         "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -754,6 +756,7 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
     },
     {
         "auto": True,
+        "index": 3,
         "default": False,
         "enabled": True,
         "ipv4": [{"address": "172.16.1.5", "network_prefix": 23}],
@@ -769,6 +772,7 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
     },
     {
         "auto": False,
+        "index": 4,
         "default": False,
         "enabled": False,
         "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #54148. Replaces the call to `socket.if_nametoindex` added in #53505 with data from the `network` integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
