### PR TITLE
OVO Energy Long-term Statistics

### DIFF
--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -1,13 +1,17 @@
 """Support for OVO Energy sensors."""
-from datetime import timedelta
+from __future__ import annotations
+
+from datetime import datetime, timedelta
 
 from ovoenergy import OVODailyUsage
 from ovoenergy.ovoenergy import OVOEnergy
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import DEVICE_CLASS_ENERGY, DEVICE_CLASS_MONETARY
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util.dt import utc_from_timestamp
 
 from . import OVOEnergyDeviceEntity
 from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
@@ -64,15 +68,32 @@ class OVOEnergySensor(OVOEnergyDeviceEntity, SensorEntity):
         key: str,
         name: str,
         icon: str,
-        unit_of_measurement: str = "",
+        device_class: str | None,
+        unit_of_measurement: str | None,
     ) -> None:
         """Initialize OVO Energy sensor."""
+        self._device_class = device_class
         self._unit_of_measurement = unit_of_measurement
 
         super().__init__(coordinator, client, key, name, icon)
 
     @property
-    def unit_of_measurement(self) -> str:
+    def device_class(self) -> str | None:
+        """Return the class of this sensor."""
+        return self._device_class
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the time when the sensor was last reset, if any."""
+        return utc_from_timestamp(0)
+
+    @property
+    def state_class(self) -> str:
+        """Return the state class of this entity."""
+        return "measurement"
+
+    @property
+    def unit_of_measurement(self) -> str | None:
         """Return the unit this state is expressed in."""
         return self._unit_of_measurement
 
@@ -89,6 +110,7 @@ class OVOEnergyLastElectricityReading(OVOEnergySensor):
             f"{client.account_id}_last_electricity_reading",
             "OVO Last Electricity Reading",
             "mdi:flash",
+            DEVICE_CLASS_ENERGY,
             "kWh",
         )
 
@@ -124,6 +146,7 @@ class OVOEnergyLastGasReading(OVOEnergySensor):
             f"{DOMAIN}_{client.account_id}_last_gas_reading",
             "OVO Last Gas Reading",
             "mdi:gas-cylinder",
+            DEVICE_CLASS_ENERGY,
             "kWh",
         )
 
@@ -160,6 +183,7 @@ class OVOEnergyLastElectricityCost(OVOEnergySensor):
             f"{DOMAIN}_{client.account_id}_last_electricity_cost",
             "OVO Last Electricity Cost",
             "mdi:cash-multiple",
+            DEVICE_CLASS_MONETARY,
             currency,
         )
 
@@ -196,6 +220,7 @@ class OVOEnergyLastGasCost(OVOEnergySensor):
             f"{DOMAIN}_{client.account_id}_last_gas_cost",
             "OVO Last Gas Cost",
             "mdi:cash-multiple",
+            DEVICE_CLASS_MONETARY,
             currency,
         )
 

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -72,15 +72,10 @@ class OVOEnergySensor(OVOEnergyDeviceEntity, SensorEntity):
         unit_of_measurement: str | None,
     ) -> None:
         """Initialize OVO Energy sensor."""
-        self._device_class = device_class
+        self._attr_device_class = device_class
         self._unit_of_measurement = unit_of_measurement
 
         super().__init__(coordinator, client, key, name, icon)
-
-    @property
-    def device_class(self) -> str | None:
-        """Return the class of this sensor."""
-        return self._device_class
 
     @property
     def last_reset(self) -> datetime | None:

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -1,7 +1,7 @@
 """Support for OVO Energy sensors."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from ovoenergy import OVODailyUsage
 from ovoenergy.ovoenergy import OVOEnergy
@@ -61,6 +61,9 @@ async def async_setup_entry(
 class OVOEnergySensor(OVOEnergyDeviceEntity, SensorEntity):
     """Defines a OVO Energy sensor."""
 
+    _attr_last_reset = utc_from_timestamp(0)
+    _attr_state_class = "measurement"
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
@@ -76,16 +79,6 @@ class OVOEnergySensor(OVOEnergyDeviceEntity, SensorEntity):
         self._unit_of_measurement = unit_of_measurement
 
         super().__init__(coordinator, client, key, name, icon)
-
-    @property
-    def last_reset(self) -> datetime | None:
-        """Return the time when the sensor was last reset, if any."""
-        return utc_from_timestamp(0)
-
-    @property
-    def state_class(self) -> str:
-        """Return the state class of this entity."""
-        return "measurement"
 
     @property
     def unit_of_measurement(self) -> str | None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds `device_class`, `last_reset` and `state_class` to OVO Energy sensors to enable LTS

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (which adds functionality to an existing integration)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] 🥈 Silver

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
