### PR TITLE
 Name dsmr_reader sensors more consistent

### DIFF
--- a/homeassistant/components/dsmr_reader/definitions.py
+++ b/homeassistant/components/dsmr_reader/definitions.py
@@ -48,7 +48,7 @@ class DSMRReaderSensorEntityDescription(SensorEntityDescription):
 SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     DSMRReaderSensorEntityDescription(
         key="dsmr/reading/electricity_delivered_1",
-        name="Low tariff usage",
+        name="Current low tariff usage",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_MEASUREMENT,
@@ -56,7 +56,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/reading/electricity_returned_1",
-        name="Low tariff returned",
+        name="Current low tariff returned",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_MEASUREMENT,
@@ -64,7 +64,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/reading/electricity_delivered_2",
-        name="High tariff usage",
+        name="Current high tariff usage",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_MEASUREMENT,
@@ -72,7 +72,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/reading/electricity_returned_2",
-        name="High tariff returned",
+        name="Current high tariff returned",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_MEASUREMENT,
@@ -142,7 +142,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/reading/extra_device_delivered",
-        name="Gas meter usage",
+        name="Current gas meter usage",
         entity_registry_enabled_default=False,
         icon="mdi:fire",
         unit_of_measurement=VOLUME_CUBIC_METERS,
@@ -226,7 +226,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/electricity1",
-        name="Low tariff usage",
+        name="Current day low tariff usage",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_MEASUREMENT,
@@ -234,7 +234,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/electricity2",
-        name="High tariff usage",
+        name="Current day high tariff usage",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_MEASUREMENT,
@@ -242,7 +242,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/electricity1_returned",
-        name="Low tariff return",
+        name="Current day low tariff return",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_MEASUREMENT,
@@ -250,7 +250,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/electricity2_returned",
-        name="High tariff return",
+        name="Current day high tariff return",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_MEASUREMENT,
@@ -258,7 +258,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/electricity_merged",
-        name="Power usage total",
+        name="Current day power usage total",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_MEASUREMENT,
@@ -266,7 +266,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/electricity_returned_merged",
-        name="Power return total",
+        name="Current day power return total",
         device_class=DEVICE_CLASS_ENERGY,
         unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_MEASUREMENT,
@@ -292,7 +292,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/gas",
-        name="Gas usage",
+        name="Current day gas usage",
         icon="mdi:counter",
         unit_of_measurement=VOLUME_CUBIC_METERS,
     ),
@@ -304,7 +304,7 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/total_cost",
-        name="Total cost",
+        name="Current day total cost",
         icon="mdi:currency-eur",
         unit_of_measurement=CURRENCY_EURO,
     ),


### PR DESCRIPTION
I am playing around with the energy dashboard and noticed the naming of the sensors was wrong (duplicate).
I've changed the naming so it conforms more to the rest of the naming scheme. Current year, Current month, Current day, Current.
Given that this might be a breaking change, I'll leave it up to the HA people if this is worth merging.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This name change will break dashboard entries because of the new naming. Currently when configuring the new energy dashboard there are multiple entries with the same name making it confusing and illogical.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
