### PR TITLE
2021.8.3

### DIFF
--- a/homeassistant/components/ebox/sensor.py
+++ b/homeassistant/components/ebox/sensor.py
@@ -122,10 +122,12 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     ),
 )
 
+SENSOR_TYPE_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_MONITORED_VARIABLES): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_TYPES)]
+            cv.ensure_list, [vol.In(SENSOR_TYPE_KEYS)]
         ),
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,

--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -1,4 +1,5 @@
 """Support for Enphase Envoy solar energy monitor."""
+from __future__ import annotations
 
 import logging
 
@@ -22,14 +23,15 @@ ICON = "mdi:flash"
 CONST_DEFAULT_HOST = "envoy"
 _LOGGER = logging.getLogger(__name__)
 
+SENSOR_KEYS: list[str] = [desc.key for desc in SENSORS]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_IP_ADDRESS, default=CONST_DEFAULT_HOST): cv.string,
         vol.Optional(CONF_USERNAME, default="envoy"): cv.string,
         vol.Optional(CONF_PASSWORD, default=""): cv.string,
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSORS)): vol.All(
-            cv.ensure_list, [vol.In(list(SENSORS))]
+        vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_KEYS): vol.All(
+            cv.ensure_list, [vol.In(SENSOR_KEYS)]
         ),
         vol.Optional(CONF_NAME, default=""): cv.string,
     }

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -238,9 +238,10 @@ class HomeAccessory(Accessory):
             model = self.config[ATTR_MODEL]
         else:
             model = domain.title()
+        sw_version = None
         if self.config.get(ATTR_SOFTWARE_VERSION) is not None:
             sw_version = format_sw_version(self.config[ATTR_SOFTWARE_VERSION])
-        else:
+        if sw_version is None:
             sw_version = __version__
 
         self.set_info_service(

--- a/homeassistant/components/network/models.py
+++ b/homeassistant/components/network/models.py
@@ -24,6 +24,7 @@ class Adapter(TypedDict):
     """Configured network adapters."""
 
     name: str
+    index: int
     enabled: bool
     auto: bool
     default: bool

--- a/homeassistant/components/network/util.py
+++ b/homeassistant/components/network/util.py
@@ -116,6 +116,7 @@ def _ifaddr_adapter_to_ha(
 
     return {
         "name": adapter.nice_name,
+        "index": adapter.index,
         "enabled": False,
         "auto": auto,
         "default": default,

--- a/homeassistant/components/sms/gateway.py
+++ b/homeassistant/components/sms/gateway.py
@@ -25,6 +25,10 @@ class Gateway:
             await self._worker.set_incoming_sms_async()
         except gammu.ERR_NOTSUPPORTED:
             _LOGGER.warning("Your phone does not support incoming SMS notifications!")
+        except gammu.GSMError:
+            _LOGGER.warning(
+                "GSM error, your phone does not support incoming SMS notifications!"
+            )
         else:
             await self._worker.set_incoming_callback_async(self.sms_callback)
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -155,9 +155,8 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
                     for ipv4 in ipv4s
                     if not ipaddress.ip_address(ipv4["address"]).is_loopback
                 )
-            if adapter["ipv6"]:
-                ifi = socket.if_nametoindex(adapter["name"])
-                interfaces.append(ifi)
+            if adapter["ipv6"] and adapter["index"] not in interfaces:
+                interfaces.append(adapter["index"])
 
     ipv6 = True
     if not any(adapter["enabled"] and adapter["ipv6"] for adapter in adapters):

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -2,7 +2,7 @@
   "domain": "zeroconf",
   "name": "Zero-configuration networking (zeroconf)",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
-  "requirements": ["zeroconf==0.33.3"],
+  "requirements": ["zeroconf==0.33.4"],
   "dependencies": ["network", "api"],
   "codeowners": ["@bdraco"],
   "quality_scale": "internal",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 8
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -33,7 +33,7 @@ sqlalchemy==1.4.17
 voluptuous-serialize==2.4.0
 voluptuous==0.12.1
 yarl==1.6.3
-zeroconf==0.33.3
+zeroconf==0.33.4
 
 pycryptodome>=3.6.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2439,7 +2439,7 @@ zeep[async]==4.0.0
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.33.3
+zeroconf==0.33.4
 
 # homeassistant.components.zha
 zha-quirks==0.0.59

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1341,7 +1341,7 @@ youless-api==0.10
 zeep[async]==4.0.0
 
 # homeassistant.components.zeroconf
-zeroconf==0.33.3
+zeroconf==0.33.4
 
 # homeassistant.components.zha
 zha-quirks==0.0.59

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -133,6 +133,39 @@ async def test_home_accessory(hass, hk_driver):
     )
     assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == "0.4.3"
 
+    acc4 = HomeAccessory(
+        hass,
+        hk_driver,
+        "Home Accessory that exceeds the maximum maximum maximum maximum maximum maximum length",
+        entity_id2,
+        3,
+        {
+            ATTR_MODEL: "Awesome Model that exceeds the maximum maximum maximum maximum maximum maximum length",
+            ATTR_MANUFACTURER: "Lux Brands that exceeds the maximum maximum maximum maximum maximum maximum length",
+            ATTR_SOFTWARE_VERSION: "will_not_match_regex",
+            ATTR_INTEGRATION: "luxe that exceeds the maximum maximum maximum maximum maximum maximum length",
+        },
+    )
+    assert acc4.available is False
+    serv = acc4.services[0]  # SERV_ACCESSORY_INFO
+    assert (
+        serv.get_characteristic(CHAR_NAME).value
+        == "Home Accessory that exceeds the maximum maximum maximum maximum "
+    )
+    assert (
+        serv.get_characteristic(CHAR_MANUFACTURER).value
+        == "Lux Brands that exceeds the maximum maximum maximum maximum maxi"
+    )
+    assert (
+        serv.get_characteristic(CHAR_MODEL).value
+        == "Awesome Model that exceeds the maximum maximum maximum maximum m"
+    )
+    assert (
+        serv.get_characteristic(CHAR_SERIAL_NUMBER).value
+        == "light.accessory_that_exceeds_the_maximum_maximum_maximum_maximum"
+    )
+    assert serv.get_characteristic(CHAR_FIRMWARE_REVISION).value == hass_version
+
     hass.states.async_set(entity_id, "on")
     await hass.async_block_till_done()
     with patch(

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -21,15 +21,19 @@ def _generate_mock_adapters():
     mock_lo0 = Mock(spec=ifaddr.Adapter)
     mock_lo0.nice_name = "lo0"
     mock_lo0.ips = [ifaddr.IP("127.0.0.1", 8, "lo0")]
+    mock_lo0.index = 0
     mock_eth0 = Mock(spec=ifaddr.Adapter)
     mock_eth0.nice_name = "eth0"
     mock_eth0.ips = [ifaddr.IP(("2001:db8::", 1, 1), 8, "eth0")]
+    mock_eth0.index = 1
     mock_eth1 = Mock(spec=ifaddr.Adapter)
     mock_eth1.nice_name = "eth1"
     mock_eth1.ips = [ifaddr.IP("192.168.1.5", 23, "eth1")]
+    mock_eth1.index = 2
     mock_vtun0 = Mock(spec=ifaddr.Adapter)
     mock_vtun0.nice_name = "vtun0"
     mock_vtun0.ips = [ifaddr.IP("169.254.3.2", 16, "vtun0")]
+    mock_vtun0.index = 3
     return [mock_eth0, mock_lo0, mock_eth1, mock_vtun0]
 
 
@@ -51,6 +55,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_sto
     assert network_obj.adapters == [
         {
             "auto": False,
+            "index": 1,
             "default": False,
             "enabled": False,
             "ipv4": [],
@@ -65,6 +70,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_sto
             "name": "eth0",
         },
         {
+            "index": 0,
             "auto": False,
             "default": False,
             "enabled": False,
@@ -73,6 +79,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_sto
             "name": "lo0",
         },
         {
+            "index": 2,
             "auto": True,
             "default": True,
             "enabled": True,
@@ -81,6 +88,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_sto
             "name": "eth1",
         },
         {
+            "index": 3,
             "auto": False,
             "default": False,
             "enabled": False,
@@ -107,6 +115,7 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage
     assert network_obj.configured_adapters == []
     assert network_obj.adapters == [
         {
+            "index": 1,
             "auto": True,
             "default": False,
             "enabled": True,
@@ -122,6 +131,7 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage
             "name": "eth0",
         },
         {
+            "index": 0,
             "auto": False,
             "default": True,
             "enabled": False,
@@ -130,6 +140,7 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage
             "name": "lo0",
         },
         {
+            "index": 2,
             "auto": True,
             "default": False,
             "enabled": True,
@@ -138,6 +149,7 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage
             "name": "eth1",
         },
         {
+            "index": 3,
             "auto": False,
             "default": False,
             "enabled": False,
@@ -165,6 +177,7 @@ async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
     assert network_obj.adapters == [
         {
             "auto": True,
+            "index": 1,
             "default": False,
             "enabled": True,
             "ipv4": [],
@@ -180,6 +193,7 @@ async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 0,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
@@ -188,6 +202,7 @@ async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
         },
         {
             "auto": True,
+            "index": 2,
             "default": False,
             "enabled": True,
             "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -196,6 +211,7 @@ async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 3,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
@@ -222,6 +238,7 @@ async def test_async_detect_interfaces_setting_exception(hass, hass_storage):
     assert network_obj.adapters == [
         {
             "auto": True,
+            "index": 1,
             "default": False,
             "enabled": True,
             "ipv4": [],
@@ -237,6 +254,7 @@ async def test_async_detect_interfaces_setting_exception(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 0,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
@@ -245,6 +263,7 @@ async def test_async_detect_interfaces_setting_exception(hass, hass_storage):
         },
         {
             "auto": True,
+            "index": 2,
             "default": False,
             "enabled": True,
             "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -253,6 +272,7 @@ async def test_async_detect_interfaces_setting_exception(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 3,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
@@ -285,6 +305,7 @@ async def test_interfaces_configured_from_storage(hass, hass_storage):
     assert network_obj.adapters == [
         {
             "auto": False,
+            "index": 1,
             "default": False,
             "enabled": True,
             "ipv4": [],
@@ -300,6 +321,7 @@ async def test_interfaces_configured_from_storage(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 0,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
@@ -308,6 +330,7 @@ async def test_interfaces_configured_from_storage(hass, hass_storage):
         },
         {
             "auto": True,
+            "index": 2,
             "default": True,
             "enabled": True,
             "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -316,6 +339,7 @@ async def test_interfaces_configured_from_storage(hass, hass_storage):
         },
         {
             "auto": False,
+            "index": 3,
             "default": False,
             "enabled": True,
             "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
@@ -356,6 +380,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
     assert response["result"][ATTR_ADAPTERS] == [
         {
             "auto": False,
+            "index": 1,
             "default": False,
             "enabled": True,
             "ipv4": [],
@@ -371,6 +396,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": False,
+            "index": 0,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
@@ -379,6 +405,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": True,
+            "index": 2,
             "default": True,
             "enabled": True,
             "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -387,6 +414,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": False,
+            "index": 3,
             "default": False,
             "enabled": True,
             "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
@@ -407,6 +435,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
     assert response["result"][ATTR_ADAPTERS] == [
         {
             "auto": False,
+            "index": 1,
             "default": False,
             "enabled": False,
             "ipv4": [],
@@ -422,6 +451,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": False,
+            "index": 0,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
@@ -430,6 +460,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": True,
+            "index": 2,
             "default": True,
             "enabled": True,
             "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -438,6 +469,7 @@ async def test_interfaces_configured_from_storage_websocket_update(
         },
         {
             "auto": False,
+            "index": 3,
             "default": False,
             "enabled": False,
             "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -725,6 +725,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(
 _ADAPTERS_WITH_MANUAL_CONFIG = [
     {
         "auto": True,
+        "index": 1,
         "default": False,
         "enabled": True,
         "ipv4": [],
@@ -746,6 +747,7 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
     },
     {
         "auto": True,
+        "index": 2,
         "default": False,
         "enabled": True,
         "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
@@ -754,6 +756,7 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
     },
     {
         "auto": True,
+        "index": 3,
         "default": False,
         "enabled": True,
         "ipv4": [{"address": "172.16.1.5", "network_prefix": 23}],
@@ -769,6 +772,7 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
     },
     {
         "auto": False,
+        "index": 4,
         "default": False,
         "enabled": False,
         "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],


### PR DESCRIPTION
- Gracefully handle additional GSM errors ([@ocalvo] - [#54114]) ([sms docs])
- Handle software version being None when setting up HomeKit accessories ([@nzapponi] - [#54130]) ([homekit docs])
- Fix sensor PLATFORM_SCHEMA for ebox and enphase_envoy ([@mib1185] - [#54142]) ([enphase_envoy docs])
- Fetch interface index from network integration instead of socket.if_nametoindex in zeroconf ([@bdraco] - [#54152]) ([zeroconf docs]) ([network docs])
- Bump zeroconf to 0.33.4 to ensure zeroconf can startup when ipv6 is disabled ([@bdraco] - [#54165]) ([zeroconf docs])

[#54114]: https://github.com/home-assistant/core/pull/54114
[#54130]: https://github.com/home-assistant/core/pull/54130
[#54142]: https://github.com/home-assistant/core/pull/54142
[#54152]: https://github.com/home-assistant/core/pull/54152
[#54165]: https://github.com/home-assistant/core/pull/54165
[@bdraco]: https://github.com/bdraco
[@mib1185]: https://github.com/mib1185
[@nzapponi]: https://github.com/nzapponi
[@ocalvo]: https://github.com/ocalvo
[enphase_envoy docs]: https://www.home-assistant.io/integrations/enphase_envoy/
[homekit docs]: https://www.home-assistant.io/integrations/homekit/
[network docs]: https://www.home-assistant.io/integrations/network/
[sms docs]: https://www.home-assistant.io/integrations/sms/
[zeroconf docs]: https://www.home-assistant.io/integrations/zeroconf/