### PR TITLE
Remove deprecated Xiaomi Miio fan speeds

### DIFF
--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -420,19 +420,11 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
         self._supported_features = 0
         self._speed_count = 100
         self._preset_modes = []
-        # the speed_list attribute is deprecated, support will end with release 2021.7
-        self._speed_list = []
 
     @property
     def supported_features(self):
         """Flag supported features."""
         return self._supported_features
-
-    # the speed_list attribute is deprecated, support will end with release 2021.7
-    @property
-    def speed_list(self) -> list:
-        """Get the list of available speeds."""
-        return self._speed_list
 
     @property
     def speed_count(self):
@@ -516,9 +508,6 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
             "Turning the miio device on failed.", self._device.on
         )
 
-        # Remove the async_set_speed call is async_set_percentage and async_set_preset_modes have been implemented
-        if speed:
-            await self.async_set_speed(speed)
         # If operation mode was set the device must not be turned on.
         if percentage:
             await self.async_set_percentage(percentage)
@@ -610,61 +599,39 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
         if self._model == MODEL_AIRPURIFIER_PRO:
             self._device_features = FEATURE_FLAGS_AIRPURIFIER_PRO
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRPURIFIER_PRO
-            # SUPPORT_SET_SPEED was disabled
-            # the device supports preset_modes only
             self._preset_modes = PRESET_MODES_AIRPURIFIER_PRO
             self._supported_features = SUPPORT_PRESET_MODE
             self._speed_count = 1
-            # the speed_list attribute is deprecated, support will end with release 2021.7
-            self._speed_list = OPERATION_MODES_AIRPURIFIER_PRO
         elif self._model == MODEL_AIRPURIFIER_PRO_V7:
             self._device_features = FEATURE_FLAGS_AIRPURIFIER_PRO_V7
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRPURIFIER_PRO_V7
-            # SUPPORT_SET_SPEED was disabled
-            # the device supports preset_modes only
             self._preset_modes = PRESET_MODES_AIRPURIFIER_PRO_V7
             self._supported_features = SUPPORT_PRESET_MODE
             self._speed_count = 1
-            # the speed_list attribute is deprecated, support will end with release 2021.7
-            self._speed_list = OPERATION_MODES_AIRPURIFIER_PRO_V7
         elif self._model in [MODEL_AIRPURIFIER_2S, MODEL_AIRPURIFIER_2H]:
             self._device_features = FEATURE_FLAGS_AIRPURIFIER_2S
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRPURIFIER_2S
-            # SUPPORT_SET_SPEED was disabled
-            # the device supports preset_modes only
             self._preset_modes = PRESET_MODES_AIRPURIFIER_2S
             self._supported_features = SUPPORT_PRESET_MODE
             self._speed_count = 1
-            # the speed_list attribute is deprecated, support will end with release 2021.7
-            self._speed_list = OPERATION_MODES_AIRPURIFIER_2S
         elif self._model in MODELS_PURIFIER_MIOT:
             self._device_features = FEATURE_FLAGS_AIRPURIFIER_3
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRPURIFIER_3
-            # SUPPORT_SET_SPEED was disabled
-            # the device supports preset_modes only
             self._preset_modes = PRESET_MODES_AIRPURIFIER_3
             self._supported_features = SUPPORT_SET_SPEED | SUPPORT_PRESET_MODE
             self._speed_count = 3
-            # the speed_list attribute is deprecated, support will end with release 2021.7
-            self._speed_list = OPERATION_MODES_AIRPURIFIER_3
         elif self._model == MODEL_AIRPURIFIER_V3:
             self._device_features = FEATURE_FLAGS_AIRPURIFIER_V3
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRPURIFIER_V3
-            # SUPPORT_SET_SPEED was disabled
-            # the device supports preset_modes only
             self._preset_modes = PRESET_MODES_AIRPURIFIER_V3
             self._supported_features = SUPPORT_PRESET_MODE
             self._speed_count = 1
-            # the speed_list attribute is deprecated, support will end with release 2021.7
-            self._speed_list = OPERATION_MODES_AIRPURIFIER_V3
         else:
             self._device_features = FEATURE_FLAGS_AIRPURIFIER
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRPURIFIER
             self._preset_modes = PRESET_MODES_AIRPURIFIER
             self._supported_features = SUPPORT_PRESET_MODE
             self._speed_count = 1
-            # the speed_list attribute is deprecated, support will end with release 2021.7
-            self._speed_list = []
 
         self._state_attrs.update(
             {attribute: None for attribute in self._available_attributes}
@@ -690,15 +657,6 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
                 return ranged_value_to_percentage(
                     (1, self._speed_count), self.REVERSE_SPEED_MODE_MAPPING[mode]
                 )
-
-        return None
-
-    # the speed attribute is deprecated, support will end with release 2021.7
-    @property
-    def speed(self):
-        """Return the current speed."""
-        if self._state:
-            return AirpurifierOperationMode(self._state_attrs[ATTR_MODE]).name
 
         return None
 
@@ -729,21 +687,6 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
             "Setting operation mode of the miio device failed.",
             self._device.set_mode,
             self.PRESET_MODE_MAPPING[preset_mode],
-        )
-
-    # the async_set_speed function is deprecated, support will end with release 2021.7
-    # it is added here only for compatibility with legacy speeds
-    async def async_set_speed(self, speed: str) -> None:
-        """Set the speed of the fan."""
-        if self.supported_features & SUPPORT_SET_SPEED == 0:
-            return
-
-        _LOGGER.debug("Setting the operation mode to: %s", speed)
-
-        await self._try_command(
-            "Setting operation mode of the miio device failed.",
-            self._device.set_mode,
-            AirpurifierOperationMode[speed.title()],
         )
 
     async def async_set_led_on(self):
@@ -892,15 +835,6 @@ class XiaomiAirPurifierMiot(XiaomiAirPurifier):
 
         return None
 
-    # the speed attribute is deprecated, support will end with release 2021.7
-    @property
-    def speed(self):
-        """Return the current speed."""
-        if self._state:
-            return AirpurifierMiotOperationMode(self._mode).name
-
-        return None
-
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the percentage of the fan.
 
@@ -933,23 +867,6 @@ class XiaomiAirPurifierMiot(XiaomiAirPurifier):
             self._mode = self.PRESET_MODE_MAPPING[preset_mode].value
             self.async_write_ha_state()
 
-    # the async_set_speed function is deprecated, support will end with release 2021.7
-    # it is added here only for compatibility with legacy speeds
-    async def async_set_speed(self, speed: str) -> None:
-        """Set the speed of the fan."""
-        if self.supported_features & SUPPORT_SET_SPEED == 0:
-            return
-
-        _LOGGER.debug("Setting the operation mode to: %s", speed)
-
-        if await self._try_command(
-            "Setting operation mode of the miio device failed.",
-            self._device.set_mode,
-            AirpurifierMiotOperationMode[speed.title()],
-        ):
-            self._mode = AirpurifierMiotOperationMode[speed.title()].value
-            self.async_write_ha_state()
-
 
 class XiaomiAirFresh(XiaomiGenericDevice):
     """Representation of a Xiaomi Air Fresh."""
@@ -974,8 +891,6 @@ class XiaomiAirFresh(XiaomiGenericDevice):
 
         self._device_features = FEATURE_FLAGS_AIRFRESH
         self._available_attributes = AVAILABLE_ATTRIBUTES_AIRFRESH
-        # the speed_list attribute is deprecated, support will end with release 2021.7
-        self._speed_list = OPERATION_MODES_AIRFRESH
         self._speed_count = 4
         self._preset_modes = PRESET_MODES_AIRFRESH
         self._supported_features = SUPPORT_SET_SPEED | SUPPORT_PRESET_MODE
@@ -1002,15 +917,6 @@ class XiaomiAirFresh(XiaomiGenericDevice):
                 return ranged_value_to_percentage(
                     (1, self._speed_count), self.REVERSE_SPEED_MODE_MAPPING[mode]
                 )
-
-        return None
-
-    # the speed attribute is deprecated, support will end with release 2021.7
-    @property
-    def speed(self):
-        """Return the current speed."""
-        if self._state:
-            return AirfreshOperationMode(self._mode).name
 
         return None
 
@@ -1047,23 +953,6 @@ class XiaomiAirFresh(XiaomiGenericDevice):
             self.PRESET_MODE_MAPPING[preset_mode],
         ):
             self._mode = self.PRESET_MODE_MAPPING[preset_mode].value
-            self.async_write_ha_state()
-
-    # the async_set_speed function is deprecated, support will end with release 2021.7
-    # it is added here only for compatibility with legacy speeds
-    async def async_set_speed(self, speed: str) -> None:
-        """Set the speed of the fan."""
-        if self.supported_features & SUPPORT_SET_SPEED == 0:
-            return
-
-        _LOGGER.debug("Setting the operation mode to: %s", speed)
-
-        if await self._try_command(
-            "Setting operation mode of the miio device failed.",
-            self._device.set_mode,
-            AirfreshOperationMode[speed.title()],
-        ):
-            self._mode = AirfreshOperationMode[speed.title()].value
             self.async_write_ha_state()
 
     async def async_set_led_on(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- Remove deprecated speed_list.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Clean up deprecated fan speed_list api.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
