### PR TITLE
Add siren support for available tones provided as a dict

### DIFF
--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -70,8 +70,8 @@ def process_turn_on_params(
             isinstance(siren.available_tones, dict)
             and tone in siren.available_tones.values()
         )
-        if not siren.available_tones or not (
-            tone in siren.available_tones or is_tone_dict_value
+        if not siren.available_tones or (
+            tone not in siren.available_tones and not is_tone_dict_value
         ):
             raise ValueError(
                 f"Invalid tone specified for entity {siren.entity_id}: {tone}, "

--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -70,9 +70,8 @@ def process_turn_on_params(
             isinstance(siren.available_tones, dict)
             and tone in siren.available_tones.values()
         )
-        if not (
-            siren.available_tones
-            and (tone in siren.available_tones or is_tone_dict_value)
+        if not siren.available_tones or not (
+            tone in siren.available_tones or is_tone_dict_value
         ):
             raise ValueError(
                 f"Invalid tone specified for entity {siren.entity_id}: {tone}, "

--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -70,8 +70,10 @@ def process_turn_on_params(
             isinstance(siren.available_tones, dict)
             and tone in siren.available_tones.values()
         )
-        if not siren.available_tones or (
-            tone not in siren.available_tones and not is_tone_dict_value
+        if (
+            not siren.available_tones
+            or tone not in siren.available_tones
+            and not is_tone_dict_value
         ):
             raise ValueError(
                 f"Invalid tone specified for entity {siren.entity_id}: {tone}, "

--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -64,10 +64,28 @@ def process_turn_on_params(
 
     if not supported_features & SUPPORT_TONES:
         params.pop(ATTR_TONE, None)
-    elif (tone := params.get(ATTR_TONE)) is not None and (
-        not siren.available_tones or tone not in siren.available_tones
-    ):
-        raise ValueError(f"Invalid tone received for entity {siren.entity_id}: {tone}")
+    elif (tone := params.get(ATTR_TONE)) is not None:
+        # Raise an exception if the specified tone isn't available
+        is_tone_dict_value = bool(
+            isinstance(siren.available_tones, dict)
+            and tone in siren.available_tones.values()
+        )
+        if not (
+            siren.available_tones
+            and (tone in siren.available_tones or is_tone_dict_value)
+        ):
+            raise ValueError(
+                f"Invalid tone specified for entity {siren.entity_id}: {tone}, "
+                "check the available_tones attribute for valid tones to pass in"
+            )
+
+        # If available tones is a dict, and the tone provided is a dict value, we need
+        # to transform it to the corresponding dict key before returning
+        if is_tone_dict_value:
+            assert isinstance(siren.available_tones, dict)
+            params[ATTR_TONE] = next(
+                key for key, value in siren.available_tones.items() if value == tone
+            )
 
     if not supported_features & SUPPORT_DURATION:
         params.pop(ATTR_DURATION, None)
@@ -131,7 +149,7 @@ class SirenEntity(ToggleEntity):
     """Representation of a siren device."""
 
     entity_description: SirenEntityDescription
-    _attr_available_tones: list[int | str] | None = None
+    _attr_available_tones: list[int | str] | dict[int, str] | None = None
 
     @final
     @property
@@ -145,7 +163,7 @@ class SirenEntity(ToggleEntity):
         return None
 
     @property
-    def available_tones(self) -> list[int | str] | None:
+    def available_tones(self) -> list[int | str] | dict[int, str] | None:
         """
         Return a list of available tones.
 

--- a/tests/components/siren/test_init.py
+++ b/tests/components/siren/test_init.py
@@ -48,9 +48,32 @@ async def test_no_available_tones(hass):
         process_turn_on_params(siren, {"tone": "test"})
 
 
-async def test_missing_tones(hass):
-    """Test ValueError when setting a tone that is missing from available_tones."""
+async def test_available_tones_list(hass):
+    """Test that valid tones from tone list will get passed in."""
+    siren = MockSirenEntity(SUPPORT_TONES, ["a", "b"])
+    siren.hass = hass
+    assert process_turn_on_params(siren, {"tone": "a"}) == {"tone": "a"}
+
+
+async def test_available_tones_dict(hass):
+    """Test that valid tones from available_tones dict will get passed in."""
+    siren = MockSirenEntity(SUPPORT_TONES, {1: "a", 2: "b"})
+    siren.hass = hass
+    assert process_turn_on_params(siren, {"tone": "a"}) == {"tone": 1}
+    assert process_turn_on_params(siren, {"tone": 1}) == {"tone": 1}
+
+
+async def test_missing_tones_list(hass):
+    """Test ValueError when setting a tone that is missing from available_tones list."""
     siren = MockSirenEntity(SUPPORT_TONES, ["a", "b"])
     siren.hass = hass
     with pytest.raises(ValueError):
         process_turn_on_params(siren, {"tone": "test"})
+
+
+async def test_missing_tones_dict(hass):
+    """Test ValueError when setting a tone that is missing from available_tones dict."""
+    siren = MockSirenEntity(SUPPORT_TONES, {1: "a", 2: "b"})
+    siren.hass = hass
+    with pytest.raises(ValueError):
+        process_turn_on_params(siren, {"tone": 3})


### PR DESCRIPTION
## Proposed change
The motivation for this PR is related to the zwave_js siren platform. Because of our original implementation, users had to specify the string value of the tone, which isn't always friendly, e.g. `Rain (2 sec)` or `01DING~1 (5 sec)`. We know that some platforms have both IDs and display values for strings, so with this change, we can provide the `available_tones` attribute as a dictionary and let the user choose either type to make the call with. As a bonus, the `process_turn_on_params` took inspiration from the `vol.In` voluptuous schema and will automatically convert values to keys to simplify downstream logic.

The zwave_js changes can be in a separate PR because this doesn't impact existing usecases of the `available_tones` attribute.

CC @firstof9 since I got this idea from our discussion earlier


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1016

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
