### PR TITLE
Don't block motionEye setup on NoURLAvailableError 

### DIFF
--- a/homeassistant/components/motioneye/__init__.py
+++ b/homeassistant/components/motioneye/__init__.py
@@ -250,7 +250,7 @@ def _add_camera(
                 KEY_WEB_HOOK_NOTIFICATIONS_ENABLED,
                 camera,
             )
-            | _set_webhook(
+            or _set_webhook(
                 _build_url(
                     device,
                     url,

--- a/homeassistant/components/motioneye/__init__.py
+++ b/homeassistant/components/motioneye/__init__.py
@@ -53,7 +53,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
-from homeassistant.helpers.network import get_url
+from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -145,12 +145,21 @@ def listen_for_new_cameras(
 
 
 @callback
-def async_generate_motioneye_webhook(hass: HomeAssistant, webhook_id: str) -> str:
+def async_generate_motioneye_webhook(
+    hass: HomeAssistant, webhook_id: str
+) -> str | None:
     """Generate the full local URL for a webhook_id."""
-    return "{}{}".format(
-        get_url(hass, allow_cloud=False),
-        async_generate_path(webhook_id),
-    )
+    try:
+        return "{}{}".format(
+            get_url(hass, allow_cloud=False),
+            async_generate_path(webhook_id),
+        )
+    except NoURLAvailableError:
+        _LOGGER.warning(
+            "Unable to get Home Assistant URL. Have you set the internal and/or "
+            "external URLs in Configuration -> General?"
+        )
+        return None
 
 
 @callback
@@ -228,28 +237,31 @@ def _add_camera(
     if entry.options.get(CONF_WEBHOOK_SET, DEFAULT_WEBHOOK_SET):
         url = async_generate_motioneye_webhook(hass, entry.data[CONF_WEBHOOK_ID])
 
-        if _set_webhook(
-            _build_url(
-                device,
-                url,
-                EVENT_MOTION_DETECTED,
-                EVENT_MOTION_DETECTED_KEYS,
-            ),
-            KEY_WEB_HOOK_NOTIFICATIONS_URL,
-            KEY_WEB_HOOK_NOTIFICATIONS_HTTP_METHOD,
-            KEY_WEB_HOOK_NOTIFICATIONS_ENABLED,
-            camera,
-        ) | _set_webhook(
-            _build_url(
-                device,
-                url,
-                EVENT_FILE_STORED,
-                EVENT_FILE_STORED_KEYS,
-            ),
-            KEY_WEB_HOOK_STORAGE_URL,
-            KEY_WEB_HOOK_STORAGE_HTTP_METHOD,
-            KEY_WEB_HOOK_STORAGE_ENABLED,
-            camera,
+        if url and (
+            _set_webhook(
+                _build_url(
+                    device,
+                    url,
+                    EVENT_MOTION_DETECTED,
+                    EVENT_MOTION_DETECTED_KEYS,
+                ),
+                KEY_WEB_HOOK_NOTIFICATIONS_URL,
+                KEY_WEB_HOOK_NOTIFICATIONS_HTTP_METHOD,
+                KEY_WEB_HOOK_NOTIFICATIONS_ENABLED,
+                camera,
+            )
+            | _set_webhook(
+                _build_url(
+                    device,
+                    url,
+                    EVENT_FILE_STORED,
+                    EVENT_FILE_STORED_KEYS,
+                ),
+                KEY_WEB_HOOK_STORAGE_URL,
+                KEY_WEB_HOOK_STORAGE_HTTP_METHOD,
+                KEY_WEB_HOOK_STORAGE_ENABLED,
+                camera,
+            )
         ):
             hass.async_create_task(client.async_set_camera(camera_id, camera))
 

--- a/homeassistant/components/motioneye/__init__.py
+++ b/homeassistant/components/motioneye/__init__.py
@@ -250,7 +250,7 @@ def _add_camera(
                 KEY_WEB_HOOK_NOTIFICATIONS_ENABLED,
                 camera,
             )
-            or _set_webhook(
+            | _set_webhook(
                 _build_url(
                     device,
                     url,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

   * Catch `NoURLAvailableError` and allow setup to proceed (webhooks just won't be set)
   * Log a warning to steer the user to the action they need to take.
   * Test coverage for above.
   * Closes #54061

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54061
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
