### PR TITLE
Fix Google Calendar event loading

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -115,6 +115,7 @@ _SINGLE_CALSEARCH_CONFIG = vol.Schema(
         vol.Optional(CONF_OFFSET): cv.string,
         vol.Optional(CONF_SEARCH): cv.string,
         vol.Optional(CONF_TRACK): cv.boolean,
+        vol.Optional("max_results"): vol.All(cv.deprecated),  # Now unused
     }
 )
 

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -41,6 +41,7 @@ CONF_CAL_ID = "cal_id"
 CONF_TRACK = "track"
 CONF_SEARCH = "search"
 CONF_IGNORE_AVAILABILITY = "ignore_availability"
+CONF_MAX_RESULTS = "max_results"
 CONF_CALENDAR_ACCESS = "calendar_access"
 
 DEFAULT_CONF_TRACK_NEW = True
@@ -107,16 +108,19 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-_SINGLE_CALSEARCH_CONFIG = vol.Schema(
-    {
-        vol.Required(CONF_NAME): cv.string,
-        vol.Required(CONF_DEVICE_ID): cv.string,
-        vol.Optional(CONF_IGNORE_AVAILABILITY, default=True): cv.boolean,
-        vol.Optional(CONF_OFFSET): cv.string,
-        vol.Optional(CONF_SEARCH): cv.string,
-        vol.Optional(CONF_TRACK): cv.boolean,
-        vol.Optional("max_results"): vol.All(cv.deprecated),  # Now unused
-    }
+_SINGLE_CALSEARCH_CONFIG = vol.All(
+    cv.deprecated(CONF_MAX_RESULTS),
+    vol.Schema(
+        {
+            vol.Required(CONF_NAME): cv.string,
+            vol.Required(CONF_DEVICE_ID): cv.string,
+            vol.Optional(CONF_IGNORE_AVAILABILITY, default=True): cv.boolean,
+            vol.Optional(CONF_OFFSET): cv.string,
+            vol.Optional(CONF_SEARCH): cv.string,
+            vol.Optional(CONF_TRACK): cv.boolean,
+            vol.Optional(CONF_MAX_RESULTS): cv.positive_int,  # Now unused
+        }
+    ),
 )
 
 DEVICE_SCHEMA = vol.Schema(

--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -41,7 +41,6 @@ CONF_CAL_ID = "cal_id"
 CONF_TRACK = "track"
 CONF_SEARCH = "search"
 CONF_IGNORE_AVAILABILITY = "ignore_availability"
-CONF_MAX_RESULTS = "max_results"
 CONF_CALENDAR_ACCESS = "calendar_access"
 
 DEFAULT_CONF_TRACK_NEW = True
@@ -116,7 +115,6 @@ _SINGLE_CALSEARCH_CONFIG = vol.Schema(
         vol.Optional(CONF_OFFSET): cv.string,
         vol.Optional(CONF_SEARCH): cv.string,
         vol.Optional(CONF_TRACK): cv.boolean,
-        vol.Optional(CONF_MAX_RESULTS): cv.positive_int,
     }
 )
 

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -18,7 +18,6 @@ from homeassistant.util import Throttle, dt
 from . import (
     CONF_CAL_ID,
     CONF_IGNORE_AVAILABILITY,
-    CONF_MAX_RESULTS,
     CONF_SEARCH,
     CONF_TRACK,
     DEFAULT_CONF_OFFSET,
@@ -30,7 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_GOOGLE_SEARCH_PARAMS = {
     "orderBy": "startTime",
-    "maxResults": 5,
     "singleEvents": True,
 }
 
@@ -71,7 +69,6 @@ class GoogleCalendarEventDevice(CalendarEventDevice):
             calendar,
             data.get(CONF_SEARCH),
             data.get(CONF_IGNORE_AVAILABILITY),
-            data.get(CONF_MAX_RESULTS),
         )
         self._event = None
         self._name = data[CONF_NAME]
@@ -113,15 +110,12 @@ class GoogleCalendarEventDevice(CalendarEventDevice):
 class GoogleCalendarData:
     """Class to utilize calendar service object to get next event."""
 
-    def __init__(
-        self, calendar_service, calendar_id, search, ignore_availability, max_results
-    ):
+    def __init__(self, calendar_service, calendar_id, search, ignore_availability):
         """Set up how we are going to search the google calendar."""
         self.calendar_service = calendar_service
         self.calendar_id = calendar_id
         self.search = search
         self.ignore_availability = ignore_availability
-        self.max_results = max_results
         self.event = None
 
     def _prepare_query(self):
@@ -132,8 +126,7 @@ class GoogleCalendarData:
             return None, None
         params = dict(DEFAULT_GOOGLE_SEARCH_PARAMS)
         params["calendarId"] = self.calendar_id
-        if self.max_results:
-            params["maxResults"] = self.max_results
+
         if self.search:
             params["q"] = self.search
 
@@ -147,18 +140,30 @@ class GoogleCalendarData:
         params["timeMin"] = start_date.isoformat("T")
         params["timeMax"] = end_date.isoformat("T")
 
+        event_list = []
         events = await hass.async_add_executor_job(service.events)
+        page_token = None
+        while True:
+            page_token = await self.async_get_events_page(
+                hass, events, params, page_token, event_list
+            )
+            if not page_token:
+                break
+        return event_list
+
+    async def async_get_events_page(self, hass, events, params, page_token, event_list):
+        """Get a page of events in a specific time frame."""
+        params["pageToken"] = page_token
         result = await hass.async_add_executor_job(events.list(**params).execute)
 
         items = result.get("items", [])
-        event_list = []
         for item in items:
             if not self.ignore_availability and "transparency" in item:
                 if item["transparency"] == "opaque":
                     event_list.append(item)
             else:
                 event_list.append(item)
-        return event_list
+        return result.get("nextPageToken")
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -126,6 +126,7 @@ class GoogleCalendarData:
             return None, None
         params = dict(DEFAULT_GOOGLE_SEARCH_PARAMS)
         params["calendarId"] = self.calendar_id
+        params["maxResults"] = 100  # Page size
 
         if self.search:
             params["q"] = self.search


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes #54158: Originally, the Google Calendar integration only fetched ``max_results`` (default 5) appointments. If the calendar contains more than ``max_results``, the remaining appointments are skipped. The [documentation](https://www.home-assistant.io/integrations/calendar.google/) describes the ``max_results`` setting, but users only find that after they faced the missing appointments scenario. Next, the documentation does not say that Google does not support a page size beyond 2500 (some users set a page size of 99999).

The [Google API](https://googleapis.github.io/google-api-python-client/docs/dyn/calendar_v3.events.html#list) is based on pagination (default page size 250). The original implementation fetched just one page. The improved implementation of this PR fetches all pages, using Google's default page size (250). With this, users will not miss appointments and do not need to bother about the configuration setting.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54158
- Link to documentation pull request: home-assistant/home-assistant.io#18830

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
