### PR TITLE
Add template functions to get area_id and area_name

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -69,9 +69,6 @@ _ENVIRONMENT_STRICT = "template.environment_strict"
 _RE_JINJA_DELIMITERS = re.compile(r"\{%|\{\{|\{#")
 # Match "simple" ints and floats. -1.0, 1, +5, 5.0
 _IS_NUMERIC = re.compile(r"^[+-]?(?!0\d)\d*(?:\.\d*)?$")
-# Match ID strings generated using homeassistant.util.uuid.random_uuid_hex
-# ("0a" matches but "0x0a" and "0A" don't match)
-_ID_STRING = re.compile(r"^[0-9a-f]+$")
 
 _RESERVED_NAMES = {"contextfunction", "evalcontextfunction", "environmentfunction"}
 
@@ -959,13 +956,13 @@ def area_id(hass: HomeAssistant, lookup_value: str) -> str | None:
     if area := area_reg.async_get_area_by_name(str(lookup_value)):
         return area.id
 
-    try:
-        ent_reg = entity_registry.async_get(hass)
-        # Import here, not at top-level to avoid circular import
-        from homeassistant.helpers import (  # pylint: disable=import-outside-toplevel
-            config_validation as cv,
-        )
+    ent_reg = entity_registry.async_get(hass)
+    # Import here, not at top-level to avoid circular import
+    from homeassistant.helpers import (  # pylint: disable=import-outside-toplevel
+        config_validation as cv,
+    )
 
+    try:
         cv.entity_id(lookup_value)
         if entity := ent_reg.async_get(lookup_value):
             return entity.area_id
@@ -973,10 +970,9 @@ def area_id(hass: HomeAssistant, lookup_value: str) -> str | None:
         pass
 
     # Check if this could be a device ID (hex string)
-    if _ID_STRING.match(str(lookup_value)):
-        dev_reg = device_registry.async_get(hass)
-        if device := dev_reg.async_get(lookup_value):
-            return device.area_id
+    dev_reg = device_registry.async_get(hass)
+    if device := dev_reg.async_get(lookup_value):
+        return device.area_id
 
     return None
 
@@ -995,14 +991,14 @@ def area_name(hass: HomeAssistant, lookup_value: str) -> str | None:
     if area:
         return area.name
 
-    try:
-        # Import here, not at top-level to avoid circular import
-        from homeassistant.helpers import (  # pylint: disable=import-outside-toplevel
-            config_validation as cv,
-        )
+    ent_reg = entity_registry.async_get(hass)
+    # Import here, not at top-level to avoid circular import
+    from homeassistant.helpers import (  # pylint: disable=import-outside-toplevel
+        config_validation as cv,
+    )
 
+    try:
         cv.entity_id(lookup_value)
-        ent_reg = entity_registry.async_get(hass)
         if entity := ent_reg.async_get(lookup_value):
             if entity.area_id:
                 return _get_area_name(area_reg, entity.area_id)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -964,10 +964,11 @@ def area_id(hass: HomeAssistant, lookup_value: str) -> str | None:
 
     try:
         cv.entity_id(lookup_value)
-        if entity := ent_reg.async_get(lookup_value):
-            return entity.area_id
     except vol.Invalid:
         pass
+    else:
+        if entity := ent_reg.async_get(lookup_value):
+            return entity.area_id
 
     # Check if this could be a device ID (hex string)
     dev_reg = device_registry.async_get(hass)
@@ -999,12 +1000,13 @@ def area_name(hass: HomeAssistant, lookup_value: str) -> str | None:
 
     try:
         cv.entity_id(lookup_value)
+    except vol.Invalid:
+        pass
+    else:
         if entity := ent_reg.async_get(lookup_value):
             if entity.area_id:
                 return _get_area_name(area_reg, entity.area_id)
             return None
-    except vol.Invalid:
-        pass
 
     dev_reg = device_registry.async_get(hass)
     if (device := dev_reg.async_get(lookup_value)) and device.area_id:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -964,7 +964,7 @@ def area_id(hass: HomeAssistant, lookup_value: str) -> str | None:
     try:
         cv.entity_id(lookup_value)
         ent_reg = entity_registry.async_get(hass)
-        if (entity := ent_reg.async_get(lookup_value)) and entity.area_id:
+        if entity := ent_reg.async_get(lookup_value):
             return entity.area_id
     except vol.Invalid:
         pass
@@ -973,7 +973,7 @@ def area_id(hass: HomeAssistant, lookup_value: str) -> str | None:
     # name
     if _ID_STRING.match(str(lookup_value)):
         dev_reg = device_registry.async_get(hass)
-        if (device := dev_reg.async_get(lookup_value)) and device.area_id:
+        if device := dev_reg.async_get(lookup_value):
             return device.area_id
 
     return None

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -966,13 +966,13 @@ def area_id(hass: HomeAssistant, lookup_value: str) -> str | None:
 
     # Check if this could be a device ID (hex string). If not, assume it is an area
     # name
-    if _ID_STRING.match(lookup_value):
+    if _ID_STRING.match(str(lookup_value)):
         dev_reg = device_registry.async_get(hass)
         if device := dev_reg.async_get(lookup_value):
             return device.area_id
 
     area_reg = area_registry.async_get(hass)
-    area = area_reg.async_get_area_by_name(lookup_value)
+    area = area_reg.async_get_area_by_name(str(lookup_value))
     return area.id if area else None
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -45,7 +45,6 @@ from homeassistant.core import (
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import (
     area_registry,
-    config_validation as cv,
     device_registry,
     entity_registry,
     location as loc_helper,
@@ -962,6 +961,11 @@ def area_id(hass: HomeAssistant, lookup_value: str) -> str | None:
         return area.id
 
     try:
+        # Import here, not at top-level to avoid circular import
+        from homeassistant.helpers import (  # pylint: disable=import-outside-toplevel
+            config_validation as cv,
+        )
+
         cv.entity_id(lookup_value)
         ent_reg = entity_registry.async_get(hass)
         if entity := ent_reg.async_get(lookup_value):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1842,6 +1842,82 @@ async def test_area_id(hass):
     assert info.rate_limit is None
 
 
+async def test_area_name(hass):
+    """Test area_name function."""
+    config_entry = MockConfigEntry(domain="light")
+    device_registry = mock_device_registry(hass)
+    entity_registry = mock_registry(hass)
+    area_registry = mock_area_registry(hass)
+
+    # Test non existing entity id
+    info = render_to_info(hass, "{{ area_name('sensor.fake') }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test non existing device id (hex value)
+    info = render_to_info(hass, "{{ area_name('123abc') }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test non existing area id
+    info = render_to_info(hass, "{{ area_name('1234567890') }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test wrong value type
+    info = render_to_info(hass, "{{ area_name(56) }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test device with single entity, which has no area
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_entry = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "5678",
+        config_entry=config_entry,
+        device_id=device_entry.id,
+    )
+    info = render_to_info(hass, f"{{{{ area_name('{device_entry.id}') }}}}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ area_name('{entity_entry.entity_id}') }}}}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test device ID, entity ID and area id as input. Try a filter too
+    area_entry = area_registry.async_get_or_create("123abc")
+    device_entry = device_registry.async_update_device(
+        device_entry.id, area_id=area_entry.id
+    )
+    entity_entry = entity_registry.async_update_entity(
+        entity_entry.entity_id, area_id=area_entry.id
+    )
+
+    info = render_to_info(hass, f"{{{{ '{device_entry.id}' | area_name }}}}")
+    assert_result_info(info, area_entry.name)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ area_name('{entity_entry.entity_id}') }}}}")
+    assert_result_info(info, area_entry.name)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ area_name('{area_entry.id}') }}}}")
+    assert_result_info(info, area_entry.name)
+    assert info.rate_limit is None
+
+    # Try to get an area ID that's a valid device ID as it should be preferred
+    object.__setattr__(area_entry, "id", device_entry.id)
+
+    info = render_to_info(hass, f"{{{{ area_name('{device_entry.id}') }}}}")
+    assert_result_info(info, area_entry.name)
+    assert info.rate_limit is None
+
+
 def test_closest_function_to_coord(hass):
     """Test closest function to coord."""
     hass.states.async_set(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1757,6 +1757,11 @@ async def test_area_id(hass):
     assert_result_info(info, None)
     assert info.rate_limit is None
 
+    # Test wrong value type
+    info = render_to_info(hass, "{{ area_id(56) }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
     area_entry_entity_id = area_registry.async_get_or_create("sensor.fake")
 
     # Test device with single entity, which has no area

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1828,17 +1828,6 @@ async def test_area_id(hass):
     assert_result_info(info, area_entry_entity_id.id)
     assert info.rate_limit is None
 
-    # Try to get an area name that's a valid device ID or entity ID as it should have
-    # an exception
-    area_registry.async_get_or_create(device_entry.id)
-    area_registry.async_get_or_create(entity_entry.entity_id)
-
-    info = render_to_info(hass, f"{{{{ area_id('{device_entry.id}') }}}}")
-    assert isinstance(info.exception, TemplateError)
-
-    info = render_to_info(hass, f"{{{{ area_id('{entity_entry.entity_id}') }}}}")
-    assert isinstance(info.exception, TemplateError)
-
 
 async def test_area_name(hass):
     """Test area_name function."""
@@ -1907,12 +1896,6 @@ async def test_area_name(hass):
     info = render_to_info(hass, f"{{{{ area_name('{area_entry.id}') }}}}")
     assert_result_info(info, area_entry.name)
     assert info.rate_limit is None
-
-    # Try to get an area ID that's a valid device ID as it should have an exception
-    area_registry.async_get_or_create(device_entry.id)
-
-    info = render_to_info(hass, f"{{{{ area_name('{device_entry.id}') }}}}")
-    assert isinstance(info.exception, TemplateError)
 
 
 def test_closest_function_to_coord(hass):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1784,8 +1784,8 @@ async def test_area_id(hass):
     assert_result_info(info, None)
     assert info.rate_limit is None
 
-    # Test device ID, entity ID and area name as input with area name that looks like a device ID
-    # try a filter too
+    # Test device ID, entity ID and area name as input with area name that looks like
+    # a device ID. Try a filter too
     area_entry_hex = area_registry.async_get_or_create("123abc")
     device_entry = device_registry.async_update_device(
         device_entry.id, area_id=area_entry_hex.id
@@ -1806,7 +1806,8 @@ async def test_area_id(hass):
     assert_result_info(info, area_entry_hex.id)
     assert info.rate_limit is None
 
-    # Test device ID, entity ID and area name as input with area name that looks like a entity ID
+    # Test device ID, entity ID and area name as input with area name that looks like an
+    # entity ID
     area_entry_entity_id = area_registry.async_get_or_create("sensor.fake")
     device_entry = device_registry.async_update_device(
         device_entry.id, area_id=area_entry_entity_id.id
@@ -1824,6 +1825,19 @@ async def test_area_id(hass):
     assert info.rate_limit is None
 
     info = render_to_info(hass, f"{{{{ area_id('{area_entry_entity_id.name}') }}}}")
+    assert_result_info(info, area_entry_entity_id.id)
+    assert info.rate_limit is None
+
+    # Try to get an area name that's a valid device ID or entity ID as it should be
+    # preferred
+    area_entry_device_id = area_registry.async_get_or_create(device_entry.id)
+    area_entry_entity_id = area_registry.async_get_or_create(entity_entry.entity_id)
+
+    info = render_to_info(hass, f"{{{{ area_id('{device_entry.id}') }}}}")
+    assert_result_info(info, area_entry_device_id.id)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ area_id('{entity_entry.entity_id}') }}}}")
     assert_result_info(info, area_entry_entity_id.id)
     assert info.rate_limit is None
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -23,7 +23,12 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import UnitSystem
 
-from tests.common import MockConfigEntry, mock_device_registry, mock_registry
+from tests.common import (
+    MockConfigEntry,
+    mock_area_registry,
+    mock_device_registry,
+    mock_registry,
+)
 
 
 def _set_up_units(hass):
@@ -1513,7 +1518,7 @@ async def test_expand(hass):
 
 
 async def test_device_entities(hass):
-    """Test expand function."""
+    """Test device_entities function."""
     config_entry = MockConfigEntry(domain="light")
     device_registry = mock_device_registry(hass)
     entity_registry = mock_registry(hass)
@@ -1727,6 +1732,94 @@ async def test_device_attr(hass):
         hass, f"{{{{ is_device_attr('{device_entry.id}', 'model', 'test') }}}}"
     )
     assert_result_info(info, True)
+    assert info.rate_limit is None
+
+
+async def test_area_id(hass):
+    """Test area_id function."""
+    config_entry = MockConfigEntry(domain="light")
+    device_registry = mock_device_registry(hass)
+    entity_registry = mock_registry(hass)
+    area_registry = mock_area_registry(hass)
+
+    # Test non existing entity id
+    info = render_to_info(hass, "{{ area_id('sensor.fake') }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test non existing device id (hex value)
+    info = render_to_info(hass, "{{ area_id('123abc') }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test non existing area name
+    info = render_to_info(hass, "{{ area_id('fake area name') }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    area_entry_entity_id = area_registry.async_get_or_create("sensor.fake")
+
+    # Test device with single entity, which has no area
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_entry = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "5678",
+        config_entry=config_entry,
+        device_id=device_entry.id,
+    )
+    info = render_to_info(hass, f"{{{{ area_id('{device_entry.id}') }}}}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ area_id('{entity_entry.entity_id}') }}}}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test device ID, entity ID and area name as input with area name that looks like a device ID
+    # try a filter too
+    area_entry_hex = area_registry.async_get_or_create("123abc")
+    device_entry = device_registry.async_update_device(
+        device_entry.id, area_id=area_entry_hex.id
+    )
+    entity_entry = entity_registry.async_update_entity(
+        entity_entry.entity_id, area_id=area_entry_hex.id
+    )
+
+    info = render_to_info(hass, f"{{{{ '{device_entry.id}' | area_id }}}}")
+    assert_result_info(info, area_entry_hex.id)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ area_id('{entity_entry.entity_id}') }}}}")
+    assert_result_info(info, area_entry_hex.id)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ area_id('{area_entry_hex.name}') }}}}")
+    assert_result_info(info, area_entry_hex.id)
+    assert info.rate_limit is None
+
+    # Test device ID, entity ID and area name as input with area name that looks like a entity ID
+    area_entry_entity_id = area_registry.async_get_or_create("sensor.fake")
+    device_entry = device_registry.async_update_device(
+        device_entry.id, area_id=area_entry_entity_id.id
+    )
+    entity_entry = entity_registry.async_update_entity(
+        entity_entry.entity_id, area_id=area_entry_entity_id.id
+    )
+
+    info = render_to_info(hass, f"{{{{ area_id('{device_entry.id}') }}}}")
+    assert_result_info(info, area_entry_entity_id.id)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ area_id('{entity_entry.entity_id}') }}}}")
+    assert_result_info(info, area_entry_entity_id.id)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ area_id('{area_entry_entity_id.name}') }}}}")
+    assert_result_info(info, area_entry_entity_id.id)
     assert info.rate_limit is None
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1828,18 +1828,16 @@ async def test_area_id(hass):
     assert_result_info(info, area_entry_entity_id.id)
     assert info.rate_limit is None
 
-    # Try to get an area name that's a valid device ID or entity ID as it should be
-    # preferred
-    area_entry_device_id = area_registry.async_get_or_create(device_entry.id)
-    area_entry_entity_id = area_registry.async_get_or_create(entity_entry.entity_id)
+    # Try to get an area name that's a valid device ID or entity ID as it should have
+    # an exception
+    area_registry.async_get_or_create(device_entry.id)
+    area_registry.async_get_or_create(entity_entry.entity_id)
 
     info = render_to_info(hass, f"{{{{ area_id('{device_entry.id}') }}}}")
-    assert_result_info(info, area_entry_device_id.id)
-    assert info.rate_limit is None
+    assert isinstance(info.exception, TemplateError)
 
     info = render_to_info(hass, f"{{{{ area_id('{entity_entry.entity_id}') }}}}")
-    assert_result_info(info, area_entry_entity_id.id)
-    assert info.rate_limit is None
+    assert isinstance(info.exception, TemplateError)
 
 
 async def test_area_name(hass):
@@ -1910,12 +1908,11 @@ async def test_area_name(hass):
     assert_result_info(info, area_entry.name)
     assert info.rate_limit is None
 
-    # Try to get an area ID that's a valid device ID as it should be preferred
-    object.__setattr__(area_entry, "id", device_entry.id)
+    # Try to get an area ID that's a valid device ID as it should have an exception
+    area_registry.async_get_or_create(device_entry.id)
 
     info = render_to_info(hass, f"{{{{ area_name('{device_entry.id}') }}}}")
-    assert_result_info(info, area_entry.name)
-    assert info.rate_limit is None
+    assert isinstance(info.exception, TemplateError)
 
 
 def test_closest_function_to_coord(hass):


### PR DESCRIPTION
## Proposed change
This came from a suggestion in #templates on Discord.

- `area_id`: Takes an entity ID, device ID, or area name and return an area ID if it can be found. 
- `area_name`: Takes an entity ID, device ID, or area ID and return an area name if it can be found. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
