### PR TITLE
Add `unique_id` and `device_info` for SMS sensor

### DIFF
--- a/homeassistant/components/sms/sensor.py
+++ b/homeassistant/components/sms/sensor.py
@@ -10,22 +10,28 @@ from .const import DOMAIN, SMS_GATEWAY
 
 _LOGGER = logging.getLogger(__name__)
 
-SENSOR_DESCRIPTION = {
-    "signal": SensorEntityDescription(
-        key="signal",
-        name="GSM Signal IMEI",
-        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
-        unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
-        entity_registry_enabled_default=False,
-    )
-}
-
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the GSM Signal Sensor sensor."""
     gateway = hass.data[DOMAIN][SMS_GATEWAY]
     imei = await gateway.get_imei_async()
-    async_add_entities([GSMSignalSensor(hass, gateway, imei, SENSOR_DESCRIPTION)], True)
+    async_add_entities(
+        [
+            GSMSignalSensor(
+                hass,
+                gateway,
+                imei,
+                SensorEntityDescription(
+                    key="signal",
+                    name="GSM Signal IMEI",
+                    device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+                    unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
+                    entity_registry_enabled_default=False,
+                ),
+            )
+        ],
+        True,
+    )
 
 
 class GSMSignalSensor(SensorEntity):

--- a/homeassistant/components/sms/sensor.py
+++ b/homeassistant/components/sms/sensor.py
@@ -16,12 +16,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     gateway = hass.data[DOMAIN][SMS_GATEWAY]
     entities = []
     imei = await gateway.get_imei_async()
-    name = f"gsm_signal_imei_{imei}"
     entities.append(
         GSMSignalSensor(
             hass,
             gateway,
-            name,
+            imei,
         )
     )
     async_add_entities(entities, True)
@@ -34,28 +33,21 @@ class GSMSignalSensor(SensorEntity):
         self,
         hass,
         gateway,
-        name,
+        imei,
     ):
         """Initialize the GSM Signal sensor."""
+        self._attr_device_class = DEVICE_CLASS_SIGNAL_STRENGTH
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, imei)},
+            "name": "SMS Gateway",
+        }
+        self._attr_entity_registry_enabled_default = False
+        self._attr_name = f"GSM Signal IMEI {imei}"
+        self._attr_unique_id = f"{imei}_gsm_signal"
+        self._attr_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS
         self._hass = hass
         self._gateway = gateway
-        self._name = name
         self._state = None
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit the value is expressed in."""
-        return SIGNAL_STRENGTH_DECIBELS
-
-    @property
-    def device_class(self):
-        """Return the class of this sensor."""
-        return DEVICE_CLASS_SIGNAL_STRENGTH
 
     @property
     def available(self):
@@ -78,8 +70,3 @@ class GSMSignalSensor(SensorEntity):
     def extra_state_attributes(self):
         """Return the sensor attributes."""
         return self._state
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        return False

--- a/homeassistant/components/sms/sensor.py
+++ b/homeassistant/components/sms/sensor.py
@@ -40,7 +40,7 @@ class GSMSignalSensor(SensorEntity):
     def __init__(self, hass, gateway, imei, description):
         """Initialize the GSM Signal sensor."""
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, imei)},
+            "identifiers": {(DOMAIN, str(imei))},
             "name": "SMS Gateway",
         }
         self._attr_unique_id = str(imei)

--- a/homeassistant/components/sms/sensor.py
+++ b/homeassistant/components/sms/sensor.py
@@ -16,25 +16,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     gateway = hass.data[DOMAIN][SMS_GATEWAY]
     entities = []
     imei = await gateway.get_imei_async()
-    entities.append(
-        GSMSignalSensor(
-            hass,
-            gateway,
-            imei,
-        )
-    )
+    entities.append(GSMSignalSensor(hass, gateway, imei))
     async_add_entities(entities, True)
 
 
 class GSMSignalSensor(SensorEntity):
     """Implementation of a GSM Signal sensor."""
 
-    def __init__(
-        self,
-        hass,
-        gateway,
-        imei,
-    ):
+    def __init__(self, hass, gateway, imei):
         """Initialize the GSM Signal sensor."""
         self._attr_device_class = DEVICE_CLASS_SIGNAL_STRENGTH
         self._attr_device_info = {

--- a/homeassistant/components/sms/sensor.py
+++ b/homeassistant/components/sms/sensor.py
@@ -23,7 +23,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 imei,
                 SensorEntityDescription(
                     key="signal",
-                    name="GSM Signal IMEI",
+                    name=f"gsm_signal_imei_{imei}",
                     device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
                     unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
                     entity_registry_enabled_default=False,
@@ -43,8 +43,7 @@ class GSMSignalSensor(SensorEntity):
             "identifiers": {(DOMAIN, imei)},
             "name": "SMS Gateway",
         }
-        self._attr_name = f"{description.name} {imei}"
-        self._attr_unique_id = imei
+        self._attr_unique_id = str(imei)
         self._hass = hass
         self._gateway = gateway
         self._state = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A friend of mine asked me to take a look at #40532
This PR adds `unique_id` and `device_info` properties for sensor entity to fix this issue. I'm not using this integration so I cannot test the code locally.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40532
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
