### PR TITLE
Purge entity and device registries when importing lcn from configuration.yaml

### DIFF
--- a/homeassistant/components/lcn/config_flow.py
+++ b/homeassistant/components/lcn/config_flow.py
@@ -16,9 +16,9 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import CONF_DIM_MODE, CONF_SK_NUM_TRIES, DOMAIN
+from .helpers import purge_device_registry, purge_entity_registry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,13 +93,10 @@ class LcnFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # check if we already have a host with the same address configured
         if entry := get_config_entry(self.hass, data):
             entry.source = config_entries.SOURCE_IMPORT
-
             # Cleanup entity and device registry, if we imported from configuration.yaml to
             # remove orphans when entities were removed from configuration
-            entity_registry = er.async_get(self.hass)
-            entity_registry.async_clear_config_entry(entry.entry_id)
-            device_registry = dr.async_get(self.hass)
-            device_registry.async_clear_config_entry(entry.entry_id)
+            purge_entity_registry(self.hass, entry.entry_id, data)
+            purge_device_registry(self.hass, entry.entry_id, data)
 
             self.hass.config_entries.async_update_entry(entry, data=data)
             return self.async_abort(reason="existing_configuration_updated")

--- a/homeassistant/components/lcn/config_flow.py
+++ b/homeassistant/components/lcn/config_flow.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import pypck
 
@@ -16,6 +15,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_DIM_MODE, CONF_SK_NUM_TRIES, DOMAIN
 from .helpers import purge_device_registry, purge_entity_registry
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def get_config_entry(
-    hass: HomeAssistant, data: dict[str, Any]
+    hass: HomeAssistant, data: ConfigType
 ) -> config_entries.ConfigEntry | None:
     """Check config entries for already configured entries based on the ip address/port."""
     return next(
@@ -38,7 +38,7 @@ def get_config_entry(
     )
 
 
-async def validate_connection(host_name: str, data: dict[str, Any]) -> dict[str, Any]:
+async def validate_connection(host_name: str, data: ConfigType) -> ConfigType:
     """Validate if a connection to LCN can be established."""
     host = data[CONF_IP_ADDRESS]
     port = data[CONF_PORT]
@@ -70,7 +70,7 @@ class LcnFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_import(self, data: dict[str, Any]) -> FlowResult:
+    async def async_step_import(self, data: ConfigType) -> FlowResult:
         """Import existing configuration from LCN."""
         host_name = data[CONF_HOST]
         # validate the imported connection parameters

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -304,7 +304,10 @@ def purge_device_registry(
             references_entry_data.add(device.id)
 
     orphaned_ids = (
-        set(device_registry.devices)
+        {
+            entry.id
+            for entry in dr.async_entries_for_config_entry(device_registry, entry_id)
+        }
         - references_entities
         - references_host
         - references_entry_data

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -5,7 +5,7 @@ import asyncio
 from copy import deepcopy
 from itertools import chain
 import re
-from typing import Union, cast
+from typing import Any, Union, cast
 
 import pypck
 import voluptuous as vol
@@ -248,7 +248,7 @@ def import_lcn_config(lcn_config: ConfigType) -> list[ConfigType]:
 
 
 def purge_entity_registry(
-    hass: HomeAssistant, entry_id: str, entry_data: ConfigType
+    hass: HomeAssistant, entry_id: str, entry_data: dict[str, Any]
 ) -> None:
     """Remove orphans from entity registry which are not in entry data."""
     entity_registry = er.async_get(hass)
@@ -278,7 +278,7 @@ def purge_entity_registry(
 
 
 def purge_device_registry(
-    hass: HomeAssistant, entry_id: str, entry_data: ConfigType
+    hass: HomeAssistant, entry_id: str, entry_data: dict[str, Any]
 ) -> None:
     """Remove orphans from device registry which are not in entry data."""
     device_registry = dr.async_get(hass)

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -255,8 +255,8 @@ def purge_entity_registry(
 
     # Find all entities that are referenced in the config entry.
     references_config_entry = {
-        entity.entity_id
-        for entity in er.async_entries_for_config_entry(entity_registry, entry_id)
+        entity_entry.entity_id
+        for entity_entry in er.async_entries_for_config_entry(entity_registry, entry_id)
     }
 
     # Find all entities that are referenced by the entry_data.

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -5,7 +5,7 @@ import asyncio
 from copy import deepcopy
 from itertools import chain
 import re
-from typing import Any, Union, cast
+from typing import Union, cast
 
 import pypck
 import voluptuous as vol
@@ -248,7 +248,7 @@ def import_lcn_config(lcn_config: ConfigType) -> list[ConfigType]:
 
 
 def purge_entity_registry(
-    hass: HomeAssistant, entry_id: str, entry_data: dict[str, Any]
+    hass: HomeAssistant, entry_id: str, entry_data: ConfigType
 ) -> None:
     """Remove orphans from entity registry which are not in entry data."""
     entity_registry = er.async_get(hass)
@@ -278,7 +278,7 @@ def purge_entity_registry(
 
 
 def purge_device_registry(
-    hass: HomeAssistant, entry_id: str, entry_data: dict[str, Any]
+    hass: HomeAssistant, entry_id: str, entry_data: ConfigType
 ) -> None:
     """Remove orphans from device registry which are not in entry data."""
     device_registry = dr.async_get(hass)

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -7,6 +7,8 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.lcn.const import CONF_DIM_MODE, CONF_SK_NUM_TRIES, DOMAIN
 from homeassistant.const import (
+    CONF_DEVICES,
+    CONF_ENTITIES,
     CONF_HOST,
     CONF_IP_ADDRESS,
     CONF_PASSWORD,
@@ -24,6 +26,8 @@ IMPORT_DATA = {
     CONF_PASSWORD: "lcn",
     CONF_SK_NUM_TRIES: 0,
     CONF_DIM_MODE: "STEPS200",
+    CONF_DEVICES: [],
+    CONF_ENTITIES: [],
 }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR fixes the bug that all LCN entities/devices loose their area information when HomeAssistant is restarted.

Therefore a more conservative method is implemented to purge the EntityRegistry/DeviceRegistry by just removing the orphaned entities/devices instead of deleting all of them.

The LCN integration is about to be migrated from `configuration.yaml` to ConfigEntries. Until migration is completed, the configuration is imported from `configuration.yaml` and converted to a ConfigEntry. The ConfigEntry is then used to setup the platforms, entities, ...
If the `configuration.yaml` is changed, the ConfigEntry will be updated. A special case occurs, if an entry is removed from the `configuration.yaml`. This results in orphaned entries/devices in the EntityRegistry/DeviceRegistry which have to be cleaned up.
Up to now, all entries for the corresponding `config_entry.entry_id` where removed prior to importing the `configuration.yaml` regadless of any configuration change. Unfortunately this leads to a loss of dependence to the area information which was reported in #53885.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53885
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
