### PR TITLE
Update DeviceInfo static types

### DIFF
--- a/homeassistant/components/nest/device_info.py
+++ b/homeassistant/components/nest/device_info.py
@@ -40,7 +40,7 @@ class NestDeviceInfo:
         )
 
     @property
-    def device_name(self) -> str:
+    def device_name(self) -> str | None:
         """Return the name of the physical device that includes the sensor."""
         if InfoTrait.NAME in self._device.traits:
             trait: InfoTrait = self._device.traits[InfoTrait.NAME]
@@ -56,11 +56,11 @@ class NestDeviceInfo:
         return self.device_model
 
     @property
-    def device_model(self) -> str:
+    def device_model(self) -> str | None:
         """Return device model information."""
         # The API intentionally returns minimal information about specific
         # devices, instead relying on traits, but we can infer a generic model
         # name based on the type
-        if self._device.type in DEVICE_TYPE_MAP:
-            return DEVICE_TYPE_MAP[self._device.type]
-        return "Unknown"
+        if self._device.type is None:
+            return None
+        return DEVICE_TYPE_MAP.get(self._device.type)

--- a/homeassistant/components/nest/device_info.py
+++ b/homeassistant/components/nest/device_info.py
@@ -61,6 +61,4 @@ class NestDeviceInfo:
         # The API intentionally returns minimal information about specific
         # devices, instead relying on traits, but we can infer a generic model
         # name based on the type
-        if self._device.type is None:
-            return None
         return DEVICE_TYPE_MAP.get(self._device.type)

--- a/homeassistant/components/nest/legacy/__init__.py
+++ b/homeassistant/components/nest/legacy/__init__.py
@@ -9,6 +9,7 @@ from nest.nest import APIError, AuthorizationError
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
@@ -17,7 +18,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
 from homeassistant.helpers.entity import Entity
@@ -96,7 +97,7 @@ def nest_update_event_broker(hass, nest):
     _LOGGER.debug("Stop listening for nest.update_event")
 
 
-async def async_setup_legacy(hass, config) -> bool:
+async def async_setup_legacy(hass: HomeAssistant, config: dict) -> bool:
     """Set up Nest components using the legacy nest API."""
     if DOMAIN not in config:
         return True
@@ -122,7 +123,7 @@ async def async_setup_legacy(hass, config) -> bool:
     return True
 
 
-async def async_setup_legacy_entry(hass, entry) -> bool:
+async def async_setup_legacy_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Nest from legacy config entry."""
 
     nest = Nest(access_token=entry.data["tokens"]["access_token"])

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -686,10 +686,10 @@ class SynologyDSMDeviceEntity(SynologyDSMBaseEntity):
         """Initialize the Synology DSM disk or volume entity."""
         super().__init__(api, entity_type, entity_info, coordinator)
         self._device_id = device_id
-        self._device_name = None
-        self._device_manufacturer = None
-        self._device_model = None
-        self._device_firmware = None
+        self._device_name: str | None = None
+        self._device_manufacturer: str | None = None
+        self._device_model: str | None = None
+        self._device_firmware: str | None = None
         self._device_type = None
 
         if "volume" in entity_type:
@@ -730,8 +730,8 @@ class SynologyDSMDeviceEntity(SynologyDSMBaseEntity):
                 (DOMAIN, f"{self._api.information.serial}_{self._device_id}")
             },
             "name": f"Synology NAS ({self._device_name} - {self._device_type})",
-            "manufacturer": self._device_manufacturer,  # type: ignore[typeddict-item]
-            "model": self._device_model,  # type: ignore[typeddict-item]
-            "sw_version": self._device_firmware,  # type: ignore[typeddict-item]
+            "manufacturer": self._device_manufacturer,
+            "model": self._device_model,
+            "sw_version": self._device_firmware,
             "via_device": (DOMAIN, self._api.information.serial),
         }

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -165,13 +165,13 @@ def get_unit_of_measurement(hass: HomeAssistant, entity_id: str) -> str | None:
 class DeviceInfo(TypedDict, total=False):
     """Entity device information for device registry."""
 
-    name: str
+    name: str | None
     connections: set[tuple[str, str]]
     identifiers: set[tuple[str, str]]
-    manufacturer: str
-    model: str
-    suggested_area: str
-    sw_version: str
+    manufacturer: str | None
+    model: str | None
+    suggested_area: str | None
+    sw_version: str | None
     via_device: tuple[str, str]
     entry_type: str | None
     default_name: str

--- a/tests/components/nest/device_info_test.py
+++ b/tests/components/nest/device_info_test.py
@@ -93,11 +93,11 @@ def test_device_invalid_type():
 
     device_info = NestDeviceInfo(device)
     assert device_info.device_name == "My Doorbell"
-    assert device_info.device_model == "Unknown"
+    assert device_info.device_model is None
     assert device_info.device_brand == "Google Nest"
     assert device_info.device_info == {
         "identifiers": {("nest", "some-device-id")},
         "name": "My Doorbell",
         "manufacturer": "Google Nest",
-        "model": "Unknown",
+        "model": None,
     }

--- a/tests/components/nest/sensor_sdm_test.py
+++ b/tests/components/nest/sensor_sdm_test.py
@@ -208,5 +208,5 @@ async def test_device_with_unknown_type(hass):
     device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device.name == "My Sensor"
-    assert device.model == "Unknown"
+    assert device.model is None
     assert device.identifiers == {("nest", "some-device-id")}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update nest and device helper static types based on post-merge discussion in PR #53475

Bump nest to 0.3.6: https://github.com/allenporter/python-google-nest-sdm/compare/0.3.5...0.3.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
