### PR TITLE
Add modbus get_hub

### DIFF
--- a/homeassistant/components/flexit/climate.py
+++ b/homeassistant/components/flexit/climate.py
@@ -17,9 +17,8 @@ from homeassistant.components.modbus.const import (
     CALL_TYPE_WRITE_REGISTER,
     CONF_HUB,
     DEFAULT_HUB,
-    MODBUS_DOMAIN,
 )
-from homeassistant.components.modbus.modbus import ModbusHub
+from homeassistant.components.modbus.modbus import ModbusHub, get_hub
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_NAME,
@@ -53,7 +52,7 @@ async def async_setup_platform(
     """Set up the Flexit Platform."""
     modbus_slave = config.get(CONF_SLAVE)
     name = config.get(CONF_NAME)
-    hub = hass.data[MODBUS_DOMAIN][config.get(CONF_HUB)]
+    hub = get_hub(config[CONF_HUB])
     async_add_entities([Flexit(hub, modbus_slave, name)], True)
 
 

--- a/homeassistant/components/flexit/climate.py
+++ b/homeassistant/components/flexit/climate.py
@@ -11,6 +11,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
+from homeassistant.components.modbus import get_hub
 from homeassistant.components.modbus.const import (
     CALL_TYPE_REGISTER_HOLDING,
     CALL_TYPE_REGISTER_INPUT,
@@ -18,7 +19,7 @@ from homeassistant.components.modbus.const import (
     CONF_HUB,
     DEFAULT_HUB,
 )
-from homeassistant.components.modbus.modbus import ModbusHub, get_hub
+from homeassistant.components.modbus.modbus import ModbusHub
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_NAME,
@@ -52,7 +53,7 @@ async def async_setup_platform(
     """Set up the Flexit Platform."""
     modbus_slave = config.get(CONF_SLAVE)
     name = config.get(CONF_NAME)
-    hub = get_hub(config[CONF_HUB])
+    hub = get_hub(hass, config[CONF_HUB])
     async_add_entities([Flexit(hub, modbus_slave, name)], True)
 
 

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -119,6 +119,8 @@ from .validators import number_validator, scan_interval_validator, struct_valida
 
 _LOGGER = logging.getLogger(__name__)
 
+ModbusDict: dict = {}
+
 BASE_SCHEMA = vol.Schema({vol.Optional(CONF_NAME, default=DEFAULT_HUB): cv.string})
 
 

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -42,6 +42,7 @@ from homeassistant.const import (
     CONF_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
 )
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
@@ -114,12 +115,10 @@ from .const import (
     DEFAULT_TEMP_UNIT,
     MODBUS_DOMAIN as DOMAIN,
 )
-from .modbus import async_modbus_setup
+from .modbus import ModbusHub, async_modbus_setup
 from .validators import number_validator, scan_interval_validator, struct_validator
 
 _LOGGER = logging.getLogger(__name__)
-
-ModbusDict: dict = {}
 
 BASE_SCHEMA = vol.Schema({vol.Optional(CONF_NAME, default=DEFAULT_HUB): cv.string})
 
@@ -359,7 +358,7 @@ SERVICE_WRITE_COIL_SCHEMA = vol.Schema(
 )
 
 
-def get_hub(hass, name: str):
+def get_hub(hass: HomeAssistant, name: str) -> ModbusHub:
     """Return modbus hub with name."""
     return hass.data[DOMAIN][name]
 

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -359,6 +359,11 @@ SERVICE_WRITE_COIL_SCHEMA = vol.Schema(
 )
 
 
+def get_hub(hass, name: str):
+    """Return modbus hub with name."""
+    return hass.data[DOMAIN][name]
+
+
 async def async_setup(hass, config):
     """Set up Modbus component."""
     return await async_modbus_setup(

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -9,8 +9,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from . import get_hub
 from .base_platform import BasePlatform
-from .modbus import get_hub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ async def async_setup_platform(
         return
 
     for entry in discovery_info[CONF_BINARY_SENSORS]:
-        hub = get_hub(discovery_info[CONF_NAME])
+        hub = get_hub(hass, discovery_info[CONF_NAME])
         sensors.append(ModbusBinarySensor(hub, entry))
 
     async_add_entities(sensors)

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .base_platform import BasePlatform
-from .const import MODBUS_DOMAIN
+from .modbus import get_hub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ async def async_setup_platform(
         return
 
     for entry in discovery_info[CONF_BINARY_SENSORS]:
-        hub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
+        hub = get_hub(discovery_info[CONF_NAME])
         sensors.append(ModbusBinarySensor(hub, entry))
 
     async_add_entities(sensors)

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -39,9 +39,8 @@ from .const import (
     DATA_TYPE_UINT16,
     DATA_TYPE_UINT32,
     DATA_TYPE_UINT64,
-    MODBUS_DOMAIN,
 )
-from .modbus import ModbusHub
+from .modbus import ModbusHub, get_hub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -59,7 +58,7 @@ async def async_setup_platform(
 
     entities = []
     for entity in discovery_info[CONF_CLIMATES]:
-        hub: ModbusHub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
+        hub: ModbusHub = get_hub(discovery_info[CONF_NAME])
         entities.append(ModbusThermostat(hub, entity))
 
     async_add_entities(entities)

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -23,6 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from . import get_hub
 from .base_platform import BaseStructPlatform
 from .const import (
     ATTR_TEMPERATURE,
@@ -40,7 +41,7 @@ from .const import (
     DATA_TYPE_UINT32,
     DATA_TYPE_UINT64,
 )
-from .modbus import ModbusHub, get_hub
+from .modbus import ModbusHub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -58,7 +59,7 @@ async def async_setup_platform(
 
     entities = []
     for entity in discovery_info[CONF_CLIMATES]:
-        hub: ModbusHub = get_hub(discovery_info[CONF_NAME])
+        hub: ModbusHub = get_hub(hass, discovery_info[CONF_NAME])
         entities.append(ModbusThermostat(hub, entity))
 
     async_add_entities(entities)

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -19,6 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from . import get_hub
 from .base_platform import BasePlatform
 from .const import (
     CALL_TYPE_COIL,
@@ -31,7 +32,7 @@ from .const import (
     CONF_STATUS_REGISTER,
     CONF_STATUS_REGISTER_TYPE,
 )
-from .modbus import ModbusHub, get_hub
+from .modbus import ModbusHub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -49,7 +50,7 @@ async def async_setup_platform(
 
     covers = []
     for cover in discovery_info[CONF_COVERS]:
-        hub: ModbusHub = get_hub(discovery_info[CONF_NAME])
+        hub: ModbusHub = get_hub(hass, discovery_info[CONF_NAME])
         covers.append(ModbusCover(hub, cover))
 
     async_add_entities(covers)

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -30,9 +30,8 @@ from .const import (
     CONF_STATE_OPENING,
     CONF_STATUS_REGISTER,
     CONF_STATUS_REGISTER_TYPE,
-    MODBUS_DOMAIN,
 )
-from .modbus import ModbusHub
+from .modbus import ModbusHub, get_hub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -50,7 +49,7 @@ async def async_setup_platform(
 
     covers = []
     for cover in discovery_info[CONF_COVERS]:
-        hub: ModbusHub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
+        hub: ModbusHub = get_hub(discovery_info[CONF_NAME])
         covers.append(ModbusCover(hub, cover))
 
     async_add_entities(covers)

--- a/homeassistant/components/modbus/fan.py
+++ b/homeassistant/components/modbus/fan.py
@@ -8,9 +8,10 @@ from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
+from . import get_hub
 from .base_platform import BaseSwitch
 from .const import CONF_FANS
-from .modbus import ModbusHub, get_hub
+from .modbus import ModbusHub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +26,7 @@ async def async_setup_platform(
     fans = []
 
     for entry in discovery_info[CONF_FANS]:
-        hub: ModbusHub = get_hub(discovery_info[CONF_NAME])
+        hub: ModbusHub = get_hub(hass, discovery_info[CONF_NAME])
         fans.append(ModbusFan(hub, entry))
     async_add_entities(fans)
 

--- a/homeassistant/components/modbus/fan.py
+++ b/homeassistant/components/modbus/fan.py
@@ -9,8 +9,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
 from .base_platform import BaseSwitch
-from .const import CONF_FANS, MODBUS_DOMAIN
-from .modbus import ModbusHub
+from .const import CONF_FANS
+from .modbus import ModbusHub, get_hub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ async def async_setup_platform(
     fans = []
 
     for entry in discovery_info[CONF_FANS]:
-        hub: ModbusHub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
+        hub: ModbusHub = get_hub(discovery_info[CONF_NAME])
         fans.append(ModbusFan(hub, entry))
     async_add_entities(fans)
 

--- a/homeassistant/components/modbus/light.py
+++ b/homeassistant/components/modbus/light.py
@@ -9,8 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
 from .base_platform import BaseSwitch
-from .const import MODBUS_DOMAIN
-from .modbus import ModbusHub
+from .modbus import ModbusHub, get_hub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +24,7 @@ async def async_setup_platform(
 
     lights = []
     for entry in discovery_info[CONF_LIGHTS]:
-        hub: ModbusHub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
+        hub: ModbusHub = get_hub(discovery_info[CONF_NAME])
         lights.append(ModbusLight(hub, entry))
     async_add_entities(lights)
 

--- a/homeassistant/components/modbus/light.py
+++ b/homeassistant/components/modbus/light.py
@@ -8,8 +8,9 @@ from homeassistant.const import CONF_LIGHTS, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
+from . import get_hub
 from .base_platform import BaseSwitch
-from .modbus import ModbusHub, get_hub
+from .modbus import ModbusHub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -24,7 +25,7 @@ async def async_setup_platform(
 
     lights = []
     for entry in discovery_info[CONF_LIGHTS]:
-        hub: ModbusHub = get_hub(discovery_info[CONF_NAME])
+        hub: ModbusHub = get_hub(hass, discovery_info[CONF_NAME])
         lights.append(ModbusLight(hub, entry))
     async_add_entities(lights)
 

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -286,23 +286,17 @@ class ModbusHub:
         self._async_cancel_listener = None
         self._config_delay = 0
 
-    def _pymodbus_close(self):
-        """Close sync. pymodbus."""
+    async def async_close(self):
+        """Disconnect client."""
+        if self._async_cancel_listener:
+            self._async_cancel_listener()
+            self._async_cancel_listener = None
         if self._client:
             try:
                 self._client.close()
             except ModbusException as exception_error:
                 self._log_error(str(exception_error))
         self._client = None
-
-    async def async_close(self):
-        """Disconnect client."""
-        if self._async_cancel_listener:
-            self._async_cancel_listener()
-            self._async_cancel_listener = None
-
-        async with self._lock:
-            return await self.hass.async_add_executor_job(self._pymodbus_close)
 
     def _pymodbus_connect(self):
         """Connect client."""

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -11,8 +11,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .base_platform import BaseStructPlatform
-from .const import MODBUS_DOMAIN
-from .modbus import ModbusHub
+from .modbus import ModbusHub, get_hub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +30,7 @@ async def async_setup_platform(
         return
 
     for entry in discovery_info[CONF_SENSORS]:
-        hub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
+        hub = get_hub(discovery_info[CONF_NAME])
         sensors.append(ModbusRegisterSensor(hub, entry))
 
     async_add_entities(sensors)

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -10,8 +10,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from . import get_hub
 from .base_platform import BaseStructPlatform
-from .modbus import ModbusHub, get_hub
+from .modbus import ModbusHub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -30,7 +31,7 @@ async def async_setup_platform(
         return
 
     for entry in discovery_info[CONF_SENSORS]:
-        hub = get_hub(discovery_info[CONF_NAME])
+        hub = get_hub(hass, discovery_info[CONF_NAME])
         sensors.append(ModbusRegisterSensor(hub, entry))
 
     async_add_entities(sensors)

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -8,8 +8,9 @@ from homeassistant.const import CONF_NAME, CONF_SWITCHES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
+from . import get_hub
 from .base_platform import BaseSwitch
-from .modbus import ModbusHub, get_hub
+from .modbus import ModbusHub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -25,7 +26,7 @@ async def async_setup_platform(
         return
 
     for entry in discovery_info[CONF_SWITCHES]:
-        hub: ModbusHub = get_hub(discovery_info[CONF_NAME])
+        hub: ModbusHub = get_hub(hass, discovery_info[CONF_NAME])
         switches.append(ModbusSwitch(hub, entry))
     async_add_entities(switches)
 

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -9,8 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
 from .base_platform import BaseSwitch
-from .const import MODBUS_DOMAIN
-from .modbus import ModbusHub
+from .modbus import ModbusHub, get_hub
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
@@ -26,7 +25,7 @@ async def async_setup_platform(
         return
 
     for entry in discovery_info[CONF_SWITCHES]:
-        hub: ModbusHub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
+        hub: ModbusHub = get_hub(discovery_info[CONF_NAME])
         switches.append(ModbusSwitch(hub, entry))
     async_add_entities(switches)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added new function get_hub(name) to modbus.py, this allows entities as well as other integrations to get hold of the hub for a given name, and thereby avoiding the use of hass.data[DOMAIN]

While at it all entities are also changed to use get_hub.

I marked it as a bug-fix due to the late review comments, but it can also be seen as a new feature or quality improvement.

Due to a change in core, it is no longer allowed to schedule jobs when closing down (error: event loop closed) so replaced with direct calls, which are of no concern since there are no IO involved.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
No need for this to be put in a dot release.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
