### PR TITLE
Update manifest.json for city Bikeintegration

### DIFF
--- a/homeassistant/components/citybikes/manifest.json
+++ b/homeassistant/components/citybikes/manifest.json
@@ -1,7 +1,10 @@
 {
   "domain": "citybikes",
   "name": "CityBikes",
+  "version" : "1.0.0",
   "documentation": "https://www.home-assistant.io/integrations/citybikes",
+  "dependencies": [],
   "codeowners": [],
+  "requirements": [],
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION

## Proposed change
Update manifest.json to prevent this error:
`
2021-08-07 20:47:57 ERROR (SyncWorker_3) [homeassistant.loader] The custom integration 'citybikes_velib' does not have a valid version key (None) in the manifest file and was blocked from loading. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions for more details
`

Following this guidlines
https://developers.home-assistant.io/docs/creating_integration_manifest

## Type of change


- [ ] Dependency upgrade
- [*] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [*] There is no commented out code in this PR.
- [*] I have followed the [development checklist][dev-checklist]
- [*] The code has been formatted using Black (`black --fast homeassistant tests`)
- [*] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [*] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:


- [*] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

