### PR TITLE
Configurable default `hvac_mode` for KNX climate

### DIFF
--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -12,7 +12,6 @@ from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_IDLE,
     CURRENT_HVAC_OFF,
-    HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
     PRESET_AWAY,
     SUPPORT_PRESET_MODE,
@@ -187,6 +186,7 @@ class KNXClimate(KnxEntity, ClimateEntity):
             f"{self._device.target_temperature.group_address}_"
             f"{self._device._setpoint_shift.group_address}"
         )
+        self.default_hvac_mode: str = config[ClimateSchema.CONF_DEFAULT_CONTROLLER_MODE]
 
     async def async_update(self) -> None:
         """Request a state update from KNX bus."""
@@ -231,10 +231,9 @@ class KNXClimate(KnxEntity, ClimateEntity):
             return HVAC_MODE_OFF
         if self._device.mode is not None and self._device.mode.supports_controller_mode:
             return CONTROLLER_MODES.get(
-                self._device.mode.controller_mode.value, HVAC_MODE_HEAT
+                self._device.mode.controller_mode.value, self.default_hvac_mode
             )
-        # default to "heat"
-        return HVAC_MODE_HEAT
+        return self.default_hvac_mode
 
     @property
     def hvac_modes(self) -> list[str]:
@@ -248,12 +247,11 @@ class KNXClimate(KnxEntity, ClimateEntity):
 
         if self._device.supports_on_off:
             if not ha_controller_modes:
-                ha_controller_modes.append(HVAC_MODE_HEAT)
+                ha_controller_modes.append(self.default_hvac_mode)
             ha_controller_modes.append(HVAC_MODE_OFF)
 
         hvac_modes = list(set(filter(None, ha_controller_modes)))
-        # default to ["heat"]
-        return hvac_modes if hvac_modes else [HVAC_MODE_HEAT]
+        return hvac_modes if hvac_modes else [self.default_hvac_mode]
 
     @property
     def hvac_action(self) -> str | None:

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -16,6 +16,7 @@ from xknx.telegram.address import IndividualAddress, parse_device_group_address
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES as BINARY_SENSOR_DEVICE_CLASSES,
 )
+from homeassistant.components.climate.const import HVAC_MODE_HEAT, HVAC_MODES
 from homeassistant.components.cover import DEVICE_CLASSES as COVER_DEVICE_CLASSES
 from homeassistant.components.sensor import STATE_CLASSES_SCHEMA
 from homeassistant.const import (
@@ -287,6 +288,7 @@ class ClimateSchema(KNXPlatformSchema):
     CONF_OPERATION_MODE_STANDBY_ADDRESS = "operation_mode_standby_address"
     CONF_OPERATION_MODES = "operation_modes"
     CONF_CONTROLLER_MODES = "controller_modes"
+    CONF_DEFAULT_CONTROLLER_MODE = "default_controller_mode"
     CONF_ON_OFF_ADDRESS = "on_off_address"
     CONF_ON_OFF_STATE_ADDRESS = "on_off_state_address"
     CONF_ON_OFF_INVERT = "on_off_invert"
@@ -362,6 +364,9 @@ class ClimateSchema(KNXPlatformSchema):
                 vol.Optional(CONF_CONTROLLER_MODES): vol.All(
                     cv.ensure_list, [vol.In(CONTROLLER_MODES)]
                 ),
+                vol.Optional(
+                    CONF_DEFAULT_CONTROLLER_MODE, default=HVAC_MODE_HEAT
+                ): vol.In(HVAC_MODES),
                 vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
                 vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
             }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Configurable default `hvac_mode` for KNX climate.
A `default_controller_mode` configuration key is added to the config schema to define the default HA hvac_mode (controller_mode is the KNX term for what HA considers hvac_mode). Previously it defaulted to "heat". This can be used for climate devices that support cooling only.

```yaml
knx:
    - name: "KNX Climate"
      temperature_address: "0/1/49"
      target_temperature_address: "0/2/49"
      target_temperature_state_address: "0/2/48"
      operation_mode_state_address: "0/3/48"
      on_off_state_address: "0/0/11"
      default_controller_mode: "cool"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18851

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
