### PR TITLE
Remove zwave_js transition on individual color channels

### DIFF
--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -301,7 +301,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         # fallback to setting the color(s) one by one if multicolor fails
         # not sure this is needed at all, but just in case
         for color, value in colors.items():
-            await self._async_set_color(color, value, zwave_transition)
+            await self._async_set_color(color, value)
 
     async def _async_set_color(
         self,

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -1021,8 +1021,7 @@ async def test_multicast_set_value_options(
             ],
             ATTR_COMMAND_CLASS: 51,
             ATTR_PROPERTY: "targetColor",
-            ATTR_PROPERTY_KEY: 2,
-            ATTR_VALUE: 2,
+            ATTR_VALUE: '{ "warmWhite": 0, "coldWhite": 0, "red": 255, "green": 0, "blue": 0 }',
             ATTR_OPTIONS: {"transitionDuration": 1},
         },
         blocking=True,
@@ -1038,9 +1037,11 @@ async def test_multicast_set_value_options(
     assert args["valueId"] == {
         "commandClass": 51,
         "property": "targetColor",
-        "propertyKey": 2,
     }
-    assert args["value"] == 2
+    assert (
+        args["value"]
+        == '{ "warmWhite": 0, "coldWhite": 0, "red": 255, "green": 0, "blue": 0 }'
+    )
     assert args["options"] == {"transitionDuration": 1}
 
     client.async_send_command.reset_mock()

--- a/tests/fixtures/zwave_js/bulb_6_multi_color_state.json
+++ b/tests/fixtures/zwave_js/bulb_6_multi_color_state.json
@@ -267,8 +267,7 @@
                 "min": 0,
                 "max": 255,
                 "label": "Target value (Warm White)",
-                "description": "The target value of the Warm White color.",
-                "valueChangeOptions": ["transitionDuration"]
+                "description": "The target value of the Warm White color."
             }
         },
         {
@@ -286,8 +285,7 @@
                 "min": 0,
                 "max": 255,
                 "label": "Target value (Cold White)",
-                "description": "The target value of the Cold White color.",
-                "valueChangeOptions": ["transitionDuration"]
+                "description": "The target value of the Cold White color."
             }
         },
         {
@@ -305,8 +303,7 @@
                 "min": 0,
                 "max": 255,
                 "label": "Target value (Red)",
-                "description": "The target value of the Red color.",
-                "valueChangeOptions": ["transitionDuration"]
+                "description": "The target value of the Red color."
             }
         },
         {
@@ -324,8 +321,7 @@
                 "min": 0,
                 "max": 255,
                 "label": "Target value (Green)",
-                "description": "The target value of the Green color.",
-                "valueChangeOptions": ["transitionDuration"]
+                "description": "The target value of the Green color."
             }
         },
         {
@@ -343,8 +339,7 @@
                 "min": 0,
                 "max": 255,
                 "label": "Target value (Blue)",
-                "description": "The target value of the Blue color.",
-                "valueChangeOptions": ["transitionDuration"]
+                "description": "The target value of the Blue color."
             }
         },
         {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove transition on individual color channels as it's not supported by zwave

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54302
- This PR is related to issue: n/a
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
