### PR TITLE
Ensure internal/external URL have no path

### DIFF
--- a/homeassistant/components/config/core.py
+++ b/homeassistant/components/config/core.py
@@ -44,8 +44,8 @@ class CheckConfigView(HomeAssistantView):
         vol.Optional("unit_system"): cv.unit_system,
         vol.Optional("location_name"): str,
         vol.Optional("time_zone"): cv.time_zone,
-        vol.Optional("external_url"): vol.Any(cv.url, None),
-        vol.Optional("internal_url"): vol.Any(cv.url, None),
+        vol.Optional("external_url"): vol.Any(cv.url_no_path, None),
+        vol.Optional("internal_url"): vol.Any(cv.url_no_path, None),
         vol.Optional("currency"): cv.currency,
     }
 )

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -10,6 +10,7 @@ import re
 import shutil
 from types import ModuleType
 from typing import Any, Callable
+from urllib.parse import urlparse
 
 from awesomeversion import AwesomeVersion
 import voluptuous as vol
@@ -161,6 +162,19 @@ def _no_duplicate_auth_mfa_module(
     return configs
 
 
+def _filter_bad_internal_external_urls(conf: dict) -> dict:
+    """Filter internal/external URL with a path."""
+    for key in CONF_INTERNAL_URL, CONF_EXTERNAL_URL:
+        if key in conf and urlparse(conf[key]).path not in ("", "/"):
+            # We warn but do not fix, because if this was incorrectly configured,
+            # adjusting this valie might impact security.
+            _LOGGER.warning(
+                "Invalid %s set. It's not allowed to have a path (/bla)", key
+            )
+
+    return conf
+
+
 PACKAGES_CONFIG_SCHEMA = cv.schema_with_slug_keys(  # Package names are slugs
     vol.Schema({cv.string: vol.Any(dict, list, None)})  # Component config
 )
@@ -188,59 +202,64 @@ CUSTOMIZE_CONFIG_SCHEMA = vol.Schema(
     }
 )
 
-CORE_CONFIG_SCHEMA = CUSTOMIZE_CONFIG_SCHEMA.extend(
-    {
-        CONF_NAME: vol.Coerce(str),
-        CONF_LATITUDE: cv.latitude,
-        CONF_LONGITUDE: cv.longitude,
-        CONF_ELEVATION: vol.Coerce(int),
-        vol.Optional(CONF_TEMPERATURE_UNIT): cv.temperature_unit,
-        CONF_UNIT_SYSTEM: cv.unit_system,
-        CONF_TIME_ZONE: cv.time_zone,
-        vol.Optional(CONF_INTERNAL_URL): cv.url,
-        vol.Optional(CONF_EXTERNAL_URL): cv.url,
-        vol.Optional(CONF_ALLOWLIST_EXTERNAL_DIRS): vol.All(
-            cv.ensure_list, [vol.IsDir()]  # pylint: disable=no-value-for-parameter
-        ),
-        vol.Optional(LEGACY_CONF_WHITELIST_EXTERNAL_DIRS): vol.All(
-            cv.ensure_list, [vol.IsDir()]  # pylint: disable=no-value-for-parameter
-        ),
-        vol.Optional(CONF_ALLOWLIST_EXTERNAL_URLS): vol.All(cv.ensure_list, [cv.url]),
-        vol.Optional(CONF_PACKAGES, default={}): PACKAGES_CONFIG_SCHEMA,
-        vol.Optional(CONF_AUTH_PROVIDERS): vol.All(
-            cv.ensure_list,
-            [
-                auth_providers.AUTH_PROVIDER_SCHEMA.extend(
-                    {
-                        CONF_TYPE: vol.NotIn(
-                            ["insecure_example"],
-                            "The insecure_example auth provider"
-                            " is for testing only.",
-                        )
-                    }
-                )
-            ],
-            _no_duplicate_auth_provider,
-        ),
-        vol.Optional(CONF_AUTH_MFA_MODULES): vol.All(
-            cv.ensure_list,
-            [
-                auth_mfa_modules.MULTI_FACTOR_AUTH_MODULE_SCHEMA.extend(
-                    {
-                        CONF_TYPE: vol.NotIn(
-                            ["insecure_example"],
-                            "The insecure_example mfa module is for testing only.",
-                        )
-                    }
-                )
-            ],
-            _no_duplicate_auth_mfa_module,
-        ),
-        # pylint: disable=no-value-for-parameter
-        vol.Optional(CONF_MEDIA_DIRS): cv.schema_with_slug_keys(vol.IsDir()),
-        vol.Optional(CONF_LEGACY_TEMPLATES): cv.boolean,
-        vol.Optional(CONF_CURRENCY): cv.currency,
-    }
+CORE_CONFIG_SCHEMA = vol.All(
+    CUSTOMIZE_CONFIG_SCHEMA.extend(
+        {
+            CONF_NAME: vol.Coerce(str),
+            CONF_LATITUDE: cv.latitude,
+            CONF_LONGITUDE: cv.longitude,
+            CONF_ELEVATION: vol.Coerce(int),
+            vol.Optional(CONF_TEMPERATURE_UNIT): cv.temperature_unit,
+            CONF_UNIT_SYSTEM: cv.unit_system,
+            CONF_TIME_ZONE: cv.time_zone,
+            vol.Optional(CONF_INTERNAL_URL): cv.url,
+            vol.Optional(CONF_EXTERNAL_URL): cv.url,
+            vol.Optional(CONF_ALLOWLIST_EXTERNAL_DIRS): vol.All(
+                cv.ensure_list, [vol.IsDir()]  # pylint: disable=no-value-for-parameter
+            ),
+            vol.Optional(LEGACY_CONF_WHITELIST_EXTERNAL_DIRS): vol.All(
+                cv.ensure_list, [vol.IsDir()]  # pylint: disable=no-value-for-parameter
+            ),
+            vol.Optional(CONF_ALLOWLIST_EXTERNAL_URLS): vol.All(
+                cv.ensure_list, [cv.url]
+            ),
+            vol.Optional(CONF_PACKAGES, default={}): PACKAGES_CONFIG_SCHEMA,
+            vol.Optional(CONF_AUTH_PROVIDERS): vol.All(
+                cv.ensure_list,
+                [
+                    auth_providers.AUTH_PROVIDER_SCHEMA.extend(
+                        {
+                            CONF_TYPE: vol.NotIn(
+                                ["insecure_example"],
+                                "The insecure_example auth provider"
+                                " is for testing only.",
+                            )
+                        }
+                    )
+                ],
+                _no_duplicate_auth_provider,
+            ),
+            vol.Optional(CONF_AUTH_MFA_MODULES): vol.All(
+                cv.ensure_list,
+                [
+                    auth_mfa_modules.MULTI_FACTOR_AUTH_MODULE_SCHEMA.extend(
+                        {
+                            CONF_TYPE: vol.NotIn(
+                                ["insecure_example"],
+                                "The insecure_example mfa module is for testing only.",
+                            )
+                        }
+                    )
+                ],
+                _no_duplicate_auth_mfa_module,
+            ),
+            # pylint: disable=no-value-for-parameter
+            vol.Optional(CONF_MEDIA_DIRS): cv.schema_with_slug_keys(vol.IsDir()),
+            vol.Optional(CONF_LEGACY_TEMPLATES): cv.boolean,
+            vol.Optional(CONF_CURRENCY): cv.currency,
+        }
+    ),
+    _filter_bad_internal_external_urls,
 )
 
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -167,7 +167,7 @@ def _filter_bad_internal_external_urls(conf: dict) -> dict:
     for key in CONF_INTERNAL_URL, CONF_EXTERNAL_URL:
         if key in conf and urlparse(conf[key]).path not in ("", "/"):
             # We warn but do not fix, because if this was incorrectly configured,
-            # adjusting this valie might impact security.
+            # adjusting this value might impact security.
             _LOGGER.warning(
                 "Invalid %s set. It's not allowed to have a path (/bla)", key
             )

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -19,6 +19,7 @@ import threading
 from time import monotonic
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, cast
+from urllib.parse import urlparse
 
 import attr
 import voluptuous as vol
@@ -1717,19 +1718,35 @@ class Config:
         )
         data = await store.async_load()
 
-        if data:
-            self._update(
-                source=SOURCE_STORAGE,
-                latitude=data.get("latitude"),
-                longitude=data.get("longitude"),
-                elevation=data.get("elevation"),
-                unit_system=data.get("unit_system"),
-                location_name=data.get("location_name"),
-                time_zone=data.get("time_zone"),
-                external_url=data.get("external_url", _UNDEF),
-                internal_url=data.get("internal_url", _UNDEF),
-                currency=data.get("currency"),
-            )
+        if not data:
+            return
+
+        # In 2021.9 we fixed validation to disallow a path (because that's never correct)
+        # but this data still lives in storage, so we print a warning.
+        if "external_url" in data and urlparse(data["external_url"]).path not in (
+            "",
+            "/",
+        ):
+            _LOGGER.warning("Invalid external_url set. It's not allowed to have a path")
+
+        if "internal_url" in data and urlparse(data["internal_url"]).path not in (
+            "",
+            "/",
+        ):
+            _LOGGER.warning("Invalid internal_url set. It's not allowed to have a path")
+
+        self._update(
+            source=SOURCE_STORAGE,
+            latitude=data.get("latitude"),
+            longitude=data.get("longitude"),
+            elevation=data.get("elevation"),
+            unit_system=data.get("unit_system"),
+            location_name=data.get("location_name"),
+            time_zone=data.get("time_zone"),
+            external_url=data.get("external_url", _UNDEF),
+            internal_url=data.get("internal_url", _UNDEF),
+            currency=data.get("currency"),
+        )
 
     async def async_store(self) -> None:
         """Store [homeassistant] core config."""

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -649,6 +649,16 @@ def url(value: Any) -> str:
     raise vol.Invalid("invalid url")
 
 
+def url_no_path(value: Any) -> str:
+    """Validate a url without a path."""
+    url_in = url(value)
+
+    if urlparse(url_in).path not in ("", "/"):
+        raise vol.Invalid("url it not allowed to have a path component")
+
+    return url_in
+
+
 def x10_address(value: str) -> str:
     """Validate an x10 address."""
     regex = re.compile(r"([A-Pa-p]{1})(?:[2-9]|1[0-6]?)$")

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -120,6 +120,25 @@ def test_url():
         assert schema(value)
 
 
+def test_url_no_path():
+    """Test URL."""
+    schema = vol.Schema(cv.url_no_path)
+
+    for value in (
+        "https://localhost/test/index.html",
+        "http://home-assistant.io/test/",
+    ):
+        with pytest.raises(vol.MultipleInvalid):
+            schema(value)
+
+    for value in (
+        "http://localhost",
+        "http://home-assistant.io",
+        "https://community.home-assistant.io/",
+    ):
+        assert schema(value)
+
+
 def test_platform_config():
     """Test platform config validation."""
     options = ({}, {"hello": "world"})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,6 +215,19 @@ def test_core_config_schema():
     )
 
 
+def test_core_config_schema_internal_external_warning(caplog):
+    """Test that we warn for internal/external URL with path."""
+    config_util.CORE_CONFIG_SCHEMA(
+        {
+            "external_url": "https://www.example.com/bla",
+            "internal_url": "http://example.local/yo",
+        }
+    )
+
+    assert "Invalid external_url set" in caplog.text
+    assert "Invalid internal_url set" in caplog.text
+
+
 def test_customize_dict_schema():
     """Test basic customize config validation."""
     values = ({ATTR_FRIENDLY_NAME: None}, {ATTR_ASSUMED_STATE: "2"})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1374,6 +1374,21 @@ async def test_additional_data_in_core_config(hass, hass_storage):
     assert config.location_name == "Test Name"
 
 
+async def test_incorrect_internal_external_url(hass, hass_storage, caplog):
+    """Test that we warn when detecting invalid internal/extenral url."""
+    config = ha.Config(hass)
+    hass_storage[ha.CORE_STORAGE_KEY] = {
+        "version": 1,
+        "data": {
+            "internal_url": "https://community.home-assistant.io/profile",
+            "external_url": "https://www.home-assistant.io/blue",
+        },
+    }
+    await config.async_load()
+    assert "Invalid external_url set" in caplog.text
+    assert "Invalid internal_url set" in caplog.text
+
+
 async def test_start_events(hass):
     """Test events fired when starting Home Assistant."""
     hass.state = ha.CoreState.not_running


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Internal/External URLs are not allowed to have a path as Home Assistant does not support being hosted on a path. By tightening validation we prevent users from setting a value that will never work.

 - Setting value with path via UI is now invalid
 - Existing YAML values will print a warning
 - Existing storage values will print a warning

Due to security, I don't want to "fix" their internal/external urls and strip the path. I also don't want to set the storage values to None, because the user might not see the warning in that case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
