### PR TITLE
Use dict for zwave_js siren.available_tones

### DIFF
--- a/homeassistant/components/siren/services.yaml
+++ b/homeassistant/components/siren/services.yaml
@@ -7,7 +7,7 @@ turn_on:
       domain: siren
   fields:
     tone:
-      description: The tone to emit when turning the siren on. Must be supported by the integration.
+      description: The tone to emit when turning the siren on. When `available_tones` property is a map, either the key or the value can be used. Must be supported by the integration.
       example: fire
       required: false
       selector:

--- a/homeassistant/components/zwave_js/siren.py
+++ b/homeassistant/components/zwave_js/siren.py
@@ -58,9 +58,9 @@ class ZwaveSirenEntity(ZWaveBaseEntity, SirenEntity):
         """Initialize a ZwaveSirenEntity entity."""
         super().__init__(config_entry, client, info)
         # Entity class attributes
-        self._attr_available_tones = list(
-            self.info.primary_value.metadata.states.values()
-        )
+        self._attr_available_tones = {
+            int(id): val for id, val in self.info.primary_value.metadata.states.items()
+        }
         self._attr_supported_features = (
             SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_VOLUME_SET
         )
@@ -82,22 +82,14 @@ class ZwaveSirenEntity(ZWaveBaseEntity, SirenEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        tone: str | None = kwargs.get(ATTR_TONE)
+        tone_id: int | None = kwargs.get(ATTR_TONE)
         options = {}
         if (volume := kwargs.get(ATTR_VOLUME_LEVEL)) is not None:
             options["volume"] = round(volume * 100)
         # Play the default tone if a tone isn't provided
-        if tone is None:
+        if tone_id is None:
             await self.async_set_value(ToneID.DEFAULT, options)
             return
-
-        tone_id = int(
-            next(
-                key
-                for key, value in self.info.primary_value.metadata.states.items()
-                if value == tone
-            )
-        )
 
         await self.async_set_value(tone_id, options)
 

--- a/tests/components/zwave_js/test_siren.py
+++ b/tests/components/zwave_js/test_siren.py
@@ -2,6 +2,7 @@
 from zwave_js_server.event import Event
 
 from homeassistant.components.siren import ATTR_TONE, ATTR_VOLUME_LEVEL
+from homeassistant.components.siren.const import ATTR_AVAILABLE_TONES
 from homeassistant.const import STATE_OFF, STATE_ON
 
 SIREN_ENTITY = "siren.indoor_siren_6_2"
@@ -65,6 +66,39 @@ async def test_siren(hass, client, aeotec_zw164_siren, integration):
 
     assert state
     assert state.state == STATE_OFF
+    assert state.attributes.get(ATTR_AVAILABLE_TONES) == {
+        0: "off",
+        1: "01DING~1 (5 sec)",
+        2: "02DING~1 (9 sec)",
+        3: "03TRAD~1 (11 sec)",
+        4: "04ELEC~1 (2 sec)",
+        5: "05WEST~1 (13 sec)",
+        6: "06CHIM~1 (7 sec)",
+        7: "07CUCK~1 (31 sec)",
+        8: "08TRAD~1 (6 sec)",
+        9: "09SMOK~1 (11 sec)",
+        10: "10SMOK~1 (6 sec)",
+        11: "11FIRE~1 (35 sec)",
+        12: "12COSE~1 (5 sec)",
+        13: "13KLAX~1 (38 sec)",
+        14: "14DEEP~1 (41 sec)",
+        15: "15WARN~1 (37 sec)",
+        16: "16TORN~1 (46 sec)",
+        17: "17ALAR~1 (35 sec)",
+        18: "18DEEP~1 (62 sec)",
+        19: "19ALAR~1 (15 sec)",
+        20: "20ALAR~1 (7 sec)",
+        21: "21DIGI~1 (8 sec)",
+        22: "22ALER~1 (64 sec)",
+        23: "23SHIP~1 (4 sec)",
+        25: "25CHRI~1 (4 sec)",
+        26: "26GONG~1 (12 sec)",
+        27: "27SING~1 (1 sec)",
+        28: "28TONA~1 (5 sec)",
+        29: "29UPWA~1 (2 sec)",
+        30: "30DOOR~1 (27 sec)",
+        255: "default",
+    }
 
     # Test turn on with default
     await hass.services.async_call(
@@ -90,6 +124,28 @@ async def test_siren(hass, client, aeotec_zw164_siren, integration):
         {
             "entity_id": SIREN_ENTITY,
             ATTR_TONE: "01DING~1 (5 sec)",
+            ATTR_VOLUME_LEVEL: 0.5,
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == node.node_id
+    assert args["valueId"] == TONE_ID_VALUE_ID
+    assert args["value"] == 1
+    assert args["options"] == {"volume": 50}
+
+    client.async_send_command.reset_mock()
+
+    # Test turn on with specific tone ID and volume level
+    await hass.services.async_call(
+        "siren",
+        "turn_on",
+        {
+            "entity_id": SIREN_ENTITY,
+            ATTR_TONE: 1,
             ATTR_VOLUME_LEVEL: 0.5,
         },
         blocking=True,


### PR DESCRIPTION
## Proposed change
Follow up to https://github.com/home-assistant/core/pull/54198 to make it possible to provide either the key or the value for the tone when calling the `siren.turn_on` service for `zwave_js`

Also realized it was worth updating the service description to mention this feature.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
