### PR TITLE
Add light transition for Shelly integration

### DIFF
--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -1,6 +1,7 @@
 """Constants for the Shelly integration."""
 from __future__ import annotations
 
+import re
 from typing import Final
 
 COAP: Final = "coap"
@@ -11,6 +12,19 @@ REST: Final = "rest"
 
 CONF_COAP_PORT: Final = "coap_port"
 DEFAULT_COAP_PORT: Final = 5683
+FIRMWARE_PATTERN: Final = re.compile(r"^(\d{8})")
+
+# Firmware 1.11.0 release date, this firmware supports light transition
+LIGHT_TRANSITION_MIN_FIRMWARE_DATE: Final = 20210226
+
+MODELS_SUPPORTING_LIGHT_TRANSITION: Final = (
+    "SHBDUO-1",
+    "SHBLB-1",
+    "SHDM-1",
+    "SHDM-2",
+    "SHRGBW2",
+    "SHVIN-1",
+)
 
 # Used in "_async_update_data" as timeout for polling data from devices.
 POLLING_TIMEOUT_SEC: Final = 18

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -17,6 +17,9 @@ FIRMWARE_PATTERN: Final = re.compile(r"^(\d{8})")
 # Firmware 1.11.0 release date, this firmware supports light transition
 LIGHT_TRANSITION_MIN_FIRMWARE_DATE: Final = 20210226
 
+# max light transition time in milliseconds
+MAX_TRANSITION_TIME: Final = 5000
+
 MODELS_SUPPORTING_LIGHT_TRANSITION: Final = (
     "SHBDUO-1",
     "SHBLB-1",

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -22,7 +22,7 @@ MAX_TRANSITION_TIME: Final = 5000
 
 MODELS_SUPPORTING_LIGHT_TRANSITION: Final = (
     "SHBDUO-1",
-    "SHBLB-1",
+    "SHCB-1",
     "SHDM-1",
     "SHDM-2",
     "SHRGBW2",

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -44,6 +44,7 @@ from .const import (
     KELVIN_MIN_VALUE_COLOR,
     KELVIN_MIN_VALUE_WHITE,
     LIGHT_TRANSITION_MIN_FIRMWARE_DATE,
+    MAX_TRANSITION_TIME,
     MODELS_SUPPORTING_LIGHT_TRANSITION,
     SHBLB_1_RGB_EFFECTS,
     STANDARD_RGB_EFFECTS,
@@ -275,7 +276,9 @@ class ShellyLight(ShellyBlockEntity, LightEntity):
         params: dict[str, Any] = {"turn": "on"}
 
         if ATTR_TRANSITION in kwargs:
-            params["transition"] = int(kwargs[ATTR_TRANSITION] * 1000)
+            params["transition"] = min(
+                int(kwargs[ATTR_TRANSITION] * 1000), MAX_TRANSITION_TIME
+            )
 
         if ATTR_BRIGHTNESS in kwargs and brightness_supported(supported_color_modes):
             brightness_pct = int(100 * (kwargs[ATTR_BRIGHTNESS] + 1) / 255)
@@ -331,7 +334,9 @@ class ShellyLight(ShellyBlockEntity, LightEntity):
         params: dict[str, Any] = {"turn": "off"}
 
         if ATTR_TRANSITION in kwargs:
-            params["transition"] = int(kwargs[ATTR_TRANSITION] * 1000)
+            params["transition"] = min(
+                int(kwargs[ATTR_TRANSITION] * 1000), MAX_TRANSITION_TIME
+            )
 
         self.control_result = await self.set_state(**params)
 

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -14,12 +14,14 @@ from homeassistant.components.light import (
     ATTR_EFFECT,
     ATTR_RGB_COLOR,
     ATTR_RGBW_COLOR,
+    ATTR_TRANSITION,
     COLOR_MODE_BRIGHTNESS,
     COLOR_MODE_COLOR_TEMP,
     COLOR_MODE_ONOFF,
     COLOR_MODE_RGB,
     COLOR_MODE_RGBW,
     SUPPORT_EFFECT,
+    SUPPORT_TRANSITION,
     LightEntity,
     brightness_supported,
 )
@@ -37,9 +39,12 @@ from .const import (
     COAP,
     DATA_CONFIG_ENTRY,
     DOMAIN,
+    FIRMWARE_PATTERN,
     KELVIN_MAX_VALUE,
     KELVIN_MIN_VALUE_COLOR,
     KELVIN_MIN_VALUE_WHITE,
+    LIGHT_TRANSITION_MIN_FIRMWARE_DATE,
+    MODELS_SUPPORTING_LIGHT_TRANSITION,
     SHBLB_1_RGB_EFFECTS,
     STANDARD_RGB_EFFECTS,
 )
@@ -109,6 +114,14 @@ class ShellyLight(ShellyBlockEntity, LightEntity):
 
         if hasattr(block, "effect"):
             self._supported_features |= SUPPORT_EFFECT
+
+        if wrapper.model in MODELS_SUPPORTING_LIGHT_TRANSITION:
+            match = FIRMWARE_PATTERN.search(wrapper.device.settings.get("fw"))
+            if (
+                match is not None
+                and int(match[0]) >= LIGHT_TRANSITION_MIN_FIRMWARE_DATE
+            ):
+                self._supported_features |= SUPPORT_TRANSITION
 
     @property
     def supported_features(self) -> int:
@@ -261,6 +274,9 @@ class ShellyLight(ShellyBlockEntity, LightEntity):
         supported_color_modes = self._supported_color_modes
         params: dict[str, Any] = {"turn": "on"}
 
+        if ATTR_TRANSITION in kwargs:
+            params["transition"] = int(kwargs[ATTR_TRANSITION] * 1000)
+
         if ATTR_BRIGHTNESS in kwargs and brightness_supported(supported_color_modes):
             brightness_pct = int(100 * (kwargs[ATTR_BRIGHTNESS] + 1) / 255)
             if hasattr(self.block, "gain"):
@@ -312,7 +328,13 @@ class ShellyLight(ShellyBlockEntity, LightEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off light."""
-        self.control_result = await self.set_state(turn="off")
+        params: dict[str, Any] = {"turn": "off"}
+
+        if ATTR_TRANSITION in kwargs:
+            params["transition"] = int(kwargs[ATTR_TRANSITION] * 1000)
+
+        self.control_result = await self.set_state(**params)
+
         self.async_write_ha_state()
 
     async def set_light_mode(self, set_mode: str | None) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for light transition for Shelly lights with firmware 1.11 or later.
The firmware limits the maximum transition time to 5 seconds.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18862

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
