### PR TITLE
Support incrementing brightness using native api for Philips Hue lights

### DIFF
--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -9,6 +9,7 @@ import async_timeout
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_BRIGHTNESS_STEP,
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_FLASH,
@@ -19,6 +20,7 @@ from homeassistant.components.light import (
     FLASH_LONG,
     FLASH_SHORT,
     SUPPORT_BRIGHTNESS,
+    SUPPORT_BRIGHTNESS_INC,
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
     SUPPORT_EFFECT,
@@ -51,7 +53,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_HUE_ON_OFF = SUPPORT_FLASH | SUPPORT_TRANSITION
-SUPPORT_HUE_DIMMABLE = SUPPORT_HUE_ON_OFF | SUPPORT_BRIGHTNESS
+SUPPORT_HUE_DIMMABLE = SUPPORT_HUE_ON_OFF | SUPPORT_BRIGHTNESS | SUPPORT_BRIGHTNESS_INC
 SUPPORT_HUE_COLOR_TEMP = SUPPORT_HUE_DIMMABLE | SUPPORT_COLOR_TEMP
 SUPPORT_HUE_COLOR = SUPPORT_HUE_DIMMABLE | SUPPORT_EFFECT | SUPPORT_COLOR
 SUPPORT_HUE_EXTENDED = SUPPORT_HUE_COLOR_TEMP | SUPPORT_HUE_COLOR
@@ -484,6 +486,9 @@ class HueLight(CoordinatorEntity, LightEntity):
 
         if ATTR_BRIGHTNESS in kwargs:
             command["bri"] = hass_to_hue_brightness(kwargs[ATTR_BRIGHTNESS])
+
+        if ATTR_BRIGHTNESS_STEP in kwargs:
+            command["bri_inc"] = kwargs[ATTR_BRIGHTNESS_STEP]
 
         flash = kwargs.get(ATTR_FLASH)
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -46,6 +46,7 @@ SUPPORT_FLASH = 8
 SUPPORT_COLOR = 16  # Deprecated, replaced by color modes
 SUPPORT_TRANSITION = 32
 SUPPORT_WHITE_VALUE = 128  # Deprecated, replaced by color modes
+SUPPORT_BRIGHTNESS_INC = 256
 
 # Color mode of the light
 ATTR_COLOR_MODE = "color_mode"
@@ -353,17 +354,21 @@ async def async_setup(hass, config):  # noqa: C901
         if params and (
             ATTR_BRIGHTNESS_STEP in params or ATTR_BRIGHTNESS_STEP_PCT in params
         ):
-            brightness = light.brightness if light.is_on else 0
+            supports_inc = light.supported_features & SUPPORT_BRIGHTNESS_INC
+            if not supports_inc or ATTR_BRIGHTNESS_STEP_PCT in params:
+                brightness = light.brightness if light.is_on else 0
 
-            if ATTR_BRIGHTNESS_STEP in params:
-                brightness += params.pop(ATTR_BRIGHTNESS_STEP)
+                if ATTR_BRIGHTNESS_STEP in params:
+                    brightness += params.pop(ATTR_BRIGHTNESS_STEP)
 
-            else:
-                brightness += round(params.pop(ATTR_BRIGHTNESS_STEP_PCT) / 100 * 255)
+                else:
+                    brightness += round(
+                        params.pop(ATTR_BRIGHTNESS_STEP_PCT) / 100 * 255
+                    )
 
-            params[ATTR_BRIGHTNESS] = max(0, min(255, brightness))
+                params[ATTR_BRIGHTNESS] = max(0, min(255, brightness))
 
-            preprocess_turn_on_alternatives(hass, params)
+                preprocess_turn_on_alternatives(hass, params)
 
         if (not params or not light.is_on) or (
             params and ATTR_TRANSITION not in params

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -583,6 +583,7 @@ async def test_light_turn_on_service(hass, mock_bridge):
     updated_light_response["2"] = LIGHT_2_ON
 
     mock_bridge.mock_light_responses.append(updated_light_response)
+    mock_bridge.mock_light_responses.append(updated_light_response)
 
     await hass.services.async_call(
         "light",
@@ -619,6 +620,20 @@ async def test_light_turn_on_service(hass, mock_bridge):
     assert mock_bridge.mock_requests[4]["json"] == {
         "on": True,
         "xy": (0.138, 0.08),
+        "alert": "none",
+    }
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": "light.hue_lamp_2", "brightness_step": 20},
+        blocking=True,
+    )
+
+    assert len(mock_bridge.mock_requests) == 8
+    assert mock_bridge.mock_requests[6]["json"] == {
+        "on": True,
+        "bri_inc": 20,
         "alert": "none",
     }
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -776,12 +776,16 @@ async def test_light_brightness_step(hass, enable_custom_integrations):
     platform.init(empty=True)
     platform.ENTITIES.append(platform.MockLight("Test_0", STATE_ON))
     platform.ENTITIES.append(platform.MockLight("Test_1", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_2", STATE_ON))
     entity0 = platform.ENTITIES[0]
     entity0.supported_features = light.SUPPORT_BRIGHTNESS
     entity0.brightness = 100
     entity1 = platform.ENTITIES[1]
     entity1.supported_features = light.SUPPORT_BRIGHTNESS
     entity1.brightness = 50
+    entity2 = platform.ENTITIES[2]
+    entity2.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_BRIGHTNESS_INC
+    entity2.brightness = 50
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -830,6 +834,17 @@ async def test_light_brightness_step(hass, enable_custom_integrations):
     )
 
     assert entity0.state == "off"  # 126 - 126; brightness is 0, light should turn off
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": entity2.entity_id, "brightness_step": -10},
+        blocking=True,
+    )
+
+    _, data = entity2.last_call("turn_on")
+    assert "brightness_step" in data
+    assert data["brightness_step"] == -10
 
 
 async def test_light_brightness_pct_conversion(hass, enable_custom_integrations):


### PR DESCRIPTION
For now only Hue lights are supported. Light implementations should add `SUPPORT_BRIGHTNESS_INC` to `supported_features` to receive the raw `brightness_step` value and transform it to a native request.

This feature can also be used to stop transitions. For example, an event might trigger turn_on with `transition=5`, and another event can then cancel that transition by calling `turn_on` with `brightness_step=0`.

Ref #53100

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #53100
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
