### PR TITLE
Use EntityDescription - juicenet

### DIFF
--- a/homeassistant/components/juicenet/entity.py
+++ b/homeassistant/components/juicenet/entity.py
@@ -15,11 +15,6 @@ class JuiceNetDevice(CoordinatorEntity):
         self.type = sensor_type
 
     @property
-    def name(self):
-        """Return the name of the device."""
-        return self.device.name
-
-    @property
     def unique_id(self):
         """Return a unique ID."""
         return f"{self.device.id}-{self.type}"

--- a/homeassistant/components/juicenet/sensor.py
+++ b/homeassistant/components/juicenet/sensor.py
@@ -27,10 +27,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="status",
         name="Charging Status",
-        unit_of_measurement=None,
-        icon=None,
-        device_class=None,
-        state_class=None,
     ),
     SensorEntityDescription(
         key="temperature",
@@ -46,7 +42,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         icon="mdi:flash",
         device_class=DEVICE_CLASS_VOLTAGE,
-        state_class=None,
     ),
     SensorEntityDescription(
         key="amps",
@@ -69,8 +64,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         name="Charge time",
         unit_of_measurement=TIME_SECONDS,
         icon="mdi:timer-outline",
-        device_class=None,
-        state_class=None,
     ),
     SensorEntityDescription(
         key="energy_added",
@@ -78,7 +71,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         unit_of_measurement=ENERGY_WATT_HOUR,
         icon="mdi:flash",
         device_class=DEVICE_CLASS_ENERGY,
-        state_class=None,
     ),
 )
 

--- a/homeassistant/components/juicenet/sensor.py
+++ b/homeassistant/components/juicenet/sensor.py
@@ -28,6 +28,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="status",
         name="Charging Status",
         unit_of_measurement=None,
+        icon=None,
         device_class=None,
         state_class=None,
     ),
@@ -35,6 +36,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="temperature",
         name="Temperature",
         unit_of_measurement=TEMP_CELSIUS,
+        icon="mdi:thermometer",
         device_class=DEVICE_CLASS_TEMPERATURE,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
@@ -42,6 +44,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="voltage",
         name="Voltage",
         unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
+        icon="mdi:flash",
         device_class=DEVICE_CLASS_VOLTAGE,
         state_class=None,
     ),
@@ -49,6 +52,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="amps",
         name="Amps",
         unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+        icon="mdi:flash",
         device_class=DEVICE_CLASS_CURRENT,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
@@ -56,6 +60,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="watts",
         name="Watts",
         unit_of_measurement=POWER_WATT,
+        icon="mdi:flash",
         device_class=DEVICE_CLASS_POWER,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
@@ -63,6 +68,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="charge_time",
         name="Charge time",
         unit_of_measurement=TIME_SECONDS,
+        icon="mdi:timer-outline",
         device_class=None,
         state_class=None,
     ),
@@ -70,6 +76,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="energy_added",
         name="Energy added",
         unit_of_measurement=ENERGY_WATT_HOUR,
+        icon="mdi:flash",
         device_class=DEVICE_CLASS_ENERGY,
         state_class=None,
     ),
@@ -103,8 +110,7 @@ class JuiceNetSensorDevice(JuiceNetDevice, SensorEntity):
     def icon(self):
         """Return the icon of the sensor."""
         icon = None
-        sensor_type = self.entity_description.key
-        if sensor_type == "status":
+        if self.entity_description.key == "status":
             status = self.device.status
             if status == "standby":
                 icon = "mdi:power-plug-off"
@@ -112,18 +118,8 @@ class JuiceNetSensorDevice(JuiceNetDevice, SensorEntity):
                 icon = "mdi:power-plug"
             elif status == "charging":
                 icon = "mdi:battery-positive"
-        elif sensor_type == "temperature":
-            icon = "mdi:thermometer"
-        elif sensor_type == "voltage":
-            icon = "mdi:flash"
-        elif sensor_type == "amps":
-            icon = "mdi:flash"
-        elif sensor_type == "watts":
-            icon = "mdi:flash"
-        elif sensor_type == "charge_time":
-            icon = "mdi:timer-outline"
-        elif sensor_type == "energy_added":
-            icon = "mdi:flash"
+        else:
+            icon = self.entity_description.icon
         return icon
 
     @property


### PR DESCRIPTION
## Proposed change
Update `juicenet` to use `EntityDescription` for sensor metadata.
-> #53201

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
