### PR TITLE
Revert "Use entity class attributes for Bluesound (#53033)"

### DIFF
--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -203,29 +203,33 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class BluesoundPlayer(MediaPlayerEntity):
     """Representation of a Bluesound Player."""
 
-    _attr_media_content_type = MEDIA_TYPE_MUSIC
-
-    def __init__(self, hass, host, port=DEFAULT_PORT, name=None, init_callback=None):
+    def __init__(self, hass, host, port=None, name=None, init_callback=None):
         """Initialize the media player."""
         self.host = host
         self._hass = hass
         self.port = port
         self._polling_session = async_get_clientsession(hass)
         self._polling_task = None  # The actual polling task.
-        self._attr_name = name
+        self._name = name
+        self._icon = None
         self._capture_items = []
         self._services_items = []
         self._preset_items = []
         self._sync_status = {}
         self._status = None
-        self._is_online = None
+        self._last_status_update = None
+        self._is_online = False
         self._retry_remove = None
+        self._muted = False
         self._master = None
-        self._group_name = None
-        self._bluesound_device_name = None
         self._is_master = False
+        self._group_name = None
         self._group_list = []
+        self._bluesound_device_name = None
+
         self._init_callback = init_callback
+        if self.port is None:
+            self.port = DEFAULT_PORT
 
     class _TimeoutException(Exception):
         pass
@@ -248,12 +252,12 @@ class BluesoundPlayer(MediaPlayerEntity):
             return None
         self._sync_status = resp["SyncStatus"].copy()
 
-        if not self.name:
-            self._attr_name = self._sync_status.get("@name", self.host)
+        if not self._name:
+            self._name = self._sync_status.get("@name", self.host)
         if not self._bluesound_device_name:
             self._bluesound_device_name = self._sync_status.get("@name", self.host)
-        if not self.icon:
-            self._attr_icon = self._sync_status.get("@icon", self.host)
+        if not self._icon:
+            self._icon = self._sync_status.get("@icon", self.host)
 
         master = self._sync_status.get("master")
         if master is not None:
@@ -287,14 +291,14 @@ class BluesoundPlayer(MediaPlayerEntity):
                 await self.async_update_status()
 
         except (asyncio.TimeoutError, ClientError, BluesoundPlayer._TimeoutException):
-            _LOGGER.info("Node %s is offline, retrying later", self.name)
+            _LOGGER.info("Node %s is offline, retrying later", self._name)
             await asyncio.sleep(NODE_OFFLINE_CHECK_TIMEOUT)
             self.start_polling()
 
         except CancelledError:
-            _LOGGER.debug("Stopping the polling of node %s", self.name)
+            _LOGGER.debug("Stopping the polling of node %s", self._name)
         except Exception:
-            _LOGGER.exception("Unexpected error in %s", self.name)
+            _LOGGER.exception("Unexpected error in %s", self._name)
             raise
 
     def start_polling(self):
@@ -398,7 +402,7 @@ class BluesoundPlayer(MediaPlayerEntity):
             if response.status == HTTP_OK:
                 result = await response.text()
                 self._is_online = True
-                self._attr_media_position_updated_at = dt_util.utcnow()
+                self._last_status_update = dt_util.utcnow()
                 self._status = xmltodict.parse(result)["status"].copy()
 
                 group_name = self._status.get("groupName")
@@ -434,58 +438,11 @@ class BluesoundPlayer(MediaPlayerEntity):
 
         except (asyncio.TimeoutError, ClientError):
             self._is_online = False
-            self._attr_media_position_updated_at = None
+            self._last_status_update = None
             self._status = None
             self.async_write_ha_state()
-            _LOGGER.info("Client connection error, marking %s as offline", self.name)
+            _LOGGER.info("Client connection error, marking %s as offline", self._name)
             raise
-        self.update_state_attr()
-
-    def update_state_attr(self):
-        """Update state attributes."""
-        if self._status is None:
-            self._attr_state = STATE_OFF
-            self._attr_supported_features = 0
-        elif self.is_grouped and not self.is_master:
-            self._attr_state = STATE_GROUPED
-            self._attr_supported_features = (
-                SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE
-            )
-        else:
-            status = self._status.get("state")
-            self._attr_state = STATE_IDLE
-            if status in ("pause", "stop"):
-                self._attr_state = STATE_PAUSED
-            elif status in ("stream", "play"):
-                self._attr_state = STATE_PLAYING
-            supported = SUPPORT_CLEAR_PLAYLIST
-            if self._status.get("indexing", "0") == "0":
-                supported = (
-                    supported
-                    | SUPPORT_PAUSE
-                    | SUPPORT_PREVIOUS_TRACK
-                    | SUPPORT_NEXT_TRACK
-                    | SUPPORT_PLAY_MEDIA
-                    | SUPPORT_STOP
-                    | SUPPORT_PLAY
-                    | SUPPORT_SELECT_SOURCE
-                    | SUPPORT_SHUFFLE_SET
-                )
-            if self.volume_level is not None and self.volume_level >= 0:
-                supported = (
-                    supported
-                    | SUPPORT_VOLUME_STEP
-                    | SUPPORT_VOLUME_SET
-                    | SUPPORT_VOLUME_MUTE
-                )
-            if self._status.get("canSeek", "") == "1":
-                supported = supported | SUPPORT_SEEK
-            self._attr_supported_features = supported
-        self._attr_extra_state_attributes = {}
-        if self._group_list:
-            self._attr_extra_state_attributes = {ATTR_BLUESOUND_GROUP: self._group_list}
-        self._attr_extra_state_attributes[ATTR_MASTER] = self._is_master
-        self._attr_shuffle = self._status.get("shuffle", "0") == "1"
 
     async def async_trigger_sync_on_all(self):
         """Trigger sync status update on all devices."""
@@ -586,6 +543,27 @@ class BluesoundPlayer(MediaPlayerEntity):
         return self._services_items
 
     @property
+    def media_content_type(self):
+        """Content type of current playing media."""
+        return MEDIA_TYPE_MUSIC
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        if self._status is None:
+            return STATE_OFF
+
+        if self.is_grouped and not self.is_master:
+            return STATE_GROUPED
+
+        status = self._status.get("state")
+        if status in ("pause", "stop"):
+            return STATE_PAUSED
+        if status in ("stream", "play"):
+            return STATE_PLAYING
+        return STATE_IDLE
+
+    @property
     def media_title(self):
         """Title of current playing media."""
         if self._status is None or (self.is_grouped and not self.is_master):
@@ -639,7 +617,7 @@ class BluesoundPlayer(MediaPlayerEntity):
             return None
 
         mediastate = self.state
-        if self.media_position_updated_at is None or mediastate == STATE_IDLE:
+        if self._last_status_update is None or mediastate == STATE_IDLE:
             return None
 
         position = self._status.get("secs")
@@ -648,9 +626,7 @@ class BluesoundPlayer(MediaPlayerEntity):
 
         position = float(position)
         if mediastate == STATE_PLAYING:
-            position += (
-                dt_util.utcnow() - self.media_position_updated_at
-            ).total_seconds()
+            position += (dt_util.utcnow() - self._last_status_update).total_seconds()
 
         return position
 
@@ -664,6 +640,11 @@ class BluesoundPlayer(MediaPlayerEntity):
         if duration is None:
             return None
         return float(duration)
+
+    @property
+    def media_position_updated_at(self):
+        """Last time status was updated."""
+        return self._last_status_update
 
     @property
     def volume_level(self):
@@ -688,9 +669,19 @@ class BluesoundPlayer(MediaPlayerEntity):
         return mute
 
     @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
     def bluesound_device_name(self):
         """Return the device name as returned by the device."""
         return self._bluesound_device_name
+
+    @property
+    def icon(self):
+        """Return the icon of the device."""
+        return self._icon
 
     @property
     def source_list(self):
@@ -787,14 +778,57 @@ class BluesoundPlayer(MediaPlayerEntity):
         return None
 
     @property
-    def is_master(self) -> bool:
+    def supported_features(self):
+        """Flag of media commands that are supported."""
+        if self._status is None:
+            return 0
+
+        if self.is_grouped and not self.is_master:
+            return SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE
+
+        supported = SUPPORT_CLEAR_PLAYLIST
+
+        if self._status.get("indexing", "0") == "0":
+            supported = (
+                supported
+                | SUPPORT_PAUSE
+                | SUPPORT_PREVIOUS_TRACK
+                | SUPPORT_NEXT_TRACK
+                | SUPPORT_PLAY_MEDIA
+                | SUPPORT_STOP
+                | SUPPORT_PLAY
+                | SUPPORT_SELECT_SOURCE
+                | SUPPORT_SHUFFLE_SET
+            )
+
+        current_vol = self.volume_level
+        if current_vol is not None and current_vol >= 0:
+            supported = (
+                supported
+                | SUPPORT_VOLUME_STEP
+                | SUPPORT_VOLUME_SET
+                | SUPPORT_VOLUME_MUTE
+            )
+
+        if self._status.get("canSeek", "") == "1":
+            supported = supported | SUPPORT_SEEK
+
+        return supported
+
+    @property
+    def is_master(self):
         """Return true if player is a coordinator."""
         return self._is_master
 
     @property
-    def is_grouped(self) -> bool:
+    def is_grouped(self):
         """Return true if player is a coordinator."""
         return self._master is not None or self._is_master
+
+    @property
+    def shuffle(self):
+        """Return true if shuffle is active."""
+        return self._status.get("shuffle", "0") == "1"
 
     async def async_join(self, master):
         """Join the player to a group."""
@@ -814,6 +848,17 @@ class BluesoundPlayer(MediaPlayerEntity):
             await master_device[0].async_add_slave(self)
         else:
             _LOGGER.error("Master not found %s", master_device)
+
+    @property
+    def extra_state_attributes(self):
+        """List members in group."""
+        attributes = {}
+        if self._group_list:
+            attributes = {ATTR_BLUESOUND_GROUP: self._group_list}
+
+        attributes[ATTR_MASTER] = self._is_master
+
+        return attributes
 
     def rebuild_bluesound_group(self):
         """Rebuild the list of entities in speaker group."""


### PR DESCRIPTION
This reverts commit 804499968ee6b5967b45ca7825f054a39fb405c9.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Revert #53033 by @tkdrob to fix #54324

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
