### PR TITLE
Update the Qubino Flush Shutter fixture

### DIFF
--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 WINDOW_COVER_ENTITY = "cover.zws_12"
 GDC_COVER_ENTITY = "cover.aeon_labs_garage_door_controller_gen5"
 BLIND_COVER_ENTITY = "cover.window_blind_controller"
-SHUTTER_COVER_ENTITY = "cover.flush_shutter_dc"
+SHUTTER_COVER_ENTITY = "cover.flush_shutter"
 AEOTEC_SHUTTER_COVER_ENTITY = "cover.nano_shutter_v_3"
 
 

--- a/tests/fixtures/zwave_js/cover_qubino_shutter_state.json
+++ b/tests/fixtures/zwave_js/cover_qubino_shutter_state.json
@@ -1,48 +1,104 @@
 {
-  "nodeId": 5,
+  "nodeId": 20,
   "index": 0,
   "installerIcon": 6656,
   "userIcon": 6656,
   "status": 4,
   "ready": true,
-  "deviceClass": {
-    "basic": { "key": 4, "label": "Routing Slave" },
-    "generic": { "key": 17, "label": "Routing Slave" },
-    "specific": { "key": 7, "label": "Routing Slave" },
-    "mandatorySupportedCCs": [],
-    "mandatoryControlCCs": []
-  },
   "isListening": true,
-  "isFrequentListening": false,
   "isRouting": true,
-  "maxBaudRate": 40000,
   "isSecure": false,
-  "version": 4,
-  "isBeaming": true,
   "manufacturerId": 345,
-  "productId": 83,
+  "productId": 82,
   "productType": 3,
-  "firmwareVersion": "7.2",
+  "firmwareVersion": "71.0",
   "zwavePlusVersion": 1,
-  "nodeType": 0,
-  "roleType": 5,
   "deviceConfig": {
-    "manufacturerId": 345,
+    "filename": "/data/db/devices/0x0159/zmnhcd_4.1.json",
+    "isEmbedded": true,
     "manufacturer": "Qubino",
-    "label": "ZMNHOD",
-    "description": "Flush Shutter DC",
-    "devices": [{ "productType": "0x0003", "productId": "0x0053" }],
-    "firmwareVersion": { "min": "0.0", "max": "255.255" },
-    "paramInformation": { "_map": {} }
+    "manufacturerId": 345,
+    "label": "ZMNHCD",
+    "description": "Flush Shutter",
+    "devices": [
+      {
+        "productType": 3,
+        "productId": 82
+      }
+    ],
+    "firmwareVersion": {
+      "min": "4.1",
+      "max": "255.255"
+    },
+    "paramInformation": {
+      "_map": {}
+    }
   },
-  "label": "ZMNHOD",
-  "neighbors": [1, 2],
-  "interviewAttempts": 1,
+  "label": "ZMNHCD",
+  "interviewAttempts": 0,
   "endpoints": [
-    { "nodeId": 5, "index": 0, "installerIcon": 6656, "userIcon": 6656 }
+    {
+      "nodeId": 20,
+      "index": 0,
+      "installerIcon": 6656,
+      "userIcon": 6656,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing Slave"
+        },
+        "generic": {
+          "key": 17,
+          "label": "Multilevel Switch"
+        },
+        "specific": {
+          "key": 7,
+          "label": "Motor Control Class C"
+        },
+        "mandatorySupportedCCs": [
+          32,
+          38,
+          37,
+          114,
+          134
+        ],
+        "mandatoryControlledCCs": []
+      }
+    }
   ],
-  "commandClasses": [],
   "values": [
+    {
+      "endpoint": 0,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value"
+      },
+      "value": false
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ]
+      }
+    },
     {
       "endpoint": 0,
       "commandClass": 38,
@@ -54,10 +110,14 @@
         "type": "number",
         "readable": true,
         "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
         "min": 0,
-        "max": 99,
-        "label": "Target value"
-      }
+        "max": 99
+      },
+      "value": 99
     },
     {
       "endpoint": 0,
@@ -84,11 +144,11 @@
         "type": "number",
         "readable": true,
         "writeable": false,
+        "label": "Current value",
         "min": 0,
-        "max": 99,
-        "label": "Current value"
+        "max": 99
       },
-      "value": "unknown"
+      "value": 0
     },
     {
       "endpoint": 0,
@@ -102,7 +162,9 @@
         "readable": true,
         "writeable": true,
         "label": "Perform a level change (Up)",
-        "ccSpecific": { "switchType": 2 }
+        "ccSpecific": {
+          "switchType": 2
+        }
       }
     },
     {
@@ -117,146 +179,9 @@
         "readable": true,
         "writeable": true,
         "label": "Perform a level change (Down)",
-        "ccSpecific": { "switchType": 2 }
-      }
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 37,
-      "commandClassName": "Binary Switch",
-      "property": "currentValue",
-      "propertyName": "currentValue",
-      "ccVersion": 1,
-      "metadata": {
-        "type": "boolean",
-        "readable": true,
-        "writeable": false,
-        "label": "Current value"
-      },
-      "value": "unknown"
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 37,
-      "commandClassName": "Binary Switch",
-      "property": "targetValue",
-      "propertyName": "targetValue",
-      "ccVersion": 1,
-      "metadata": {
-        "type": "boolean",
-        "readable": true,
-        "writeable": true,
-        "label": "Target value"
-      }
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 114,
-      "commandClassName": "Manufacturer Specific",
-      "property": "manufacturerId",
-      "propertyName": "manufacturerId",
-      "ccVersion": 2,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "min": 0,
-        "max": 65535,
-        "label": "Manufacturer ID"
-      },
-      "value": 345
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 114,
-      "commandClassName": "Manufacturer Specific",
-      "property": "productType",
-      "propertyName": "productType",
-      "ccVersion": 2,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "min": 0,
-        "max": 65535,
-        "label": "Product type"
-      },
-      "value": 3
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 114,
-      "commandClassName": "Manufacturer Specific",
-      "property": "productId",
-      "propertyName": "productId",
-      "ccVersion": 2,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "min": 0,
-        "max": 65535,
-        "label": "Product ID"
-      },
-      "value": 83
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 134,
-      "commandClassName": "Version",
-      "property": "libraryType",
-      "propertyName": "libraryType",
-      "ccVersion": 2,
-      "metadata": {
-        "type": "any",
-        "readable": true,
-        "writeable": false,
-        "label": "Library type"
-      },
-      "value": 3
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 134,
-      "commandClassName": "Version",
-      "property": "protocolVersion",
-      "propertyName": "protocolVersion",
-      "ccVersion": 2,
-      "metadata": {
-        "type": "any",
-        "readable": true,
-        "writeable": false,
-        "label": "Z-Wave protocol version"
-      },
-      "value": "4.38"
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 134,
-      "commandClassName": "Version",
-      "property": "firmwareVersions",
-      "propertyName": "firmwareVersions",
-      "ccVersion": 2,
-      "metadata": {
-        "type": "any",
-        "readable": true,
-        "writeable": false,
-        "label": "Z-Wave chip firmware versions"
-      },
-      "value": ["7.2"]
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 134,
-      "commandClassName": "Version",
-      "property": "hardwareVersion",
-      "propertyName": "hardwareVersion",
-      "ccVersion": 2,
-      "metadata": {
-        "type": "any",
-        "readable": true,
-        "writeable": false,
-        "label": "Z-Wave chip hardware version"
+        "ccSpecific": {
+          "switchType": 2
+        }
       }
     },
     {
@@ -273,29 +198,14 @@
         "readable": true,
         "writeable": false,
         "label": "Electric Consumed [kWh]",
-        "unit": "kWh",
-        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 0 }
+        "ccSpecific": {
+          "meterType": 1,
+          "rateType": 1,
+          "scale": 0
+        },
+        "unit": "kWh"
       },
-      "value": 0
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 50,
-      "commandClassName": "Meter",
-      "property": "deltaTime",
-      "propertyKey": 65537,
-      "propertyName": "deltaTime",
-      "propertyKeyName": "Electric_kWh_Consumed",
-      "ccVersion": 4,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "label": "Electric Consumed [kWh] (prev. time delta)",
-        "unit": "s",
-        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 0 }
-      },
-      "value": 0
+      "value": 7.9
     },
     {
       "endpoint": 0,
@@ -311,27 +221,12 @@
         "readable": true,
         "writeable": false,
         "label": "Electric Consumed [W]",
-        "unit": "W",
-        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 2 }
-      },
-      "value": 0
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 50,
-      "commandClassName": "Meter",
-      "property": "deltaTime",
-      "propertyKey": 66049,
-      "propertyName": "deltaTime",
-      "propertyKeyName": "Electric_W_Consumed",
-      "ccVersion": 4,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "label": "Electric Consumed [W] (prev. time delta)",
-        "unit": "s",
-        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 2 }
+        "ccSpecific": {
+          "meterType": 1,
+          "rateType": 1,
+          "scale": 2
+        },
+        "unit": "W"
       },
       "value": 0
     },
@@ -351,117 +246,29 @@
     },
     {
       "endpoint": 0,
-      "commandClass": 50,
-      "commandClassName": "Meter",
-      "property": "previousValue",
-      "propertyKey": 65537,
-      "propertyName": "previousValue",
-      "propertyKeyName": "Electric_kWh_Consumed",
-      "ccVersion": 4,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "label": "Electric Consumed [kWh] (prev. value)",
-        "unit": "kWh",
-        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 0 }
-      }
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 50,
-      "commandClassName": "Meter",
-      "property": "previousValue",
-      "propertyKey": 66049,
-      "propertyName": "previousValue",
-      "propertyKeyName": "Electric_W_Consumed",
-      "ccVersion": 4,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "label": "Electric Consumed [W] (prev. value)",
-        "unit": "W",
-        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 2 }
-      }
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 113,
-      "commandClassName": "Notification",
-      "property": "alarmType",
-      "propertyName": "alarmType",
-      "ccVersion": 5,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "min": 0,
-        "max": 255,
-        "label": "Alarm Type"
-      }
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 113,
-      "commandClassName": "Notification",
-      "property": "alarmLevel",
-      "propertyName": "alarmLevel",
-      "ccVersion": 5,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "min": 0,
-        "max": 255,
-        "label": "Alarm Level"
-      }
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 113,
-      "commandClassName": "Notification",
-      "property": "Power Management",
-      "propertyKey": "Over-load status",
-      "propertyName": "Power Management",
-      "propertyKeyName": "Over-load status",
-      "ccVersion": 5,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": false,
-        "min": 0,
-        "max": 255,
-        "label": "Over-load status",
-        "states": { "0": "idle", "8": "Over-load detected" },
-        "ccSpecific": { "notificationType": 8 }
-      },
-      "value": 0
-    },
-    {
-      "endpoint": 0,
       "commandClass": 112,
       "commandClassName": "Configuration",
       "property": 10,
-      "propertyName": "Activate/deactivate functions ALL ON / ALL OFF",
+      "propertyName": "ALL ON/ALL OFF",
       "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 2,
-        "min": 0,
-        "max": 65535,
+        "description": "Responds to commands ALL ON / ALL OFF from Main Controller",
+        "label": "ALL ON/ALL OFF",
         "default": 255,
-        "format": 1,
-        "allowManualEntry": false,
+        "min": 0,
+        "max": 255,
         "states": {
-          "0": "ALL ON is not active, ALL OFF is not active",
+          "0": "ALL ON is not active ALL OFF is not active",
           "1": "ALL ON is not active ALL OFF active",
           "2": "ALL ON is not active ALL OFF is not active",
           "255": "ALL ON active, ALL OFF active"
         },
-        "label": "Activate/deactivate functions ALL ON / ALL OFF",
+        "valueSize": 2,
+        "format": 0,
+        "allowManualEntry": false,
         "isFromConfig": true
       },
       "value": 255
@@ -471,19 +278,20 @@
       "commandClass": 112,
       "commandClassName": "Configuration",
       "property": 40,
-      "propertyName": "Power report (Watts) on power change for Q1 or Q2",
+      "propertyName": "Power reporting in watts on power change",
       "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 1,
+        "description": "Power consumption change threshold for sending updates",
+        "label": "Power reporting in watts on power change",
+        "default": 1,
         "min": 0,
         "max": 100,
-        "default": 1,
+        "valueSize": 1,
         "format": 0,
         "allowManualEntry": true,
-        "label": "Power report (Watts) on power change for Q1 or Q2",
         "isFromConfig": true
       },
       "value": 10
@@ -493,19 +301,20 @@
       "commandClass": 112,
       "commandClassName": "Configuration",
       "property": 42,
-      "propertyName": "Power report (Watts) by time interval for Q1 or Q2",
+      "propertyName": "Power reporting in Watts by time interval",
       "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 2,
+        "label": "Power reporting in Watts by time interval",
+        "default": 300,
         "min": 0,
         "max": 32767,
-        "default": 300,
+        "unit": "seconds",
+        "valueSize": 2,
         "format": 0,
         "allowManualEntry": true,
-        "label": "Power report (Watts) by time interval for Q1 or Q2",
         "isFromConfig": true
       },
       "value": 0
@@ -521,17 +330,18 @@
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 1,
+        "description": "Operation Mode (Shutter or Venetian)",
+        "label": "Operating modes",
+        "default": 0,
         "min": 0,
         "max": 255,
-        "default": 0,
-        "format": 1,
-        "allowManualEntry": false,
         "states": {
-          "0": "Shutter mode.",
+          "0": "Shutter mode",
           "1": "Venetian mode (up/down and slate rotation)"
         },
-        "label": "Operating modes",
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false,
         "isFromConfig": true
       },
       "value": 0
@@ -547,16 +357,18 @@
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 2,
+        "description": "Slat full turn time in tenths of a second.",
+        "label": "Slats tilting full turn time",
+        "default": 150,
         "min": 0,
         "max": 32767,
-        "default": 150,
+        "unit": "tenths of a second",
+        "valueSize": 2,
         "format": 0,
         "allowManualEntry": true,
-        "label": "Slats tilting full turn time",
         "isFromConfig": true
       },
-      "value": 630
+      "value": 150
     },
     {
       "endpoint": 0,
@@ -569,42 +381,21 @@
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 1,
-        "min": 0,
-        "max": 255,
-        "default": 1,
-        "format": 1,
-        "allowManualEntry": false,
-        "states": {
-          "0": "Return to previous position only with Z-wave",
-          "1": "Return to previous position with Z-wave or button"
-        },
+        "description": "Slats position after up/down movement.",
         "label": "Slats position",
+        "default": 1,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Previous position for Z-wave control only",
+          "1": "Return to previous position in all cases"
+        },
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": false,
         "isFromConfig": true
       },
       "value": 1
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 112,
-      "commandClassName": "Configuration",
-      "property": 74,
-      "propertyName": "Motor moving up/down time",
-      "ccVersion": 1,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": true,
-        "valueSize": 2,
-        "min": 0,
-        "max": 32767,
-        "default": 0,
-        "format": 0,
-        "allowManualEntry": true,
-        "label": "Motor moving up/down time",
-        "isFromConfig": true
-      },
-      "value": 0
     },
     {
       "endpoint": 0,
@@ -617,36 +408,41 @@
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 1,
+        "description": "Power threshold to be interpreted when motor reach the limit switch",
+        "label": "Motor operation detection",
+        "default": 10,
         "min": 0,
-        "max": 100,
-        "default": 6,
+        "max": 127,
+        "valueSize": 1,
         "format": 0,
         "allowManualEntry": true,
-        "label": "Motor operation detection",
         "isFromConfig": true
       },
-      "value": 10
+      "value": 30
     },
     {
       "endpoint": 0,
       "commandClass": 112,
       "commandClassName": "Configuration",
       "property": 78,
-      "propertyName": "Forced Shutter DC calibration",
+      "propertyName": "Forced Shutter calibration",
       "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 1,
-        "min": 0,
-        "max": 255,
+        "description": "Enters calibration mode if set to 1",
+        "label": "Forced Shutter calibration",
         "default": 0,
-        "format": 1,
+        "min": 0,
+        "max": 1,
+        "states": {
+          "0": "Default",
+          "1": "Start Calibration Process"
+        },
+        "valueSize": 1,
+        "format": 0,
         "allowManualEntry": false,
-        "states": { "0": "Default", "1": "Start calibration process." },
-        "label": "Forced Shutter DC calibration",
         "isFromConfig": true
       },
       "value": 0
@@ -662,57 +458,38 @@
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 1,
-        "min": 3,
-        "max": 50,
-        "default": 8,
-        "format": 0,
-        "allowManualEntry": true,
+        "description": "Time delay for detecting motor errors",
         "label": "Power consumption max delay time",
-        "isFromConfig": true
-      },
-      "value": 8
-    },
-    {
-      "endpoint": 0,
-      "commandClass": 112,
-      "commandClassName": "Configuration",
-      "property": 86,
-      "propertyName": "Power consumption at limit switch delay time",
-      "ccVersion": 1,
-      "metadata": {
-        "type": "number",
-        "readable": true,
-        "writeable": true,
-        "valueSize": 1,
-        "min": 3,
-        "max": 50,
         "default": 8,
+        "min": 0,
+        "max": 50,
+        "valueSize": 1,
         "format": 0,
         "allowManualEntry": true,
-        "label": "Power consumption at limit switch delay time",
         "isFromConfig": true
       },
-      "value": 8
+      "value": 30
     },
     {
       "endpoint": 0,
       "commandClass": 112,
       "commandClassName": "Configuration",
       "property": 90,
-      "propertyName": "Time delay for next motor movement",
+      "propertyName": "Relay delay time",
       "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 1,
+        "description": "Defines the minimum time delay between next motor movement",
+        "label": "Relay delay time",
+        "default": 5,
         "min": 1,
         "max": 30,
-        "default": 5,
+        "unit": "milliseconds",
+        "valueSize": 1,
         "format": 0,
         "allowManualEntry": true,
-        "label": "Time delay for next motor movement",
         "isFromConfig": true
       },
       "value": 5
@@ -728,13 +505,14 @@
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 2,
+        "description": "Adds or removes an offset from the measured temperature.",
+        "label": "Temperature sensor offset settings",
+        "default": 32536,
         "min": 1,
         "max": 32536,
-        "default": 32536,
+        "valueSize": 2,
         "format": 0,
         "allowManualEntry": true,
-        "label": "Temperature sensor offset settings",
         "isFromConfig": true
       },
       "value": 32536
@@ -750,16 +528,373 @@
         "type": "number",
         "readable": true,
         "writeable": true,
-        "valueSize": 1,
+        "description": "Threshold for sending temperature change reports",
+        "label": "Digital temperature sensor reporting",
+        "default": 5,
         "min": 0,
         "max": 127,
-        "default": 5,
+        "valueSize": 1,
         "format": 0,
         "allowManualEntry": true,
-        "label": "Digital temperature sensor reporting",
         "isFromConfig": true
       },
       "value": 5
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 74,
+      "propertyName": "Motor moving up/down time",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Shutter motor moving time of complete opening or complete closing",
+        "label": "Motor moving up/down time",
+        "default": 0,
+        "min": 0,
+        "max": 32767,
+        "valueSize": 2,
+        "format": 0,
+        "allowManualEntry": true,
+        "isFromConfig": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 80,
+      "propertyName": "Reporting to Controller",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Defines if reporting regarding power level, etc is reported to controller.",
+        "label": "Reporting to Controller",
+        "default": 1,
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "Reporting to Controller Disabled",
+          "1": "Reporting to Controller Enabled"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 86,
+      "propertyName": "Power consumption at limit switch delay time",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Sets the time delay for detecting limit switches",
+        "label": "Power consumption at limit switch delay time",
+        "default": 8,
+        "min": 3,
+        "max": 50,
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": true,
+        "isFromConfig": true
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Power Management",
+      "propertyKey": "unknown",
+      "propertyName": "Power Management",
+      "propertyKeyName": "unknown",
+      "ccVersion": 5,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": true
+      },
+      "value": 254
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Power Management",
+      "propertyKey": "Over-load status",
+      "propertyName": "Power Management",
+      "propertyKeyName": "Over-load status",
+      "ccVersion": 5,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Over-load status",
+        "ccSpecific": {
+          "notificationType": 8
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "idle",
+          "8": "Over-load detected"
+        }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Manufacturer ID",
+        "min": 0,
+        "max": 65535
+      },
+      "value": 345
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productType",
+      "propertyName": "productType",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product type",
+        "min": 0,
+        "max": 65535
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productId",
+      "propertyName": "productId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product ID",
+        "min": 0,
+        "max": 65535
+      },
+      "value": 82
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "libraryType",
+      "propertyName": "libraryType",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Library type",
+        "states": {
+          "0": "Unknown",
+          "1": "Static Controller",
+          "2": "Controller",
+          "3": "Enhanced Slave",
+          "4": "Slave",
+          "5": "Installer",
+          "6": "Routing Slave",
+          "7": "Bridge Controller",
+          "8": "Device under Test",
+          "9": "N/A",
+          "10": "AV Remote",
+          "11": "AV Device"
+        }
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "protocolVersion",
+      "propertyName": "protocolVersion",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version"
+      },
+      "value": "4.38"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string[]",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions"
+      },
+      "value": [
+        "71.0",
+        "71.0"
+      ]
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "hardwareVersion",
+      "propertyName": "hardwareVersion",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip hardware version"
+      },
+      "value": 2
     }
-  ]
+  ],
+  "isFrequentListening": false,
+  "maxDataRate": 100000,
+  "supportedDataRates": [
+    40000,
+    100000
+  ],
+  "protocolVersion": 3,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "nodeType": 1,
+  "zwavePlusNodeType": 0,
+  "zwavePlusRoleType": 5,
+  "deviceClass": {
+    "basic": {
+      "key": 4,
+      "label": "Routing Slave"
+    },
+    "generic": {
+      "key": 17,
+      "label": "Multilevel Switch"
+    },
+    "specific": {
+      "key": 7,
+      "label": "Motor Control Class C"
+    },
+    "mandatorySupportedCCs": [
+      32,
+      38,
+      37,
+      114,
+      134
+    ],
+    "mandatoryControlledCCs": []
+  },
+  "commandClasses": [
+    {
+      "id": 37,
+      "name": "Binary Switch",
+      "version": 1,
+      "isSecure": false
+    },
+    {
+      "id": 38,
+      "name": "Multilevel Switch",
+      "version": 3,
+      "isSecure": false
+    },
+    {
+      "id": 50,
+      "name": "Meter",
+      "version": 4,
+      "isSecure": false
+    },
+    {
+      "id": 89,
+      "name": "Association Group Information",
+      "version": 2,
+      "isSecure": false
+    },
+    {
+      "id": 90,
+      "name": "Device Reset Locally",
+      "version": 1,
+      "isSecure": false
+    },
+    {
+      "id": 94,
+      "name": "Z-Wave Plus Info",
+      "version": 2,
+      "isSecure": false
+    },
+    {
+      "id": 112,
+      "name": "Configuration",
+      "version": 1,
+      "isSecure": false
+    },
+    {
+      "id": 113,
+      "name": "Notification",
+      "version": 5,
+      "isSecure": false
+    },
+    {
+      "id": 114,
+      "name": "Manufacturer Specific",
+      "version": 2,
+      "isSecure": false
+    },
+    {
+      "id": 133,
+      "name": "Association",
+      "version": 2,
+      "isSecure": false
+    },
+    {
+      "id": 134,
+      "name": "Version",
+      "version": 2,
+      "isSecure": false
+    },
+    {
+      "id": 142,
+      "name": "Multi Channel Association",
+      "version": 3,
+      "isSecure": false
+    }
+  ],
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0159:0x0003:0x0052:71.0",
+  "statistics": {
+    "commandsTX": 17,
+    "commandsRX": 57,
+    "commandsDroppedRX": 0,
+    "commandsDroppedTX": 0,
+    "timeoutResponse": 0
+  }
 }


### PR DESCRIPTION
## Proposed change
Generate a new test fixture for Qubino flush shutter, as requested [here](https://github.com/home-assistant/core/pull/50643#issuecomment-894984621).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
