### PR TITLE
Adjust version tests

### DIFF
--- a/tests/components/version/test_sensor.py
+++ b/tests/components/version/test_sensor.py
@@ -35,8 +35,8 @@ async def test_version_source(hass, source, target_source, name):
         "sensor": {"platform": "version", "source": source, "image": "qemux86-64"}
     }
 
-    with patch("pyhaversion.version.HaVersion.get_version"), patch(
-        "pyhaversion.version.HaVersion.version", MOCK_VERSION
+    with patch("homeassistant.components.version.sensor.HaVersion.get_version"), patch(
+        "homeassistant.components.version.sensor.HaVersion.version", MOCK_VERSION
     ):
         assert await async_setup_component(hass, "sensor", config)
         await hass.async_block_till_done()
@@ -52,7 +52,7 @@ async def test_version_fetch_exception(hass, caplog):
     """Test fetch exception thrown during updates."""
     config = {"sensor": {"platform": "version"}}
     with patch(
-        "pyhaversion.version.HaVersion.get_version",
+        "homeassistant.components.version.sensor.HaVersion.get_version",
         side_effect=pyhaversionexceptions.HaVersionFetchException(
             "Fetch exception from pyhaversion"
         ),
@@ -66,7 +66,7 @@ async def test_version_parse_exception(hass, caplog):
     """Test parse exception thrown during updates."""
     config = {"sensor": {"platform": "version"}}
     with patch(
-        "pyhaversion.version.HaVersion.get_version",
+        "homeassistant.components.version.sensor.HaVersion.get_version",
         side_effect=pyhaversionexceptions.HaVersionParseException,
     ):
         assert await async_setup_component(hass, "sensor", config)
@@ -78,8 +78,8 @@ async def test_update(hass):
     """Test updates."""
     config = {"sensor": {"platform": "version"}}
 
-    with patch("pyhaversion.version.HaVersion.get_version"), patch(
-        "pyhaversion.version.HaVersion.version", MOCK_VERSION
+    with patch("homeassistant.components.version.sensor.HaVersion.get_version"), patch(
+        "homeassistant.components.version.sensor.HaVersion.version", MOCK_VERSION
     ):
         assert await async_setup_component(hass, "sensor", config)
         await hass.async_block_till_done()
@@ -88,8 +88,8 @@ async def test_update(hass):
     assert state
     assert state.state == MOCK_VERSION
 
-    with patch("pyhaversion.version.HaVersion.get_version"), patch(
-        "pyhaversion.version.HaVersion.version", "1234"
+    with patch("homeassistant.components.version.sensor.HaVersion.get_version"), patch(
+        "homeassistant.components.version.sensor.HaVersion.version", "1234"
     ):
 
         async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=5))

--- a/tests/components/version/test_sensor.py
+++ b/tests/components/version/test_sensor.py
@@ -1,31 +1,49 @@
 """The test for the version sensor platform."""
+from datetime import timedelta
 from unittest.mock import patch
 
 from pyhaversion import HaVersionSource, exceptions as pyhaversionexceptions
 import pytest
 
-from homeassistant.components.version.sensor import ALL_SOURCES
+from homeassistant.components.version.sensor import HA_VERSION_SOURCES
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt
+
+from tests.common import async_fire_time_changed
 
 MOCK_VERSION = "10.0"
 
 
 @pytest.mark.parametrize(
-    "source",
-    ALL_SOURCES,
+    "source,target_source,name",
+    (
+        (
+            ("local", HaVersionSource.LOCAL, "current_version"),
+            ("docker", HaVersionSource.CONTAINER, "latest_version"),
+            ("hassio", HaVersionSource.SUPERVISOR, "latest_version"),
+        )
+        + tuple(
+            (source, HaVersionSource(source), "latest_version")
+            for source in HA_VERSION_SOURCES
+            if source != HaVersionSource.LOCAL
+        )
+    ),
 )
-async def test_version_source(hass, source):
+async def test_version_source(hass, source, target_source, name):
     """Test the Version sensor with different sources."""
     config = {
         "sensor": {"platform": "version", "source": source, "image": "qemux86-64"}
     }
 
-    with patch("pyhaversion.version.HaVersion.version", MOCK_VERSION):
+    with patch("pyhaversion.version.HaVersion.get_version"), patch(
+        "pyhaversion.version.HaVersion.version", MOCK_VERSION
+    ):
         assert await async_setup_component(hass, "sensor", config)
         await hass.async_block_till_done()
 
-    name = "current_version" if source == HaVersionSource.LOCAL else "latest_version"
     state = hass.states.get(f"sensor.{name}")
+    assert state
+    assert state.attributes["source"] == target_source
 
     assert state.state == MOCK_VERSION
 
@@ -54,3 +72,29 @@ async def test_version_parse_exception(hass, caplog):
         assert await async_setup_component(hass, "sensor", config)
         await hass.async_block_till_done()
         assert "Could not parse data received for HaVersionSource.LOCAL" in caplog.text
+
+
+async def test_update(hass):
+    """Test updates."""
+    config = {"sensor": {"platform": "version"}}
+
+    with patch("pyhaversion.version.HaVersion.get_version"), patch(
+        "pyhaversion.version.HaVersion.version", MOCK_VERSION
+    ):
+        assert await async_setup_component(hass, "sensor", config)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.current_version")
+    assert state
+    assert state.state == MOCK_VERSION
+
+    with patch("pyhaversion.version.HaVersion.get_version"), patch(
+        "pyhaversion.version.HaVersion.version", "1234"
+    ):
+
+        async_fire_time_changed(hass, dt.utcnow() + timedelta(minutes=5))
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.current_version")
+    assert state
+    assert state.state == "1234"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Add name and source targets as params.
- Verify conversion of old keys. 
- Patch `get_version` to stop the test from doing I/O
- Add test to verify state updates 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
