### PR TITLE
Fix pi_hole sensor icon

### DIFF
--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -161,7 +161,7 @@ def _async_platforms(entry: ConfigEntry) -> list[str]:
 class PiHoleEntity(CoordinatorEntity):
     """Representation of a Pi-hole entity."""
 
-    _attr_icon: str | None = "mdi:pi-hole"
+    _attr_icon: str = "mdi:pi-hole"
 
     def __init__(
         self,

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -161,6 +161,8 @@ def _async_platforms(entry: ConfigEntry) -> list[str]:
 class PiHoleEntity(CoordinatorEntity):
     """Representation of a Pi-hole entity."""
 
+    _attr_icon: str | None = "mdi:pi-hole"
+
     def __init__(
         self,
         api: Hole,
@@ -173,11 +175,6 @@ class PiHoleEntity(CoordinatorEntity):
         self.api = api
         self._name = name
         self._server_unique_id = server_unique_id
-
-    @property
-    def icon(self) -> str:
-        """Icon to use in the frontend, if any."""
-        return "mdi:pi-hole"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/pi_hole/const.py
+++ b/homeassistant/components/pi_hole/const.py
@@ -1,6 +1,7 @@
 """Constants for the pi_hole integration."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import timedelta
 
 from homeassistant.components.sensor import SensorEntityDescription
@@ -29,56 +30,63 @@ DATA_KEY_API = "api"
 DATA_KEY_COORDINATOR = "coordinator"
 
 
-SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
+@dataclass
+class PiHoleSensorEntityDescription(SensorEntityDescription):
+    """Describes PiHole sensor entity."""
+
+    icon: str = "mdi:pi-hole"
+
+
+SENSOR_TYPES: tuple[PiHoleSensorEntityDescription, ...] = (
+    PiHoleSensorEntityDescription(
         key="ads_blocked_today",
         name="Ads Blocked Today",
         unit_of_measurement="ads",
         icon="mdi:close-octagon-outline",
     ),
-    SensorEntityDescription(
+    PiHoleSensorEntityDescription(
         key="ads_percentage_today",
         name="Ads Percentage Blocked Today",
         unit_of_measurement=PERCENTAGE,
         icon="mdi:close-octagon-outline",
     ),
-    SensorEntityDescription(
+    PiHoleSensorEntityDescription(
         key="clients_ever_seen",
         name="Seen Clients",
         unit_of_measurement="clients",
         icon="mdi:account-outline",
     ),
-    SensorEntityDescription(
+    PiHoleSensorEntityDescription(
         key="dns_queries_today",
         name="DNS Queries Today",
         unit_of_measurement="queries",
         icon="mdi:comment-question-outline",
     ),
-    SensorEntityDescription(
+    PiHoleSensorEntityDescription(
         key="domains_being_blocked",
         name="Domains Blocked",
         unit_of_measurement="domains",
         icon="mdi:block-helper",
     ),
-    SensorEntityDescription(
+    PiHoleSensorEntityDescription(
         key="queries_cached",
         name="DNS Queries Cached",
         unit_of_measurement="queries",
         icon="mdi:comment-question-outline",
     ),
-    SensorEntityDescription(
+    PiHoleSensorEntityDescription(
         key="queries_forwarded",
         name="DNS Queries Forwarded",
         unit_of_measurement="queries",
         icon="mdi:comment-question-outline",
     ),
-    SensorEntityDescription(
+    PiHoleSensorEntityDescription(
         key="unique_clients",
         name="DNS Unique Clients",
         unit_of_measurement="clients",
         icon="mdi:account-outline",
     ),
-    SensorEntityDescription(
+    PiHoleSensorEntityDescription(
         key="unique_domains",
         name="DNS Unique Domains",
         unit_of_measurement="domains",

--- a/homeassistant/components/pi_hole/sensor.py
+++ b/homeassistant/components/pi_hole/sensor.py
@@ -58,6 +58,7 @@ class PiHoleSensor(PiHoleEntity, SensorEntity):
 
         self._attr_name = f"{name} {description.name}"
         self._attr_unique_id = f"{self._server_unique_id}/{description.name}"
+        self._attr_icon = description.icon  # Necessary to overwrite inherited value
 
     @property
     def state(self) -> Any:

--- a/homeassistant/components/pi_hole/sensor.py
+++ b/homeassistant/components/pi_hole/sensor.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from hole import Hole
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -19,6 +19,7 @@ from .const import (
     DATA_KEY_COORDINATOR,
     DOMAIN as PIHOLE_DOMAIN,
     SENSOR_TYPES,
+    PiHoleSensorEntityDescription,
 )
 
 
@@ -44,13 +45,15 @@ async def async_setup_entry(
 class PiHoleSensor(PiHoleEntity, SensorEntity):
     """Representation of a Pi-hole sensor."""
 
+    entity_description: PiHoleSensorEntityDescription
+
     def __init__(
         self,
         api: Hole,
         coordinator: DataUpdateCoordinator,
         name: str,
         server_unique_id: str,
-        description: SensorEntityDescription,
+        description: PiHoleSensorEntityDescription,
     ) -> None:
         """Initialize a Pi-hole sensor."""
         super().__init__(api, coordinator, name, server_unique_id)


### PR DESCRIPTION
## Proposed change
Fix issue introduced with #54319.
Missed that `PiHoleSensor` inherits from `PiHoleEntity` which implements a custom `icon` property. For the sensor to use the `entity_description.icon`, we need to overwrite that.

/CC: @frenck


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
