### PR TITLE
Avoid increasing yeelight rate limit when the state is already set

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import math
 
 import voluptuous as vol
 import yeelight
@@ -576,6 +577,13 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
     async def async_set_brightness(self, brightness, duration) -> None:
         """Set bulb brightness."""
         if brightness:
+            if math.floor(self.brightness) == math.floor(brightness):
+                _LOGGER.debug("brightness already set to: %s", brightness)
+                # Already set, and since we get pushed updates
+                # we avoid setting it again to ensure we do not
+                # hit the rate limit
+                return
+
             _LOGGER.debug("Setting brightness: %s", brightness)
             await self._bulb.async_set_brightness(
                 brightness / 255 * 100, duration=duration, light_type=self.light_type
@@ -585,6 +593,13 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
     async def async_set_hs(self, hs_color, duration) -> None:
         """Set bulb's color."""
         if hs_color and COLOR_MODE_HS in self.supported_color_modes:
+            if self.hs_color == hs_color:
+                _LOGGER.debug("HS already set to: %s", hs_color)
+                # Already set, and since we get pushed updates
+                # we avoid setting it again to ensure we do not
+                # hit the rate limit
+                return
+
             _LOGGER.debug("Setting HS: %s", hs_color)
             await self._bulb.async_set_hsv(
                 hs_color[0], hs_color[1], duration=duration, light_type=self.light_type
@@ -594,9 +609,16 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
     async def async_set_rgb(self, rgb, duration) -> None:
         """Set bulb's color."""
         if rgb and COLOR_MODE_RGB in self.supported_color_modes:
+            if self.rgb_color == rgb:
+                _LOGGER.debug("RGB already set to: %s", rgb)
+                # Already set, and since we get pushed updates
+                # we avoid setting it again to ensure we do not
+                # hit the rate limit
+                return
+
             _LOGGER.debug("Setting RGB: %s", rgb)
             await self._bulb.async_set_rgb(
-                rgb[0], rgb[1], rgb[2], duration=duration, light_type=self.light_type
+                *rgb, duration=duration, light_type=self.light_type
             )
 
     @_async_cmd
@@ -604,7 +626,13 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         """Set bulb's color temperature."""
         if colortemp and COLOR_MODE_COLOR_TEMP in self.supported_color_modes:
             temp_in_k = mired_to_kelvin(colortemp)
-            _LOGGER.debug("Setting color temp: %s K", temp_in_k)
+
+            if self.color_temp == colortemp:
+                _LOGGER.debug("Color temp already set to: %s", temp_in_k)
+                # Already set, and since we get pushed updates
+                # we avoid setting it again to ensure we do not
+                # hit the rate limit
+                return
 
             await self._bulb.async_set_color_temp(
                 temp_in_k, duration=duration, light_type=self.light_type

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -593,7 +593,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
     async def async_set_hs(self, hs_color, duration) -> None:
         """Set bulb's color."""
         if hs_color and COLOR_MODE_HS in self.supported_color_modes:
-            if self.hs_color == hs_color:
+            if self.color_mode == COLOR_MODE_HS and self.hs_color == hs_color:
                 _LOGGER.debug("HS already set to: %s", hs_color)
                 # Already set, and since we get pushed updates
                 # we avoid setting it again to ensure we do not
@@ -609,7 +609,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
     async def async_set_rgb(self, rgb, duration) -> None:
         """Set bulb's color."""
         if rgb and COLOR_MODE_RGB in self.supported_color_modes:
-            if self.rgb_color == rgb:
+            if self.color_mode == COLOR_MODE_RGB and self.rgb_color == rgb:
                 _LOGGER.debug("RGB already set to: %s", rgb)
                 # Already set, and since we get pushed updates
                 # we avoid setting it again to ensure we do not
@@ -627,7 +627,10 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         if colortemp and COLOR_MODE_COLOR_TEMP in self.supported_color_modes:
             temp_in_k = mired_to_kelvin(colortemp)
 
-            if self.color_temp == colortemp:
+            if (
+                self.color_mode == COLOR_MODE_COLOR_TEMP
+                and self.color_temp == colortemp
+            ):
                 _LOGGER.debug("Color temp already set to: %s", temp_in_k)
                 # Already set, and since we get pushed updates
                 # we avoid setting it again to ensure we do not

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -1,6 +1,6 @@
 """Test the Yeelight light."""
 import logging
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 from yeelight import (
     BulbException,
@@ -19,6 +19,7 @@ from yeelight.main import _MODEL_SPECS
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_BRIGHTNESS_PCT,
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_FLASH,
@@ -426,6 +427,95 @@ async def test_services(hass: HomeAssistant, caplog):
     assert (
         len([x for x in caplog.records if x.levelno == logging.ERROR]) == err_count + 1
     )
+
+
+async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant):
+    """Ensure we suppress state changes that will increase the rate limit when there is no change."""
+    mocked_bulb = _mocked_bulb()
+    properties = {**PROPERTIES}
+    properties.pop("active_mode")
+    properties["color_mode"] = "3"  # HSV
+    mocked_bulb.last_properties = properties
+    mocked_bulb.bulb_type = BulbType.Color
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={**CONFIG_ENTRY_DATA, CONF_NIGHTLIGHT_SWITCH: False}
+    )
+    config_entry.add_to_hass(hass)
+    with patch(f"{MODULE}.AsyncBulb", return_value=mocked_bulb):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        # We use asyncio.create_task now to avoid
+        # blocking starting so we need to block again
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: ENTITY_LIGHT,
+            ATTR_HS_COLOR: (PROPERTIES["hue"], PROPERTIES["sat"]),
+        },
+        blocking=True,
+    )
+    assert mocked_bulb.async_set_hsv.mock_calls == []
+    assert mocked_bulb.async_set_rgb.mock_calls == []
+    assert mocked_bulb.async_set_color_temp.mock_calls == []
+    assert mocked_bulb.async_set_brightness.mock_calls == []
+
+    rgb = int(PROPERTIES["rgb"])
+    blue = rgb & 0xFF
+    green = (rgb >> 8) & 0xFF
+    red = (rgb >> 16) & 0xFF
+
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_RGB_COLOR: (red, green, blue)},
+        blocking=True,
+    )
+    assert mocked_bulb.async_set_hsv.mock_calls == []
+    assert mocked_bulb.async_set_rgb.mock_calls == []
+    assert mocked_bulb.async_set_color_temp.mock_calls == []
+    assert mocked_bulb.async_set_brightness.mock_calls == []
+
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: ENTITY_LIGHT,
+            ATTR_BRIGHTNESS_PCT: PROPERTIES["current_brightness"],
+        },
+        blocking=True,
+    )
+    assert mocked_bulb.async_set_hsv.mock_calls == []
+    assert mocked_bulb.async_set_rgb.mock_calls == []
+    assert mocked_bulb.async_set_color_temp.mock_calls == []
+    assert mocked_bulb.async_set_brightness.mock_calls == []
+
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_COLOR_TEMP: 250},
+        blocking=True,
+    )
+    assert mocked_bulb.async_set_hsv.mock_calls == []
+    assert mocked_bulb.async_set_rgb.mock_calls == []
+    assert mocked_bulb.async_set_color_temp.mock_calls == []
+    assert mocked_bulb.async_set_brightness.mock_calls == []
+
+    # This last change should generate a call
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_HS_COLOR: (5, 5)},
+        blocking=True,
+    )
+    assert mocked_bulb.async_set_hsv.mock_calls == [
+        call(5.0, 5.0, duration=350, light_type=ANY)
+    ]
+    assert mocked_bulb.async_set_rgb.mock_calls == []
+    assert mocked_bulb.async_set_color_temp.mock_calls == []
+    assert mocked_bulb.async_set_brightness.mock_calls == []
 
 
 async def test_device_types(hass: HomeAssistant, caplog):


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When testing with HomeKit, I noticed it was too easy to hit
the ratelimit with yeelights

- Now that yeelight is pushing back changes, we can avoid
  increasing the rate limit when the state is already set
  to the requested state.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
