### PR TITLE
Don't discover `zwave_js` values that don't have a value

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -224,7 +224,7 @@ async def async_setup_entry(  # noqa: C901
             entry: ConfigEntry,
             client: ZwaveClient,
             device: device_registry.DeviceEntry,
-            disc_info: ZwaveDiscoveryInfo,
+            _disc_info: ZwaveDiscoveryInfo,
             registered_unique_ids: dict[str, dict[str, set[str]]],
             platform_setup_tasks: dict[str, asyncio.Task],
             value_updates_disc_info: dict[str, ZwaveDiscoveryInfo],
@@ -240,21 +240,21 @@ async def async_setup_entry(  # noqa: C901
 
             value: Value = event["value"]
 
-            for disc_info in async_discover_value(value):
+            for _disc_info in async_discover_value(value):
                 await async_handle_discovered_info(
                     hass,
                     ent_reg,
                     entry,
                     client,
                     device,
-                    disc_info,
+                    _disc_info,
                     registered_unique_ids,
                     platform_setup_tasks,
                     value_updates_disc_info,
                 )
 
             listen_to_value_updated_events_if_needed(
-                disc_info.node, value_updates_disc_info
+                _disc_info.node, value_updates_disc_info
             )
 
         # add listener for value update events

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -131,9 +131,36 @@ async def test_disabled_indcator_sensor(
     assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
 
 
-async def test_disabled_basic_sensor(hass, ge_in_wall_dimmer_switch, integration):
-    """Test sensor is created from Basic CC and is disabled."""
+async def test_value_update_creates_entity(hass, ge_in_wall_dimmer_switch, integration):
+    """Test sensor is created from Basic CC when a value is received and is disabled."""
     ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(BASIC_SENSOR)
+
+    # We expect no entity because the value has no value
+    assert entity_entry is None
+
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": ge_in_wall_dimmer_switch.node_id,
+            "args": {
+                "commandClassName": "Basic",
+                "commandClass": 32,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": 1,
+                "prevValue": None,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+
+    # Now that we've received a value for this value, we should see an entity created
+    ge_in_wall_dimmer_switch.receive_event(event)
+    await hass.async_block_till_done()
+
     entity_entry = ent_reg.async_get(BASIC_SENSOR)
 
     assert entity_entry

--- a/tests/fixtures/zwave_js/climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints_state.json
+++ b/tests/fixtures/zwave_js/climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints_state.json
@@ -455,7 +455,8 @@
 					"15": "Full power",
 					"31": "Manufacturer specific"
 				}
-			}
+			},
+			"value": 0
 		},
 		{
 			"endpoint": 1,


### PR DESCRIPTION
## Breaking change
You may end up finding some dangling entities (unavailable permanently) due to a change to the `zwave_js` integration. These entities were effectively non-functional so there is no real usability impact, we are simply narrowing down the entity creation to entities that actually matter.


## Proposed change
It occurred to me during a conversation in #devs_zwave that we currently discover zwave values whether they have values or not. In some cases, like for the Sound Switch CC, this makes sense, because the primary value will never have a value. But in most cases, it is assumed that the primary value has a value. This leads to entities that get discovered that are not really functional. In particular, there are many cases of Basic CC values that will never have a value that we create entities for.

For this change, unless the schema dictates it, we do not discover values that aren't readable or that don't have a value. We also add a new value update listener that will listen specifically for values that go from `None` to non`None` so we can fire a discovery update for them.

This is not a *necessary* change but I do think it's a nice improvement to the UX where we strike a balance between minimizing the number of "false positive" entities created while having a mechanism to handle "false negatives".

To demonstrate and test this behavior, I updated the Basic CC sensor test to one that verifies that now the Basic CC sensor in question doesn't get created until the test sends a value updated event for that value.

CC @blhoward


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
