### PR TITLE
2021.8.6

### DIFF
--- a/homeassistant/components/canary/sensor.py
+++ b/homeassistant/components/canary/sensor.py
@@ -113,7 +113,6 @@ class CanarySensor(CoordinatorEntity, SensorEntity):
             canary_sensor_type = SensorType.BATTERY
 
         self._canary_type = canary_sensor_type
-        self._attr_state = self.reading
         self._attr_unique_id = f"{device.device_id}_{sensor_type[0]}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, str(device.device_id))},
@@ -143,6 +142,11 @@ class CanarySensor(CoordinatorEntity, SensorEntity):
             return round(float(value), SENSOR_VALUE_PRECISION)
 
         return None
+
+    @property
+    def state(self) -> float | None:
+        """Return the state of the sensor."""
+        return self.reading
 
     @property
     def extra_state_attributes(self) -> dict[str, str] | None:

--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -2,7 +2,7 @@
   "domain": "cloud",
   "name": "Home Assistant Cloud",
   "documentation": "https://www.home-assistant.io/integrations/cloud",
-  "requirements": ["hass-nabucasa==0.45.1"],
+  "requirements": ["hass-nabucasa==0.46.0"],
   "dependencies": ["http", "webhook"],
   "after_dependencies": ["google_assistant", "alexa"],
   "codeowners": ["@home-assistant/cloud"],

--- a/homeassistant/components/co2signal/sensor.py
+++ b/homeassistant/components/co2signal/sensor.py
@@ -118,7 +118,8 @@ class CO2Sensor(update_coordinator.CoordinatorEntity[CO2SignalResponse], SensorE
     def available(self) -> bool:
         """Return True if entity is available."""
         return (
-            super().available and self._description.key in self.coordinator.data["data"]
+            super().available
+            and self.coordinator.data["data"].get(self._description.key) is not None
         )
 
     @property

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -59,8 +59,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                 config_entry.data[CONF_API_KEY],
                 config_entry.data.get(CONF_LATITUDE, hass.config.latitude),
                 config_entry.data.get(CONF_LONGITUDE, hass.config.longitude),
-                websession,
                 altitude=config_entry.data.get(CONF_ELEVATION, hass.config.elevation),
+                session=websession,
             )
         )
         await openuv.async_update()

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -71,7 +71,7 @@ class OpenUvFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         websession = aiohttp_client.async_get_clientsession(self.hass)
-        client = Client(user_input[CONF_API_KEY], 0, 0, websession)
+        client = Client(user_input[CONF_API_KEY], 0, 0, session=websession)
 
         try:
             await client.uv_index()

--- a/homeassistant/components/openuv/manifest.json
+++ b/homeassistant/components/openuv/manifest.json
@@ -3,7 +3,7 @@
   "name": "OpenUV",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/openuv",
-  "requirements": ["pyopenuv==1.0.9"],
+  "requirements": ["pyopenuv==2.1.0"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -5,7 +5,7 @@ import logging
 import aiohttp
 import tibber
 
-from homeassistant.const import CONF_ACCESS_TOKEN, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_NAME, EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -62,7 +62,7 @@ async def async_setup_entry(hass, entry):
     # have to use discovery to load platform.
     hass.async_create_task(
         discovery.async_load_platform(
-            hass, "notify", DOMAIN, {}, hass.data[DATA_HASS_CONFIG]
+            hass, "notify", DOMAIN, {CONF_NAME: DOMAIN}, hass.data[DATA_HASS_CONFIG]
         )
     )
     return True

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 8
-PATCH_VERSION: Final = "5"
+PATCH_VERSION: Final = "6"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -16,7 +16,7 @@ cryptography==3.3.2
 defusedxml==0.7.1
 distro==1.5.0
 emoji==1.2.0
-hass-nabucasa==0.45.1
+hass-nabucasa==0.46.0
 home-assistant-frontend==20210809.0
 httpx==0.18.2
 ifaddr==0.1.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1649,7 +1649,7 @@ pyobihai==1.3.1
 pyombi==0.1.10
 
 # homeassistant.components.openuv
-pyopenuv==1.0.9
+pyopenuv==2.1.0
 
 # homeassistant.components.opnsense
 pyopnsense==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -750,7 +750,7 @@ habitipy==0.2.0
 hangups==0.4.14
 
 # homeassistant.components.cloud
-hass-nabucasa==0.45.1
+hass-nabucasa==0.46.0
 
 # homeassistant.components.splunk
 hass_splunk==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -938,7 +938,7 @@ pynx584==0.5
 pynzbgetapi==0.2.0
 
 # homeassistant.components.openuv
-pyopenuv==1.0.9
+pyopenuv==2.1.0
 
 # homeassistant.components.opnsense
 pyopnsense==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -428,7 +428,7 @@ habitipy==0.2.0
 hangups==0.4.14
 
 # homeassistant.components.cloud
-hass-nabucasa==0.45.1
+hass-nabucasa==0.46.0
 
 # homeassistant.components.tasmota
 hatasmota==0.2.20

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -118,9 +118,10 @@ async def test_sensors_attributes_pro(hass, canary) -> None:
         await hass.async_block_till_done()
 
     entity_id = "sensor.home_dining_room_air_quality"
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.attributes[ATTR_AIR_QUALITY] == STATE_AIR_QUALITY_ABNORMAL
+    state1 = hass.states.get(entity_id)
+    assert state1
+    assert state1.state == "0.59"
+    assert state1.attributes[ATTR_AIR_QUALITY] == STATE_AIR_QUALITY_ABNORMAL
 
     instance.get_latest_readings.return_value = [
         mock_reading("temperature", "21.12"),
@@ -133,9 +134,10 @@ async def test_sensors_attributes_pro(hass, canary) -> None:
     await hass.helpers.entity_component.async_update_entity(entity_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.attributes[ATTR_AIR_QUALITY] == STATE_AIR_QUALITY_VERY_ABNORMAL
+    state2 = hass.states.get(entity_id)
+    assert state2
+    assert state2.state == "0.4"
+    assert state2.attributes[ATTR_AIR_QUALITY] == STATE_AIR_QUALITY_VERY_ABNORMAL
 
     instance.get_latest_readings.return_value = [
         mock_reading("temperature", "21.12"),
@@ -148,9 +150,10 @@ async def test_sensors_attributes_pro(hass, canary) -> None:
     await hass.helpers.entity_component.async_update_entity(entity_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.attributes[ATTR_AIR_QUALITY] == STATE_AIR_QUALITY_NORMAL
+    state3 = hass.states.get(entity_id)
+    assert state3
+    assert state3.state == "1.0"
+    assert state3.attributes[ATTR_AIR_QUALITY] == STATE_AIR_QUALITY_NORMAL
 
 
 async def test_sensors_flex(hass, canary) -> None:


### PR DESCRIPTION
- Handle CO2Signal response value being None ([@balloob] - [#54377]) ([co2signal docs])
- Fix Canary sensor state ([@ludeeus] - [#54380]) ([canary docs])
- Re-add Tibber notify service name ([@Danielhiversen] - [#54401]) ([tibber docs])
- Bump hass_nabucasa to 0.46.0 ([@balloob] - [#54421]) ([cloud docs])
- Bump pyopenuv to 2.1.0 ([@bachya] - [#54436]) ([openuv docs])

[#54377]: https://github.com/home-assistant/core/pull/54377
[#54380]: https://github.com/home-assistant/core/pull/54380
[#54401]: https://github.com/home-assistant/core/pull/54401
[#54421]: https://github.com/home-assistant/core/pull/54421
[#54436]: https://github.com/home-assistant/core/pull/54436
[@Danielhiversen]: https://github.com/Danielhiversen
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[@ludeeus]: https://github.com/ludeeus
[canary docs]: https://www.home-assistant.io/integrations/canary/
[cloud docs]: https://www.home-assistant.io/integrations/cloud/
[co2signal docs]: https://www.home-assistant.io/integrations/co2signal/
[openuv docs]: https://www.home-assistant.io/integrations/openuv/
[tibber docs]: https://www.home-assistant.io/integrations/tibber/