### PR TITLE
Move temperature conversions to sensor base class (8/8)

### DIFF
--- a/homeassistant/components/vallox/sensor.py
+++ b/homeassistant/components/vallox/sensor.py
@@ -141,7 +141,7 @@ class ValloxSensor(SensorEntity):
         return self._name
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._unit_of_measurement
 
@@ -161,7 +161,7 @@ class ValloxSensor(SensorEntity):
         return self._available
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state."""
         return self._state
 

--- a/homeassistant/components/vasttrafik/sensor.py
+++ b/homeassistant/components/vasttrafik/sensor.py
@@ -110,7 +110,7 @@ class VasttrafikDepartureSensor(SensorEntity):
         return self._attributes
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the next departure time."""
         return self._state
 

--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -45,14 +45,14 @@ class VelbusSensor(VelbusEntity, SensorEntity):
         return self._module.get_class(self._channel)
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         if self._is_counter:
             return self._module.get_counter_state(self._channel)
         return self._module.get_state(self._channel)
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit this state is expressed in."""
         if self._is_counter:
             return self._module.get_counter_unit(self._channel)

--- a/homeassistant/components/vera/sensor.py
+++ b/homeassistant/components/vera/sensor.py
@@ -53,12 +53,12 @@ class VeraSensor(VeraDevice[veraApi.VeraSensor], SensorEntity):
         self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     @property
-    def state(self) -> str:
+    def native_value(self) -> str:
         """Return the name of the sensor."""
         return self.current_value
 
     @property
-    def unit_of_measurement(self) -> str | None:
+    def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement of this entity, if any."""
 
         if self.vera_device.category == veraApi.CATEGORY_TEMPERATURE_SENSOR:

--- a/homeassistant/components/verisure/sensor.py
+++ b/homeassistant/components/verisure/sensor.py
@@ -51,7 +51,7 @@ class VerisureThermometer(CoordinatorEntity, SensorEntity):
     coordinator: VerisureDataUpdateCoordinator
 
     _attr_device_class = DEVICE_CLASS_TEMPERATURE
-    _attr_unit_of_measurement = TEMP_CELSIUS
+    _attr_native_unit_of_measurement = TEMP_CELSIUS
 
     def __init__(
         self, coordinator: VerisureDataUpdateCoordinator, serial_number: str
@@ -84,7 +84,7 @@ class VerisureThermometer(CoordinatorEntity, SensorEntity):
         }
 
     @property
-    def state(self) -> str | None:
+    def native_value(self) -> str | None:
         """Return the state of the entity."""
         return self.coordinator.data["climate"][self.serial_number]["temperature"]
 
@@ -104,7 +104,7 @@ class VerisureHygrometer(CoordinatorEntity, SensorEntity):
     coordinator: VerisureDataUpdateCoordinator
 
     _attr_device_class = DEVICE_CLASS_HUMIDITY
-    _attr_unit_of_measurement = PERCENTAGE
+    _attr_native_unit_of_measurement = PERCENTAGE
 
     def __init__(
         self, coordinator: VerisureDataUpdateCoordinator, serial_number: str
@@ -137,7 +137,7 @@ class VerisureHygrometer(CoordinatorEntity, SensorEntity):
         }
 
     @property
-    def state(self) -> str | None:
+    def native_value(self) -> str | None:
         """Return the state of the entity."""
         return self.coordinator.data["climate"][self.serial_number]["humidity"]
 
@@ -156,7 +156,7 @@ class VerisureMouseDetection(CoordinatorEntity, SensorEntity):
 
     coordinator: VerisureDataUpdateCoordinator
 
-    _attr_unit_of_measurement = "Mice"
+    _attr_native_unit_of_measurement = "Mice"
 
     def __init__(
         self, coordinator: VerisureDataUpdateCoordinator, serial_number: str
@@ -186,7 +186,7 @@ class VerisureMouseDetection(CoordinatorEntity, SensorEntity):
         }
 
     @property
-    def state(self) -> str | None:
+    def native_value(self) -> str | None:
         """Return the state of the entity."""
         return self.coordinator.data["mice"][self.serial_number]["detections"]
 

--- a/homeassistant/components/versasense/sensor.py
+++ b/homeassistant/components/versasense/sensor.py
@@ -65,12 +65,12 @@ class VSensor(SensorEntity):
         return self._name
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._unit
 

--- a/homeassistant/components/version/sensor.py
+++ b/homeassistant/components/version/sensor.py
@@ -151,5 +151,5 @@ class VersionSensor(SensorEntity):
     async def async_update(self):
         """Get the latest version information."""
         await self.data.async_update()
-        self._attr_state = self.data.api.version
+        self._attr_native_value = self.data.api.version
         self._attr_extra_state_attributes = self.data.api.version_data

--- a/homeassistant/components/viaggiatreno/sensor.py
+++ b/homeassistant/components/viaggiatreno/sensor.py
@@ -103,7 +103,7 @@ class ViaggiaTrenoSensor(SensorEntity):
         return self._name
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
@@ -113,7 +113,7 @@ class ViaggiaTrenoSensor(SensorEntity):
         return self._icon
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._unit
 

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -369,12 +369,12 @@ class ViCareSensor(SensorEntity):
         return self._sensor[CONF_ICON]
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._sensor[CONF_UNIT_OF_MEASUREMENT]
 

--- a/homeassistant/components/vilfo/sensor.py
+++ b/homeassistant/components/vilfo/sensor.py
@@ -72,7 +72,7 @@ class VilfoRouterSensor(SensorEntity):
         return f"{parent_device_name} {sensor_name}"
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state."""
         return self._state
 
@@ -82,7 +82,7 @@ class VilfoRouterSensor(SensorEntity):
         return self._unique_id
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity."""
         return SENSOR_TYPES[self.sensor_type].get(ATTR_UNIT)
 

--- a/homeassistant/components/volkszaehler/sensor.py
+++ b/homeassistant/components/volkszaehler/sensor.py
@@ -97,7 +97,7 @@ class VolkszaehlerSensor(SensorEntity):
         return SENSOR_TYPES[self.type][2]
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return SENSOR_TYPES[self.type][1]
 
@@ -107,7 +107,7 @@ class VolkszaehlerSensor(SensorEntity):
         return self.vz_api.available
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the resources."""
         return self._state
 

--- a/homeassistant/components/volvooncall/sensor.py
+++ b/homeassistant/components/volvooncall/sensor.py
@@ -15,11 +15,11 @@ class VolvoSensor(VolvoEntity, SensorEntity):
     """Representation of a Volvo sensor."""
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state."""
         return self.instrument.state
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return self.instrument.unit

--- a/homeassistant/components/vultr/sensor.py
+++ b/homeassistant/components/vultr/sensor.py
@@ -92,12 +92,12 @@ class VultrSensor(SensorEntity):
         return self._icon
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement to present the value in."""
         return self._units
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the value of this given sensor type."""
         try:
             return round(float(self.data.get(self._condition)), 2)

--- a/homeassistant/components/wallbox/sensor.py
+++ b/homeassistant/components/wallbox/sensor.py
@@ -1,6 +1,6 @@
 """Home Assistant component for accessing the Wallbox Portal API. The sensor component creates multiple sensors regarding wallbox performance."""
 
-from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
@@ -28,7 +28,7 @@ async def async_setup_entry(hass, config, async_add_entities):
     )
 
 
-class WallboxSensor(CoordinatorEntity, Entity):
+class WallboxSensor(CoordinatorEntity, SensorEntity):
     """Representation of the Wallbox portal."""
 
     def __init__(self, coordinator, idx, ent, config):

--- a/homeassistant/components/wallbox/sensor.py
+++ b/homeassistant/components/wallbox/sensor.py
@@ -46,12 +46,12 @@ class WallboxSensor(CoordinatorEntity, Entity):
         return self._name
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self.coordinator.data[self._ent]
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of the sensor."""
         return self._unit
 

--- a/homeassistant/components/waqi/sensor.py
+++ b/homeassistant/components/waqi/sensor.py
@@ -129,7 +129,7 @@ class WaqiSensor(SensorEntity):
         return "mdi:cloud"
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the device."""
         if self._data is not None:
             return self._data.get("aqi")
@@ -146,7 +146,7 @@ class WaqiSensor(SensorEntity):
         return self.uid
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return "AQI"
 

--- a/homeassistant/components/waterfurnace/sensor.py
+++ b/homeassistant/components/waterfurnace/sensor.py
@@ -101,7 +101,7 @@ class WaterFurnaceSensor(SensorEntity):
         return self._name
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
@@ -111,7 +111,7 @@ class WaterFurnaceSensor(SensorEntity):
         return self._icon
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the units of measurement."""
         return self._unit_of_measurement
 

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -202,7 +202,7 @@ class WazeTravelTime(SensorEntity):
         return self._name
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         if self._waze_data.duration is not None:
             return round(self._waze_data.duration)
@@ -210,7 +210,7 @@ class WazeTravelTime(SensorEntity):
         return None
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return TIME_MINUTES
 

--- a/homeassistant/components/websocket_api/sensor.py
+++ b/homeassistant/components/websocket_api/sensor.py
@@ -53,12 +53,12 @@ class APICount(SensorEntity):
         return "Connected clients"
 
     @property
-    def state(self) -> int:
+    def native_value(self) -> int:
         """Return current API count."""
         return self.count
 
     @property
-    def unit_of_measurement(self) -> str:
+    def native_unit_of_measurement(self) -> str:
         """Return the unit of measurement."""
         return "clients"
 

--- a/homeassistant/components/whois/sensor.py
+++ b/homeassistant/components/whois/sensor.py
@@ -70,12 +70,12 @@ class WhoisSensor(SensorEntity):
         return "mdi:calendar-clock"
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement to present the value in."""
         return TIME_DAYS
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the expiration days for hostname."""
         return self._state
 

--- a/homeassistant/components/wiffi/sensor.py
+++ b/homeassistant/components/wiffi/sensor.py
@@ -78,12 +78,12 @@ class NumberEntity(WiffiEntity, SensorEntity):
         return self._device_class
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity."""
         return self._unit_of_measurement
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the value of the entity."""
         return self._value
 
@@ -111,7 +111,7 @@ class StringEntity(WiffiEntity, SensorEntity):
         self.reset_expiration_date()
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the value of the entity."""
         return self._value
 

--- a/homeassistant/components/wink/sensor.py
+++ b/homeassistant/components/wink/sensor.py
@@ -62,7 +62,7 @@ class WinkSensorEntity(WinkDevice, SensorEntity):
         self.hass.data[DOMAIN]["entities"]["sensor"].append(self)
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state."""
         state = None
         if self.capability == "humidity":
@@ -82,7 +82,7 @@ class WinkSensorEntity(WinkDevice, SensorEntity):
         return state
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 

--- a/homeassistant/components/wirelesstag/sensor.py
+++ b/homeassistant/components/wirelesstag/sensor.py
@@ -83,7 +83,7 @@ class WirelessTagSensor(WirelessTagBaseSensor, SensorEntity):
         return self.name.lower().replace(" ", "_")
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
@@ -93,7 +93,7 @@ class WirelessTagSensor(WirelessTagBaseSensor, SensorEntity):
         return self._sensor_type
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._sensor.unit
 

--- a/homeassistant/components/withings/sensor.py
+++ b/homeassistant/components/withings/sensor.py
@@ -30,11 +30,11 @@ class WithingsHealthSensor(BaseWithingsSensor, SensorEntity):
     """Implementation of a Withings sensor."""
 
     @property
-    def state(self) -> None | str | int | float:
+    def native_value(self) -> None | str | int | float:
         """Return the state of the entity."""
         return self._state_data
 
     @property
-    def unit_of_measurement(self) -> str:
+    def native_unit_of_measurement(self) -> str:
         """Return the unit of measurement of this entity, if any."""
         return self._attribute.unit_of_measurement

--- a/homeassistant/components/wled/sensor.py
+++ b/homeassistant/components/wled/sensor.py
@@ -48,7 +48,7 @@ class WLEDEstimatedCurrentSensor(WLEDEntity, SensorEntity):
     """Defines a WLED estimated current sensor."""
 
     _attr_icon = "mdi:power"
-    _attr_unit_of_measurement = ELECTRIC_CURRENT_MILLIAMPERE
+    _attr_native_unit_of_measurement = ELECTRIC_CURRENT_MILLIAMPERE
     _attr_device_class = DEVICE_CLASS_CURRENT
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator) -> None:
@@ -66,7 +66,7 @@ class WLEDEstimatedCurrentSensor(WLEDEntity, SensorEntity):
         }
 
     @property
-    def state(self) -> int:
+    def native_value(self) -> int:
         """Return the state of the sensor."""
         return self.coordinator.data.info.leds.power
 
@@ -84,7 +84,7 @@ class WLEDUptimeSensor(WLEDEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.data.info.mac_address}_uptime"
 
     @property
-    def state(self) -> str:
+    def native_value(self) -> str:
         """Return the state of the sensor."""
         uptime = utcnow() - timedelta(seconds=self.coordinator.data.info.uptime)
         return uptime.replace(microsecond=0).isoformat()
@@ -95,7 +95,7 @@ class WLEDFreeHeapSensor(WLEDEntity, SensorEntity):
 
     _attr_icon = "mdi:memory"
     _attr_entity_registry_enabled_default = False
-    _attr_unit_of_measurement = DATA_BYTES
+    _attr_native_unit_of_measurement = DATA_BYTES
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator) -> None:
         """Initialize WLED free heap sensor."""
@@ -104,7 +104,7 @@ class WLEDFreeHeapSensor(WLEDEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.data.info.mac_address}_free_heap"
 
     @property
-    def state(self) -> int:
+    def native_value(self) -> int:
         """Return the state of the sensor."""
         return self.coordinator.data.info.free_heap
 
@@ -113,7 +113,7 @@ class WLEDWifiSignalSensor(WLEDEntity, SensorEntity):
     """Defines a WLED Wi-Fi signal sensor."""
 
     _attr_icon = "mdi:wifi"
-    _attr_unit_of_measurement = PERCENTAGE
+    _attr_native_unit_of_measurement = PERCENTAGE
     _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator) -> None:
@@ -123,7 +123,7 @@ class WLEDWifiSignalSensor(WLEDEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.data.info.mac_address}_wifi_signal"
 
     @property
-    def state(self) -> int | None:
+    def native_value(self) -> int | None:
         """Return the state of the sensor."""
         if not self.coordinator.data.info.wifi:
             return None
@@ -134,7 +134,7 @@ class WLEDWifiRSSISensor(WLEDEntity, SensorEntity):
     """Defines a WLED Wi-Fi RSSI sensor."""
 
     _attr_device_class = DEVICE_CLASS_SIGNAL_STRENGTH
-    _attr_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
     _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator) -> None:
@@ -144,7 +144,7 @@ class WLEDWifiRSSISensor(WLEDEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.data.info.mac_address}_wifi_rssi"
 
     @property
-    def state(self) -> int | None:
+    def native_value(self) -> int | None:
         """Return the state of the sensor."""
         if not self.coordinator.data.info.wifi:
             return None
@@ -164,7 +164,7 @@ class WLEDWifiChannelSensor(WLEDEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.data.info.mac_address}_wifi_channel"
 
     @property
-    def state(self) -> int | None:
+    def native_value(self) -> int | None:
         """Return the state of the sensor."""
         if not self.coordinator.data.info.wifi:
             return None
@@ -184,7 +184,7 @@ class WLEDWifiBSSIDSensor(WLEDEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.data.info.mac_address}_wifi_bssid"
 
     @property
-    def state(self) -> str | None:
+    def native_value(self) -> str | None:
         """Return the state of the sensor."""
         if not self.coordinator.data.info.wifi:
             return None

--- a/homeassistant/components/wolflink/sensor.py
+++ b/homeassistant/components/wolflink/sensor.py
@@ -63,7 +63,7 @@ class WolfLinkSensor(CoordinatorEntity, SensorEntity):
         return f"{self.wolf_object.name}"
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state. Wolf Client is returning only changed values so we need to store old value here."""
         if self.wolf_object.parameter_id in self.coordinator.data:
             new_state = self.coordinator.data[self.wolf_object.parameter_id]
@@ -95,7 +95,7 @@ class WolfLinkHours(WolfLinkSensor):
         return "mdi:clock"
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return TIME_HOURS
 
@@ -109,7 +109,7 @@ class WolfLinkTemperature(WolfLinkSensor):
         return DEVICE_CLASS_TEMPERATURE
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return TEMP_CELSIUS
 
@@ -123,7 +123,7 @@ class WolfLinkPressure(WolfLinkSensor):
         return DEVICE_CLASS_PRESSURE
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return PRESSURE_BAR
 
@@ -132,7 +132,7 @@ class WolfLinkPercentage(WolfLinkSensor):
     """Class for percentage based entities."""
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return self.wolf_object.unit
 
@@ -146,7 +146,7 @@ class WolfLinkState(WolfLinkSensor):
         return "wolflink__state"
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state converting with supported values."""
         state = super().state
         resolved_state = [

--- a/homeassistant/components/worldclock/sensor.py
+++ b/homeassistant/components/worldclock/sensor.py
@@ -54,7 +54,7 @@ class WorldClockSensor(SensorEntity):
         return self._name
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the device."""
         return self._state
 

--- a/homeassistant/components/worldtidesinfo/sensor.py
+++ b/homeassistant/components/worldtidesinfo/sensor.py
@@ -88,7 +88,7 @@ class WorldTidesInfoSensor(SensorEntity):
         return attr
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the device."""
         if self.data:
             if "High" in str(self.data["extremes"][0]["type"]):

--- a/homeassistant/components/worxlandroid/sensor.py
+++ b/homeassistant/components/worxlandroid/sensor.py
@@ -68,12 +68,12 @@ class WorxLandroidSensor(SensorEntity):
         return f"worxlandroid-{self.sensor}"
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement of the sensor."""
         if self.sensor == "battery":
             return PERCENTAGE

--- a/homeassistant/components/wsdot/sensor.py
+++ b/homeassistant/components/wsdot/sensor.py
@@ -88,7 +88,7 @@ class WashingtonStateTransportSensor(SensorEntity):
         return self._name
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
@@ -96,7 +96,7 @@ class WashingtonStateTransportSensor(SensorEntity):
 class WashingtonStateTravelTimeSensor(WashingtonStateTransportSensor):
     """Travel time sensor from WSDOT."""
 
-    _attr_unit_of_measurement = TIME_MINUTES
+    _attr_native_unit_of_measurement = TIME_MINUTES
 
     def __init__(self, name, access_code, travel_time_id):
         """Construct a travel time sensor."""

--- a/homeassistant/components/xbee/__init__.py
+++ b/homeassistant/components/xbee/__init__.py
@@ -369,7 +369,7 @@ class XBeeDigitalOut(XBeeDigitalIn):
 class XBeeAnalogIn(SensorEntity):
     """Representation of a GPIO pin configured as an analog input."""
 
-    _attr_unit_of_measurement = PERCENTAGE
+    _attr_native_unit_of_measurement = PERCENTAGE
 
     def __init__(self, config, device):
         """Initialize the XBee analog in device."""
@@ -416,7 +416,7 @@ class XBeeAnalogIn(SensorEntity):
         return self._config.should_poll
 
     @property
-    def state(self):
+    def sensor_state(self):
         """Return the state of the entity."""
         return self._value
 

--- a/homeassistant/components/xbee/sensor.py
+++ b/homeassistant/components/xbee/sensor.py
@@ -47,7 +47,7 @@ class XBeeTemperatureSensor(SensorEntity):
     """Representation of XBee Pro temperature sensor."""
 
     _attr_device_class = DEVICE_CLASS_TEMPERATURE
-    _attr_unit_of_measurement = TEMP_CELSIUS
+    _attr_native_unit_of_measurement = TEMP_CELSIUS
 
     def __init__(self, config, device):
         """Initialize the sensor."""
@@ -61,7 +61,7 @@ class XBeeTemperatureSensor(SensorEntity):
         return self._config.name
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._temp
 

--- a/homeassistant/components/xbox/sensor.py
+++ b/homeassistant/components/xbox/sensor.py
@@ -33,7 +33,7 @@ class XboxSensorEntity(XboxBaseSensorEntity, SensorEntity):
     """Representation of a Xbox presence state."""
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the requested attribute."""
         if not self.coordinator.last_update_success:
             return None

--- a/homeassistant/components/xbox_live/sensor.py
+++ b/homeassistant/components/xbox_live/sensor.py
@@ -98,7 +98,7 @@ class XboxSensor(SensorEntity):
         return False
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 

--- a/homeassistant/components/xiaomi_aqara/sensor.py
+++ b/homeassistant/components/xiaomi_aqara/sensor.py
@@ -125,7 +125,7 @@ class XiaomiSensor(XiaomiDevice, SensorEntity):
             return None
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         try:
             return SENSOR_TYPES.get(self._data_key)[0]
@@ -142,7 +142,7 @@ class XiaomiSensor(XiaomiDevice, SensorEntity):
         )
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
@@ -176,7 +176,7 @@ class XiaomiBatterySensor(XiaomiDevice, SensorEntity):
     """Representation of a XiaomiSensor."""
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return PERCENTAGE
 
@@ -186,7 +186,7 @@ class XiaomiBatterySensor(XiaomiDevice, SensorEntity):
         return DEVICE_CLASS_BATTERY
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -100,34 +100,34 @@ SENSOR_TYPES = {
     ATTR_TEMPERATURE: XiaomiMiioSensorDescription(
         key=ATTR_TEMPERATURE,
         name="Temperature",
-        unit_of_measurement=TEMP_CELSIUS,
+        native_unit_of_measurement=TEMP_CELSIUS,
         device_class=DEVICE_CLASS_TEMPERATURE,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     ATTR_HUMIDITY: XiaomiMiioSensorDescription(
         key=ATTR_HUMIDITY,
         name="Humidity",
-        unit_of_measurement=PERCENTAGE,
+        native_unit_of_measurement=PERCENTAGE,
         device_class=DEVICE_CLASS_HUMIDITY,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     ATTR_PRESSURE: XiaomiMiioSensorDescription(
         key=ATTR_PRESSURE,
         name="Pressure",
-        unit_of_measurement=PRESSURE_HPA,
+        native_unit_of_measurement=PRESSURE_HPA,
         device_class=DEVICE_CLASS_PRESSURE,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     ATTR_LOAD_POWER: XiaomiMiioSensorDescription(
         key=ATTR_LOAD_POWER,
         name="Load Power",
-        unit_of_measurement=POWER_WATT,
+        native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
     ),
     ATTR_WATER_LEVEL: XiaomiMiioSensorDescription(
         key=ATTR_WATER_LEVEL,
         name="Water Level",
-        unit_of_measurement=PERCENTAGE,
+        native_unit_of_measurement=PERCENTAGE,
         icon="mdi:water-check",
         state_class=STATE_CLASS_MEASUREMENT,
         valid_min_value=0.0,
@@ -136,27 +136,27 @@ SENSOR_TYPES = {
     ATTR_ACTUAL_SPEED: XiaomiMiioSensorDescription(
         key=ATTR_ACTUAL_SPEED,
         name="Actual Speed",
-        unit_of_measurement="rpm",
+        native_unit_of_measurement="rpm",
         icon="mdi:fast-forward",
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     ATTR_MOTOR_SPEED: XiaomiMiioSensorDescription(
         key=ATTR_MOTOR_SPEED,
         name="Motor Speed",
-        unit_of_measurement="rpm",
+        native_unit_of_measurement="rpm",
         icon="mdi:fast-forward",
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     ATTR_ILLUMINANCE: XiaomiMiioSensorDescription(
         key=ATTR_ILLUMINANCE,
         name="Illuminance",
-        unit_of_measurement=UNIT_LUMEN,
+        native_unit_of_measurement=UNIT_LUMEN,
         device_class=DEVICE_CLASS_ILLUMINANCE,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     ATTR_AIR_QUALITY: XiaomiMiioSensorDescription(
         key=ATTR_AIR_QUALITY,
-        unit_of_measurement="AQI",
+        native_unit_of_measurement="AQI",
         icon="mdi:cloud",
         state_class=STATE_CLASS_MEASUREMENT,
     ),
@@ -331,7 +331,7 @@ class XiaomiAirQualityMonitor(XiaomiMiioEntity, SensorEntity):
         return self._available
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the device."""
         return self._state
 
@@ -378,7 +378,7 @@ class XiaomiGatewaySensor(XiaomiGatewayDevice, SensorEntity):
         self.entity_description = description
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._sub_device.status[self.entity_description.key]
 
@@ -403,7 +403,7 @@ class XiaomiGatewayIlluminanceSensor(SensorEntity):
         return self._available
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the device."""
         return self._state
 

--- a/homeassistant/components/xs1/sensor.py
+++ b/homeassistant/components/xs1/sensor.py
@@ -37,11 +37,11 @@ class XS1Sensor(XS1DeviceEntity, SensorEntity):
         return self.device.name()
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self.device.value()
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return self.device.unit()

--- a/homeassistant/components/yandex_transport/sensor.py
+++ b/homeassistant/components/yandex_transport/sensor.py
@@ -108,7 +108,7 @@ class DiscoverYandexTransport(SensorEntity):
         self._attrs = attrs
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 

--- a/homeassistant/components/zabbix/sensor.py
+++ b/homeassistant/components/zabbix/sensor.py
@@ -94,12 +94,12 @@ class ZabbixTriggerCountSensor(SensorEntity):
         return self._name
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the units of measurement."""
         return "issues"
 

--- a/homeassistant/components/zamg/sensor.py
+++ b/homeassistant/components/zamg/sensor.py
@@ -171,12 +171,12 @@ class ZamgSensor(SensorEntity):
         return f"{self.client_name} {self.variable}"
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self.probe.get_data(self.variable)
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return SENSOR_TYPES[self.variable][1]
 

--- a/homeassistant/components/zestimate/sensor.py
+++ b/homeassistant/components/zestimate/sensor.py
@@ -77,7 +77,7 @@ class ZestimateDataSensor(SensorEntity):
         return f"{self._name} {self.address}"
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         try:
             return round(float(self._state), 1)

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -135,12 +135,12 @@ class Sensor(ZhaEntity, SensorEntity):
         return self._state_class
 
     @property
-    def unit_of_measurement(self) -> str | None:
+    def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement of this entity."""
         return self._unit
 
     @property
-    def state(self) -> StateType:
+    def native_value(self) -> StateType:
         """Return the state of the entity."""
         assert self.SENSOR_ATTR is not None
         raw_state = self._channel.cluster.get(self.SENSOR_ATTR)
@@ -274,7 +274,7 @@ class SmartEnergyMetering(Sensor):
         return self._channel.formatter_function(value)
 
     @property
-    def unit_of_measurement(self) -> str:
+    def native_unit_of_measurement(self) -> str:
         """Return Unit of measurement."""
         return self._channel.unit_of_measurement
 

--- a/homeassistant/components/zodiac/sensor.py
+++ b/homeassistant/components/zodiac/sensor.py
@@ -196,7 +196,7 @@ class ZodiacSensor(SensorEntity):
         return "zodiac__sign"
 
     @property
-    def state(self) -> str:
+    def native_value(self) -> str:
         """Return the state of the device."""
         return self._state
 

--- a/homeassistant/components/zoneminder/sensor.py
+++ b/homeassistant/components/zoneminder/sensor.py
@@ -71,7 +71,7 @@ class ZMSensorMonitors(SensorEntity):
         return f"{self._monitor.name} Status"
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
@@ -107,12 +107,12 @@ class ZMSensorEvents(SensorEntity):
         return f"{self._monitor.name} {self.time_period.title}"
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return "Events"
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
@@ -136,7 +136,7 @@ class ZMSensorRunState(SensorEntity):
         return "Run State"
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 

--- a/homeassistant/components/zwave/sensor.py
+++ b/homeassistant/components/zwave/sensor.py
@@ -56,12 +56,12 @@ class ZWaveSensor(ZWaveDeviceEntity, SensorEntity):
         return True
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement the value is expressed in."""
         return self._units
 
@@ -70,7 +70,7 @@ class ZWaveMultilevelSensor(ZWaveSensor):
     """Representation of a multi level sensor Z-Wave sensor."""
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         if self._units in ("C", "F"):
             return round(self._state, 1)
@@ -87,7 +87,7 @@ class ZWaveMultilevelSensor(ZWaveSensor):
         return None
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         if self._units == "C":
             return TEMP_CELSIUS

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -181,14 +181,14 @@ class ZWaveStringSensor(ZwaveSensorBase):
     """Representation of a Z-Wave String sensor."""
 
     @property
-    def state(self) -> str | None:
+    def native_value(self) -> str | None:
         """Return state of the sensor."""
         if self.info.primary_value.value is None:
             return None
         return str(self.info.primary_value.value)
 
     @property
-    def unit_of_measurement(self) -> str | None:
+    def native_unit_of_measurement(self) -> str | None:
         """Return unit of measurement the value is expressed in."""
         if self.info.primary_value.metadata.unit is None:
             return None
@@ -215,14 +215,14 @@ class ZWaveNumericSensor(ZwaveSensorBase):
             )
 
     @property
-    def state(self) -> float:
+    def native_value(self) -> float:
         """Return state of the sensor."""
         if self.info.primary_value.value is None:
             return 0
         return round(float(self.info.primary_value.value), 2)
 
     @property
-    def unit_of_measurement(self) -> str | None:
+    def native_unit_of_measurement(self) -> str | None:
         """Return unit of measurement the value is expressed in."""
         if self.info.primary_value.metadata.unit is None:
             return None
@@ -345,7 +345,7 @@ class ZWaveListSensor(ZwaveSensorBase):
         )
 
     @property
-    def state(self) -> str | None:
+    def native_value(self) -> str | None:
         """Return state of the sensor."""
         if self.info.primary_value.value is None:
             return None
@@ -387,7 +387,7 @@ class ZWaveConfigParameterSensor(ZwaveSensorBase):
         )
 
     @property
-    def state(self) -> str | None:
+    def native_value(self) -> str | None:
         """Return state of the sensor."""
         if self.info.primary_value.value is None:
             return None
@@ -439,7 +439,7 @@ class ZWaveNodeStatusSensor(SensorEntity):
         self._attr_device_info = {
             "identifiers": {get_device_id(self.client, self.node)},
         }
-        self._attr_state: str = node.status.name.lower()
+        self._attr_native_value: str = node.status.name.lower()
 
     async def async_poll_value(self, _: bool) -> None:
         """Poll a value."""
@@ -447,7 +447,7 @@ class ZWaveNodeStatusSensor(SensorEntity):
 
     def _status_changed(self, _: dict) -> None:
         """Call when status event is received."""
-        self._attr_state = self.node.status.name.lower()
+        self._attr_native_value = self.node.status.name.lower()
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/tests/components/vultr/test_sensor.py
+++ b/tests/components/vultr/test_sensor.py
@@ -29,6 +29,7 @@ class TestVultrSensorSetup(unittest.TestCase):
     def add_entities(self, devices, action):
         """Mock add devices."""
         for device in devices:
+            device.hass = self.hass
             self.DEVICES.append(device)
 
     def setUp(self):

--- a/tests/components/wsdot/test_sensor.py
+++ b/tests/components/wsdot/test_sensor.py
@@ -35,6 +35,9 @@ async def test_setup(hass, requests_mock):
 
     def add_entities(new_entities, update_before_add=False):
         """Mock add entities."""
+        for entity in new_entities:
+            entity.hass = hass
+
         if update_before_add:
             for entity in new_entities:
                 entity.update()

--- a/tests/components/zwave/test_sensor.py
+++ b/tests/components/zwave/test_sensor.py
@@ -70,8 +70,10 @@ def test_get_device_detects_battery_sensor(mock_openzwave):
     assert device.device_class == homeassistant.const.DEVICE_CLASS_BATTERY
 
 
-def test_multilevelsensor_value_changed_temp_fahrenheit(mock_openzwave):
+def test_multilevelsensor_value_changed_temp_fahrenheit(hass, mock_openzwave):
     """Test value changed for Z-Wave multilevel sensor for temperature."""
+    hass.config.units.temperature_unit = homeassistant.const.TEMP_FAHRENHEIT
+
     node = MockNode(
         command_classes=[
             const.COMMAND_CLASS_SENSOR_MULTILEVEL,
@@ -82,6 +84,7 @@ def test_multilevelsensor_value_changed_temp_fahrenheit(mock_openzwave):
     values = MockEntityValues(primary=value)
 
     device = sensor.get_device(node=node, values=values, node_config={})
+    device.hass = hass
     assert device.state == 191.0
     assert device.unit_of_measurement == homeassistant.const.TEMP_FAHRENHEIT
     assert device.device_class == homeassistant.const.DEVICE_CLASS_TEMPERATURE
@@ -90,8 +93,9 @@ def test_multilevelsensor_value_changed_temp_fahrenheit(mock_openzwave):
     assert device.state == 198.0
 
 
-def test_multilevelsensor_value_changed_temp_celsius(mock_openzwave):
+def test_multilevelsensor_value_changed_temp_celsius(hass, mock_openzwave):
     """Test value changed for Z-Wave multilevel sensor for temperature."""
+    hass.config.units.temperature_unit = homeassistant.const.TEMP_CELSIUS
     node = MockNode(
         command_classes=[
             const.COMMAND_CLASS_SENSOR_MULTILEVEL,
@@ -102,6 +106,7 @@ def test_multilevelsensor_value_changed_temp_celsius(mock_openzwave):
     values = MockEntityValues(primary=value)
 
     device = sensor.get_device(node=node, values=values, node_config={})
+    device.hass = hass
     assert device.state == 38.9
     assert device.unit_of_measurement == homeassistant.const.TEMP_CELSIUS
     assert device.device_class == homeassistant.const.DEVICE_CLASS_TEMPERATURE
@@ -110,7 +115,7 @@ def test_multilevelsensor_value_changed_temp_celsius(mock_openzwave):
     assert device.state == 38.0
 
 
-def test_multilevelsensor_value_changed_other_units(mock_openzwave):
+def test_multilevelsensor_value_changed_other_units(hass, mock_openzwave):
     """Test value changed for Z-Wave multilevel sensor for other units."""
     node = MockNode(
         command_classes=[
@@ -124,6 +129,7 @@ def test_multilevelsensor_value_changed_other_units(mock_openzwave):
     values = MockEntityValues(primary=value)
 
     device = sensor.get_device(node=node, values=values, node_config={})
+    device.hass = hass
     assert device.state == 190.96
     assert device.unit_of_measurement == homeassistant.const.ENERGY_KILO_WATT_HOUR
     assert device.device_class is None
@@ -132,7 +138,7 @@ def test_multilevelsensor_value_changed_other_units(mock_openzwave):
     assert device.state == 197.96
 
 
-def test_multilevelsensor_value_changed_integer(mock_openzwave):
+def test_multilevelsensor_value_changed_integer(hass, mock_openzwave):
     """Test value changed for Z-Wave multilevel sensor for other units."""
     node = MockNode(
         command_classes=[
@@ -144,6 +150,7 @@ def test_multilevelsensor_value_changed_integer(mock_openzwave):
     values = MockEntityValues(primary=value)
 
     device = sensor.get_device(node=node, values=values, node_config={})
+    device.hass = hass
     assert device.state == 5
     assert device.unit_of_measurement == "counts"
     assert device.device_class is None
@@ -152,7 +159,7 @@ def test_multilevelsensor_value_changed_integer(mock_openzwave):
     assert device.state == 6
 
 
-def test_alarm_sensor_value_changed(mock_openzwave):
+def test_alarm_sensor_value_changed(hass, mock_openzwave):
     """Test value changed for Z-Wave sensor."""
     node = MockNode(
         command_classes=[const.COMMAND_CLASS_ALARM, const.COMMAND_CLASS_SENSOR_ALARM]
@@ -161,6 +168,7 @@ def test_alarm_sensor_value_changed(mock_openzwave):
     values = MockEntityValues(primary=value)
 
     device = sensor.get_device(node=node, values=values, node_config={})
+    device.hass = hass
     assert device.state == 12.34
     assert device.unit_of_measurement == homeassistant.const.PERCENTAGE
     assert device.device_class is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move temperature conversions to sensor base class `SensorEntity` (8/8)

Temperature conversion will only be done for sensors with device class set to `temperature`.
Temperature conversion will still be done for other sensor entities during a transition period, which will end with Home Assistant Core 2022.3.0.
Temperature conversion for non sensor entities is unaffected by this PR.

This PR migrates sensors in integrations v-z to be compatible with unit conversion in `SensorEntity`.

Additional PRs will be opened to migrate sensors from other integrations


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
