### PR TITLE
Deprecate Wink integration

### DIFF
--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -111,25 +111,28 @@ CHIME_TONES = TONES + ["inactive"]
 AUTO_SHUTOFF_TIMES = [None, -1, 30, 60, 120]
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Inclusive(
-                    CONF_EMAIL, CONF_OAUTH, msg=CONF_MISSING_OAUTH_MSG
-                ): cv.string,
-                vol.Inclusive(
-                    CONF_PASSWORD, CONF_OAUTH, msg=CONF_MISSING_OAUTH_MSG
-                ): cv.string,
-                vol.Inclusive(
-                    CONF_CLIENT_ID, CONF_OAUTH, msg=CONF_MISSING_OAUTH_MSG
-                ): cv.string,
-                vol.Inclusive(
-                    CONF_CLIENT_SECRET, CONF_OAUTH, msg=CONF_MISSING_OAUTH_MSG
-                ): cv.string,
-                vol.Optional(CONF_LOCAL_CONTROL, default=False): cv.boolean,
-            }
-        )
-    },
+    vol.All(
+        cv.deprecated(DOMAIN),
+        {
+            DOMAIN: vol.Schema(
+                {
+                    vol.Inclusive(
+                        CONF_EMAIL, CONF_OAUTH, msg=CONF_MISSING_OAUTH_MSG
+                    ): cv.string,
+                    vol.Inclusive(
+                        CONF_PASSWORD, CONF_OAUTH, msg=CONF_MISSING_OAUTH_MSG
+                    ): cv.string,
+                    vol.Inclusive(
+                        CONF_CLIENT_ID, CONF_OAUTH, msg=CONF_MISSING_OAUTH_MSG
+                    ): cv.string,
+                    vol.Inclusive(
+                        CONF_CLIENT_SECRET, CONF_OAUTH, msg=CONF_MISSING_OAUTH_MSG
+                    ): cv.string,
+                    vol.Optional(CONF_LOCAL_CONTROL, default=False): cv.boolean,
+                }
+            ),
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
 
@@ -282,6 +285,10 @@ def _request_oauth_completion(hass, config):
 
 def setup(hass, config):  # noqa: C901
     """Set up the Wink component."""
+    _LOGGER.warning(
+        "The Wink integration has been deprecated and is pending removal in "
+        "Home Assistant Core 2021.11"
+    )
 
     if hass.data.get(DOMAIN) is None:
         hass.data[DOMAIN] = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The Wink integration has been deprecated and is pending removal in Home Assistant 2021.11.
Their developer portal, needed for obtaining an API token, has been taken offline and their customer support has confirmed no new token or client/secret can be obtained. This makes it impossible to use this integration.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Deprecates the Wink integration. The developer portal for obtaining keys is offline:

<https://developer.wink.com/>


Additionally, a user has quotes us a response from the Wink customer support:

> Thanks for contacting Wink support. Unfortunately, the Wink API site is not available currently. We are not accepting any new applications to use the Wink API at this time. If you were in the past issued a Client ID and Secret, then you can continue to use them as any existing API applications will still function. However, we are not able to help you submit a new application to use the API or obtain new tokens, or a new set of Client ID and Secret.


<https://github.com/home-assistant/home-assistant.io/issues/17286>


![image](https://user-images.githubusercontent.com/195327/129090403-9bbf5a2b-d2ee-4282-838d-92643096f901.png)


Currently, 7 instances are reporting the use for this integration. Therefore introducing a deprecation period for the default deprecation period of 2 release cycles.


![image](https://user-images.githubusercontent.com/195327/129090569-876d03a6-5730-4d3f-9f0e-84eaa9015baf.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18884

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
