### PR TITLE
Expose Sonos features as switch entities

### DIFF
--- a/homeassistant/components/sonos/binary_sensor.py
+++ b/homeassistant/components/sonos/binary_sensor.py
@@ -46,7 +46,7 @@ class SonosPowerEntity(SonosEntity, BinarySensorEntity):
         """Return the entity's device class."""
         return DEVICE_CLASS_BATTERY_CHARGING
 
-    async def async_update(self) -> None:
+    async def _async_poll(self) -> None:
         """Poll the device for the current state."""
         await self.speaker.async_poll_battery()
 

--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -137,6 +137,7 @@ PLAYABLE_MEDIA_TYPES = [
 
 SONOS_CREATE_ALARM = "sonos_create_alarm"
 SONOS_CREATE_BATTERY = "sonos_create_battery"
+SONOS_CREATE_SWITCHES = "sonos_create_swtiches"
 SONOS_CREATE_MEDIA_PLAYER = "sonos_create_media_player"
 SONOS_ENTITY_CREATED = "sonos_entity_created"
 SONOS_POLL_UPDATE = "sonos_poll_update"

--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -137,7 +137,7 @@ PLAYABLE_MEDIA_TYPES = [
 
 SONOS_CREATE_ALARM = "sonos_create_alarm"
 SONOS_CREATE_BATTERY = "sonos_create_battery"
-SONOS_CREATE_SWITCHES = "sonos_create_swtiches"
+SONOS_CREATE_SWITCHES = "sonos_create_switches"
 SONOS_CREATE_MEDIA_PLAYER = "sonos_create_media_player"
 SONOS_ENTITY_CREATED = "sonos_entity_created"
 SONOS_POLL_UPDATE = "sonos_poll_update"

--- a/homeassistant/components/sonos/entity.py
+++ b/homeassistant/components/sonos/entity.py
@@ -84,7 +84,7 @@ class SonosEntity(Entity):
         except (OSError, SoCoException) as ex:
             _LOGGER.debug("Error connecting to %s: %s", self.entity_id, ex)
 
-    async def _async_poll(self) -> None:
+    async def _async_poll(self) -> None:  # pylint: disable=no-self-use
         """Poll the specific functionality. Should be implemented by platforms if needed."""
         return
 

--- a/homeassistant/components/sonos/entity.py
+++ b/homeassistant/components/sonos/entity.py
@@ -30,10 +30,11 @@ _LOGGER = logging.getLogger(__name__)
 class SonosEntity(Entity):
     """Representation of a Sonos entity."""
 
+    _attr_should_poll = False
+
     def __init__(self, speaker: SonosSpeaker) -> None:
         """Initialize a SonosEntity."""
         self.speaker = speaker
-        self._attr_should_poll = False
 
     async def async_added_to_hass(self) -> None:
         """Handle common setup when added to hass."""
@@ -79,9 +80,13 @@ class SonosEntity(Entity):
             self.speaker.subscriptions_failed = True
             await self.speaker.async_unsubscribe()
         try:
-            await self.async_update()  # pylint: disable=no-member
+            await self._async_poll()
         except (OSError, SoCoException) as ex:
             _LOGGER.debug("Error connecting to %s: %s", self.entity_id, ex)
+
+    async def _async_poll(self) -> None:
+        """Poll the specific functionality. Should be implemented by platforms if needed."""
+        return
 
     @property
     def soco(self) -> SoCo:

--- a/homeassistant/components/sonos/entity.py
+++ b/homeassistant/components/sonos/entity.py
@@ -1,6 +1,7 @@
 """Entity representing a Sonos player."""
 from __future__ import annotations
 
+from abc import abstractmethod
 import datetime
 import logging
 
@@ -84,9 +85,9 @@ class SonosEntity(Entity):
         except (OSError, SoCoException) as ex:
             _LOGGER.debug("Error connecting to %s: %s", self.entity_id, ex)
 
+    @abstractmethod
     async def _async_poll(self) -> None:
         """Poll the specific functionality. Should be implemented by platforms if needed."""
-        raise NotImplementedError
 
     @property
     def soco(self) -> SoCo:

--- a/homeassistant/components/sonos/entity.py
+++ b/homeassistant/components/sonos/entity.py
@@ -84,9 +84,9 @@ class SonosEntity(Entity):
         except (OSError, SoCoException) as ex:
             _LOGGER.debug("Error connecting to %s: %s", self.entity_id, ex)
 
-    async def _async_poll(self) -> None:  # pylint: disable=no-self-use
+    async def _async_poll(self) -> None:
         """Poll the specific functionality. Should be implemented by platforms if needed."""
-        return
+        raise NotImplementedError
 
     @property
     def soco(self) -> SoCo:

--- a/homeassistant/components/sonos/entity.py
+++ b/homeassistant/components/sonos/entity.py
@@ -33,6 +33,7 @@ class SonosEntity(Entity):
     def __init__(self, speaker: SonosSpeaker) -> None:
         """Initialize a SonosEntity."""
         self.speaker = speaker
+        self._attr_should_poll = False
 
     async def async_added_to_hass(self) -> None:
         """Handle common setup when added to hass."""
@@ -107,8 +108,3 @@ class SonosEntity(Entity):
     def available(self) -> bool:
         """Return whether this device is available."""
         return self.speaker.available
-
-    @property
-    def should_poll(self) -> bool:
-        """Return that we should not be polled (we handle that internally)."""
-        return False

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -292,7 +292,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
             return STATE_PLAYING
         return STATE_IDLE
 
-    async def async_update(self) -> None:
+    async def _async_poll(self) -> None:
         """Retrieve latest state by polling."""
         await self.hass.data[DATA_SONOS].favorites[
             self.speaker.household_id

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -119,12 +119,7 @@ ATTR_ENABLED = "enabled"
 ATTR_INCLUDE_LINKED_ZONES = "include_linked_zones"
 ATTR_MASTER = "master"
 ATTR_WITH_GROUP = "with_group"
-ATTR_BUTTONS_ENABLED = "buttons_enabled"
-ATTR_CROSSFADE = "crossfade"
-ATTR_NIGHT_SOUND = "night_sound"
-ATTR_SPEECH_ENHANCE = "speech_enhance"
 ATTR_QUEUE_POSITION = "queue_position"
-ATTR_STATUS_LIGHT = "status_light"
 ATTR_EQ_BASS = "bass_level"
 ATTR_EQ_TREBLE = "treble_level"
 
@@ -233,11 +228,6 @@ async def async_setup_entry(
     platform.async_register_entity_service(  # type: ignore
         SERVICE_SET_OPTION,
         {
-            vol.Optional(ATTR_BUTTONS_ENABLED): cv.boolean,
-            vol.Optional(ATTR_CROSSFADE): cv.boolean,
-            vol.Optional(ATTR_NIGHT_SOUND): cv.boolean,
-            vol.Optional(ATTR_SPEECH_ENHANCE): cv.boolean,
-            vol.Optional(ATTR_STATUS_LIGHT): cv.boolean,
             vol.Optional(ATTR_EQ_BASS): vol.All(
                 vol.Coerce(int), vol.Range(min=-10, max=10)
             ),
@@ -618,30 +608,10 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
     @soco_error()
     def set_option(
         self,
-        buttons_enabled: bool | None = None,
-        crossfade: bool | None = None,
-        night_sound: bool | None = None,
-        speech_enhance: bool | None = None,
-        status_light: bool | None = None,
         bass_level: int | None = None,
         treble_level: int | None = None,
     ) -> None:
         """Modify playback options."""
-        if buttons_enabled is not None:
-            self.soco.buttons_enabled = buttons_enabled
-
-        if crossfade is not None:
-            self.soco.cross_fade = crossfade
-
-        if night_sound is not None and self.speaker.night_mode is not None:
-            self.soco.night_mode = night_sound
-
-        if speech_enhance is not None and self.speaker.dialog_mode is not None:
-            self.soco.dialog_mode = speech_enhance
-
-        if status_light is not None:
-            self.soco.status_light = status_light
-
         if bass_level is not None:
             self.soco.bass = bass_level
 
@@ -670,12 +640,6 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
 
         if self.speaker.treble_level is not None:
             attributes[ATTR_EQ_TREBLE] = self.speaker.treble_level
-
-        if self.speaker.night_mode is not None:
-            attributes[ATTR_NIGHT_SOUND] = self.speaker.night_mode
-
-        if self.speaker.dialog_mode is not None:
-            attributes[ATTR_SPEECH_ENHANCE] = self.speaker.dialog_mode
 
         if self.media.queue_position is not None:
             attributes[ATTR_QUEUE_POSITION] = self.media.queue_position

--- a/homeassistant/components/sonos/sensor.py
+++ b/homeassistant/components/sonos/sensor.py
@@ -45,7 +45,7 @@ class SonosBatteryEntity(SonosEntity, SensorEntity):
         """Get the unit of measurement."""
         return PERCENTAGE
 
-    async def async_update(self) -> None:
+    async def _async_poll(self) -> None:
         """Poll the device for the current state."""
         await self.speaker.async_poll_battery()
 

--- a/homeassistant/components/sonos/services.yaml
+++ b/homeassistant/components/sonos/services.yaml
@@ -94,33 +94,6 @@ set_option:
     device:
       integration: sonos
   fields:
-    buttons_enabled:
-      name: Buttons enabled
-      description: Enable control buttons on the device
-      example: "true"
-      selector:
-        boolean:
-    crossfade:
-      name: Crossfade
-      description: Enable crossfade on the device
-      example: "true"
-      selector:
-        boolean:
-    night_sound:
-      name: Night sound
-      description: Enable Night Sound mode
-      selector:
-        boolean:
-    speech_enhance:
-      name: Speech enhance
-      description: Enable Speech Enhancement mode
-      selector:
-        boolean:
-    status_light:
-      name: Status light
-      description: Enable Status (LED) Light
-      selector:
-        boolean:
     bass_level:
       name: Bass Level
       description: Bass level for EQ.

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -46,6 +46,7 @@ from .const import (
     SONOS_CREATE_ALARM,
     SONOS_CREATE_BATTERY,
     SONOS_CREATE_MEDIA_PLAYER,
+    SONOS_CREATE_SWITCHES,
     SONOS_ENTITY_CREATED,
     SONOS_POLL_UPDATE,
     SONOS_REBOOTED,
@@ -191,8 +192,13 @@ class SonosSpeaker:
         self.muted: bool | None = None
         self.night_mode: bool | None = None
         self.dialog_mode: bool | None = None
+        self.cross_fade: bool | None = None
         self.bass_level: int | None = None
         self.treble_level: int | None = None
+
+        # Misc features
+        self.buttons_enabled: bool | None = None
+        self.status_light: bool | None = None
 
         # Grouping
         self.coordinator: SonosSpeaker | None = None
@@ -239,6 +245,8 @@ class SonosSpeaker:
             dispatcher_send(self.hass, SONOS_CREATE_ALARM, self, new_alarms)
         else:
             self._platforms_ready.add(SWITCH_DOMAIN)
+
+        dispatcher_send(self.hass, SONOS_CREATE_SWITCHES, self)
 
         self._event_dispatchers = {
             "AlarmClock": self.async_dispatch_alarms,

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -136,7 +136,6 @@ class SonosSwitchEntity(SonosEntity, SwitchEntity):
         self._attr_icon = FEATURE_ICONS.get(feature_type)
 
         if feature_type in POLL_REQUIRED:
-            self._attr_entity_registry_enabled_default = False
             self._attr_should_poll = True
 
     async def _async_poll(self) -> None:

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -126,9 +126,12 @@ class SonosSwitchEntity(SonosEntity, SwitchEntity):
         """Initialize the switch."""
         super().__init__(speaker)
         self.feature_type = feature_type
+        self.entity_id = ENTITY_ID_FORMAT.format(
+            f"sonos_{speaker.zone_name}_{FRIENDLY_NAMES[feature_type]}"
+        )
         self.needs_coordinator = feature_type in COORDINATOR_FEATURES
         self._attr_entity_category = ENTITY_CATEGORY_CONFIG
-        self._attr_name = f"Sonos {speaker.zone_name} {FRIENDLY_NAMES[feature_type]}"
+        self._attr_name = f"{speaker.zone_name} {FRIENDLY_NAMES[feature_type]}"
         self._attr_unique_id = f"{speaker.soco.uid}-{feature_type}"
         self._attr_icon = FEATURE_ICONS.get(feature_type)
 

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -60,6 +60,14 @@ FRIENDLY_NAMES = {
     ATTR_TOUCH_CONTROLS: "Touch Controls",
 }
 
+FEATURE_ICONS = {
+    ATTR_NIGHT_SOUND: "mdi:chat-sleep",
+    ATTR_SPEECH_ENHANCEMENT: "mdi:ear-hearing",
+    ATTR_CROSSFADE: "mdi:swap-horizontal",
+    ATTR_STATUS_LIGHT: "mdi:led-on",
+    ATTR_TOUCH_CONTROLS: "mdi:gesture-tap",
+}
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Sonos from a config entry."""
@@ -115,18 +123,8 @@ class SonosSwitchEntity(SonosEntity, SwitchEntity):
         self.feature_type = feature_type
         self._attr_name = f"Sonos {speaker.zone_name} {FRIENDLY_NAMES[feature_type]}"
         self._attr_unique_id = f"{speaker.soco.uid}-{feature_type}"
+        self._attr_icon = FEATURE_ICONS.get(feature_type)
         self._attr_is_on = is_on
-
-        if feature_type == ATTR_NIGHT_SOUND:
-            self._attr_icon = "mdi:chat-sleep"
-        elif feature_type == ATTR_SPEECH_ENHANCEMENT:
-            self._attr_icon = "mdi:ear-hearing"
-        elif feature_type == ATTR_CROSSFADE:
-            self._attr_icon = "mdi:swap-horizontal"
-        elif feature_type == ATTR_STATUS_LIGHT:
-            self._attr_icon = "mdi:led-on"
-        elif feature_type == ATTR_TOUCH_CONTROLS:
-            self._attr_icon = "mdi:gesture-tap"
 
         if feature_type in POLL_REQUIRED:
             self._attr_entity_registry_enabled_default = False

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -143,11 +143,11 @@ class SonosSwitchEntity(SonosEntity, SwitchEntity):
             return self._attr_is_on
         return getattr(self.speaker, self.feature_type)
 
-    def turn_on(self) -> None:
+    def turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
         self.send_command(True)
 
-    def turn_off(self) -> None:
+    def turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
         self.send_command(False)
 

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -136,6 +136,11 @@ class SonosSwitchEntity(SonosEntity, SwitchEntity):
             self._attr_entity_registry_enabled_default = False
             self._attr_should_poll = True
 
+    async def _async_poll(self) -> None:
+        """Handle polling for subscription-based switches when subscription fails."""
+        if not self.should_poll:
+            await self.hass.async_add_executor_job(self.update)
+
     def update(self) -> None:
         """Fetch switch state if necessary."""
         state = getattr(self.soco, self.feature_type)

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -7,7 +7,7 @@ import logging
 from soco.exceptions import SoCoException, SoCoUPnPException
 
 from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity
-from homeassistant.const import ATTR_TIME
+from homeassistant.const import ATTR_TIME, ENTITY_CATEGORY_CONFIG
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -121,6 +121,7 @@ class SonosSwitchEntity(SonosEntity, SwitchEntity):
         """Initialize the switch."""
         super().__init__(speaker)
         self.feature_type = feature_type
+        self._attr_entity_category = ENTITY_CATEGORY_CONFIG
         self._attr_name = f"Sonos {speaker.zone_name} {FRIENDLY_NAMES[feature_type]}"
         self._attr_unique_id = f"{speaker.soco.uid}-{feature_type}"
         self._attr_icon = FEATURE_ICONS.get(feature_type)

--- a/homeassistant/components/sonos/switch.py
+++ b/homeassistant/components/sonos/switch.py
@@ -205,7 +205,7 @@ class SonosAlarmEntity(SonosEntity, SwitchEntity):
             str(self.alarm.start_time)[0:5],
         )
 
-    async def async_update(self) -> None:
+    async def _async_poll(self) -> None:
         """Call the central alarm polling method."""
         await self.hass.data[DATA_SONOS].alarms[self.household_id].async_poll()
 

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -95,6 +95,4 @@ async def test_entity_basic(hass, config_entry, discover):
     attributes = state.attributes
     assert attributes["friendly_name"] == "Zone A"
     assert attributes["is_volume_muted"] is False
-    assert attributes["night_sound"] is True
-    assert attributes["speech_enhance"] is True
     assert attributes["volume_level"] == 0.19

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -1,10 +1,7 @@
 """Tests for the Sonos Alarm switch platform."""
 from copy import copy
-from datetime import timedelta
-from unittest.mock import patch
 
 from homeassistant.components.sonos import DOMAIN
-from homeassistant.components.sonos.const import DATA_SONOS_DISCOVERY_MANAGER
 from homeassistant.components.sonos.switch import (
     ATTR_DURATION,
     ATTR_ID,
@@ -13,15 +10,9 @@ from homeassistant.components.sonos.switch import (
     ATTR_RECURRENCE,
     ATTR_VOLUME,
 )
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_TIME, STATE_ON
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt
-
-from .conftest import SonosMockEvent
-
-from tests.common import async_fire_time_changed
 
 
 async def setup_platform(hass, config_entry, config):
@@ -77,38 +68,10 @@ async def test_switch_attributes(hass, config_entry, config, soco):
     assert crossfade_state.state == STATE_ON
 
     status_light = entity_registry.entities["switch.sonos_zone_a_status_light"]
-    assert hass.states.get(status_light.entity_id) is None
-
-    touch_controls = entity_registry.entities["switch.sonos_zone_a_touch_controls"]
-    assert hass.states.get(touch_controls.entity_id) is None
-
-    # Enable disabled entities
-    for entity in (crossfade, status_light, touch_controls):
-        entity_registry.async_update_entity(
-            entity_id=entity.entity_id, disabled_by=None
-        )
-    await hass.async_block_till_done()
-
-    # Fire event to cancel poll timer and avoid triggering errors during time jump
-    service = soco.contentDirectory
-    empty_event = SonosMockEvent(soco, service, {})
-    subscription = service.subscribe.return_value
-    subscription.callback(event=empty_event)
-    await hass.async_block_till_done()
-
-    # Mock shutdown calls during config entry reload
-    with patch.object(hass.data[DATA_SONOS_DISCOVERY_MANAGER], "async_shutdown") as m:
-        async_fire_time_changed(
-            hass,
-            dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-        )
-        await hass.async_block_till_done()
-        assert m.called
-
-    crossfade_state = hass.states.get(crossfade.entity_id)
-    assert crossfade_state.state == STATE_ON
     status_light_state = hass.states.get(status_light.entity_id)
     assert status_light_state.state == STATE_ON
+
+    touch_controls = entity_registry.entities["switch.sonos_zone_a_touch_controls"]
     touch_controls_state = hass.states.get(touch_controls.entity_id)
     assert touch_controls_state.state == STATE_ON
 

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -1,7 +1,10 @@
 """Tests for the Sonos Alarm switch platform."""
 from copy import copy
+from datetime import timedelta
+from unittest.mock import patch
 
 from homeassistant.components.sonos import DOMAIN
+from homeassistant.components.sonos.const import DATA_SONOS_DISCOVERY_MANAGER
 from homeassistant.components.sonos.switch import (
     ATTR_DURATION,
     ATTR_ID,
@@ -10,9 +13,15 @@ from homeassistant.components.sonos.switch import (
     ATTR_RECURRENCE,
     ATTR_VOLUME,
 )
+from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_TIME, STATE_ON
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt
+
+from .conftest import SonosMockEvent
+
+from tests.common import async_fire_time_changed
 
 
 async def setup_platform(hass, config_entry, config):
@@ -30,10 +39,14 @@ async def test_entity_registry(hass, config_entry, config):
 
     assert "media_player.zone_a" in entity_registry.entities
     assert "switch.sonos_alarm_14" in entity_registry.entities
+    assert "switch.sonos_zone_a_status_light" in entity_registry.entities
+    assert "switch.sonos_zone_a_night_sound" in entity_registry.entities
+    assert "switch.sonos_zone_a_speech_enhancement" in entity_registry.entities
+    assert "switch.sonos_zone_a_touch_controls" in entity_registry.entities
 
 
-async def test_alarm_attributes(hass, config_entry, config):
-    """Test for correct sonos alarm state."""
+async def test_switch_attributes(hass, config_entry, config, soco):
+    """Test for correct Sonos switch states."""
     await setup_platform(hass, config_entry, config)
 
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
@@ -48,6 +61,55 @@ async def test_alarm_attributes(hass, config_entry, config):
     assert alarm_state.attributes.get(ATTR_VOLUME) == 0.25
     assert alarm_state.attributes.get(ATTR_PLAY_MODE) == "SHUFFLE_NOREPEAT"
     assert not alarm_state.attributes.get(ATTR_INCLUDE_LINKED_ZONES)
+
+    night_sound = entity_registry.entities["switch.sonos_zone_a_night_sound"]
+    night_sound_state = hass.states.get(night_sound.entity_id)
+    assert night_sound_state.state == STATE_ON
+
+    speech_enhancement = entity_registry.entities[
+        "switch.sonos_zone_a_speech_enhancement"
+    ]
+    speech_enhancement_state = hass.states.get(speech_enhancement.entity_id)
+    assert speech_enhancement_state.state == STATE_ON
+
+    crossfade = entity_registry.entities["switch.sonos_zone_a_crossfade"]
+    assert hass.states.get(crossfade.entity_id) is None
+
+    status_light = entity_registry.entities["switch.sonos_zone_a_status_light"]
+    assert hass.states.get(status_light.entity_id) is None
+
+    touch_controls = entity_registry.entities["switch.sonos_zone_a_touch_controls"]
+    assert hass.states.get(touch_controls.entity_id) is None
+
+    # Enable disabled entities
+    for entity in (crossfade, status_light, touch_controls):
+        entity_registry.async_update_entity(
+            entity_id=entity.entity_id, disabled_by=None
+        )
+    await hass.async_block_till_done()
+
+    # Fire event to cancel poll timer and avoid triggering errors during time jump
+    service = soco.contentDirectory
+    empty_event = SonosMockEvent(soco, service, {})
+    subscription = service.subscribe.return_value
+    subscription.callback(event=empty_event)
+    await hass.async_block_till_done()
+
+    # Mock shutdown calls during config entry reload
+    with patch.object(hass.data[DATA_SONOS_DISCOVERY_MANAGER], "async_shutdown") as m:
+        async_fire_time_changed(
+            hass,
+            dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+        )
+        await hass.async_block_till_done()
+        assert m.called
+
+    crossfade_state = hass.states.get(crossfade.entity_id)
+    assert crossfade_state.state == STATE_ON
+    status_light_state = hass.states.get(status_light.entity_id)
+    assert status_light_state.state == STATE_ON
+    touch_controls_state = hass.states.get(touch_controls.entity_id)
+    assert touch_controls_state.state == STATE_ON
 
 
 async def test_alarm_create_delete(

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -73,7 +73,8 @@ async def test_switch_attributes(hass, config_entry, config, soco):
     assert speech_enhancement_state.state == STATE_ON
 
     crossfade = entity_registry.entities["switch.sonos_zone_a_crossfade"]
-    assert hass.states.get(crossfade.entity_id) is None
+    crossfade_state = hass.states.get(crossfade.entity_id)
+    assert crossfade_state.state == STATE_ON
 
     status_light = entity_registry.entities["switch.sonos_zone_a_status_light"]
     assert hass.states.get(status_light.entity_id) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `sonos.set_option` service has been removed and replaced with individual `switch` entities which both control the features and display if currently enabled.

The `night_sound` and `speech_enhance` attributes on the Sonos `media_player` entities are also removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the legacy `sonos.set_option` service which provided the ability to enable/disable the following speaker-level features:
* Night Sound & Speech Enhancement _(only available on home theater devices)_
* Crossfade, Status Light, Touch Controls _(disabled by default)_

Each of these features are now exposed as a separate `switch` entity per speaker.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54405
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18897

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
