### PR TITLE
Use zwave_js.number platform for Basic CC values

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -543,7 +543,7 @@ DISCOVERY_SCHEMAS = [
         entity_registry_enabled_default=False,
     ),
     # number
-    # Basic CC with currentValue and targetValue
+    # Basic CC
     ZWaveDiscoverySchema(
         platform="number",
         hint="Basic",

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -565,19 +565,6 @@ DISCOVERY_SCHEMAS = [
         ],
         entity_registry_enabled_default=False,
     ),
-    # sensor for basic CC without targetValue (just currentValue)
-    ZWaveDiscoverySchema(
-        platform="sensor",
-        hint="numeric_sensor",
-        primary_value=ZWaveValueDiscoverySchema(
-            command_class={
-                CommandClass.BASIC,
-            },
-            type={"number"},
-            property={"currentValue"},
-        ),
-        entity_registry_enabled_default=False,
-    ),
     # binary switches
     ZWaveDiscoverySchema(
         platform="switch",

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -542,7 +542,30 @@ DISCOVERY_SCHEMAS = [
         allow_multi=True,
         entity_registry_enabled_default=False,
     ),
-    # sensor for basic CC
+    # number
+    # Basic CC with currentValue and targetValue
+    ZWaveDiscoverySchema(
+        platform="number",
+        hint="Basic",
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={
+                CommandClass.BASIC,
+            },
+            type={"number"},
+            property={"currentValue"},
+        ),
+        required_values=[
+            ZWaveValueDiscoverySchema(
+                command_class={
+                    CommandClass.BASIC,
+                },
+                type={"number"},
+                property={"targetValue"},
+            )
+        ],
+        entity_registry_enabled_default=False,
+    ),
+    # sensor for basic CC without targetValue (just currentValue)
     ZWaveDiscoverySchema(
         platform="sensor",
         hint="numeric_sensor",

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -542,8 +542,7 @@ DISCOVERY_SCHEMAS = [
         allow_multi=True,
         entity_registry_enabled_default=False,
     ),
-    # number
-    # Basic CC
+    # number for Basic CC
     ZWaveDiscoverySchema(
         platform="number",
         hint="Basic",

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -198,22 +198,6 @@ class ZWaveStringSensor(ZwaveSensorBase):
 class ZWaveNumericSensor(ZwaveSensorBase):
     """Representation of a Z-Wave Numeric sensor."""
 
-    def __init__(
-        self,
-        config_entry: ConfigEntry,
-        client: ZwaveClient,
-        info: ZwaveDiscoveryInfo,
-    ) -> None:
-        """Initialize a ZWaveNumericSensor entity."""
-        super().__init__(config_entry, client, info)
-
-        # Entity class attributes
-        if self.info.primary_value.command_class == CommandClass.BASIC:
-            self._attr_name = self.generate_name(
-                include_value_name=True,
-                alternate_value_name=self.info.primary_value.command_class_name,
-            )
-
     @property
     def native_value(self) -> float:
         """Return state of the sensor."""

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -16,7 +16,7 @@ NOTIFICATION_MOTION_BINARY_SENSOR = (
 )
 NOTIFICATION_MOTION_SENSOR = "sensor.multisensor_6_home_security_motion_sensor_status"
 INDICATOR_SENSOR = "sensor.z_wave_thermostat_indicator_value"
-BASIC_SENSOR = "sensor.livingroomlight_basic"
+BASIC_NUMBER_ENTITY = "number.livingroomlight_basic"
 PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
     "binary_sensor.august_smart_lock_pro_3rd_gen_the_current_status_of_the_door"
 )

--- a/tests/components/zwave_js/test_number.py
+++ b/tests/components/zwave_js/test_number.py
@@ -1,6 +1,10 @@
 """Test the Z-Wave JS number platform."""
 from zwave_js_server.event import Event
 
+from homeassistant.helpers import entity_registry as er
+
+from .common import BASIC_NUMBER_ENTITY
+
 NUMBER_ENTITY = "number.thermostat_hvac_valve_control"
 
 
@@ -67,3 +71,13 @@ async def test_number(hass, client, aeotec_radiator_thermostat, integration):
 
     state = hass.states.get(NUMBER_ENTITY)
     assert state.state == "99.0"
+
+
+async def test_disabled_basic_number(hass, ge_in_wall_dimmer_switch, integration):
+    """Test number is created from Basic CC and is disabled."""
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(BASIC_NUMBER_ENTITY)
+
+    assert entity_entry
+    assert entity_entry.disabled
+    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -28,7 +28,6 @@ from homeassistant.helpers import entity_registry as er
 
 from .common import (
     AIR_TEMPERATURE_SENSOR,
-    BASIC_SENSOR,
     CURRENT_SENSOR,
     DATETIME_LAST_RESET,
     DATETIME_ZERO,
@@ -125,16 +124,6 @@ async def test_disabled_indcator_sensor(
     """Test sensor is created from Indicator CC and is disabled."""
     ent_reg = er.async_get(hass)
     entity_entry = ent_reg.async_get(INDICATOR_SENSOR)
-
-    assert entity_entry
-    assert entity_entry.disabled
-    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
-
-
-async def test_disabled_basic_sensor(hass, ge_in_wall_dimmer_switch, integration):
-    """Test sensor is created from Basic CC and is disabled."""
-    ent_reg = er.async_get(hass)
-    entity_entry = ent_reg.async_get(BASIC_SENSOR)
 
     assert entity_entry
     assert entity_entry.disabled


### PR DESCRIPTION
## Breaking change
`sensor` entities created for Basic CC values will now be created as `number` entities so they can be controlled. This will make existing sensor entities for Basic CC values permanently unavailable. Those entities are safe to remove from your system.

## Proposed change
The Basic CC always comes with two values, `currentValue` and `targetValue`. We currently only have a discovery schema for `currentValue` which creates a sensor, making these Basic CC values noninteractive. This change will create a `number` platform entity for Basic CC values instead of sensors.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
