### PR TITLE
Add support for total and total_increasing sensor state classes

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -76,12 +76,12 @@ STATE_CLASS_AMOUNT: Final = "amount"
 # The state represents a measurement in present time
 STATE_CLASS_MEASUREMENT: Final = "measurement"
 # The state represents a monotonically increasing total, e.g. an amount of consumed gas
-STATE_CLASS_METER: Final = "meter"
+STATE_CLASS_AMOUNT_INCRESING: Final = "amount_increasing"
 
 STATE_CLASSES: Final[list[str]] = [
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_AMOUNT,
-    STATE_CLASS_METER,
+    STATE_CLASS_AMOUNT_INCRESING,
 ]
 
 STATE_CLASSES_SCHEMA: Final = vol.All(vol.Lower, vol.In(STATE_CLASSES))

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -71,10 +71,18 @@ DEVICE_CLASSES: Final[list[str]] = [
 
 DEVICE_CLASSES_SCHEMA: Final = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))
 
+# The state represents a total amount, e.g. a value of a stock portfolio
+STATE_CLASS_AMOUNT: Final = "amount"
 # The state represents a measurement in present time
 STATE_CLASS_MEASUREMENT: Final = "measurement"
+# The state represents a monotonically increasing total, e.g. an amount of consumed gas
+STATE_CLASS_METER: Final = "meter"
 
-STATE_CLASSES: Final[list[str]] = [STATE_CLASS_MEASUREMENT]
+STATE_CLASSES: Final[list[str]] = [
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_AMOUNT,
+    STATE_CLASS_METER,
+]
 
 STATE_CLASSES_SCHEMA: Final = vol.All(vol.Lower, vol.In(STATE_CLASSES))
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -169,10 +169,10 @@ class SensorEntity(Entity):
                 report_issue = self._suggest_report_issue()
                 _LOGGER.warning(
                     "Entity %s (%s) with state_class %s has set last_reset. Setting "
-                    "last_reset for entities with state_class other than 'total' or "
-                    "total_increasing is deprecated and will be removed from Home "
-                    "Assistant Core 2021.10. Please update your configuration if "
-                    "state_class is manually configured, otherwise %s",
+                    "last_reset for entities with state_class other than 'total' is "
+                    "deprecated and will be removed from Home Assistant Core 2021.10. "
+                    "Please update your configuration if state_class is manually "
+                    "configured, otherwise %s",
                     self.entity_id,
                     type(self),
                     self.state_class,

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -126,6 +126,7 @@ class SensorEntity(Entity):
     _attr_native_unit_of_measurement: str | None
     _attr_native_value: StateType = None
     _attr_state_class: str | None
+    _last_reset_reported = False
     _temperature_conversion_reported = False
 
     @property
@@ -159,6 +160,25 @@ class SensorEntity(Entity):
     def state_attributes(self) -> dict[str, Any] | None:
         """Return state attributes."""
         if last_reset := self.last_reset:
+            if (
+                last_reset is not None
+                and self.state_class == STATE_CLASS_MEASUREMENT
+                and not self._last_reset_reported
+            ):
+                self._last_reset_reported = True
+                report_issue = self._suggest_report_issue()
+                _LOGGER.warning(
+                    "Entity %s (%s) with state_class %s has set last_reset. Setting "
+                    "last_reset for entities with state_class other than 'total' or "
+                    "total_increasing is deprecated and will be removed from Home "
+                    "Assistant Core 2021.10. Please update your configuration if "
+                    "state_class is manually configured, otherwise %s",
+                    self.entity_id,
+                    type(self),
+                    self.state_class,
+                    report_issue,
+                )
+
             return {ATTR_LAST_RESET: last_reset.isoformat()}
 
         return None

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -71,17 +71,17 @@ DEVICE_CLASSES: Final[list[str]] = [
 
 DEVICE_CLASSES_SCHEMA: Final = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))
 
-# The state represents a total amount, e.g. a value of a stock portfolio
-STATE_CLASS_AMOUNT: Final = "amount"
 # The state represents a measurement in present time
 STATE_CLASS_MEASUREMENT: Final = "measurement"
+# The state represents a total amount, e.g. a value of a stock portfolio
+STATE_CLASS_TOTAL: Final = "total"
 # The state represents a monotonically increasing total, e.g. an amount of consumed gas
-STATE_CLASS_AMOUNT_INCRESING: Final = "amount_increasing"
+STATE_CLASS_TOTAL_INCRESING: Final = "total_increasing"
 
 STATE_CLASSES: Final[list[str]] = [
     STATE_CLASS_MEASUREMENT,
-    STATE_CLASS_AMOUNT,
-    STATE_CLASS_AMOUNT_INCRESING,
+    STATE_CLASS_TOTAL,
+    STATE_CLASS_TOTAL_INCRESING,
 ]
 
 STATE_CLASSES_SCHEMA: Final = vol.All(vol.Lower, vol.In(STATE_CLASSES))

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -76,12 +76,12 @@ STATE_CLASS_MEASUREMENT: Final = "measurement"
 # The state represents a total amount, e.g. a value of a stock portfolio
 STATE_CLASS_TOTAL: Final = "total"
 # The state represents a monotonically increasing total, e.g. an amount of consumed gas
-STATE_CLASS_TOTAL_INCRESING: Final = "total_increasing"
+STATE_CLASS_TOTAL_INCREASING: Final = "total_increasing"
 
 STATE_CLASSES: Final[list[str]] = [
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL,
-    STATE_CLASS_TOTAL_INCRESING,
+    STATE_CLASS_TOTAL_INCREASING,
 ]
 
 STATE_CLASSES_SCHEMA: Final = vol.All(vol.Lower, vol.In(STATE_CLASSES))

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -301,10 +301,13 @@ def compile_statistics(
                 reset = False
                 if (
                     state_class != STATE_CLASS_METER
-                    and (last_reset := state.attributes["last_reset"]) != old_last_reset
+                    and (last_reset := state.attributes.get("last_reset"))
+                    != old_last_reset
                 ):
                     reset = True
-                if state_class == STATE_CLASS_METER and (
+                elif old_state is None and last_reset is None:
+                    reset = True
+                elif state_class == STATE_CLASS_METER and (
                     old_state is None or fstate < old_state
                 ):
                     reset = True

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -18,7 +18,7 @@ from homeassistant.components.sensor import (
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL,
-    STATE_CLASS_TOTAL_INCRESING,
+    STATE_CLASS_TOTAL_INCREASING,
     STATE_CLASSES,
 )
 from homeassistant.const import (
@@ -70,7 +70,7 @@ DEVICE_CLASS_OR_UNIT_STATISTICS = {
         DEVICE_CLASS_GAS: {"sum"},
         DEVICE_CLASS_MONETARY: {"sum"},
     },
-    STATE_CLASS_TOTAL_INCRESING: {
+    STATE_CLASS_TOTAL_INCREASING: {
         DEVICE_CLASS_ENERGY: {"sum"},
         DEVICE_CLASS_GAS: {"sum"},
     },
@@ -300,14 +300,14 @@ def compile_statistics(
 
                 reset = False
                 if (
-                    state_class != STATE_CLASS_TOTAL_INCRESING
+                    state_class != STATE_CLASS_TOTAL_INCREASING
                     and (last_reset := state.attributes.get("last_reset"))
                     != old_last_reset
                 ):
                     reset = True
                 elif old_state is None and last_reset is None:
                     reset = True
-                elif state_class == STATE_CLASS_TOTAL_INCRESING and (
+                elif state_class == STATE_CLASS_TOTAL_INCREASING and (
                     old_state is None or fstate < old_state
                 ):
                     reset = True

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -17,8 +17,8 @@ from homeassistant.components.sensor import (
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_AMOUNT,
+    STATE_CLASS_AMOUNT_INCRESING,
     STATE_CLASS_MEASUREMENT,
-    STATE_CLASS_METER,
     STATE_CLASSES,
 )
 from homeassistant.const import (
@@ -70,7 +70,7 @@ DEVICE_CLASS_OR_UNIT_STATISTICS = {
         DEVICE_CLASS_GAS: {"sum"},
         DEVICE_CLASS_MONETARY: {"sum"},
     },
-    STATE_CLASS_METER: {
+    STATE_CLASS_AMOUNT_INCRESING: {
         DEVICE_CLASS_ENERGY: {"sum"},
         DEVICE_CLASS_GAS: {"sum"},
     },
@@ -300,14 +300,14 @@ def compile_statistics(
 
                 reset = False
                 if (
-                    state_class != STATE_CLASS_METER
+                    state_class != STATE_CLASS_AMOUNT_INCRESING
                     and (last_reset := state.attributes.get("last_reset"))
                     != old_last_reset
                 ):
                     reset = True
                 elif old_state is None and last_reset is None:
                     reset = True
-                elif state_class == STATE_CLASS_METER and (
+                elif state_class == STATE_CLASS_AMOUNT_INCRESING and (
                     old_state is None or fstate < old_state
                 ):
                     reset = True

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -299,7 +299,10 @@ def compile_statistics(
                     continue
 
                 reset = False
-                if (last_reset := state.attributes["last_reset"]) != old_last_reset:
+                if (
+                    state_class != STATE_CLASS_METER
+                    and (last_reset := state.attributes["last_reset"]) != old_last_reset
+                ):
                     reset = True
                 if state_class == STATE_CLASS_METER and (
                     old_state is None or fstate < old_state

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -16,9 +16,9 @@ from homeassistant.components.sensor import (
     DEVICE_CLASS_MONETARY,
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
-    STATE_CLASS_AMOUNT,
-    STATE_CLASS_AMOUNT_INCRESING,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL,
+    STATE_CLASS_TOTAL_INCRESING,
     STATE_CLASSES,
 )
 from homeassistant.const import (
@@ -53,7 +53,7 @@ from . import ATTR_LAST_RESET, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 DEVICE_CLASS_OR_UNIT_STATISTICS = {
-    STATE_CLASS_AMOUNT: {
+    STATE_CLASS_TOTAL: {
         DEVICE_CLASS_ENERGY: {"sum"},
         DEVICE_CLASS_GAS: {"sum"},
         DEVICE_CLASS_MONETARY: {"sum"},
@@ -70,7 +70,7 @@ DEVICE_CLASS_OR_UNIT_STATISTICS = {
         DEVICE_CLASS_GAS: {"sum"},
         DEVICE_CLASS_MONETARY: {"sum"},
     },
-    STATE_CLASS_AMOUNT_INCRESING: {
+    STATE_CLASS_TOTAL_INCRESING: {
         DEVICE_CLASS_ENERGY: {"sum"},
         DEVICE_CLASS_GAS: {"sum"},
     },
@@ -300,14 +300,14 @@ def compile_statistics(
 
                 reset = False
                 if (
-                    state_class != STATE_CLASS_AMOUNT_INCRESING
+                    state_class != STATE_CLASS_TOTAL_INCRESING
                     and (last_reset := state.attributes.get("last_reset"))
                     != old_last_reset
                 ):
                     reset = True
                 elif old_state is None and last_reset is None:
                     reset = True
-                elif state_class == STATE_CLASS_AMOUNT_INCRESING and (
+                elif state_class == STATE_CLASS_TOTAL_INCRESING and (
                     old_state is None or fstate < old_state
                 ):
                     reset = True

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -45,8 +45,8 @@ async def test_deprecated_last_reset(hass, caplog, enable_custom_integrations):
     assert (
         "Entity sensor.test (<class 'custom_components.test.sensor.MockSensor'>) "
         "with state_class measurement has set last_reset. Setting last_reset for "
-        "entities with state_class other than 'total' or total_increasing is "
-        "deprecated and will be removed from Home Assistant Core 2021.10. Please "
-        "update your configuration if state_class is manually configured, otherwise "
-        "report it to the custom component author."
+        "entities with state_class other than 'total' is deprecated and will be "
+        "removed from Home Assistant Core 2021.10. Please update your configuration if "
+        "state_class is manually configured, otherwise report it to the custom "
+        "component author."
     ) in caplog.text

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1,6 +1,7 @@
 """The test for sensor device automation."""
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 
 async def test_deprecated_temperature_conversion(
@@ -27,4 +28,25 @@ async def test_deprecated_temperature_conversion(
         "deprecated and will be removed from Home Assistant Core 2022.3. Please update "
         "your configuration if device_class is manually configured, otherwise report it "
         "to the custom component author."
+    ) in caplog.text
+
+
+async def test_deprecated_last_reset(hass, caplog, enable_custom_integrations):
+    """Test warning on deprecated last reset."""
+    platform = getattr(hass.components, "test.sensor")
+    platform.init(empty=True)
+    platform.ENTITIES["0"] = platform.MockSensor(
+        name="Test", state_class="measurement", last_reset=dt_util.utc_from_timestamp(0)
+    )
+
+    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    assert (
+        "Entity sensor.test (<class 'custom_components.test.sensor.MockSensor'>) "
+        "with state_class measurement has set last_reset. Setting last_reset for "
+        "entities with state_class other than 'total' or total_increasing is "
+        "deprecated and will be removed from Home Assistant Core 2021.10. Please "
+        "update your configuration if state_class is manually configured, otherwise "
+        "report it to the custom component author."
     ) in caplog.text

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -154,7 +154,7 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
     assert "Error while processing event StatisticsTask" not in caplog.text
 
 
-@pytest.mark.parametrize("state_class", ["measurement", "amount"])
+@pytest.mark.parametrize("state_class", ["measurement", "total"])
 @pytest.mark.parametrize(
     "device_class,unit,native_unit,factor",
     [
@@ -249,7 +249,7 @@ def test_compile_hourly_sum_statistics_amount(
         ("gas", "ft³", "m³", 0.0283168466),
     ],
 )
-def test_compile_hourly_sum_statistics_amount_no_reset(
+def test_compile_hourly_sum_statistics_total_no_reset(
     hass_recorder, caplog, device_class, unit, native_unit, factor
 ):
     """Test compiling hourly statistics."""
@@ -259,7 +259,7 @@ def test_compile_hourly_sum_statistics_amount_no_reset(
     setup_component(hass, "sensor", {})
     attributes = {
         "device_class": device_class,
-        "state_class": "amount",
+        "state_class": "total",
         "unit_of_measurement": unit,
     }
     seq = [10, 15, 20, 10, 30, 40, 50, 60, 70]
@@ -329,7 +329,7 @@ def test_compile_hourly_sum_statistics_amount_no_reset(
         ("gas", "ft³", "m³", 0.0283168466),
     ],
 )
-def test_compile_hourly_sum_statistics_amount_increasing(
+def test_compile_hourly_sum_statistics_total_increasing(
     hass_recorder, caplog, device_class, unit, native_unit, factor
 ):
     """Test compiling hourly statistics."""
@@ -339,7 +339,7 @@ def test_compile_hourly_sum_statistics_amount_increasing(
     setup_component(hass, "sensor", {})
     attributes = {
         "device_class": device_class,
-        "state_class": "amount_increasing",
+        "state_class": "total_increasing",
         "unit_of_measurement": unit,
     }
     seq = [10, 15, 20, 10, 30, 40, 50, 60, 70]

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -329,7 +329,7 @@ def test_compile_hourly_sum_statistics_amount_no_reset(
         ("gas", "ft³", "m³", 0.0283168466),
     ],
 )
-def test_compile_hourly_sum_statistics_meter(
+def test_compile_hourly_sum_statistics_amount_increasing(
     hass_recorder, caplog, device_class, unit, native_unit, factor
 ):
     """Test compiling hourly statistics."""
@@ -339,7 +339,7 @@ def test_compile_hourly_sum_statistics_meter(
     setup_component(hass, "sensor", {})
     attributes = {
         "device_class": device_class,
-        "state_class": "meter",
+        "state_class": "amount_increasing",
         "unit_of_measurement": unit,
     }
     seq = [10, 15, 20, 10, 30, 40, 50, 60, 70]

--- a/tests/testing_config/custom_components/test/sensor.py
+++ b/tests/testing_config/custom_components/test/sensor.py
@@ -72,6 +72,11 @@ class MockSensor(MockEntity, sensor.SensorEntity):
         return self._handle("device_class")
 
     @property
+    def last_reset(self):
+        """Return the last_reset of this sensor."""
+        return self._handle("last_reset")
+
+    @property
     def native_unit_of_measurement(self):
         """Return the native unit_of_measurement of this sensor."""
         return self._handle("native_unit_of_measurement")
@@ -80,3 +85,8 @@ class MockSensor(MockEntity, sensor.SensorEntity):
     def native_value(self):
         """Return the native value of this sensor."""
         return self._handle("native_value")
+
+    @property
+    def state_class(self):
+        """Return the state class of this sensor."""
+        return self._handle("state_class")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Although not a breaking change from a user's perspective, this is a significant change from a developer's perspective.
It should be noted that the state class `total` was removed.

Details here: https://github.com/home-assistant/developers.home-assistant/pull/1028

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for `total` and `total_increasing` sensor state classes:

```py
# The state represents a measurement in present time
STATE_CLASS_MEASUREMENT: Final = "measurement"
# The state represents a total amount, e.g. a value of a stock portfolio
STATE_CLASS_TOTAL: Final = "total"
# The state represents a monotonically increasing total, e.g. an amount of consumed gas
STATE_CLASS_TOTAL_INCREASING: Final = "total_increasing"
```

If the sensor's state class is `STATE_CLASS_TOTAL`, the last_reset attribute can optionally be set to indicate a new meter cycle.

If the sensor's state class is `STATE_CLASS_TOTAL_INCREASING`, a decreasing value is interpreted as the start of a new meter cycle or the replacement of the meter. The last_reset attribute will be ignored when compiling statistics. This state class is useful for gas meters, electricity meters, water meters etc.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull requests: 
  - blog post: https://github.com/home-assistant/developers.home-assistant/pull/1023
  - developer documentation: TODO

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
