### PR TITLE
Fix event type names for non-specified Traccar events

### DIFF
--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -111,11 +111,7 @@ PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
         ),
         vol.Optional(CONF_EVENT, default=[]): vol.All(
             cv.ensure_list,
-            [
-                vol.Any(
-                    *EVENTS,
-                )
-            ],
+            [vol.In(EVENTS)],
         ),
     }
 )
@@ -207,6 +203,8 @@ class TraccarScanner:
     ):
         """Initialize."""
 
+        if EVENT_ALL_EVENTS in event_types:
+            event_types = EVENTS
         self._event_types = {camelcase(evt): evt for evt in event_types}
         self._custom_attributes = custom_attributes
         self._scan_interval = scan_interval
@@ -322,9 +320,8 @@ class TraccarScanner:
                     ),
                     None,
                 )
-                event_types = {camelcase(evt): evt for evt in EVENTS}
                 self._hass.bus.async_fire(
-                    f"traccar_{event_types.get(event['type'])}",
+                    f"traccar_{self._event_types.get(event['type'])}",
                     {
                         "device_traccar_id": event["deviceId"],
                         "device_name": device_name,

--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -74,6 +74,26 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
 SCAN_INTERVAL = DEFAULT_SCAN_INTERVAL
 
+EVENTS = [
+    EVENT_DEVICE_MOVING,
+    EVENT_COMMAND_RESULT,
+    EVENT_DEVICE_FUEL_DROP,
+    EVENT_GEOFENCE_ENTER,
+    EVENT_DEVICE_OFFLINE,
+    EVENT_DRIVER_CHANGED,
+    EVENT_GEOFENCE_EXIT,
+    EVENT_DEVICE_OVERSPEED,
+    EVENT_DEVICE_ONLINE,
+    EVENT_DEVICE_STOPPED,
+    EVENT_MAINTENANCE,
+    EVENT_ALARM,
+    EVENT_TEXT_MESSAGE,
+    EVENT_DEVICE_UNKNOWN,
+    EVENT_IGNITION_OFF,
+    EVENT_IGNITION_ON,
+    EVENT_ALL_EVENTS,
+]
+
 PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_PASSWORD): cv.string,
@@ -93,23 +113,7 @@ PLATFORM_SCHEMA = PARENT_PLATFORM_SCHEMA.extend(
             cv.ensure_list,
             [
                 vol.Any(
-                    EVENT_DEVICE_MOVING,
-                    EVENT_COMMAND_RESULT,
-                    EVENT_DEVICE_FUEL_DROP,
-                    EVENT_GEOFENCE_ENTER,
-                    EVENT_DEVICE_OFFLINE,
-                    EVENT_DRIVER_CHANGED,
-                    EVENT_GEOFENCE_EXIT,
-                    EVENT_DEVICE_OVERSPEED,
-                    EVENT_DEVICE_ONLINE,
-                    EVENT_DEVICE_STOPPED,
-                    EVENT_MAINTENANCE,
-                    EVENT_ALARM,
-                    EVENT_TEXT_MESSAGE,
-                    EVENT_DEVICE_UNKNOWN,
-                    EVENT_IGNITION_OFF,
-                    EVENT_IGNITION_ON,
-                    EVENT_ALL_EVENTS,
+                    *EVENTS,
                 )
             ],
         ),
@@ -318,8 +322,9 @@ class TraccarScanner:
                     ),
                     None,
                 )
+                event_types = {camelcase(evt): evt for evt in EVENTS}
                 self._hass.bus.async_fire(
-                    f"traccar_{self._event_types.get(event['type'])}",
+                    f"traccar_{event_types.get(event['type'])}",
                     {
                         "device_traccar_id": event["deviceId"],
                         "device_name": device_name,

--- a/tests/components/traccar/test_device_tracker.py
+++ b/tests/components/traccar/test_device_tracker.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.device_tracker.const import DOMAIN
+from homeassistant.components.traccar.device_tracker import (
+    PLATFORM_SCHEMA as TRACCAR_PLATFORM_SCHEMA,
+)
+from homeassistant.const import (
+    CONF_EVENT,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PLATFORM,
+    CONF_USERNAME,
+)
+from homeassistant.setup import async_setup_component
+
+from tests.common import async_capture_events
+
+
+async def test_import_events_catch_all(hass):
+    """Test importing all events and firing them in HA using their event types."""
+    conf_dict = {
+        DOMAIN: TRACCAR_PLATFORM_SCHEMA(
+            {
+                CONF_PLATFORM: "traccar",
+                CONF_HOST: "fake_host",
+                CONF_USERNAME: "fake_user",
+                CONF_PASSWORD: "fake_pass",
+                CONF_EVENT: ["all_events"],
+            }
+        )
+    }
+
+    device = {"id": 1, "name": "abc123"}
+    api_mock = AsyncMock()
+    api_mock.devices = [device]
+    api_mock.get_events.return_value = [
+        {
+            "deviceId": device["id"],
+            "type": "ignitionOn",
+            "serverTime": datetime.utcnow(),
+            "attributes": {},
+        },
+        {
+            "deviceId": device["id"],
+            "type": "ignitionOff",
+            "serverTime": datetime.utcnow(),
+            "attributes": {},
+        },
+    ]
+
+    events_ignition_on = async_capture_events(hass, "traccar_ignition_on")
+    events_ignition_off = async_capture_events(hass, "traccar_ignition_off")
+
+    with patch(
+        "homeassistant.components.traccar.device_tracker.API", return_value=api_mock
+    ):
+        assert await async_setup_component(hass, DOMAIN, conf_dict)
+
+    assert len(events_ignition_on) == 1
+    assert len(events_ignition_off) == 1

--- a/tests/components/traccar/test_device_tracker.py
+++ b/tests/components/traccar/test_device_tracker.py
@@ -1,7 +1,6 @@
+"""The tests for the Traccar device tracker platform."""
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
-
-import pytest
 
 from homeassistant.components.device_tracker.const import DOMAIN
 from homeassistant.components.traccar.device_tracker import (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, when we specify `all_events` in the Traccar configuration to catch all events, the component fires all of them as` traccar_None` events since only the given event list is used to build new type names.
This PR fixes the way how we build the prefixed type names to ensure that all imported events are fired correctly.

```yaml
device_tracker:
  - platform: traccar
    host: !secret traccar_host
    username: !secret traccar_username
    password: !secret traccar_password
    event: ["all_events"]
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
