### PR TITLE
Add ability to configure OpenUV "protection window" UV indices

### DIFF
--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -28,10 +28,14 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.service import verify_domain_control
 
 from .const import (
+    CONF_FROM_WINDOW,
+    CONF_TO_WINDOW,
     DATA_CLIENT,
     DATA_LISTENER,
     DATA_PROTECTION_WINDOW,
     DATA_UV,
+    DEFAULT_FROM_WINDOW,
+    DEFAULT_TO_WINDOW,
     DOMAIN,
     LOGGER,
 )
@@ -55,13 +59,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     try:
         websession = aiohttp_client.async_get_clientsession(hass)
         openuv = OpenUV(
+            config_entry,
             Client(
                 config_entry.data[CONF_API_KEY],
                 config_entry.data.get(CONF_LATITUDE, hass.config.latitude),
                 config_entry.data.get(CONF_LONGITUDE, hass.config.longitude),
                 altitude=config_entry.data.get(CONF_ELEVATION, hass.config.elevation),
                 session=websession,
-            )
+            ),
         )
         await openuv.async_update()
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = openuv
@@ -134,15 +139,19 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 class OpenUV:
     """Define a generic OpenUV object."""
 
-    def __init__(self, client: Client) -> None:
+    def __init__(self, config_entry: ConfigEntry, client: Client) -> None:
         """Initialize."""
+        self._config_entry = config_entry
         self.client = client
         self.data: dict[str, Any] = {}
 
     async def async_update_protection_data(self) -> None:
         """Update binary sensor (protection window) data."""
+        low = self._config_entry.options.get(CONF_FROM_WINDOW, DEFAULT_FROM_WINDOW)
+        high = self._config_entry.options.get(CONF_TO_WINDOW, DEFAULT_TO_WINDOW)
+
         try:
-            resp = await self.client.uv_protection_window()
+            resp = await self.client.uv_protection_window(low=low, high=high)
             self.data[DATA_PROTECTION_WINDOW] = resp["result"]
         except OpenUvError as err:
             LOGGER.error("Error during protection data update: %s", err)

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -8,16 +8,24 @@ from pyopenuv.errors import OpenUvError
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_ELEVATION,
     CONF_LATITUDE,
     CONF_LONGITUDE,
 )
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import DOMAIN
+from .const import (
+    CONF_FROM_WINDOW,
+    CONF_TO_WINDOW,
+    DEFAULT_FROM_WINDOW,
+    DEFAULT_TO_WINDOW,
+    DOMAIN,
+)
 
 
 class OpenUvFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -51,6 +59,12 @@ class OpenUvFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors if errors else {},
         )
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OpenUvOptionsFlowHandler:
+        """Define the config flow to handle options."""
+        return OpenUvOptionsFlowHandler(config_entry)
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -75,3 +89,42 @@ class OpenUvFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._show_form({CONF_API_KEY: "invalid_api_key"})
 
         return self.async_create_entry(title=identifier, data=user_input)
+
+
+class OpenUvOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a SimpliSafe options flow."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_FROM_WINDOW,
+                        description={
+                            "suggested_value": self.config_entry.options.get(
+                                CONF_FROM_WINDOW, DEFAULT_FROM_WINDOW
+                            )
+                        },
+                    ): float,
+                    vol.Optional(
+                        CONF_TO_WINDOW,
+                        description={
+                            "suggested_value": self.config_entry.options.get(
+                                CONF_FROM_WINDOW, DEFAULT_TO_WINDOW
+                            )
+                        },
+                    ): float,
+                }
+            ),
+        )

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -116,7 +116,7 @@ class OpenUvOptionsFlowHandler(config_entries.OptionsFlow):
                                 CONF_FROM_WINDOW, DEFAULT_FROM_WINDOW
                             )
                         },
-                    ): float,
+                    ): vol.Coerce(float),
                     vol.Optional(
                         CONF_TO_WINDOW,
                         description={
@@ -124,7 +124,7 @@ class OpenUvOptionsFlowHandler(config_entries.OptionsFlow):
                                 CONF_FROM_WINDOW, DEFAULT_TO_WINDOW
                             )
                         },
-                    ): float,
+                    ): vol.Coerce(float),
                 }
             ),
         )

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -92,7 +92,7 @@ class OpenUvFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class OpenUvOptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle a SimpliSafe options flow."""
+    """Handle a OpenUV options flow."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize."""

--- a/homeassistant/components/openuv/const.py
+++ b/homeassistant/components/openuv/const.py
@@ -4,10 +4,16 @@ import logging
 DOMAIN = "openuv"
 LOGGER = logging.getLogger(__package__)
 
+CONF_FROM_WINDOW = "from_window"
+CONF_TO_WINDOW = "to_window"
+
 DATA_CLIENT = "data_client"
 DATA_LISTENER = "data_listener"
 DATA_PROTECTION_WINDOW = "protection_window"
 DATA_UV = "uv"
+
+DEFAULT_FROM_WINDOW = 3.5
+DEFAULT_TO_WINDOW = 3.5
 
 TYPE_CURRENT_OZONE_LEVEL = "current_ozone_level"
 TYPE_CURRENT_UV_INDEX = "current_uv_index"

--- a/homeassistant/components/openuv/strings.json
+++ b/homeassistant/components/openuv/strings.json
@@ -17,5 +17,16 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_location%]"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure OpenUV",
+        "data": {
+          "from_window": "Starting UV index for the protection window",
+          "to_window": "Ending UV index for the protection window"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/openuv/translations/en.json
+++ b/homeassistant/components/openuv/translations/en.json
@@ -17,5 +17,16 @@
                 "title": "Fill in your information"
             }
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "from_window": "Starting UV index for the protection window",
+                    "to_window": "Ending UV index for the protection window"
+                },
+                "title": "Configure OpenUV"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the ability to configure UV window options (i.e., the "starting" and "ending" UV indices during which sunblock protection is recommended).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/home-assistant.io/issues/18910
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18911

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
