### PR TITLE
Fix tplink doing I/O in event loop and optimize

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -220,7 +220,6 @@ class SmartPlugDataUpdateCoordinator(DataUpdateCoordinator):
         alias: str,
     ) -> None:
         """Initialize DataUpdateCoordinator to gather data for specific SmartPlug."""
-        self.hass = hass
         self.smartplug = smartplug
 
         update_interval = timedelta(seconds=30)

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -220,6 +220,7 @@ class SmartPlugDataUpdateCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Initialize DataUpdateCoordinator to gather data for specific SmartPlug."""
         self.smartplug = smartplug
+        self.has_emeter = self.smartplug.has_emeter
 
         update_interval = timedelta(seconds=30)
         super().__init__(
@@ -239,9 +240,7 @@ class SmartPlugDataUpdateCoordinator(DataUpdateCoordinator):
             if self.smartplug.context is None:
                 data[CONF_ALIAS] = info["alias"]
                 data[CONF_DEVICE_ID] = info["mac"]
-                data[CONF_STATE] = (
-                    self.smartplug.state == self.smartplug.SWITCH_STATE_ON
-                )
+                data[CONF_STATE] = bool(info["relay_state"])
             else:
                 plug_from_context = next(
                     c
@@ -251,7 +250,7 @@ class SmartPlugDataUpdateCoordinator(DataUpdateCoordinator):
                 data[CONF_ALIAS] = plug_from_context["alias"]
                 data[CONF_DEVICE_ID] = self.smartplug.context
                 data[CONF_STATE] = plug_from_context["state"] == 1
-            if self.smartplug.has_emeter:
+            if self.has_emeter:
                 emeter_readings = self.smartplug.get_emeter_realtime()
                 data[CONF_EMETER_PARAMS] = {
                     ATTR_CURRENT_POWER_W: round(float(emeter_readings["power"]), 2),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Read emeter availability directly from sysinfo to avoid extra I/O, reducing the number of requests on hs300 by 6 per update cycle
* Use the state from the sysinfo dict for non-strips reducing required requests by one per update cycle
* Use executor to perform the I/O ops to avoid blocking the event loop


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #54234
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
