### PR TITLE
Add support for Swedish smart electricity meters to DSMR

### DIFF
--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -28,6 +28,8 @@ from .const import (
     CONF_TIME_BETWEEN_UPDATE,
     DEFAULT_TIME_BETWEEN_UPDATE,
     DOMAIN,
+    DSMR_VERSION_MAP,
+    DSMR_VERSIONS,
     LOGGER,
 )
 
@@ -41,7 +43,7 @@ class DSMRConnection:
         """Initialize."""
         self._host = host
         self._port = port
-        self._dsmr_version = dsmr_version
+        self._dsmr_version = DSMR_VERSION_MAP.get(dsmr_version, dsmr_version)
         self._telegram: dict[str, DSMRObject] = {}
         self._equipment_identifier = obis_ref.EQUIPMENT_IDENTIFIER
         if dsmr_version == "5L":
@@ -68,6 +70,10 @@ class DSMRConnection:
 
         def update_telegram(telegram: dict[str, DSMRObject]) -> None:
             if self._equipment_identifier in telegram:
+                self._telegram = telegram
+                transport.close()
+            # Swedish meters have no equipment identifier
+            if self._dsmr_version == "5S" and obis_ref.P1_MESSAGE_TIMESTAMP in telegram:
                 self._telegram = telegram
                 transport.close()
 
@@ -119,7 +125,7 @@ async def _validate_dsmr_connection(
     equipment_identifier_gas = conn.equipment_identifier_gas()
 
     # Check only for equipment identifier in case no gas meter is connected
-    if equipment_identifier is None:
+    if equipment_identifier is None and data[CONF_DSMR_VERSION] != "5S":
         raise CannotCommunicate
 
     return {
@@ -203,7 +209,7 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_HOST): str,
                 vol.Required(CONF_PORT): int,
-                vol.Required(CONF_DSMR_VERSION): vol.In(["2.2", "4", "5", "5B", "5L"]),
+                vol.Required(CONF_DSMR_VERSION): vol.In(DSMR_VERSIONS),
             }
         )
         return self.async_show_form(
@@ -247,7 +253,7 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         schema = vol.Schema(
             {
                 vol.Required(CONF_PORT): vol.In(list_of_ports),
-                vol.Required(CONF_DSMR_VERSION): vol.In(["2.2", "4", "5", "5B", "5L"]),
+                vol.Required(CONF_DSMR_VERSION): vol.In(DSMR_VERSIONS),
             }
         )
         return self.async_show_form(
@@ -288,8 +294,9 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             data = {**data, **info}
 
-            await self.async_set_unique_id(info[CONF_SERIAL_ID])
-            self._abort_if_unique_id_configured()
+            if info[CONF_SERIAL_ID]:
+                await self.async_set_unique_id(info[CONF_SERIAL_ID])
+                self._abort_if_unique_id_configured()
         except CannotConnect:
             errors["base"] = "cannot_connect"
         except CannotCommunicate:
@@ -316,8 +323,9 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         name = f"{host}:{port}" if host is not None else port
         data = {**import_config, **info}
 
-        await self.async_set_unique_id(info[CONF_SERIAL_ID])
-        self._abort_if_unique_id_configured(data)
+        if info[CONF_SERIAL_ID]:
+            await self.async_set_unique_id(info[CONF_SERIAL_ID])
+            self._abort_if_unique_id_configured(data)
 
         return self.async_create_entry(title=name, data=data)
 

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -28,7 +28,6 @@ from .const import (
     CONF_TIME_BETWEEN_UPDATE,
     DEFAULT_TIME_BETWEEN_UPDATE,
     DOMAIN,
-    DSMR_VERSION_MAP,
     DSMR_VERSIONS,
     LOGGER,
 )
@@ -43,7 +42,7 @@ class DSMRConnection:
         """Initialize."""
         self._host = host
         self._port = port
-        self._dsmr_version = DSMR_VERSION_MAP.get(dsmr_version, dsmr_version)
+        self._dsmr_version = dsmr_version
         self._telegram: dict[str, DSMRObject] = {}
         self._equipment_identifier = obis_ref.EQUIPMENT_IDENTIFIER
         if dsmr_version == "5L":

--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -44,6 +44,9 @@ DATA_TASK = "task"
 DEVICE_NAME_ENERGY = "Energy Meter"
 DEVICE_NAME_GAS = "Gas Meter"
 
+DSMR_VERSION_MAP = {"5S": "5L"}
+DSMR_VERSIONS = {"2.2", "4", "5", "5B", "5L", "5S"}
+
 SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.CURRENT_ELECTRICITY_USAGE,
@@ -62,11 +65,13 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_ACTIVE_TARIFF,
         name="Power Tariff",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         icon="mdi:flash",
     ),
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_USED_TARIFF_1,
         name="Energy Consumption (tarif 1)",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         device_class=DEVICE_CLASS_ENERGY,
         force_update=True,
         state_class=STATE_CLASS_TOTAL_INCREASING,
@@ -74,6 +79,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_USED_TARIFF_2,
         name="Energy Consumption (tarif 2)",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
@@ -81,6 +87,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_DELIVERED_TARIFF_1,
         name="Energy Production (tarif 1)",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
@@ -88,6 +95,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_DELIVERED_TARIFF_2,
         name="Energy Production (tarif 2)",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
@@ -137,45 +145,53 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.SHORT_POWER_FAILURE_COUNT,
         name="Short Power Failure Count",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
         icon="mdi:flash-off",
     ),
     DSMRSensorEntityDescription(
         key=obis_references.LONG_POWER_FAILURE_COUNT,
         name="Long Power Failure Count",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
         icon="mdi:flash-off",
     ),
     DSMRSensorEntityDescription(
         key=obis_references.VOLTAGE_SAG_L1_COUNT,
         name="Voltage Sags Phase L1",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.VOLTAGE_SAG_L2_COUNT,
         name="Voltage Sags Phase L2",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.VOLTAGE_SAG_L3_COUNT,
         name="Voltage Sags Phase L3",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.VOLTAGE_SWELL_L1_COUNT,
         name="Voltage Swells Phase L1",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
         icon="mdi:pulse",
     ),
     DSMRSensorEntityDescription(
         key=obis_references.VOLTAGE_SWELL_L2_COUNT,
         name="Voltage Swells Phase L2",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
         icon="mdi:pulse",
     ),
     DSMRSensorEntityDescription(
         key=obis_references.VOLTAGE_SWELL_L3_COUNT,
         name="Voltage Swells Phase L3",
+        dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         entity_registry_enabled_default=False,
         icon="mdi:pulse",
     ),
@@ -224,7 +240,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.LUXEMBOURG_ELECTRICITY_USED_TARIFF_GLOBAL,
         name="Energy Consumption (total)",
-        dsmr_versions={"5L"},
+        dsmr_versions={"5L", "5S"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
@@ -232,7 +248,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.LUXEMBOURG_ELECTRICITY_DELIVERED_TARIFF_GLOBAL,
         name="Energy Production (total)",
-        dsmr_versions={"5L"},
+        dsmr_versions={"5L", "5S"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,

--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -44,7 +44,6 @@ DATA_TASK = "task"
 DEVICE_NAME_ENERGY = "Energy Meter"
 DEVICE_NAME_GAS = "Gas Meter"
 
-DSMR_VERSION_MAP = {"5S": "5L"}
 DSMR_VERSIONS = {"2.2", "4", "5", "5B", "5L", "5S"}
 
 SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
@@ -240,7 +239,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.LUXEMBOURG_ELECTRICITY_USED_TARIFF_GLOBAL,
         name="Energy Consumption (total)",
-        dsmr_versions={"5L", "5S"},
+        dsmr_versions={"5L"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
@@ -248,7 +247,25 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key=obis_references.LUXEMBOURG_ELECTRICITY_DELIVERED_TARIFF_GLOBAL,
         name="Energy Production (total)",
-        dsmr_versions={"5L", "5S"},
+        dsmr_versions={"5L"},
+        force_update=True,
+        device_class=DEVICE_CLASS_ENERGY,
+        last_reset=dt.utc_from_timestamp(0),
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    DSMRSensorEntityDescription(
+        key=obis_references.SWEDEN_ELECTRICITY_USED_TARIFF_GLOBAL,
+        name="Energy Consumption (total)",
+        dsmr_versions={"5S"},
+        force_update=True,
+        device_class=DEVICE_CLASS_ENERGY,
+        last_reset=dt.utc_from_timestamp(0),
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    DSMRSensorEntityDescription(
+        key=obis_references.SWEDEN_ELECTRICITY_DELIVERED_TARIFF_GLOBAL,
+        name="Energy Production (total)",
+        dsmr_versions={"5S"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,

--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -250,8 +250,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         dsmr_versions={"5L"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.SWEDEN_ELECTRICITY_USED_TARIFF_GLOBAL,
@@ -259,8 +258,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         dsmr_versions={"5S"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.SWEDEN_ELECTRICITY_DELIVERED_TARIFF_GLOBAL,

--- a/homeassistant/components/dsmr/manifest.json
+++ b/homeassistant/components/dsmr/manifest.json
@@ -2,7 +2,7 @@
   "domain": "dsmr",
   "name": "DSMR Slimme Meter",
   "documentation": "https://www.home-assistant.io/integrations/dsmr",
-  "requirements": ["dsmr_parser==0.29"],
+  "requirements": ["dsmr_parser==0.30"],
   "codeowners": ["@Robbie1221", "@frenck"],
   "config_flow": true,
   "iot_class": "local_push"

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -44,7 +44,6 @@ from .const import (
     DEVICE_NAME_ENERGY,
     DEVICE_NAME_GAS,
     DOMAIN,
-    DSMR_VERSION_MAP,
     DSMR_VERSIONS,
     LOGGER,
     SENSORS,
@@ -91,7 +90,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up the DSMR sensor."""
     dsmr_version = entry.data[CONF_DSMR_VERSION]
-    _dsmr_version = DSMR_VERSION_MAP.get(dsmr_version, dsmr_version)
     entities = [
         DSMREntity(description, entry)
         for description in SENSORS
@@ -121,7 +119,7 @@ async def async_setup_entry(
             create_tcp_dsmr_reader,
             entry.data[CONF_HOST],
             entry.data[CONF_PORT],
-            _dsmr_version,
+            dsmr_version,
             update_entities_telegram,
             loop=hass.loop,
             keep_alive_interval=60,
@@ -130,7 +128,7 @@ async def async_setup_entry(
         reader_factory = partial(
             create_dsmr_reader,
             entry.data[CONF_PORT],
-            _dsmr_version,
+            dsmr_version,
             update_entities_telegram,
             loop=hass.loop,
         )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -532,7 +532,7 @@ doorbirdpy==2.1.0
 dovado==0.4.1
 
 # homeassistant.components.dsmr
-dsmr_parser==0.29
+dsmr_parser==0.30
 
 # homeassistant.components.dwd_weather_warnings
 dwdwfsapi==1.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -307,7 +307,7 @@ directv==0.4.0
 doorbirdpy==2.1.0
 
 # homeassistant.components.dsmr
-dsmr_parser==0.29
+dsmr_parser==0.30
 
 # homeassistant.components.dynalite
 dynalite_devices==0.1.46

--- a/tests/components/dsmr/conftest.py
+++ b/tests/components/dsmr/conftest.py
@@ -7,6 +7,7 @@ from dsmr_parser.obis_references import (
     EQUIPMENT_IDENTIFIER,
     EQUIPMENT_IDENTIFIER_GAS,
     LUXEMBOURG_EQUIPMENT_IDENTIFIER,
+    P1_MESSAGE_TIMESTAMP,
 )
 from dsmr_parser.objects import CosemObject
 import pytest
@@ -44,6 +45,7 @@ async def dsmr_connection_send_validate_fixture(hass):
     protocol.telegram = {
         EQUIPMENT_IDENTIFIER: CosemObject([{"value": "12345678", "unit": ""}]),
         EQUIPMENT_IDENTIFIER_GAS: CosemObject([{"value": "123456789", "unit": ""}]),
+        P1_MESSAGE_TIMESTAMP: CosemObject([{"value": "12345678", "unit": ""}]),
     }
 
     async def connection_factory(*args, **kwargs):
@@ -56,6 +58,10 @@ async def dsmr_connection_send_validate_fixture(hass):
                 EQUIPMENT_IDENTIFIER_GAS: CosemObject(
                     [{"value": "123456789", "unit": ""}]
                 ),
+            }
+        if args[1] == "5S":
+            protocol.telegram = {
+                P1_MESSAGE_TIMESTAMP: CosemObject([{"value": "12345678", "unit": ""}]),
             }
 
         return (transport, protocol)

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.components.dsmr import DOMAIN, config_flow
 from tests.common import MockConfigEntry
 
 SERIAL_DATA = {"serial_id": "12345678", "serial_id_gas": "123456789"}
+SERIAL_DATA_SWEDEN = {"serial_id": None, "serial_id_gas": None}
 
 
 def com_port():
@@ -480,6 +481,29 @@ async def test_import_luxembourg(hass, dsmr_connection_send_validate_fixture):
     assert result["type"] == "create_entry"
     assert result["title"] == "/dev/ttyUSB0"
     assert result["data"] == {**entry_data, **SERIAL_DATA}
+
+
+async def test_import_sweden(hass, dsmr_connection_send_validate_fixture):
+    """Test we can import."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "5S",
+        "precision": 4,
+        "reconnect_interval": 30,
+    }
+
+    with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=entry_data,
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "/dev/ttyUSB0"
+    assert result["data"] == {**entry_data, **SERIAL_DATA_SWEDEN}
 
 
 def test_get_serial_by_id_no_dir():

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -588,15 +588,17 @@ async def test_swedish_meter(hass, dsmr_connection_fixture):
     assert power_tariff.state == "123.456"
     assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_ENERGY
     assert power_tariff.attributes.get(ATTR_ICON) is None
-    assert power_tariff.attributes.get(ATTR_LAST_RESET) is not None
-    assert power_tariff.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
+    assert power_tariff.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_TOTAL_INCREASING
     assert (
         power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
     )
 
     power_tariff = hass.states.get("sensor.energy_production_total")
     assert power_tariff.state == "654.321"
-    assert power_tariff.attributes.get("unit_of_measurement") == ENERGY_KILO_WATT_HOUR
+    assert power_tariff.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_TOTAL_INCREASING
+    assert (
+        power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
+    )
 
 
 async def test_tcp(hass, dsmr_connection_fixture):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for Swedish smart electricity meters to DSMR

The Swedish smart meter standard is heavily influenced by the Dutch DSMR spec v5, and offers a subset of the datapoints included in the Luxembourg version.

In addition, the Swedish smart meter standard includes datapoints for reactive energy. This is not relevant for residential use and support is not included in this PR.

Source: https://www.energiforetagen.se/globalassets/energiforetagen/det-erbjuder-vi/kurser-och-konferenser/elnat/branschrekommendation-lokalt-granssnitt-v2_0-201912.pdf

Bump dsmr_parser from 0.29 to 0.30, changelog: https://github.com/ndokter/dsmr_parser/releases/tag/v0.30

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18996

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
