### PR TITLE
Remove last_reset attribute from FritzBoxEnergySensor

### DIFF
--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -1,13 +1,12 @@
 """Support for AVM FRITZ!SmartHome temperature sensor only devices."""
 from __future__ import annotations
 
-from datetime import datetime
-
 from pyfritzhome import FritzhomeDevice
 
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -28,7 +27,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util.dt import utc_from_timestamp
 
 from . import FritzBoxEntity
 from .const import (
@@ -99,7 +97,7 @@ async def async_setup_entry(
                         ATTR_ENTITY_ID: f"{device.ain}_total_energy",
                         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
                         ATTR_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
-                        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+                        ATTR_STATE_CLASS: STATE_CLASS_TOTAL_INCREASING,
                     },
                     coordinator,
                     ain,
@@ -152,12 +150,6 @@ class FritzBoxEnergySensor(FritzBoxSensor):
         if energy := self.device.energy:
             return energy / 1000  # type: ignore [no-any-return]
         return 0.0
-
-    @property
-    def last_reset(self) -> datetime:
-        """Return the time when the sensor was last reset, if any."""
-        # device does not provide timestamp of initialization
-        return utc_from_timestamp(0)
 
 
 class FritzBoxTempSensor(FritzBoxSensor):

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -10,10 +10,10 @@ from homeassistant.components.fritzbox.const import (
     DOMAIN as FB_DOMAIN,
 )
 from homeassistant.components.sensor import (
-    ATTR_LAST_RESET,
     ATTR_STATE_CLASS,
     DOMAIN as SENSOR_DOMAIN,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
 )
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import (
@@ -73,10 +73,9 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     state = hass.states.get(f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_total_energy")
     assert state
     assert state.state == "1.234"
-    assert state.attributes[ATTR_LAST_RESET] == "1970-01-01T00:00:00+00:00"
     assert state.attributes[ATTR_FRIENDLY_NAME] == f"{CONF_FAKE_NAME} Total Energy"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_KILO_WATT_HOUR
-    assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_MEASUREMENT
+    assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_TOTAL_INCREASING
 
 
 async def test_turn_on(hass: HomeAssistant, fritz: Mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove last_reset attribute from `FritzBoxEnergySensor` and set device class to `STATE_CLASS_TOTAL_INCREASING`

There are two options for sensors representing meters such as energy meters, where the sensor itself doesn't have a `last_reset` available:
- `STATE_CLASS_TOTAL_INCREASING`
 With STATE_CLASS_TOTAL_INCREASING, a new meter cycle will be detected if the value of the sensor's value decreases. This should be correct if the sensor only counts used (or delivered) energy, but not both in a single sensor, i.e. the sensor's value can't be decreased. Things will then work as expected if the sensor is for some reason reset to 0, for example after a firmware upgrade or factory reset.
- `STATE_CLASS_TOTAL`
 With STATE_CLASS_TOTAL, a new meter cycle will never be detected, and the statistics won't be correct if the sensor is reset.

This PR sets the device class to `STATE_CLASS_TOTAL_INCREASING`

Background in #54523

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
