### PR TITLE
Fix AsusWRT scanner entity DeviceInfo

### DIFF
--- a/homeassistant/components/asuswrt/device_tracker.py
+++ b/homeassistant/components/asuswrt/device_tracker.py
@@ -60,6 +60,12 @@ class AsusWrtDevice(ScannerEntity):
         self._device = device
         self._attr_unique_id = device.mac
         self._attr_name = device.name or DEFAULT_DEVICE_NAME
+        self._attr_device_info = {
+            "connections": {(CONNECTION_NETWORK_MAC, device.mac)},
+            "default_model": "ASUSWRT Tracked device",
+        }
+        if device.name:
+            self._attr_device_info["default_name"] = device.name
 
     @property
     def is_connected(self):
@@ -90,11 +96,6 @@ class AsusWrtDevice(ScannerEntity):
     def async_on_demand_update(self):
         """Update state."""
         self._device = self._router.devices[self._device.mac]
-        self._attr_device_info = {
-            "connections": {(CONNECTION_NETWORK_MAC, self._device.mac)},
-        }
-        if self._device.name:
-            self._attr_device_info["default_name"] = self._device.name
         self._attr_extra_state_attributes = {}
         if self._device.last_activity:
             self._attr_extra_state_attributes[

--- a/homeassistant/components/asuswrt/sensor.py
+++ b/homeassistant/components/asuswrt/sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 from numbers import Number
-from typing import Any
 
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
@@ -142,12 +141,12 @@ class AsusWrtSensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Initialize a AsusWrt sensor."""
         super().__init__(coordinator)
-        self._router = router
         self.entity_description = description
 
         self._attr_name = f"{DEFAULT_PREFIX} {description.name}"
         self._attr_unique_id = f"{DOMAIN} {self.name}"
-        self._attr_device_info = self._router.device_info
+        self._attr_device_info = router.device_info
+        self._attr_extra_state_attributes = {"hostname": router.host}
 
         if description.native_unit_of_measurement == DATA_GIGABYTES:
             self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
@@ -159,13 +158,7 @@ class AsusWrtSensor(CoordinatorEntity, SensorEntity):
         """Return current state."""
         descr = self.entity_description
         state = self.coordinator.data.get(descr.key)
-        if state is None:
-            return None
-        if descr.factor and isinstance(state, Number):
-            return round(state / descr.factor, descr.precision)
+        if state is not None:
+            if descr.factor and isinstance(state, Number):
+                return round(state / descr.factor, descr.precision)
         return state
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the attributes."""
-        return {"hostname": self._router.host}

--- a/homeassistant/components/asuswrt/sensor.py
+++ b/homeassistant/components/asuswrt/sensor.py
@@ -8,18 +8,17 @@ from typing import Any
 
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DATA_GIGABYTES, DATA_RATE_MEGABITS_PER_SECOND
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
-from homeassistant.util import dt as dt_util
 
 from .const import (
     DATA_ASUSWRT,
@@ -148,10 +147,12 @@ class AsusWrtSensor(CoordinatorEntity, SensorEntity):
 
         self._attr_name = f"{DEFAULT_PREFIX} {description.name}"
         self._attr_unique_id = f"{DOMAIN} {self.name}"
-        self._attr_state_class = STATE_CLASS_MEASUREMENT
+        self._attr_device_info = self._router.device_info
 
         if description.native_unit_of_measurement == DATA_GIGABYTES:
-            self._attr_last_reset = dt_util.utc_from_timestamp(0)
+            self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
+        else:
+            self._attr_state_class = STATE_CLASS_MEASUREMENT
 
     @property
     def native_value(self) -> str:
@@ -168,8 +169,3 @@ class AsusWrtSensor(CoordinatorEntity, SensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the attributes."""
         return {"hostname": self._router.host}
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device information."""
-        return self._router.device_info

--- a/homeassistant/components/asuswrt/sensor.py
+++ b/homeassistant/components/asuswrt/sensor.py
@@ -46,12 +46,14 @@ CONNECTION_SENSORS: tuple[AsusWrtSensorEntityDescription, ...] = (
         key=SENSORS_CONNECTED_DEVICE[0],
         name="Devices Connected",
         icon="mdi:router-network",
+        state_class=STATE_CLASS_MEASUREMENT,
         native_unit_of_measurement=UNIT_DEVICES,
     ),
     AsusWrtSensorEntityDescription(
         key=SENSORS_RATES[0],
         name="Download Speed",
         icon="mdi:download-network",
+        state_class=STATE_CLASS_MEASUREMENT,
         native_unit_of_measurement=DATA_RATE_MEGABITS_PER_SECOND,
         entity_registry_enabled_default=False,
         factor=125000,
@@ -60,6 +62,7 @@ CONNECTION_SENSORS: tuple[AsusWrtSensorEntityDescription, ...] = (
         key=SENSORS_RATES[1],
         name="Upload Speed",
         icon="mdi:upload-network",
+        state_class=STATE_CLASS_MEASUREMENT,
         native_unit_of_measurement=DATA_RATE_MEGABITS_PER_SECOND,
         entity_registry_enabled_default=False,
         factor=125000,
@@ -68,6 +71,7 @@ CONNECTION_SENSORS: tuple[AsusWrtSensorEntityDescription, ...] = (
         key=SENSORS_BYTES[0],
         name="Download",
         icon="mdi:download",
+        state_class=STATE_CLASS_TOTAL_INCREASING,
         native_unit_of_measurement=DATA_GIGABYTES,
         entity_registry_enabled_default=False,
         factor=1000000000,
@@ -76,6 +80,7 @@ CONNECTION_SENSORS: tuple[AsusWrtSensorEntityDescription, ...] = (
         key=SENSORS_BYTES[1],
         name="Upload",
         icon="mdi:upload",
+        state_class=STATE_CLASS_TOTAL_INCREASING,
         native_unit_of_measurement=DATA_GIGABYTES,
         entity_registry_enabled_default=False,
         factor=1000000000,
@@ -84,6 +89,7 @@ CONNECTION_SENSORS: tuple[AsusWrtSensorEntityDescription, ...] = (
         key=SENSORS_LOAD_AVG[0],
         name="Load Avg (1m)",
         icon="mdi:cpu-32-bit",
+        state_class=STATE_CLASS_MEASUREMENT,
         entity_registry_enabled_default=False,
         factor=1,
         precision=1,
@@ -92,6 +98,7 @@ CONNECTION_SENSORS: tuple[AsusWrtSensorEntityDescription, ...] = (
         key=SENSORS_LOAD_AVG[1],
         name="Load Avg (5m)",
         icon="mdi:cpu-32-bit",
+        state_class=STATE_CLASS_MEASUREMENT,
         entity_registry_enabled_default=False,
         factor=1,
         precision=1,
@@ -100,6 +107,7 @@ CONNECTION_SENSORS: tuple[AsusWrtSensorEntityDescription, ...] = (
         key=SENSORS_LOAD_AVG[2],
         name="Load Avg (15m)",
         icon="mdi:cpu-32-bit",
+        state_class=STATE_CLASS_MEASUREMENT,
         entity_registry_enabled_default=False,
         factor=1,
         precision=1,
@@ -148,13 +156,8 @@ class AsusWrtSensor(CoordinatorEntity, SensorEntity):
         self._attr_device_info = router.device_info
         self._attr_extra_state_attributes = {"hostname": router.host}
 
-        if description.native_unit_of_measurement == DATA_GIGABYTES:
-            self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
-        else:
-            self._attr_state_class = STATE_CLASS_MEASUREMENT
-
     @property
-    def native_value(self) -> str:
+    def native_value(self) -> str | None:
         """Return current state."""
         descr = self.entity_description
         state = self.coordinator.data.get(descr.key)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

For scanner entities the `_attr_device_info` is set too late, for this reason the related device are never created.
Also added `_attr_device_info` and `_attr_extra_state_attributes` and removed deprecated `_attr_last_reset` for sensor entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
