### PR TITLE
Add RESOLUTION attribute to EXT-X-STREAM-INF

### DIFF
--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -55,6 +55,14 @@ class Segment:
         return b"".join([part.data for part in self.parts])
 
 
+@attr.s
+class Resolution:
+    """Represents the resolution of the stream."""
+
+    width: int = attr.ib()
+    height: int = attr.ib()
+
+
 class IdleTimer:
     """Invoke a callback after an inactivity timeout.
 
@@ -111,6 +119,7 @@ class StreamOutput:
         self.idle_timer = idle_timer
         self._event = asyncio.Event()
         self._segments: deque[Segment] = deque(maxlen=deque_maxlen)
+        self._resolution: Resolution | None = None
 
     @property
     def name(self) -> str | None:
@@ -148,6 +157,11 @@ class StreamOutput:
             return TARGET_SEGMENT_DURATION
         return max(durations)
 
+    @property
+    def resolution(self) -> Resolution | None:
+        """Return the resolution of the video stream."""
+        return self._resolution
+
     def get_segment(self, sequence: int) -> Segment | None:
         """Retrieve a specific segment."""
         # Most hits will come in the most recent segments, so iterate reversed
@@ -164,6 +178,10 @@ class StreamOutput:
         """Wait for and retrieve the latest segment."""
         await self._event.wait()
         return self.last_segment is not None
+
+    def setup(self, resolution: Resolution | None) -> None:
+        """Initialize properties determined at stream start."""
+        self._resolution = resolution
 
     def put(self, segment: Segment) -> None:
         """Store output."""

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -53,9 +53,12 @@ class HlsMasterPlaylistView(StreamView):
             * 1.2
         )
         codecs = get_codec_string(segment.init)
+        attributes = f'BANDWIDTH={bandwidth},CODECS="{codecs}"'
+        if resolution := track.resolution:
+            attributes += f",RESOLUTION={resolution.width}x{resolution.height}"
         lines = [
             "#EXTM3U",
-            f'#EXT-X-STREAM-INF:BANDWIDTH={bandwidth},CODECS="{codecs}"',
+            f"#EXT-X-STREAM-INF:{attributes}",
             "playlist.m3u8",
         ]
         return "\n".join(lines) + "\n"

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -140,6 +140,32 @@ async def test_hls_stream(hass, hls_stream, stream_worker_sync):
     assert fail_response.status == HTTP_NOT_FOUND
 
 
+async def test_hls_stream_master_playlist(hass, hls_stream, stream_worker_sync):
+    """Exercise the master playlist details."""
+    await async_setup_component(hass, "stream", {"stream": {}})
+
+    stream_worker_sync.pause()
+
+    # Setup demo HLS track
+    source = generate_h264_video()
+    stream = create_stream(hass, source, {})
+
+    # Request stream
+    stream.add_provider(HLS_PROVIDER)
+    stream.start()
+
+    hls_client = await hls_stream(stream)
+
+    # Fetch playlist
+    playlist_response = await hls_client.get()
+    assert playlist_response.status == 200
+    assert await playlist_response.text() == (
+        "#EXTM3U\n"
+        '#EXT-X-STREAM-INF:BANDWIDTH=77844,CODECS="avc1.640015",RESOLUTION=480x320\n'
+        "playlist.m3u8\n"
+    )
+
+
 async def test_stream_timeout(hass, hass_client, stream_worker_sync):
     """Test hls stream timeout."""
     await async_setup_component(hass, "stream", {"stream": {}})

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -55,11 +55,15 @@ TIMEOUT = 15
 class FakePyAvStream:
     """A fake pyav Stream."""
 
-    def __init__(self, name, rate):
+    def __init__(
+        self, name: str, rate: fractions.Fraction, width: int = None, height: int = None
+    ):
         """Initialize the stream."""
         self.name = name
         self.time_base = fractions.Fraction(1, rate)
         self.profile = "ignored-profile"
+        self.width = width
+        self.height = height
 
         class FakeCodec:
             name = "aac"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the RESOLUTION attribute to the EXT-X-STREAM-INF tag to address a `Must Fix Issue` from Apple's [Media Stream Validator & HLS Report](https://developer.apple.com/documentation/http_live_streaming/about_apple_s_http_live_streaming_tools).

The `Must Fix Issue` cited the message: `Your EXT-X-STREAM-INF and EXT-X-I-FRAME-STREAM-INF tags MUST always provide the RESOLUTION attribute if the rendition(s) include video`.

The resolution is a property of the input stream, so this introduces a new way for the stream worker to pass information to the `StreamOutput` . The worker does not currently have a great way to track stream output additional/removals so it currently just sets this property every segment anyway for now.  Assuming we may have other properties like this in the future, so made this choice rather than just attaching more data to every `Segment` -- but open to other suggestions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
