### PR TITLE
Allow specifying discovery without a config flow

### DIFF
--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -4,5 +4,10 @@
   "documentation": "https://www.home-assistant.io/integrations/rainforest_eagle",
   "requirements": ["eagle200_reader==0.2.4", "uEagle==0.0.2"],
   "codeowners": ["@gtdiehl", "@jcalbert"],
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "dhcp": [
+    {
+      "macaddress": "D8D5B9*"
+    }
+  ]
 }

--- a/script/hassfest/config_flow.py
+++ b/script/hassfest/config_flow.py
@@ -29,31 +29,6 @@ def validate_integration(config: Config, integration: Integration):
                 "config_flow",
                 "Config flows need to be defined in the file config_flow.py",
             )
-        if integration.manifest.get("homekit"):
-            integration.add_error(
-                "config_flow",
-                "HomeKit information in a manifest requires a config flow to exist",
-            )
-        if integration.manifest.get("mqtt"):
-            integration.add_error(
-                "config_flow",
-                "MQTT information in a manifest requires a config flow to exist",
-            )
-        if integration.manifest.get("ssdp"):
-            integration.add_error(
-                "config_flow",
-                "SSDP information in a manifest requires a config flow to exist",
-            )
-        if integration.manifest.get("zeroconf"):
-            integration.add_error(
-                "config_flow",
-                "Zeroconf information in a manifest requires a config flow to exist",
-            )
-        if integration.manifest.get("dhcp"):
-            integration.add_error(
-                "config_flow",
-                "DHCP information in a manifest requires a config flow to exist",
-            )
         return
 
     config_flow = config_flow_file.read_text()
@@ -98,17 +73,7 @@ def generate_and_validate(integrations: dict[str, Integration], config: Config):
     for domain in sorted(integrations):
         integration = integrations[domain]
 
-        if not integration.manifest:
-            continue
-
-        if not (
-            integration.manifest.get("config_flow")
-            or integration.manifest.get("homekit")
-            or integration.manifest.get("mqtt")
-            or integration.manifest.get("ssdp")
-            or integration.manifest.get("zeroconf")
-            or integration.manifest.get("dhcp")
-        ):
+        if not integration.manifest or not integration.config_flow:
             continue
 
         validate_integration(config, integration)

--- a/script/hassfest/dhcp.py
+++ b/script/hassfest/dhcp.py
@@ -24,7 +24,7 @@ def generate_and_validate(integrations: list[dict[str, str]]):
     for domain in sorted(integrations):
         integration = integrations[domain]
 
-        if not integration.manifest:
+        if not integration.manifest or not integration.config_flow:
             continue
 
         match_types = integration.manifest.get("dhcp", [])

--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -97,6 +97,11 @@ class Integration:
         return self.manifest.get("quality_scale")
 
     @property
+    def config_flow(self) -> str:
+        """Return if the integration has a config flow."""
+        return self.manifest.get("config_flow")
+
+    @property
     def requirements(self) -> list[str]:
         """List of requirements."""
         return self.manifest.get("requirements", [])

--- a/script/hassfest/mqtt.py
+++ b/script/hassfest/mqtt.py
@@ -26,7 +26,7 @@ def generate_and_validate(integrations: dict[str, Integration]):
     for domain in sorted(integrations):
         integration = integrations[domain]
 
-        if not integration.manifest:
+        if not integration.manifest or not integration.config_flow:
             continue
 
         mqtt = integration.manifest.get("mqtt")

--- a/script/hassfest/ssdp.py
+++ b/script/hassfest/ssdp.py
@@ -31,7 +31,7 @@ def generate_and_validate(integrations: dict[str, Integration]):
     for domain in sorted(integrations):
         integration = integrations[domain]
 
-        if not integration.manifest:
+        if not integration.manifest or not integration.config_flow:
             continue
 
         ssdp = integration.manifest.get("ssdp")

--- a/script/hassfest/zeroconf.py
+++ b/script/hassfest/zeroconf.py
@@ -28,7 +28,7 @@ def generate_and_validate(integrations: dict[str, Integration]):
     for domain in sorted(integrations):
         integration = integrations[domain]
 
-        if not integration.manifest:
+        if not integration.manifest or not integration.config_flow:
             continue
 
         service_types = integration.manifest.get("zeroconf", [])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow specifying discovery information in the manifest without having a config flow. The discovery information will be ignored until a config flow is added.

Previously we would not allow adding it, which means we couldn't prepare for the moment that we did support discovery.

Adds discovery to rainforest EAGLE-200 as test.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
