### PR TITLE
Xiaomi Miio appropriatly raise ConfigEntryAuthFailed/ConfigEntryNotReady

### DIFF
--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -363,8 +363,7 @@ async def async_setup_gateway_entry(
 
     # Connect to gateway
     gateway = ConnectXiaomiGateway(hass, entry)
-    if not await gateway.async_connect_gateway(host, token):
-        raise ConfigEntryNotReady("Error during setup of xiaomi gateway")
+    await gateway.async_connect_gateway(host, token)
     gateway_info = gateway.gateway_info
 
     gateway_model = f"{gateway_info.model}-{gateway_info.hardware_version}"

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -40,7 +40,6 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
-    AuthException,
     ATTR_AVAILABLE,
     CONF_DEVICE,
     CONF_FLOW_TYPE,
@@ -67,6 +66,7 @@ from .const import (
     MODELS_PURIFIER_MIOT,
     MODELS_SWITCH,
     MODELS_VACUUM,
+    AuthException,
     SetupException,
 )
 from .gateway import ConnectXiaomiGateway

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -35,6 +35,7 @@ from miio.gateway.gateway import GatewayException
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -363,7 +364,7 @@ async def async_setup_gateway_entry(
     # Connect to gateway
     gateway = ConnectXiaomiGateway(hass, entry)
     if not await gateway.async_connect_gateway(host, token):
-        return False
+        raise ConfigEntryNotReady("Error during setup of xiaomi gateway")
     gateway_info = gateway.gateway_info
 
     gateway_model = f"{gateway_info.model}-{gateway_info.hardware_version}"

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -35,7 +35,6 @@ from miio.gateway.gateway import GatewayException
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import callback
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -103,10 +103,9 @@ async def async_setup_entry(
 ):
     """Set up the Xiaomi Miio components from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    if entry.data[
-        CONF_FLOW_TYPE
-    ] == CONF_GATEWAY and not await async_setup_gateway_entry(hass, entry):
-        return False
+    if entry.data[CONF_FLOW_TYPE] == CONF_GATEWAY:
+        await async_setup_gateway_entry(hass, entry)
+        return True
 
     return bool(
         entry.data[CONF_FLOW_TYPE] != CONF_DEVICE
@@ -422,8 +421,6 @@ async def async_setup_gateway_entry(
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
-
-    return True
 
 
 async def async_setup_device_entry(

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -3,6 +3,7 @@ import logging
 from re import search
 
 from micloud import MiCloud
+from micloud.micloudexception import MiCloudAccessDenied
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -231,8 +232,13 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
 
             miio_cloud = MiCloud(cloud_username, cloud_password)
-            if not await self.hass.async_add_executor_job(miio_cloud.login):
-                errors["base"] = "cloud_login_error"
+            try:
+                if not await self.hass.async_add_executor_job(miio_cloud.login):
+                    errors["base"] = "cloud_login_error"
+            except MiCloudAccessDenied:
+                 errors["base"] = "cloud_login_error"
+
+            if errors:
                 return self.async_show_form(
                     step_id="cloud", data_schema=DEVICE_CLOUD_CONFIG, errors=errors
                 )

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -236,7 +236,7 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 if not await self.hass.async_add_executor_job(miio_cloud.login):
                     errors["base"] = "cloud_login_error"
             except MiCloudAccessDenied:
-                 errors["base"] = "cloud_login_error"
+                errors["base"] = "cloud_login_error"
 
             if errors:
                 return self.async_show_form(

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -6,10 +6,10 @@ from micloud import MiCloud
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.device_registry import format_mac
 
 from .const import (
@@ -324,9 +324,11 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             await connect_device_class.async_connect_device(self.host, self.token)
         except ConfigEntryAuthFailed:
-            errors["base"] = "wrong_token"
+            if self.model is None:
+                errors["base"] = "wrong_token"
         except ConfigEntryNotReady:
-            errors["base"] = "cannot_connect"
+            if self.model is None:
+                errors["base"] = "cannot_connect"
 
         device_info = connect_device_class.device_info
 

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -10,10 +10,10 @@ from homeassistant import config_entries
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.core import callback
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.device_registry import format_mac
 
 from .const import (
+    AuthException,
     CONF_CLOUD_COUNTRY,
     CONF_CLOUD_PASSWORD,
     CONF_CLOUD_SUBDEVICES,
@@ -30,6 +30,7 @@ from .const import (
     MODELS_ALL_DEVICES,
     MODELS_GATEWAY,
     SERVER_COUNTRY_CODES,
+    SetupException,
 )
 from .device import ConnectXiaomiDevice
 
@@ -329,10 +330,10 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         connect_device_class = ConnectXiaomiDevice(self.hass)
         try:
             await connect_device_class.async_connect_device(self.host, self.token)
-        except ConfigEntryAuthFailed:
+        except AuthException:
             if self.model is None:
                 errors["base"] = "wrong_token"
-        except ConfigEntryNotReady:
+        except SetupException:
             if self.model is None:
                 errors["base"] = "cannot_connect"
 

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -13,7 +13,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
 
 from .const import (
-    AuthException,
     CONF_CLOUD_COUNTRY,
     CONF_CLOUD_PASSWORD,
     CONF_CLOUD_SUBDEVICES,
@@ -30,6 +29,7 @@ from .const import (
     MODELS_ALL_DEVICES,
     MODELS_GATEWAY,
     SERVER_COUNTRY_CODES,
+    AuthException,
     SetupException,
 )
 from .device import ConnectXiaomiDevice

--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -37,6 +37,13 @@ SUCCESS = ["ok"]
 SERVER_COUNTRY_CODES = ["cn", "de", "i2", "ru", "sg", "us"]
 DEFAULT_CLOUD_COUNTRY = "cn"
 
+# Excptions
+class AuthException(Exception):
+    """Exception indicating an authentication error."""
+    
+class SetupException(Exception):
+    """Exception indicating a failure during setup."""
+
 # Fan Models
 MODEL_AIRPURIFIER_2H = "zhimi.airpurifier.mc2"
 MODEL_AIRPURIFIER_2S = "zhimi.airpurifier.mc1"

--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -38,7 +38,7 @@ SERVER_COUNTRY_CODES = ["cn", "de", "i2", "ru", "sg", "us"]
 DEFAULT_CLOUD_COUNTRY = "cn"
 
 
-# Excptions
+# Exceptions
 class AuthException(Exception):
     """Exception indicating an authentication error."""
 

--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -37,12 +37,15 @@ SUCCESS = ["ok"]
 SERVER_COUNTRY_CODES = ["cn", "de", "i2", "ru", "sg", "us"]
 DEFAULT_CLOUD_COUNTRY = "cn"
 
+
 # Excptions
 class AuthException(Exception):
     """Exception indicating an authentication error."""
-    
+
+
 class SetupException(Exception):
     """Exception indicating a failure during setup."""
+
 
 # Fan Models
 MODEL_AIRPURIFIER_2H = "zhimi.airpurifier.mc2"

--- a/homeassistant/components/xiaomi_miio/device.py
+++ b/homeassistant/components/xiaomi_miio/device.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import AuthException, CONF_MAC, CONF_MODEL, DOMAIN, SetupException
+from .const import CONF_MAC, CONF_MODEL, DOMAIN, AuthException, SetupException
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/xiaomi_miio/device.py
+++ b/homeassistant/components/xiaomi_miio/device.py
@@ -7,12 +7,11 @@ import logging
 from construct.core import ChecksumError
 from miio import Device, DeviceException
 
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_MAC, CONF_MODEL, DOMAIN
+from .const import AuthException, CONF_MAC, CONF_MODEL, DOMAIN, SetupException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,9 +47,9 @@ class ConnectXiaomiDevice:
             )
         except DeviceException as error:
             if isinstance(error.__cause__, ChecksumError):
-                raise ConfigEntryAuthFailed(error) from error
+                raise AuthException(error) from error
 
-            raise ConfigEntryNotReady(
+            raise SetupException(
                 f"DeviceException during setup of xiaomi device with host {host}"
             ) from error
 

--- a/homeassistant/components/xiaomi_miio/device.py
+++ b/homeassistant/components/xiaomi_miio/device.py
@@ -51,7 +51,7 @@ class ConnectXiaomiDevice:
                 raise ConfigEntryAuthFailed(error) from error
 
             raise ConfigEntryNotReady(
-                "DeviceException during setup of xiaomi device with host {host}"
+                f"DeviceException during setup of xiaomi device with host {host}"
             ) from error
 
         _LOGGER.debug(

--- a/homeassistant/components/xiaomi_miio/device.py
+++ b/homeassistant/components/xiaomi_miio/device.py
@@ -59,7 +59,6 @@ class ConnectXiaomiDevice:
             self._device_info.firmware_version,
             self._device_info.hardware_version,
         )
-        return True
 
 
 class XiaomiMiioEntity(Entity):

--- a/homeassistant/components/xiaomi_miio/device.py
+++ b/homeassistant/components/xiaomi_miio/device.py
@@ -7,7 +7,7 @@ import logging
 from construct.core import ChecksumError
 from miio import Device, DeviceException
 
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -50,12 +50,9 @@ class ConnectXiaomiDevice:
             if isinstance(error.__cause__, ChecksumError):
                 raise ConfigEntryAuthFailed(error) from error
 
-            _LOGGER.error(
-                "DeviceException during setup of xiaomi device with host %s: %s",
-                host,
-                error,
-            )
-            return False
+            raise ConfigEntryNotReady(
+                "DeviceException during setup of xiaomi device with host {host}"
+            ) from error
 
         _LOGGER.debug(
             "%s %s %s detected",

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -7,7 +7,7 @@ from micloud.micloudexception import MiCloudAccessDenied
 from miio import DeviceException, gateway
 from miio.gateway.gateway import GATEWAY_MODEL_EU
 
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -81,12 +81,9 @@ class ConnectXiaomiGateway:
             if isinstance(error.__cause__, ChecksumError):
                 raise ConfigEntryAuthFailed(error) from error
 
-            _LOGGER.error(
-                "DeviceException during setup of xiaomi gateway with host %s: %s",
-                self._host,
-                error,
-            )
-            return False
+            raise ConfigEntryNotReady(
+                "DeviceException during setup of xiaomi gateway with host {self._host}"
+            ) from error
 
         # get the connected sub devices
         use_cloud = self._use_cloud or self._gateway_info.model == GATEWAY_MODEL_EU
@@ -128,12 +125,9 @@ class ConnectXiaomiGateway:
                     "Could not login to Xiaomi Miio Cloud, check the credentials"
                 ) from error
             except DeviceException as error:
-                _LOGGER.error(
-                    "DeviceException during setup of xiaomi gateway with host %s: %s",
-                    self._host,
-                    error,
-                )
-                return False
+                raise ConfigEntryNotReady(
+                    "DeviceException during setup of xiaomi gateway with host {self._host}"
+                ) from error
 
         return True
 

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -128,7 +128,7 @@ class ConnectXiaomiGateway:
             except MiCloudAccessDenied as error:
                 raise ConfigEntryAuthFailed(
                     "Could not login to Xiaomi Miio Cloud, check the credentials"
-                )
+                ) from error
             except DeviceException as error:
                 _LOGGER.error(
                     "DeviceException during setup of xiaomi gateway with host %s: %s",

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -11,13 +11,13 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    AuthException,
     ATTR_AVAILABLE,
     CONF_CLOUD_COUNTRY,
     CONF_CLOUD_PASSWORD,
     CONF_CLOUD_SUBDEVICES,
     CONF_CLOUD_USERNAME,
     DOMAIN,
+    AuthException,
     SetupException,
 )
 

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -61,8 +61,7 @@ class ConnectXiaomiGateway:
         self._cloud_password = self._config_entry.data.get(CONF_CLOUD_PASSWORD)
         self._cloud_country = self._config_entry.data.get(CONF_CLOUD_COUNTRY)
 
-        if not await self._hass.async_add_executor_job(self.connect_gateway):
-            return False
+        await self._hass.async_add_executor_job(self.connect_gateway)
 
         _LOGGER.debug(
             "%s %s %s detected",
@@ -70,7 +69,6 @@ class ConnectXiaomiGateway:
             self._gateway_info.firmware_version,
             self._gateway_info.hardware_version,
         )
-        return True
 
     def connect_gateway(self):
         """Connect the gateway in a way that can called by async_add_executor_job."""
@@ -129,8 +127,6 @@ class ConnectXiaomiGateway:
                 raise SetupException(
                     f"DeviceException during setup of xiaomi gateway with host {self._host}"
                 ) from error
-
-        return True
 
 
 class XiaomiGatewayDevice(CoordinatorEntity, Entity):

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -126,7 +126,7 @@ class ConnectXiaomiGateway:
                 ) from error
             except DeviceException as error:
                 raise ConfigEntryNotReady(
-                    "DeviceException during setup of xiaomi gateway with host {self._host}"
+                    f"DeviceException during setup of xiaomi gateway with host {self._host}"
                 ) from error
 
         return True

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -117,12 +117,10 @@ class ConnectXiaomiGateway:
             try:
                 miio_cloud = MiCloud(self._cloud_username, self._cloud_password)
                 if not miio_cloud.login():
-                    _LOGGER.error(
-                        "Failed to login to Xiaomi Miio Cloud during setup of xiaomi"
-                        " gateway with host %s",
-                        self._host,
+                    raise ConfigEntryNotReady(
+                        "Failed to login to Xiaomi Miio Cloud during setup of Xiaomi"
+                        " gateway with host {self._host}",
                     )
-                    return False
                 devices_raw = miio_cloud.get_devices(self._cloud_country)
                 self._gateway_device.get_devices_from_dict(devices_raw)
             except MiCloudAccessDenied as error:

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -1,5 +1,6 @@
 """Code to handle a Xiaomi Gateway."""
 import logging
+import time
 
 from construct.core import ChecksumError
 from micloud import MiCloud
@@ -115,10 +116,14 @@ class ConnectXiaomiGateway:
 
             try:
                 miio_cloud = MiCloud(self._cloud_username, self._cloud_password)
-                if not miio_cloud.login():
-                    raise ConfigEntryAuthFailed(
-                        "Could not login to Xiaomi Miio Cloud, check the credentials"
-                    )
+                for attempt in range(4):
+                    if miio_cloud.login():
+                        break
+                    if attempt >= 3:
+                        raise ConfigEntryAuthFailed(
+                            "Could not login to Xiaomi Miio Cloud, check the credentials"
+                        )
+                    time.sleep(30)
                 devices_raw = miio_cloud.get_devices(self._cloud_country)
                 self._gateway_device.get_devices_from_dict(devices_raw)
             except DeviceException as error:

--- a/homeassistant/components/xiaomi_miio/manifest.json
+++ b/homeassistant/components/xiaomi_miio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Xiaomi Miio",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_miio",
-  "requirements": ["construct==2.10.56", "micloud==0.3", "python-miio==0.5.8"],
+  "requirements": ["construct==2.10.56", "micloud==0.4", "python-miio==0.5.8"],
   "codeowners": ["@rytilahti", "@syssi", "@starkillerOG", "@bieniu"],
   "zeroconf": ["_miio._udp.local."],
   "iot_class": "local_polling"

--- a/homeassistant/components/xiaomi_miio/strings.json
+++ b/homeassistant/components/xiaomi_miio/strings.json
@@ -9,6 +9,7 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "wrong_token": "Checksum error, wrong token",
       "unknown_device": "The device model is not known, not able to setup the device using config flow.",
       "cloud_no_devices": "No devices found in this Xiaomi Miio cloud account.",
       "cloud_credentials_incomplete": "Cloud credentials incomplete, please fill in username, password and country",

--- a/homeassistant/components/xiaomi_miio/translations/en.json
+++ b/homeassistant/components/xiaomi_miio/translations/en.json
@@ -9,6 +9,7 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
+            "wrong_token": "Checksum error, wrong token",
             "cloud_credentials_incomplete": "Cloud credentials incomplete, please fill in username, password and country",
             "cloud_login_error": "Could not login to Xiaomi Miio Cloud, check the credentials.",
             "cloud_no_devices": "No devices found in this Xiaomi Miio cloud account.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -996,7 +996,7 @@ meteofrance-api==1.0.2
 mficlient==0.3.0
 
 # homeassistant.components.xiaomi_miio
-micloud==0.3
+micloud==0.4
 
 # homeassistant.components.miflora
 miflora==0.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -588,7 +588,7 @@ meteofrance-api==1.0.2
 mficlient==0.3.0
 
 # homeassistant.components.xiaomi_miio
-micloud==0.3
+micloud==0.4
 
 # homeassistant.components.mill
 millheater==0.6.1

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -304,7 +304,7 @@ async def test_config_flow_gateway_cloud_login_error(hass):
 
     with patch(
         "homeassistant.components.xiaomi_miio.config_flow.MiCloud.login",
-        side_effect=MiCloudAccessDenied({}),
+        side_effect=MiCloudAccessDenied(),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -612,7 +612,7 @@ async def test_config_flow_step_device_manual_model_succes(hass):
 
     with patch(
         "homeassistant.components.xiaomi_miio.device.Device.info",
-        side_effect=const.AuthException({}),
+        side_effect=DeviceException({}),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -8,7 +8,6 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.xiaomi_miio import const
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
-from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from . import TEST_MAC
 
@@ -613,7 +612,7 @@ async def test_config_flow_step_device_manual_model_succes(hass):
 
     with patch(
         "homeassistant.components.xiaomi_miio.device.Device.info",
-        side_effect=ConfigEntryAuthFailed({}),
+        side_effect=const.AuthException({}),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Xiaomi Miio config flow."""
 from unittest.mock import Mock, patch
 
+from construct.core import ChecksumError
 from micloud.micloudexception import MiCloudAccessDenied
 from miio import DeviceException
 import pytest
@@ -610,9 +611,11 @@ async def test_config_flow_step_device_manual_model_succes(hass):
     assert result["step_id"] == "manual"
     assert result["errors"] == {}
 
+    error = DeviceException({})
+    error.__cause__ = ChecksumError({})
     with patch(
         "homeassistant.components.xiaomi_miio.device.Device.info",
-        side_effect=const.AuthException({}),
+        side_effect=error,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -612,7 +612,7 @@ async def test_config_flow_step_device_manual_model_succes(hass):
 
     with patch(
         "homeassistant.components.xiaomi_miio.device.Device.info",
-        side_effect=DeviceException({}),
+        side_effect=const.AuthException({}),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Xiaomi Miio config flow."""
 from unittest.mock import Mock, patch
 
+from micloud.micloudexception import MiCloudAccessDenied
 from miio import DeviceException
 import pytest
 
@@ -287,6 +288,23 @@ async def test_config_flow_gateway_cloud_login_error(hass):
     with patch(
         "homeassistant.components.xiaomi_miio.config_flow.MiCloud.login",
         return_value=False,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                const.CONF_CLOUD_USERNAME: TEST_CLOUD_USER,
+                const.CONF_CLOUD_PASSWORD: TEST_CLOUD_PASS,
+                const.CONF_CLOUD_COUNTRY: TEST_CLOUD_COUNTRY,
+            },
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "cloud"
+    assert result["errors"] == {"base": "cloud_login_error"}
+
+    with patch(
+        "homeassistant.components.xiaomi_miio.config_flow.MiCloud.login",
+        side_effect=MiCloudAccessDenied({}),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -304,7 +304,7 @@ async def test_config_flow_gateway_cloud_login_error(hass):
 
     with patch(
         "homeassistant.components.xiaomi_miio.config_flow.MiCloud.login",
-        side_effect=MiCloudAccessDenied(),
+        side_effect=MiCloudAccessDenied({}),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add retries to xiaomi cloud login before asking for new credentials.
Specifically because the login can fail on boot of the Pi, probably because the internet connection is not fully setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/54552
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
