### PR TITLE
Remove last_reset attribute from dsmr sensors

### DIFF
--- a/homeassistant/components/dsmr/const.py
+++ b/homeassistant/components/dsmr/const.py
@@ -5,7 +5,10 @@ import logging
 
 from dsmr_parser import obis_references
 
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
+from homeassistant.components.sensor import (
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+)
 from homeassistant.const import (
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_ENERGY,
@@ -13,7 +16,6 @@ from homeassistant.const import (
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_VOLTAGE,
 )
-from homeassistant.util import dt
 
 from .models import DSMRSensorEntityDescription
 
@@ -67,32 +69,28 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         name="Energy Consumption (tarif 1)",
         device_class=DEVICE_CLASS_ENERGY,
         force_update=True,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_USED_TARIFF_2,
         name="Energy Consumption (tarif 2)",
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_DELIVERED_TARIFF_1,
         name="Energy Production (tarif 1)",
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_DELIVERED_TARIFF_2,
         name="Energy Production (tarif 2)",
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE,
@@ -229,8 +227,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         dsmr_versions={"5L"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.LUXEMBOURG_ELECTRICITY_DELIVERED_TARIFF_GLOBAL,
@@ -238,8 +235,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         dsmr_versions={"5L"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.ELECTRICITY_IMPORTED_TOTAL,
@@ -247,8 +243,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         dsmr_versions={"2.2", "4", "5", "5B"},
         force_update=True,
         device_class=DEVICE_CLASS_ENERGY,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.HOURLY_GAS_METER_READING,
@@ -258,8 +253,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         icon="mdi:fire",
         device_class=DEVICE_CLASS_GAS,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.BELGIUM_HOURLY_GAS_METER_READING,
@@ -269,8 +263,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         icon="mdi:fire",
         device_class=DEVICE_CLASS_GAS,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     DSMRSensorEntityDescription(
         key=obis_references.GAS_METER_READING,
@@ -280,7 +273,6 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
         force_update=True,
         icon="mdi:fire",
         device_class=DEVICE_CLASS_GAS,
-        last_reset=dt.utc_from_timestamp(0),
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
 )

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     DOMAIN as SENSOR_DOMAIN,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -167,8 +168,10 @@ async def test_default_setup(hass, dsmr_connection_fixture):
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_GAS
     assert gas_consumption.attributes.get(ATTR_ICON) == "mdi:fire"
-    assert gas_consumption.attributes.get(ATTR_LAST_RESET) is not None
-    assert gas_consumption.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
+    assert gas_consumption.attributes.get(ATTR_LAST_RESET) is None
+    assert (
+        gas_consumption.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_TOTAL_INCREASING
+    )
     assert (
         gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == VOLUME_CUBIC_METERS
     )
@@ -267,8 +270,10 @@ async def test_v4_meter(hass, dsmr_connection_fixture):
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_GAS
     assert gas_consumption.attributes.get("unit_of_measurement") == VOLUME_CUBIC_METERS
     assert gas_consumption.attributes.get(ATTR_ICON) == "mdi:fire"
-    assert gas_consumption.attributes.get(ATTR_LAST_RESET) is not None
-    assert gas_consumption.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
+    assert gas_consumption.attributes.get(ATTR_LAST_RESET) is None
+    assert (
+        gas_consumption.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_TOTAL_INCREASING
+    )
     assert (
         gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == VOLUME_CUBIC_METERS
     )
@@ -337,8 +342,10 @@ async def test_v5_meter(hass, dsmr_connection_fixture):
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_GAS
     assert gas_consumption.attributes.get(ATTR_ICON) == "mdi:fire"
-    assert gas_consumption.attributes.get(ATTR_LAST_RESET) is not None
-    assert gas_consumption.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
+    assert gas_consumption.attributes.get(ATTR_LAST_RESET) is None
+    assert (
+        gas_consumption.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_TOTAL_INCREASING
+    )
     assert (
         gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == VOLUME_CUBIC_METERS
     )
@@ -403,8 +410,8 @@ async def test_luxembourg_meter(hass, dsmr_connection_fixture):
     assert power_tariff.state == "123.456"
     assert power_tariff.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_ENERGY
     assert power_tariff.attributes.get(ATTR_ICON) is None
-    assert power_tariff.attributes.get(ATTR_LAST_RESET) is not None
-    assert power_tariff.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
+    assert power_tariff.attributes.get(ATTR_LAST_RESET) is None
+    assert power_tariff.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_TOTAL_INCREASING
     assert (
         power_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
     )
@@ -418,8 +425,10 @@ async def test_luxembourg_meter(hass, dsmr_connection_fixture):
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_GAS
     assert gas_consumption.attributes.get(ATTR_ICON) == "mdi:fire"
-    assert gas_consumption.attributes.get(ATTR_LAST_RESET) is not None
-    assert gas_consumption.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
+    assert gas_consumption.attributes.get(ATTR_LAST_RESET) is None
+    assert (
+        gas_consumption.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_TOTAL_INCREASING
+    )
     assert (
         gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == VOLUME_CUBIC_METERS
     )
@@ -488,8 +497,10 @@ async def test_belgian_meter(hass, dsmr_connection_fixture):
     assert gas_consumption.state == "745.695"
     assert gas_consumption.attributes.get(ATTR_DEVICE_CLASS) is DEVICE_CLASS_GAS
     assert gas_consumption.attributes.get(ATTR_ICON) == "mdi:fire"
-    assert gas_consumption.attributes.get(ATTR_LAST_RESET) is not None
-    assert gas_consumption.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
+    assert gas_consumption.attributes.get(ATTR_LAST_RESET) is None
+    assert (
+        gas_consumption.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_TOTAL_INCREASING
+    )
     assert (
         gas_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == VOLUME_CUBIC_METERS
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove last_reset attribute from `DSMREntity` and set device class to `STATE_CLASS_TOTAL_INCREASING`

There are two options for sensors representing meters such as energy meters, where the sensor itself doesn't have a `last_reset` available:
- `STATE_CLASS_TOTAL_INCREASING`
 With STATE_CLASS_TOTAL_INCREASING, a new meter cycle will be detected if the value of the sensor's value decreases. This should be correct if the sensor only counts used (or delivered) energy, but not both in a single sensor, i.e. the sensor's value can't be decreased. Things will then work as expected if the sensor is for some reason reset to 0, for example after a firmware upgrade or factory reset.
- `STATE_CLASS_TOTAL`
 With STATE_CLASS_TOTAL, a new meter cycle will never be detected, and the statistics won't be correct if the sensor is reset.

This PR sets the device class to `STATE_CLASS_TOTAL_INCREASING`

Background in #54523

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
