### PR TITLE
Relax zwave_js lock discovery rules to cover more use cases

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -359,24 +359,11 @@ DISCOVERY_SCHEMAS = [
     get_config_parameter_discovery_schema(
         property_name={"Door lock mode"},
         device_class_generic={"Entry Control"},
-        device_class_specific={
-            "Door Lock",
-            "Advanced Door Lock",
-            "Secure Keypad Door Lock",
-            "Secure Lockbox",
-        },
     ),
     # ====== START OF GENERIC MAPPING SCHEMAS =======
     # locks
     ZWaveDiscoverySchema(
         platform="lock",
-        device_class_generic={"Entry Control"},
-        device_class_specific={
-            "Door Lock",
-            "Advanced Door Lock",
-            "Secure Keypad Door Lock",
-            "Secure Lockbox",
-        },
         primary_value=ZWaveValueDiscoverySchema(
             command_class={
                 CommandClass.LOCK,
@@ -390,13 +377,6 @@ DISCOVERY_SCHEMAS = [
     ZWaveDiscoverySchema(
         platform="binary_sensor",
         hint="property",
-        device_class_generic={"Entry Control"},
-        device_class_specific={
-            "Door Lock",
-            "Advanced Door Lock",
-            "Secure Keypad Door Lock",
-            "Secure Lockbox",
-        },
         primary_value=ZWaveValueDiscoverySchema(
             command_class={
                 CommandClass.LOCK,

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -452,6 +452,14 @@ def aeotec_zw164_siren_state_fixture():
     return json.loads(load_fixture("zwave_js/aeotec_zw164_siren_state.json"))
 
 
+@pytest.fixture(name="lock_popp_electric_strike_lock_control_state", scope="session")
+def lock_popp_electric_strike_lock_control_state_fixture():
+    """Load the popp electric strike lock control node state fixture data."""
+    return json.loads(
+        load_fixture("zwave_js/lock_popp_electric_strike_lock_control_state.json")
+    )
+
+
 @pytest.fixture(name="client")
 def mock_client_fixture(controller_state, version_state, log_config_state):
     """Mock a client."""
@@ -830,8 +838,18 @@ def ge_in_wall_dimmer_switch_fixture(client, ge_in_wall_dimmer_switch_state):
 
 @pytest.fixture(name="aeotec_zw164_siren")
 def aeotec_zw164_siren_fixture(client, aeotec_zw164_siren_state):
-    """Mock a wallmote central scene node."""
+    """Mock a aeotec zw164 siren node."""
     node = Node(client, copy.deepcopy(aeotec_zw164_siren_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="lock_popp_electric_strike_lock_control")
+def lock_popp_electric_strike_lock_control_fixture(
+    client, lock_popp_electric_strike_lock_control_state
+):
+    """Mock a popp electric strike lock control node."""
+    node = Node(client, copy.deepcopy(lock_popp_electric_strike_lock_control_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -57,6 +57,17 @@ async def test_vision_security_zl7432(
         assert state.attributes["assumed_state"]
 
 
+async def test_lock_popp_electric_strike_lock_control(
+    hass, client, lock_popp_electric_strike_lock_control, integration
+):
+    """Test that the Popp Electric Strike Lock Control gets discovered correctly."""
+    assert hass.states.get("lock.node_62") is not None
+    assert (
+        hass.states.get("binary_sensor.node_62_the_current_status_of_the_door")
+        is not None
+    )
+
+
 async def test_firmware_version_range_exception(hass):
     """Test FirmwareVersionRange exception."""
     with pytest.raises(ValueError):

--- a/tests/fixtures/zwave_js/lock_popp_electric_strike_lock_control_state.json
+++ b/tests/fixtures/zwave_js/lock_popp_electric_strike_lock_control_state.json
@@ -1,0 +1,568 @@
+{
+	"nodeId": 62,
+	"index": 0,
+	"installerIcon": 768,
+	"userIcon": 768,
+	"status": 4,
+	"ready": true,
+	"isListening": false,
+	"isRouting": true,
+	"isSecure": true,
+	"manufacturerId": 340,
+	"productId": 1,
+	"productType": 5,
+	"firmwareVersion": "1.3",
+	"zwavePlusVersion": 1,
+	"interviewAttempts": 0,
+	"endpoints": [
+		{
+			"nodeId": 62,
+			"index": 0,
+			"installerIcon": 768,
+			"userIcon": 768,
+			"deviceClass": {
+				"basic": {
+					"key": 4,
+					"label": "Routing Slave"
+				},
+				"generic": {
+					"key": 64,
+					"label": "Entry Control"
+				},
+				"specific": {
+					"key": 10,
+					"label": "Lockbox"
+				},
+				"mandatorySupportedCCs": [113, 133, 98, 114, 152, 134],
+				"mandatoryControlledCCs": []
+			}
+		}
+	],
+	"values": [
+		{
+			"endpoint": 0,
+			"commandClass": 48,
+			"commandClassName": "Binary Sensor",
+			"property": "Door/Window",
+			"propertyName": "Door/Window",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Door/Window",
+				"ccSpecific": {
+					"sensorType": 10
+				}
+			},
+			"value": false
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "currentMode",
+			"propertyName": "currentMode",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Current lock mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Unsecured",
+					"1": "UnsecuredWithTimeout",
+					"16": "InsideUnsecured",
+					"17": "InsideUnsecuredWithTimeout",
+					"32": "OutsideUnsecured",
+					"33": "OutsideUnsecuredWithTimeout",
+					"254": "Unknown",
+					"255": "Secured"
+				}
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "targetMode",
+			"propertyName": "targetMode",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Target lock mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Unsecured",
+					"1": "UnsecuredWithTimeout",
+					"16": "InsideUnsecured",
+					"17": "InsideUnsecuredWithTimeout",
+					"32": "OutsideUnsecured",
+					"33": "OutsideUnsecuredWithTimeout",
+					"254": "Unknown",
+					"255": "Secured"
+				}
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "outsideHandlesCanOpenDoor",
+			"propertyName": "outsideHandlesCanOpenDoor",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Which outside handles can open the door (actual status)"
+			},
+			"value": [false, false, false, false]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "insideHandlesCanOpenDoor",
+			"propertyName": "insideHandlesCanOpenDoor",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Which inside handles can open the door (actual status)"
+			},
+			"value": [false, false, false, false]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "latchStatus",
+			"propertyName": "latchStatus",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "The current status of the latch"
+			},
+			"value": "closed"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "boltStatus",
+			"propertyName": "boltStatus",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "The current status of the bolt"
+			},
+			"value": "unlocked"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "doorStatus",
+			"propertyName": "doorStatus",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "The current status of the door"
+			},
+			"value": "closed"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "lockTimeout",
+			"propertyName": "lockTimeout",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Seconds until lock mode times out"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "operationType",
+			"propertyName": "operationType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Lock operation type",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"1": "Constant",
+					"2": "Timed"
+				}
+			},
+			"value": 2
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "outsideHandlesCanOpenDoorConfiguration",
+			"propertyName": "outsideHandlesCanOpenDoorConfiguration",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true,
+				"label": "Which outside handles can open the door (configuration)"
+			},
+			"value": [false, false, false, false]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "insideHandlesCanOpenDoorConfiguration",
+			"propertyName": "insideHandlesCanOpenDoorConfiguration",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true,
+				"label": "Which inside handles can open the door (configuration)"
+			},
+			"value": [false, false, false, false]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "lockTimeoutConfiguration",
+			"propertyName": "lockTimeoutConfiguration",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Duration of timed mode in seconds",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 113,
+			"commandClassName": "Notification",
+			"property": "Access Control",
+			"propertyKey": "Door state",
+			"propertyName": "Access Control",
+			"propertyKeyName": "Door state",
+			"ccVersion": 5,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Door state",
+				"ccSpecific": {
+					"notificationType": 6
+				},
+				"min": 0,
+				"max": 255,
+				"states": {
+					"22": "Window/door is open",
+					"23": "Window/door is closed"
+				}
+			},
+			"value": 23
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 340
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 5
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 128,
+			"commandClassName": "Battery",
+			"property": "level",
+			"propertyName": "level",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Battery level",
+				"min": 0,
+				"max": 100,
+				"unit": "%"
+			},
+			"value": 100
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 128,
+			"commandClassName": "Battery",
+			"property": "isLow",
+			"propertyName": "isLow",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Low battery level"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type",
+				"states": {
+					"0": "Unknown",
+					"1": "Static Controller",
+					"2": "Controller",
+					"3": "Enhanced Slave",
+					"4": "Slave",
+					"5": "Installer",
+					"6": "Routing Slave",
+					"7": "Bridge Controller",
+					"8": "Device under Test",
+					"9": "N/A",
+					"10": "AV Remote",
+					"11": "AV Device"
+				}
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			},
+			"value": "4.5"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "string[]",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			},
+			"value": ["1.3"]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "hardwareVersion",
+			"propertyName": "hardwareVersion",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip hardware version"
+			},
+			"value": 1
+		}
+	],
+	"isFrequentListening": "1000ms",
+	"maxDataRate": 100000,
+	"supportedDataRates": [40000, 100000],
+	"protocolVersion": 3,
+	"supportsBeaming": true,
+	"supportsSecurity": false,
+	"nodeType": 1,
+	"zwavePlusNodeType": 0,
+	"zwavePlusRoleType": 7,
+	"deviceClass": {
+		"basic": {
+			"key": 4,
+			"label": "Routing Slave"
+		},
+		"generic": {
+			"key": 64,
+			"label": "Entry Control"
+		},
+		"specific": {
+			"key": 10,
+			"label": "Lockbox"
+		},
+		"mandatorySupportedCCs": [113, 133, 98, 114, 152, 134],
+		"mandatoryControlledCCs": []
+	},
+	"commandClasses": [
+		{
+			"id": 48,
+			"name": "Binary Sensor",
+			"version": 2,
+			"isSecure": true
+		},
+		{
+			"id": 89,
+			"name": "Association Group Information",
+			"version": 1,
+			"isSecure": true
+		},
+		{
+			"id": 90,
+			"name": "Device Reset Locally",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 94,
+			"name": "Z-Wave Plus Info",
+			"version": 2,
+			"isSecure": true
+		},
+		{
+			"id": 98,
+			"name": "Door Lock",
+			"version": 2,
+			"isSecure": true
+		},
+		{
+			"id": 112,
+			"name": "Configuration",
+			"version": 1,
+			"isSecure": true
+		},
+		{
+			"id": 113,
+			"name": "Notification",
+			"version": 5,
+			"isSecure": true
+		},
+		{
+			"id": 114,
+			"name": "Manufacturer Specific",
+			"version": 2,
+			"isSecure": true
+		},
+		{
+			"id": 122,
+			"name": "Firmware Update Meta Data",
+			"version": 3,
+			"isSecure": false
+		},
+		{
+			"id": 128,
+			"name": "Battery",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 133,
+			"name": "Association",
+			"version": 2,
+			"isSecure": true
+		},
+		{
+			"id": 134,
+			"name": "Version",
+			"version": 2,
+			"isSecure": true
+		},
+		{
+			"id": 152,
+			"name": "Security",
+			"version": 1,
+			"isSecure": true
+		}
+	],
+	"interviewStage": "Complete",
+	"deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0154:0x0005:0x0001:1.3",
+	"statistics": {
+		"commandsTX": 1,
+		"commandsRX": 0,
+		"commandsDroppedRX": 0,
+		"commandsDroppedTX": 0,
+		"timeoutResponse": 0
+	}
+}


### PR DESCRIPTION
## Proposed change
In https://github.com/zwave-js/node-zwave-js/issues/3194 we discovered that our device class rules for locks were too specific to cover this particular device. Given that the lock values are only dependent on the Door Lock/Lock CC's being present, here we remove the device class rules entirely (except for the config parameter, who's rule we relax to only have generic device class)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/node-zwave-js/issues/3194
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
