### PR TITLE
Add zwave_js Protection CC select entities

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -675,6 +675,7 @@ DISCOVERY_SCHEMAS = [
             property={"local", "rf"},
             type={"number"},
         ),
+        entity_registry_enabled_default=False,
     ),
 ]
 

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -675,7 +675,6 @@ DISCOVERY_SCHEMAS = [
             property={"local", "rf"},
             type={"number"},
         ),
-        entity_registry_enabled_default=False,
     ),
 ]
 

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -666,6 +666,16 @@ DISCOVERY_SCHEMAS = [
         ),
         required_values=[SIREN_TONE_SCHEMA],
     ),
+    # select
+    # protection CC
+    ZWaveDiscoverySchema(
+        platform="select",
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.PROTECTION},
+            property={"local", "rf"},
+            type={"number"},
+        ),
+    ),
 ]
 
 

--- a/homeassistant/components/zwave_js/select.py
+++ b/homeassistant/components/zwave_js/select.py
@@ -29,6 +29,8 @@ async def async_setup_entry(
         entities: list[ZWaveBaseEntity] = []
         if info.platform_hint == "Default tone":
             entities.append(ZwaveDefaultToneSelectEntity(config_entry, client, info))
+        else:
+            entities.append(ZwaveSelectEntity(config_entry, client, info))
         async_add_entities(entities)
 
     config_entry.async_on_unload(
@@ -38,6 +40,42 @@ async def async_setup_entry(
             async_add_select,
         )
     )
+
+
+class ZwaveSelectEntity(ZWaveBaseEntity, SelectEntity):
+    """Representation of a Z-Wave select entity."""
+
+    def __init__(
+        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+    ) -> None:
+        """Initialize a ZwaveSelectEntity entity."""
+        super().__init__(config_entry, client, info)
+
+        # Entity class attributes
+        self._attr_name = self.generate_name(include_value_name=True)
+
+    @property
+    def options(self) -> list[str]:
+        """Return a set of selectable options."""
+        return list(self.info.primary_value.metadata.states.values())
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        return str(
+            self.info.primary_value.metadata.states.get(
+                str(self.info.primary_value.value), self.info.primary_value.value
+            )
+        )
+
+    async def async_select_option(self, option: str | int) -> None:
+        """Change the selected option."""
+        key = next(
+            key
+            for key, val in self.info.primary_value.metadata.states.items()
+            if val == option
+        )
+        await self.info.node.async_set_value(self.info.primary_value, int(key))
 
 
 class ZwaveDefaultToneSelectEntity(ZWaveBaseEntity, SelectEntity):

--- a/homeassistant/components/zwave_js/select.py
+++ b/homeassistant/components/zwave_js/select.py
@@ -53,11 +53,7 @@ class ZwaveSelectEntity(ZWaveBaseEntity, SelectEntity):
 
         # Entity class attributes
         self._attr_name = self.generate_name(include_value_name=True)
-
-    @property
-    def options(self) -> list[str]:
-        """Return a set of selectable options."""
-        return list(self.info.primary_value.metadata.states.values())
+        self._attr_options = list(self.info.primary_value.metadata.states.values())
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/zwave_js/select.py
+++ b/homeassistant/components/zwave_js/select.py
@@ -58,6 +58,8 @@ class ZwaveSelectEntity(ZWaveBaseEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
+        if self.info.primary_value.value is None:
+            return None
         return str(
             self.info.primary_value.metadata.states.get(
                 str(self.info.primary_value.value), self.info.primary_value.value

--- a/tests/components/zwave_js/test_select.py
+++ b/tests/components/zwave_js/test_select.py
@@ -1,6 +1,8 @@
 """Test the Z-Wave JS number platform."""
 from zwave_js_server.event import Event
 
+from homeassistant.helpers import entity_registry as er
+
 DEFAULT_TONE_SELECT_ENTITY = "select.indoor_siren_6_default_tone_2"
 PROTECTION_SELECT_ENTITY = "select.family_room_combo_local_protection_state"
 
@@ -105,6 +107,21 @@ async def test_default_tone_select(hass, client, aeotec_zw164_siren, integration
 async def test_protection_select(hass, client, inovelli_lzw36, integration):
     """Test the default tone select entity."""
     node = inovelli_lzw36
+
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(PROTECTION_SELECT_ENTITY)
+
+    # Entity should be disabled by default
+    assert entity_entry
+    assert entity_entry.disabled
+    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
+
+    # Enable entity
+    ent_reg.async_update_entity(PROTECTION_SELECT_ENTITY, disabled_by=None)
+
+    await hass.config_entries.async_reload(integration.entry_id)
+    await hass.async_block_till_done()
+
     state = hass.states.get(PROTECTION_SELECT_ENTITY)
 
     assert state

--- a/tests/components/zwave_js/test_select.py
+++ b/tests/components/zwave_js/test_select.py
@@ -1,8 +1,6 @@
 """Test the Z-Wave JS number platform."""
 from zwave_js_server.event import Event
 
-from homeassistant.helpers import entity_registry as er
-
 DEFAULT_TONE_SELECT_ENTITY = "select.indoor_siren_6_default_tone_2"
 PROTECTION_SELECT_ENTITY = "select.family_room_combo_local_protection_state"
 
@@ -107,21 +105,6 @@ async def test_default_tone_select(hass, client, aeotec_zw164_siren, integration
 async def test_protection_select(hass, client, inovelli_lzw36, integration):
     """Test the default tone select entity."""
     node = inovelli_lzw36
-
-    ent_reg = er.async_get(hass)
-    entity_entry = ent_reg.async_get(PROTECTION_SELECT_ENTITY)
-
-    # Entity should be disabled by default
-    assert entity_entry
-    assert entity_entry.disabled
-    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
-
-    # Enable entity
-    ent_reg.async_update_entity(PROTECTION_SELECT_ENTITY, disabled_by=None)
-
-    await hass.config_entries.async_reload(integration.entry_id)
-    await hass.async_block_till_done()
-
     state = hass.states.get(PROTECTION_SELECT_ENTITY)
 
     assert state

--- a/tests/components/zwave_js/test_select.py
+++ b/tests/components/zwave_js/test_select.py
@@ -1,6 +1,8 @@
 """Test the Z-Wave JS number platform."""
 from zwave_js_server.event import Event
 
+from homeassistant.const import STATE_UNKNOWN
+
 DEFAULT_TONE_SELECT_ENTITY = "select.indoor_siren_6_default_tone_2"
 PROTECTION_SELECT_ENTITY = "select.family_room_combo_local_protection_state"
 
@@ -174,3 +176,26 @@ async def test_protection_select(hass, client, inovelli_lzw36, integration):
 
     state = hass.states.get(PROTECTION_SELECT_ENTITY)
     assert state.state == "ProtectedBySequence"
+
+    # Test null value
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Protection",
+                "commandClass": 117,
+                "endpoint": 0,
+                "property": "local",
+                "newValue": None,
+                "prevValue": 1,
+                "propertyName": "local",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(PROTECTION_SELECT_ENTITY)
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/zwave_js/test_select.py
+++ b/tests/components/zwave_js/test_select.py
@@ -2,6 +2,7 @@
 from zwave_js_server.event import Event
 
 DEFAULT_TONE_SELECT_ENTITY = "select.indoor_siren_6_default_tone_2"
+PROTECTION_SELECT_ENTITY = "select.family_room_combo_local_protection_state"
 
 
 async def test_default_tone_select(hass, client, aeotec_zw164_siren, integration):
@@ -99,3 +100,77 @@ async def test_default_tone_select(hass, client, aeotec_zw164_siren, integration
 
     state = hass.states.get(DEFAULT_TONE_SELECT_ENTITY)
     assert state.state == "30DOOR~1 (27 sec)"
+
+
+async def test_protection_select(hass, client, inovelli_lzw36, integration):
+    """Test the default tone select entity."""
+    node = inovelli_lzw36
+    state = hass.states.get(PROTECTION_SELECT_ENTITY)
+
+    assert state
+    assert state.state == "Unprotected"
+    attr = state.attributes
+    assert attr["options"] == [
+        "Unprotected",
+        "ProtectedBySequence",
+        "NoOperationPossible",
+    ]
+
+    # Test select option with string value
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": PROTECTION_SELECT_ENTITY, "option": "ProtectedBySequence"},
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == node.node_id
+    assert args["valueId"] == {
+        "endpoint": 0,
+        "commandClass": 117,
+        "commandClassName": "Protection",
+        "property": "local",
+        "propertyName": "local",
+        "ccVersion": 2,
+        "metadata": {
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "label": "Local protection state",
+            "states": {
+                "0": "Unprotected",
+                "1": "ProtectedBySequence",
+                "2": "NoOperationPossible",
+            },
+        },
+        "value": 0,
+    }
+    assert args["value"] == 1
+
+    client.async_send_command.reset_mock()
+
+    # Test value update from value updated event
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Protection",
+                "commandClass": 117,
+                "endpoint": 0,
+                "property": "local",
+                "newValue": 1,
+                "prevValue": 0,
+                "propertyName": "local",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(PROTECTION_SELECT_ENTITY)
+    assert state.state == "ProtectedBySequence"


### PR DESCRIPTION
## Proposed change
Adds new `select` entities for the Protection Command Class. This has been requested before as a controllable command class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
