### PR TITLE
Improve myq error handling for opening/closing cover

### DIFF
--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -99,8 +99,6 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
         try:
             wait_task = await self._device.close(wait_for_state=False)
         except MyQError as err:
-            # Write current state which would be Open to HASS
-            self.async_write_ha_state()
             raise HomeAssistantError(
                 f"Closing of cover {self._device.name} failed with error: {err}"
             ) from err
@@ -124,8 +122,6 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
         try:
             wait_task = await self._device.open(wait_for_state=False)
         except MyQError as err:
-            # Write current state which would be closed to HASS
-            self.async_write_ha_state()
             raise HomeAssistantError(
                 f"Opening of cover {self._device.name} failed with error: {err}"
             ) from err

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -44,10 +44,7 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
         """Initialize with API object, device id."""
         super().__init__(coordinator)
         self._device = device
-        if (
-            device.device_type is not None
-            and device.device_type == MYQ_DEVICE_TYPE_GATE
-        ):
+        if device.device_type == MYQ_DEVICE_TYPE_GATE:
             self._attr_device_class = DEVICE_CLASS_GATE
         else:
             self._attr_device_class = DEVICE_CLASS_GARAGE

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -18,6 +18,7 @@ from homeassistant.components.cover import (
     CoverEntity,
 )
 from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MYQ_COORDINATOR, MYQ_GATEWAY, MYQ_TO_HASS
@@ -43,14 +44,13 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
         """Initialize with API object, device id."""
         super().__init__(coordinator)
         self._device = device
-
-    @property
-    def device_class(self):
-        """Define this cover as a garage door."""
-        device_type = self._device.device_type
-        if device_type is not None and device_type == MYQ_DEVICE_TYPE_GATE:
-            return DEVICE_CLASS_GATE
-        return DEVICE_CLASS_GARAGE
+        self._attr_device_class = (
+            DEVICE_CLASS_GATE
+            if device.device_type is not None
+            and device.device_type == MYQ_DEVICE_TYPE_GATE
+            else DEVICE_CLASS_GARAGE
+        )
+        self._attr_unique_id = device.device_id
 
     @property
     def name(self):
@@ -60,11 +60,8 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
     @property
     def available(self):
         """Return if the device is online."""
-        if not self.coordinator.last_update_success:
-            return False
-
         # Not all devices report online so assume True if its missing
-        return self._device.device_json[MYQ_DEVICE_STATE].get(
+        return super().available and self._device.device_json[MYQ_DEVICE_STATE].get(
             MYQ_DEVICE_STATE_ONLINE, True
         )
 
@@ -93,11 +90,6 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
         """Flag supported features."""
         return SUPPORT_OPEN | SUPPORT_CLOSE
 
-    @property
-    def unique_id(self):
-        """Return a unique, Home Assistant friendly identifier for this entity."""
-        return self._device.device_id
-
     async def async_close_cover(self, **kwargs):
         """Issue close command to cover."""
         if self.is_closing or self.is_closed:
@@ -106,22 +98,22 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
         try:
             wait_task = await self._device.close(wait_for_state=False)
         except MyQError as err:
-            _LOGGER.error(
-                "Closing of cover %s failed with error: %s", self._device.name, str(err)
-            )
-
-            return
+            # Write current state which would be Open to HASS
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                f"Closing of cover {self._device.name} failed with error: {err}"
+            ) from err
 
         # Write closing state to HASS
         self.async_write_ha_state()
 
         result = wait_task if isinstance(wait_task, bool) else await wait_task
 
-        if not result:
-            _LOGGER.error("Closing of cover %s failed", self._device.name)
-
         # Write final state to HASS
         self.async_write_ha_state()
+
+        if not result:
+            raise HomeAssistantError(f"Closing of cover {self._device.name} failed")
 
     async def async_open_cover(self, **kwargs):
         """Issue open command to cover."""
@@ -131,21 +123,22 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
         try:
             wait_task = await self._device.open(wait_for_state=False)
         except MyQError as err:
-            _LOGGER.error(
-                "Opening of cover %s failed with error: %s", self._device.name, str(err)
-            )
-            return
+            # Write current state which would be closed to HASS
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                f"Opening of cover {self._device.name} failed with error: {err}"
+            ) from err
 
         # Write opening state to HASS
         self.async_write_ha_state()
 
         result = wait_task if isinstance(wait_task, bool) else await wait_task
 
-        if not result:
-            _LOGGER.error("Opening of cover %s failed", self._device.name)
-
         # Write final state to HASS
         self.async_write_ha_state()
+
+        if not result:
+            raise HomeAssistantError(f"Opening of cover {self._device.name} failed")
 
     @property
     def device_info(self):

--- a/homeassistant/components/myq/cover.py
+++ b/homeassistant/components/myq/cover.py
@@ -44,12 +44,13 @@ class MyQDevice(CoordinatorEntity, CoverEntity):
         """Initialize with API object, device id."""
         super().__init__(coordinator)
         self._device = device
-        self._attr_device_class = (
-            DEVICE_CLASS_GATE
-            if device.device_type is not None
+        if (
+            device.device_type is not None
             and device.device_type == MYQ_DEVICE_TYPE_GATE
-            else DEVICE_CLASS_GARAGE
-        )
+        ):
+            self._attr_device_class = DEVICE_CLASS_GATE
+        else:
+            self._attr_device_class = DEVICE_CLASS_GARAGE
         self._attr_unique_id = device.device_id
 
     @property

--- a/homeassistant/components/myq/light.py
+++ b/homeassistant/components/myq/light.py
@@ -90,7 +90,7 @@ class MyQLight(CoordinatorEntity, LightEntity):
                 f"Turning light {self._device.name} off failed with error: {err}"
             ) from err
 
-        # Write opening state to HASS
+        # Write new state to HASS
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Raise HomeAssistantError exception upon failure of opening/closing cover instead of just logging error.
Ensure latest state is written upon failure instead of leaving state as is which would be wrong.
Setting some items as self._attr as they are fixed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
