### PR TITLE
Use new device classes in GIOS integration

### DIFF
--- a/homeassistant/components/gios/const.py
+++ b/homeassistant/components/gios/const.py
@@ -5,7 +5,16 @@ from datetime import timedelta
 from typing import Final
 
 from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
-from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    DEVICE_CLASS_AQI,
+    DEVICE_CLASS_CO,
+    DEVICE_CLASS_NITROGEN_DIOXIDE,
+    DEVICE_CLASS_OZONE,
+    DEVICE_CLASS_PM10,
+    DEVICE_CLASS_PM25,
+    DEVICE_CLASS_SULPHUR_DIOXIDE,
+)
 
 from .model import GiosSensorEntityDescription
 
@@ -36,47 +45,55 @@ SENSOR_TYPES: Final[tuple[GiosSensorEntityDescription, ...]] = (
     GiosSensorEntityDescription(
         key=ATTR_AQI,
         name="AQI",
+        device_class=DEVICE_CLASS_AQI,
         value=None,
     ),
     GiosSensorEntityDescription(
         key=ATTR_C6H6,
         name="C6H6",
+        icon="mdi:molecule",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     GiosSensorEntityDescription(
         key=ATTR_CO,
         name="CO",
+        device_class=DEVICE_CLASS_CO,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     GiosSensorEntityDescription(
         key=ATTR_NO2,
         name="NO2",
+        device_class=DEVICE_CLASS_NITROGEN_DIOXIDE,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     GiosSensorEntityDescription(
         key=ATTR_O3,
         name="O3",
+        device_class=DEVICE_CLASS_OZONE,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     GiosSensorEntityDescription(
         key=ATTR_PM10,
         name="PM10",
+        device_class=DEVICE_CLASS_PM10,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     GiosSensorEntityDescription(
         key=ATTR_PM25,
         name="PM2.5",
+        device_class=DEVICE_CLASS_PM25,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     GiosSensorEntityDescription(
         key=ATTR_SO2,
         name="SO2",
+        device_class=DEVICE_CLASS_SULPHUR_DIOXIDE,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=STATE_CLASS_MEASUREMENT,
     ),

--- a/homeassistant/components/gios/sensor.py
+++ b/homeassistant/components/gios/sensor.py
@@ -86,7 +86,6 @@ class GiosSensor(CoordinatorEntity, SensorEntity):
             "manufacturer": MANUFACTURER,
             "entry_type": "service",
         }
-        self._attr_icon = "mdi:blur"
         self._attr_name = f"{name} {description.name}"
         self._attr_unique_id = f"{coordinator.gios.station_id}-{description.key}"
         self._attrs: dict[str, Any] = {

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -18,9 +18,17 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
+    ATTR_DEVICE_CLASS,
     ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    DEVICE_CLASS_AQI,
+    DEVICE_CLASS_CO,
+    DEVICE_CLASS_NITROGEN_DIOXIDE,
+    DEVICE_CLASS_OZONE,
+    DEVICE_CLASS_PM10,
+    DEVICE_CLASS_PM25,
+    DEVICE_CLASS_SULPHUR_DIOXIDE,
     STATE_UNAVAILABLE,
 )
 from homeassistant.helpers import entity_registry as er
@@ -45,7 +53,7 @@ async def test_sensor(hass):
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
+    assert state.attributes.get(ATTR_ICON) == "mdi:molecule"
     assert state.attributes.get(ATTR_INDEX) == "bardzo dobry"
 
     entry = registry.async_get("sensor.home_c6h6")
@@ -57,12 +65,12 @@ async def test_sensor(hass):
     assert state.state == "252"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATION) == "Test Name 1"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_CO
     assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) == "dobry"
 
     entry = registry.async_get("sensor.home_co")
@@ -74,12 +82,12 @@ async def test_sensor(hass):
     assert state.state == "7"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATION) == "Test Name 1"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_NITROGEN_DIOXIDE
     assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) == "dobry"
 
     entry = registry.async_get("sensor.home_no2")
@@ -91,12 +99,12 @@ async def test_sensor(hass):
     assert state.state == "96"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATION) == "Test Name 1"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_OZONE
     assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) == "dobry"
 
     entry = registry.async_get("sensor.home_o3")
@@ -108,12 +116,12 @@ async def test_sensor(hass):
     assert state.state == "17"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATION) == "Test Name 1"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_PM10
     assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) == "dobry"
 
     entry = registry.async_get("sensor.home_pm10")
@@ -125,12 +133,12 @@ async def test_sensor(hass):
     assert state.state == "4"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATION) == "Test Name 1"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_PM25
     assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) == "dobry"
 
     entry = registry.async_get("sensor.home_pm2_5")
@@ -142,12 +150,12 @@ async def test_sensor(hass):
     assert state.state == "4"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATION) == "Test Name 1"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_SULPHUR_DIOXIDE
     assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) == "bardzo dobry"
 
     entry = registry.async_get("sensor.home_so2")
@@ -161,7 +169,7 @@ async def test_sensor(hass):
     assert state.attributes.get(ATTR_STATION) == "Test Name 1"
     assert state.attributes.get(ATTR_STATE_CLASS) is None
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_AQI
 
     entry = registry.async_get("sensor.home_aqi")
     assert entry
@@ -225,7 +233,7 @@ async def test_invalid_indexes(hass):
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
+    assert state.attributes.get(ATTR_ICON) == "mdi:molecule"
     assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_c6h6")
@@ -242,7 +250,6 @@ async def test_invalid_indexes(hass):
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_co")
@@ -259,7 +266,6 @@ async def test_invalid_indexes(hass):
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_no2")
@@ -276,7 +282,6 @@ async def test_invalid_indexes(hass):
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_o3")
@@ -293,7 +298,6 @@ async def test_invalid_indexes(hass):
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_pm10")
@@ -310,7 +314,6 @@ async def test_invalid_indexes(hass):
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_pm2_5")
@@ -327,7 +330,6 @@ async def test_invalid_indexes(hass):
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
     )
-    assert state.attributes.get(ATTR_ICON) == "mdi:blur"
     assert state.attributes.get(ATTR_INDEX) is None
 
     entry = registry.async_get("sensor.home_so2")

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -167,9 +167,9 @@ async def test_sensor(hass):
     assert state.state == "dobry"
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_STATION) == "Test Name 1"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_AQI
     assert state.attributes.get(ATTR_STATE_CLASS) is None
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
-    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_AQI
 
     entry = registry.async_get("sensor.home_aqi")
     assert entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates `gios` integration to use `DEVICE_CLASS_AQI`, `DEVICE_CLASS_PM10`, `DEVICE_CLASS_PM25`, `DEVICE_CLASS_CO`, `DEVICE_CLASS_NITROGEN_DIOXIDE`, `DEVICE_CLASS_OZONE` and `DEVICE_CLASS_SULPHUR_DIOXIDE`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
