### PR TITLE
Remove MQTT Fan legacy speeds

### DIFF
--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -10,6 +10,10 @@ from homeassistant.components.fan import (
     ATTR_OSCILLATING,
     ATTR_PERCENTAGE,
     ATTR_PRESET_MODE,
+    SPEED_HIGH,
+    SPEED_LOW,
+    SPEED_MEDIUM,
+    SPEED_OFF,
     SUPPORT_OSCILLATE,
     SUPPORT_PRESET_MODE,
     SUPPORT_SET_SPEED,
@@ -60,6 +64,9 @@ CONF_PRESET_MODE_VALUE_TEMPLATE = "preset_mode_value_template"
 CONF_PRESET_MODE_COMMAND_TEMPLATE = "preset_mode_command_template"
 CONF_PRESET_MODES_LIST = "preset_modes"
 CONF_PAYLOAD_RESET_PRESET_MODE = "payload_reset_preset_mode"
+CONF_SPEED_STATE_TOPIC = "speed_state_topic"
+CONF_SPEED_COMMAND_TOPIC = "speed_command_topic"
+CONF_SPEED_VALUE_TEMPLATE = "speed_value_template"
 CONF_OSCILLATION_STATE_TOPIC = "oscillation_state_topic"
 CONF_OSCILLATION_COMMAND_TOPIC = "oscillation_command_topic"
 CONF_OSCILLATION_VALUE_TEMPLATE = "oscillation_value_template"
@@ -70,6 +77,7 @@ CONF_PAYLOAD_OFF_SPEED = "payload_off_speed"
 CONF_PAYLOAD_LOW_SPEED = "payload_low_speed"
 CONF_PAYLOAD_MEDIUM_SPEED = "payload_medium_speed"
 CONF_PAYLOAD_HIGH_SPEED = "payload_high_speed"
+CONF_SPEED_LIST = "speeds"
 
 DEFAULT_NAME = "MQTT Fan"
 DEFAULT_PAYLOAD_ON = "ON"
@@ -113,6 +121,16 @@ def valid_preset_mode_configuration(config):
 
 
 PLATFORM_SCHEMA = vol.All(
+    # CONF_SPEED_COMMAND_TOPIC, CONF_SPEED_LIST, CONF_SPEED_STATE_TOPIC, CONF_SPEED_VALUE_TEMPLATE and
+    # Speeds SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH SPEED_OFF,
+    # are deprecated, support will be removed with release 2021.9
+    cv.deprecated(CONF_PAYLOAD_HIGH_SPEED),
+    cv.deprecated(CONF_PAYLOAD_LOW_SPEED),
+    cv.deprecated(CONF_PAYLOAD_MEDIUM_SPEED),
+    cv.deprecated(CONF_SPEED_COMMAND_TOPIC),
+    cv.deprecated(CONF_SPEED_LIST),
+    cv.deprecated(CONF_SPEED_STATE_TOPIC),
+    cv.deprecated(CONF_SPEED_VALUE_TEMPLATE),
     mqtt.MQTT_RW_PLATFORM_SCHEMA.extend(
         {
             vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -148,6 +166,10 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(
                 CONF_PAYLOAD_RESET_PRESET_MODE, default=DEFAULT_PAYLOAD_RESET
             ): cv.string,
+            vol.Optional(CONF_PAYLOAD_HIGH_SPEED, default=SPEED_HIGH): cv.string,
+            vol.Optional(CONF_PAYLOAD_LOW_SPEED, default=SPEED_LOW): cv.string,
+            vol.Optional(CONF_PAYLOAD_MEDIUM_SPEED, default=SPEED_MEDIUM): cv.string,
+            vol.Optional(CONF_PAYLOAD_OFF_SPEED, default=SPEED_OFF): cv.string,
             vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
             vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
             vol.Optional(
@@ -156,6 +178,13 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(
                 CONF_PAYLOAD_OSCILLATION_ON, default=OSCILLATE_ON_PAYLOAD
             ): cv.string,
+            vol.Optional(CONF_SPEED_COMMAND_TOPIC): mqtt.valid_publish_topic,
+            vol.Optional(
+                CONF_SPEED_LIST,
+                default=[SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH],
+            ): cv.ensure_list,
+            vol.Optional(CONF_SPEED_STATE_TOPIC): mqtt.valid_subscribe_topic,
+            vol.Optional(CONF_SPEED_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
         }
     ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema),

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -10,16 +10,10 @@ from homeassistant.components.fan import (
     ATTR_OSCILLATING,
     ATTR_PERCENTAGE,
     ATTR_PRESET_MODE,
-    ATTR_SPEED,
-    SPEED_HIGH,
-    SPEED_LOW,
-    SPEED_MEDIUM,
-    SPEED_OFF,
     SUPPORT_OSCILLATE,
     SUPPORT_PRESET_MODE,
     SUPPORT_SET_SPEED,
     FanEntity,
-    speed_list_without_preset_modes,
 )
 from homeassistant.const import (
     CONF_NAME,
@@ -34,8 +28,6 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.percentage import (
     int_states_in_range,
-    ordered_list_item_to_percentage,
-    percentage_to_ordered_list_item,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -68,9 +60,6 @@ CONF_PRESET_MODE_VALUE_TEMPLATE = "preset_mode_value_template"
 CONF_PRESET_MODE_COMMAND_TEMPLATE = "preset_mode_command_template"
 CONF_PRESET_MODES_LIST = "preset_modes"
 CONF_PAYLOAD_RESET_PRESET_MODE = "payload_reset_preset_mode"
-CONF_SPEED_STATE_TOPIC = "speed_state_topic"
-CONF_SPEED_COMMAND_TOPIC = "speed_command_topic"
-CONF_SPEED_VALUE_TEMPLATE = "speed_value_template"
 CONF_OSCILLATION_STATE_TOPIC = "oscillation_state_topic"
 CONF_OSCILLATION_COMMAND_TOPIC = "oscillation_command_topic"
 CONF_OSCILLATION_VALUE_TEMPLATE = "oscillation_value_template"
@@ -81,7 +70,6 @@ CONF_PAYLOAD_OFF_SPEED = "payload_off_speed"
 CONF_PAYLOAD_LOW_SPEED = "payload_low_speed"
 CONF_PAYLOAD_MEDIUM_SPEED = "payload_medium_speed"
 CONF_PAYLOAD_HIGH_SPEED = "payload_high_speed"
-CONF_SPEED_LIST = "speeds"
 
 DEFAULT_NAME = "MQTT Fan"
 DEFAULT_PAYLOAD_ON = "ON"
@@ -102,21 +90,10 @@ MQTT_FAN_ATTRIBUTES_BLOCKED = frozenset(
         fan.ATTR_PERCENTAGE,
         fan.ATTR_PRESET_MODE,
         fan.ATTR_PRESET_MODES,
-        fan.ATTR_SPEED_LIST,
-        fan.ATTR_SPEED,
     }
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def valid_fan_speed_configuration(config):
-    """Validate that the fan speed configuration is valid, throws if it isn't."""
-    if config.get(CONF_SPEED_COMMAND_TOPIC) and not speed_list_without_preset_modes(
-        config.get(CONF_SPEED_LIST)
-    ):
-        raise ValueError("No valid speeds configured")
-    return config
 
 
 def valid_speed_range_configuration(config):
@@ -136,16 +113,6 @@ def valid_preset_mode_configuration(config):
 
 
 PLATFORM_SCHEMA = vol.All(
-    # CONF_SPEED_COMMAND_TOPIC, CONF_SPEED_LIST, CONF_SPEED_STATE_TOPIC, CONF_SPEED_VALUE_TEMPLATE and
-    # Speeds SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH SPEED_OFF,
-    # are deprecated, support will be removed after a quarter (2021.7)
-    cv.deprecated(CONF_PAYLOAD_HIGH_SPEED),
-    cv.deprecated(CONF_PAYLOAD_LOW_SPEED),
-    cv.deprecated(CONF_PAYLOAD_MEDIUM_SPEED),
-    cv.deprecated(CONF_SPEED_COMMAND_TOPIC),
-    cv.deprecated(CONF_SPEED_LIST),
-    cv.deprecated(CONF_SPEED_STATE_TOPIC),
-    cv.deprecated(CONF_SPEED_VALUE_TEMPLATE),
     mqtt.MQTT_RW_PLATFORM_SCHEMA.extend(
         {
             vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -181,10 +148,6 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(
                 CONF_PAYLOAD_RESET_PRESET_MODE, default=DEFAULT_PAYLOAD_RESET
             ): cv.string,
-            vol.Optional(CONF_PAYLOAD_HIGH_SPEED, default=SPEED_HIGH): cv.string,
-            vol.Optional(CONF_PAYLOAD_LOW_SPEED, default=SPEED_LOW): cv.string,
-            vol.Optional(CONF_PAYLOAD_MEDIUM_SPEED, default=SPEED_MEDIUM): cv.string,
-            vol.Optional(CONF_PAYLOAD_OFF_SPEED, default=SPEED_OFF): cv.string,
             vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
             vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
             vol.Optional(
@@ -193,17 +156,9 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(
                 CONF_PAYLOAD_OSCILLATION_ON, default=OSCILLATE_ON_PAYLOAD
             ): cv.string,
-            vol.Optional(CONF_SPEED_COMMAND_TOPIC): mqtt.valid_publish_topic,
-            vol.Optional(
-                CONF_SPEED_LIST,
-                default=[SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH],
-            ): cv.ensure_list,
-            vol.Optional(CONF_SPEED_STATE_TOPIC): mqtt.valid_subscribe_topic,
-            vol.Optional(CONF_SPEED_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_STATE_VALUE_TEMPLATE): cv.template,
         }
     ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema),
-    valid_fan_speed_configuration,
     valid_speed_range_configuration,
     valid_preset_mode_configuration,
 )
@@ -240,8 +195,6 @@ class MqttFan(MqttEntity, FanEntity):
     def __init__(self, hass, config, config_entry, discovery_data):
         """Initialize the MQTT fan."""
         self._state = False
-        # self._speed will be removed after a quarter (2021.7)
-        self._speed = None
         self._percentage = None
         self._preset_mode = None
         self._oscillation = None
@@ -255,10 +208,6 @@ class MqttFan(MqttEntity, FanEntity):
         self._optimistic_oscillation = None
         self._optimistic_percentage = None
         self._optimistic_preset_mode = None
-        self._optimistic_speed = None
-
-        self._legacy_speeds_list = []
-        self._legacy_speeds_list_no_off = []
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
@@ -282,8 +231,6 @@ class MqttFan(MqttEntity, FanEntity):
                 CONF_PERCENTAGE_COMMAND_TOPIC,
                 CONF_PRESET_MODE_STATE_TOPIC,
                 CONF_PRESET_MODE_COMMAND_TOPIC,
-                CONF_SPEED_STATE_TOPIC,
-                CONF_SPEED_COMMAND_TOPIC,
                 CONF_OSCILLATION_STATE_TOPIC,
                 CONF_OSCILLATION_COMMAND_TOPIC,
             )
@@ -292,8 +239,6 @@ class MqttFan(MqttEntity, FanEntity):
             CONF_STATE: config.get(CONF_STATE_VALUE_TEMPLATE),
             ATTR_PERCENTAGE: config.get(CONF_PERCENTAGE_VALUE_TEMPLATE),
             ATTR_PRESET_MODE: config.get(CONF_PRESET_MODE_VALUE_TEMPLATE),
-            # ATTR_SPEED is deprecated in the schema, support will be removed after a quarter (2021.7)
-            ATTR_SPEED: config.get(CONF_SPEED_VALUE_TEMPLATE),
             ATTR_OSCILLATING: config.get(CONF_OSCILLATION_VALUE_TEMPLATE),
         }
         self._command_templates = {
@@ -307,21 +252,9 @@ class MqttFan(MqttEntity, FanEntity):
             "STATE_OFF": config[CONF_PAYLOAD_OFF],
             "OSCILLATE_ON_PAYLOAD": config[CONF_PAYLOAD_OSCILLATION_ON],
             "OSCILLATE_OFF_PAYLOAD": config[CONF_PAYLOAD_OSCILLATION_OFF],
-            # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
-            "SPEED_LOW": config[CONF_PAYLOAD_LOW_SPEED],
-            "SPEED_MEDIUM": config[CONF_PAYLOAD_MEDIUM_SPEED],
-            "SPEED_HIGH": config[CONF_PAYLOAD_HIGH_SPEED],
-            "SPEED_OFF": config[CONF_PAYLOAD_OFF_SPEED],
             "PERCENTAGE_RESET": config[CONF_PAYLOAD_RESET_PERCENTAGE],
             "PRESET_MODE_RESET": config[CONF_PAYLOAD_RESET_PRESET_MODE],
         }
-        # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
-        self._feature_legacy_speeds = not self._topic[CONF_SPEED_COMMAND_TOPIC] is None
-        if self._feature_legacy_speeds:
-            self._legacy_speeds_list = config[CONF_SPEED_LIST]
-            self._legacy_speeds_list_no_off = speed_list_without_preset_modes(
-                self._legacy_speeds_list
-            )
 
         self._feature_percentage = CONF_PERCENTAGE_COMMAND_TOPIC in config
         self._feature_preset_mode = CONF_PRESET_MODE_COMMAND_TOPIC in config
@@ -330,10 +263,11 @@ class MqttFan(MqttEntity, FanEntity):
         else:
             self._preset_modes = []
 
-        if self._feature_percentage:
-            self._speed_count = min(int_states_in_range(self._speed_range), 100)
-        else:
-            self._speed_count = len(self._legacy_speeds_list_no_off) or 100
+        self._speed_count = (
+            min(int_states_in_range(self._speed_range), 100)
+            if self._feature_percentage
+            else 100
+        )
 
         optimistic = config[CONF_OPTIMISTIC]
         self._optimistic = optimistic or self._topic[CONF_STATE_TOPIC] is None
@@ -346,16 +280,13 @@ class MqttFan(MqttEntity, FanEntity):
         self._optimistic_preset_mode = (
             optimistic or self._topic[CONF_PRESET_MODE_STATE_TOPIC] is None
         )
-        self._optimistic_speed = (
-            optimistic or self._topic[CONF_SPEED_STATE_TOPIC] is None
-        )
 
         self._supported_features = 0
         self._supported_features |= (
             self._topic[CONF_OSCILLATION_COMMAND_TOPIC] is not None
             and SUPPORT_OSCILLATE
         )
-        if self._feature_percentage or self._feature_legacy_speeds:
+        if self._feature_percentage:
             self._supported_features |= SUPPORT_SET_SPEED
         if self._feature_preset_mode:
             self._supported_features |= SUPPORT_PRESET_MODE
@@ -368,7 +299,7 @@ class MqttFan(MqttEntity, FanEntity):
                     tpl.hass = self.hass
                     tpl_dict[key] = tpl.async_render_with_possible_json_value
 
-    async def _subscribe_topics(self):  # noqa: C901
+    async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
         topics = {}
 
@@ -405,7 +336,6 @@ class MqttFan(MqttEntity, FanEntity):
                 return
             if rendered_percentage_payload == self._payload["PERCENTAGE_RESET"]:
                 self._percentage = None
-                self._speed = None
                 self.async_write_ha_state()
                 return
             try:
@@ -471,51 +401,6 @@ class MqttFan(MqttEntity, FanEntity):
             }
             self._preset_mode = None
 
-        # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
-        @callback
-        @log_messages(self.hass, self.entity_id)
-        def speed_received(msg):
-            """Handle new received MQTT message for the speed."""
-            speed_payload = self._value_templates[ATTR_SPEED](msg.payload)
-            if speed_payload == self._payload["SPEED_LOW"]:
-                speed = SPEED_LOW
-            elif speed_payload == self._payload["SPEED_MEDIUM"]:
-                speed = SPEED_MEDIUM
-            elif speed_payload == self._payload["SPEED_HIGH"]:
-                speed = SPEED_HIGH
-            elif speed_payload == self._payload["SPEED_OFF"]:
-                speed = SPEED_OFF
-            else:
-                speed = None
-
-            if speed and speed in self._legacy_speeds_list:
-                self._speed = speed
-            else:
-                _LOGGER.warning(
-                    "'%s' received on topic %s. '%s' is not a valid speed",
-                    msg.payload,
-                    msg.topic,
-                    speed,
-                )
-                return
-
-            if speed in self._legacy_speeds_list_no_off:
-                self._percentage = ordered_list_item_to_percentage(
-                    self._legacy_speeds_list_no_off, speed
-                )
-            elif speed == SPEED_OFF:
-                self._percentage = 0
-
-            self.async_write_ha_state()
-
-        if self._topic[CONF_SPEED_STATE_TOPIC] is not None:
-            topics[CONF_SPEED_STATE_TOPIC] = {
-                "topic": self._topic[CONF_SPEED_STATE_TOPIC],
-                "msg_callback": speed_received,
-                "qos": self._config[CONF_QOS],
-            }
-            self._speed = SPEED_OFF
-
         @callback
         @log_messages(self.hass, self.entity_id)
         def oscillation_received(msg):
@@ -552,12 +437,6 @@ class MqttFan(MqttEntity, FanEntity):
         """Return true if device is on."""
         return self._state
 
-    # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
-    @property
-    def _implemented_speed(self) -> bool:
-        """Return true if speed has been implemented."""
-        return self._feature_legacy_speeds
-
     @property
     def percentage(self):
         """Return the current percentage."""
@@ -573,21 +452,10 @@ class MqttFan(MqttEntity, FanEntity):
         """Get the list of available preset modes."""
         return self._preset_modes
 
-    # The speed_list property is deprecated in the schema, support will be removed after a quarter (2021.7)
-    @property
-    def speed_list(self) -> list:
-        """Get the list of available speeds."""
-        return self._legacy_speeds_list_no_off
-
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
         return self._supported_features
-
-    @property
-    def speed(self):
-        """Return the current speed."""
-        return self._speed
 
     @property
     def speed_count(self) -> int:
@@ -623,9 +491,6 @@ class MqttFan(MqttEntity, FanEntity):
             await self.async_set_percentage(percentage)
         if preset_mode:
             await self.async_set_preset_mode(preset_mode)
-        # The speed attribute deprecated in the schema, support will be removed after a quarter (2021.7)
-        if speed and not percentage and not preset_mode:
-            await self.async_set_speed(speed)
         if self._optimistic:
             self._state = True
             self.async_write_ha_state()
@@ -656,26 +521,13 @@ class MqttFan(MqttEntity, FanEntity):
             percentage_to_ranged_value(self._speed_range, percentage)
         )
         mqtt_payload = self._command_templates[ATTR_PERCENTAGE](percentage_payload)
-        # Legacy are deprecated in the schema, support will be removed after a quarter (2021.7)
-        if self._feature_legacy_speeds:
-            if percentage:
-                await self.async_set_speed(
-                    percentage_to_ordered_list_item(
-                        self._legacy_speeds_list_no_off,
-                        percentage,
-                    )
-                )
-            elif SPEED_OFF in self._legacy_speeds_list:
-                await self.async_set_speed(SPEED_OFF)
-
-        if self._feature_percentage:
-            mqtt.async_publish(
-                self.hass,
-                self._topic[CONF_PERCENTAGE_COMMAND_TOPIC],
-                mqtt_payload,
-                self._config[CONF_QOS],
-                self._config[CONF_RETAIN],
-            )
+        mqtt.async_publish(
+            self.hass,
+            self._topic[CONF_PERCENTAGE_COMMAND_TOPIC],
+            mqtt_payload,
+            self._config[CONF_QOS],
+            self._config[CONF_RETAIN],
+        )
 
         if self._optimistic_percentage:
             self._percentage = percentage
@@ -703,39 +555,6 @@ class MqttFan(MqttEntity, FanEntity):
         if self._optimistic_preset_mode:
             self._preset_mode = preset_mode
             self.async_write_ha_state()
-
-    # async_set_speed is deprecated, support will be removed after a quarter (2021.7)
-    async def async_set_speed(self, speed: str) -> None:
-        """Set the speed of the fan.
-
-        This method is a coroutine.
-        """
-        speed_payload = None
-        if speed in self._legacy_speeds_list:
-            if speed == SPEED_LOW:
-                speed_payload = self._payload["SPEED_LOW"]
-            elif speed == SPEED_MEDIUM:
-                speed_payload = self._payload["SPEED_MEDIUM"]
-            elif speed == SPEED_HIGH:
-                speed_payload = self._payload["SPEED_HIGH"]
-            else:
-                speed_payload = self._payload["SPEED_OFF"]
-        else:
-            _LOGGER.warning("'%s' is not a valid speed", speed)
-            return
-
-        if speed_payload:
-            mqtt.async_publish(
-                self.hass,
-                self._topic[CONF_SPEED_COMMAND_TOPIC],
-                speed_payload,
-                self._config[CONF_QOS],
-                self._config[CONF_RETAIN],
-            )
-
-            if self._optimistic_speed and speed_payload:
-                self._speed = speed
-                self.async_write_ha_state()
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Set oscillation.

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -77,9 +77,6 @@ async def test_controlling_state_via_topic(hass, mqtt_mock, caplog):
                 "payload_on": "StAtE_On",
                 "oscillation_state_topic": "oscillation-state-topic",
                 "oscillation_command_topic": "oscillation-command-topic",
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speed_state_topic": "speed-state-topic",
-                "speed_command_topic": "speed-command-topic",
                 "payload_oscillation_off": "OsC_OfF",
                 "payload_oscillation_on": "OsC_On",
                 "percentage_state_topic": "percentage-state-topic",
@@ -96,12 +93,6 @@ async def test_controlling_state_via_topic(hass, mqtt_mock, caplog):
                 ],
                 "speed_range_min": 1,
                 "speed_range_max": 200,
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speeds": ["off", "low"],
-                "payload_off_speed": "speed_OfF",
-                "payload_low_speed": "speed_lOw",
-                "payload_medium_speed": "speed_mEdium",
-                "payload_high_speed": "speed_High",
                 "payload_reset_percentage": "rEset_percentage",
                 "payload_reset_preset_mode": "rEset_preset_mode",
             }
@@ -180,33 +171,10 @@ async def test_controlling_state_via_topic(hass, mqtt_mock, caplog):
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
 
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    assert state.attributes.get("speed") == fan.SPEED_OFF
-
-    async_fire_mqtt_message(hass, "speed-state-topic", "speed_lOw")
-    state = hass.states.get("fan.test")
-    assert state.attributes.get("speed") == fan.SPEED_LOW
-
-    async_fire_mqtt_message(hass, "speed-state-topic", "speed_mEdium")
-    assert "not a valid speed" in caplog.text
-    caplog.clear()
-
-    async_fire_mqtt_message(hass, "speed-state-topic", "speed_High")
-    assert "not a valid speed" in caplog.text
-    caplog.clear()
-
-    async_fire_mqtt_message(hass, "speed-state-topic", "speed_OfF")
-    state = hass.states.get("fan.test")
-    assert state.attributes.get("speed") == fan.SPEED_OFF
-
     async_fire_mqtt_message(hass, "percentage-state-topic", "rEset_percentage")
     state = hass.states.get("fan.test")
     assert state.attributes.get(fan.ATTR_PERCENTAGE) is None
     assert state.attributes.get(fan.ATTR_SPEED) is None
-
-    async_fire_mqtt_message(hass, "speed-state-topic", "speed_very_high")
-    assert "not a valid speed" in caplog.text
-    caplog.clear()
 
 
 async def test_controlling_state_via_topic_with_different_speed_range(
@@ -284,9 +252,6 @@ async def test_controlling_state_via_topic_no_percentage_topics(
                 "name": "test",
                 "state_topic": "state-topic",
                 "command_topic": "command-topic",
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speed_state_topic": "speed-state-topic",
-                "speed_command_topic": "speed-command-topic",
                 "preset_mode_state_topic": "preset-mode-state-topic",
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "preset_modes": [
@@ -296,8 +261,6 @@ async def test_controlling_state_via_topic_no_percentage_topics(
                     "eco",
                     "breeze",
                 ],
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speeds": ["off", "low", "medium"],
             }
         },
     )
@@ -311,22 +274,16 @@ async def test_controlling_state_via_topic_no_percentage_topics(
     state = hass.states.get("fan.test")
     assert state.attributes.get("preset_mode") == "smart"
     assert state.attributes.get(fan.ATTR_PERCENTAGE) is None
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    assert state.attributes.get("speed") == fan.SPEED_OFF
 
     async_fire_mqtt_message(hass, "preset-mode-state-topic", "auto")
     state = hass.states.get("fan.test")
     assert state.attributes.get("preset_mode") == "auto"
     assert state.attributes.get(fan.ATTR_PERCENTAGE) is None
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    assert state.attributes.get("speed") == fan.SPEED_OFF
 
     async_fire_mqtt_message(hass, "preset-mode-state-topic", "whoosh")
     state = hass.states.get("fan.test")
     assert state.attributes.get("preset_mode") == "whoosh"
     assert state.attributes.get(fan.ATTR_PERCENTAGE) is None
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    assert state.attributes.get("speed") == fan.SPEED_OFF
 
     async_fire_mqtt_message(hass, "preset-mode-state-topic", "medium")
     assert "not a valid preset mode" in caplog.text
@@ -335,25 +292,6 @@ async def test_controlling_state_via_topic_no_percentage_topics(
     async_fire_mqtt_message(hass, "preset-mode-state-topic", "low")
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
-
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    async_fire_mqtt_message(hass, "speed-state-topic", "medium")
-    state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "whoosh"
-    assert state.attributes.get(fan.ATTR_PERCENTAGE) == 100
-    assert state.attributes.get("speed") == fan.SPEED_MEDIUM
-
-    async_fire_mqtt_message(hass, "speed-state-topic", "low")
-    state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "whoosh"
-    assert state.attributes.get(fan.ATTR_PERCENTAGE) == 50
-    assert state.attributes.get("speed") == fan.SPEED_LOW
-
-    async_fire_mqtt_message(hass, "speed-state-topic", "off")
-    state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "whoosh"
-    assert state.attributes.get(fan.ATTR_PERCENTAGE) == 0
-    assert state.attributes.get("speed") == fan.SPEED_OFF
 
 
 async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock, caplog):
@@ -558,22 +496,13 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock, caplog):
                 "oscillation_command_topic": "oscillation-command-topic",
                 "payload_oscillation_off": "OsC_OfF",
                 "payload_oscillation_on": "OsC_On",
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speed_command_topic": "speed-command-topic",
                 "percentage_command_topic": "percentage-command-topic",
                 "preset_mode_command_topic": "preset-mode-command-topic",
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speeds": ["off", "low", "medium"],
                 "preset_modes": [
                     "whoosh",
                     "breeze",
                     "silent",
                 ],
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "payload_off_speed": "speed_OfF",
-                "payload_low_speed": "speed_lOw",
-                "payload_medium_speed": "speed_mEdium",
-                "payload_high_speed": "speed_High",
             }
         },
     )
@@ -625,10 +554,8 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock, caplog):
         await common.async_set_percentage(hass, "fan.test", 101)
 
     await common.async_set_percentage(hass, "fan.test", 100)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("percentage-command-topic", "100", 0, False)
-    mqtt_mock.async_publish.assert_any_call(
-        "speed-command-topic", "speed_mEdium", 0, False
+    mqtt_mock.async_publish.assert_called_once_with(
+        "percentage-command-topic", "100", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
@@ -636,26 +563,15 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock, caplog):
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_percentage(hass, "fan.test", 0)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("percentage-command-topic", "0", 0, False)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    mqtt_mock.async_publish.assert_any_call(
-        "speed-command-topic", "speed_OfF", 0, False
+    mqtt_mock.async_publish.assert_called_once_with(
+        "percentage-command-topic", "0", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.attributes.get(fan.ATTR_PERCENTAGE) == 0
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    assert state.attributes.get(fan.ATTR_SPEED) == fan.SPEED_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
     await common.async_set_preset_mode(hass, "fan.test", "low")
-    assert "not a valid preset mode" in caplog.text
-    caplog.clear()
-
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_set_preset_mode(hass, "fan.test", "medium")
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
 
@@ -684,41 +600,6 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock, caplog):
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.attributes.get(fan.ATTR_PRESET_MODE) == "silent"
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_LOW)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "speed_lOw", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_MEDIUM)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "speed_mEdium", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_HIGH)
-    assert "not a valid speed" in caplog.text
-    caplog.clear()
-
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_OFF)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "speed_OfF", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
 
@@ -888,7 +769,6 @@ async def test_sending_mqtt_commands_and_optimistic_no_legacy(hass, mqtt_mock, c
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.attributes.get(fan.ATTR_PERCENTAGE) == 0
-    assert state.attributes.get(fan.ATTR_SPEED) is None
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_preset_mode(hass, "fan.test", "low")
@@ -1028,7 +908,6 @@ async def test_sending_mqtt_command_templates_(hass, mqtt_mock, caplog):
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.attributes.get(fan.ATTR_PERCENTAGE) == 0
-    assert state.attributes.get(fan.ATTR_SPEED) is None
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_preset_mode(hass, "fan.test", "low")
@@ -1111,13 +990,8 @@ async def test_sending_mqtt_commands_and_optimistic_no_percentage_topic(
                 "platform": "mqtt",
                 "name": "test",
                 "command_topic": "command-topic",
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speed_state_topic": "speed-state-topic",
-                "speed_command_topic": "speed-command-topic",
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "preset_mode_state_topic": "preset-mode-state-topic",
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speeds": ["off", "low", "medium"],
                 "preset_modes": [
                     "whoosh",
                     "breeze",
@@ -1132,32 +1006,6 @@ async def test_sending_mqtt_commands_and_optimistic_no_percentage_topic(
     state = hass.states.get("fan.test")
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    with pytest.raises(MultipleInvalid):
-        await common.async_set_percentage(hass, "fan.test", -1)
-
-    with pytest.raises(MultipleInvalid):
-        await common.async_set_percentage(hass, "fan.test", 101)
-
-    await common.async_set_percentage(hass, "fan.test", 100)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "medium", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.attributes.get(fan.ATTR_PERCENTAGE) == 100
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_percentage(hass, "fan.test", 0)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "off", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.attributes.get(fan.ATTR_PERCENTAGE) == 0
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_set_preset_mode(hass, "fan.test", "low")
-    assert "not a valid preset mode" in caplog.text
-    caplog.clear()
 
     await common.async_set_preset_mode(hass, "fan.test", "medium")
     assert "not a valid preset mode" in caplog.text
@@ -1190,185 +1038,6 @@ async def test_sending_mqtt_commands_and_optimistic_no_percentage_topic(
     assert state.attributes.get(fan.ATTR_PRESET_MODE) is None
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_LOW)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "low", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_MEDIUM)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "medium", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_HIGH)
-    assert "not a valid speed" in caplog.text
-    caplog.clear()
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_OFF)
-
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "off", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_turn_on(hass, "fan.test", speed="medium")
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("command-topic", "ON", 0, False)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "medium", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_turn_off(hass, "fan.test")
-    mqtt_mock.async_publish.assert_called_once_with("command-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_turn_on(hass, "fan.test", speed="high")
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("command-topic", "ON", 0, False)
-    mqtt_mock.async_publish.assert_any_call(
-        "preset-mode-command-topic", "high", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_turn_off(hass, "fan.test")
-    mqtt_mock.async_publish.assert_called_once_with("command-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-
-# use of speeds is deprecated, support will be removed after a quarter (2021.7)
-async def test_sending_mqtt_commands_and_optimistic_legacy_speeds_only(
-    hass, mqtt_mock, caplog
-):
-    """Test optimistic mode without state topics with legacy speeds."""
-    assert await async_setup_component(
-        hass,
-        fan.DOMAIN,
-        {
-            fan.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "speed_state_topic": "speed-state-topic",
-                "speed_command_topic": "speed-command-topic",
-                "speeds": ["off", "low", "medium", "high"],
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_percentage(hass, "fan.test", 100)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "high", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.attributes.get(fan.ATTR_PERCENTAGE) == 100
-    assert state.attributes.get(fan.ATTR_SPEED) == "off"
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_percentage(hass, "fan.test", 0)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "off", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.attributes.get(fan.ATTR_PERCENTAGE) == 0
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_preset_mode(hass, "fan.test", "low")
-    assert "not a valid preset mode" in caplog.text
-    caplog.clear()
-
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_LOW)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "low", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_MEDIUM)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "medium", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_HIGH)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "high", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_OFF)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "off", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_turn_on(hass, "fan.test", speed="medium")
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("command-topic", "ON", 0, False)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "medium", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_turn_off(hass, "fan.test")
-    mqtt_mock.async_publish.assert_called_once_with("command-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_turn_on(hass, "fan.test", speed="off")
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("command-topic", "ON", 0, False)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "off", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_turn_off(hass, "fan.test")
-    mqtt_mock.async_publish.assert_called_once_with("command-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
 
 async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, caplog):
     """Test optimistic mode with state topic and turn on attributes."""
@@ -1381,17 +1050,12 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
                 "name": "test",
                 "state_topic": "state-topic",
                 "command_topic": "command-topic",
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speed_state_topic": "speed-state-topic",
-                "speed_command_topic": "speed-command-topic",
                 "oscillation_state_topic": "oscillation-state-topic",
                 "oscillation_command_topic": "oscillation-command-topic",
                 "percentage_state_topic": "percentage-state-topic",
                 "percentage_command_topic": "percentage-command-topic",
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "preset_mode_state_topic": "preset-mode-state-topic",
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speeds": ["off", "low", "medium"],
                 "preset_modes": [
                     "whoosh",
                     "breeze",
@@ -1421,30 +1085,10 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    await common.async_turn_on(hass, "fan.test", speed=fan.SPEED_MEDIUM)
-    assert mqtt_mock.async_publish.call_count == 3
-    mqtt_mock.async_publish.assert_any_call("command-topic", "ON", 0, False)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "medium", 0, False)
-    mqtt_mock.async_publish.assert_any_call("percentage-command-topic", "100", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_turn_off(hass, "fan.test")
-    mqtt_mock.async_publish.assert_called_once_with("command-topic", "OFF", 0, False)
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
     await common.async_turn_on(hass, "fan.test", percentage=25)
-    assert mqtt_mock.async_publish.call_count == 3
+    assert mqtt_mock.async_publish.call_count == 2
     mqtt_mock.async_publish.assert_any_call("command-topic", "ON", 0, False)
     mqtt_mock.async_publish.assert_any_call("percentage-command-topic", "25", 0, False)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "low", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.state == STATE_ON
@@ -1457,7 +1101,6 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
     with pytest.raises(NotValidPresetModeError):
         await common.async_turn_on(hass, "fan.test", preset_mode="auto")
 
@@ -1525,11 +1168,9 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_turn_on(hass, "fan.test", percentage=50)
-    assert mqtt_mock.async_publish.call_count == 3
+    assert mqtt_mock.async_publish.call_count == 2
     mqtt_mock.async_publish.assert_any_call("command-topic", "ON", 0, False)
     mqtt_mock.async_publish.assert_any_call("percentage-command-topic", "50", 0, False)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "low", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.state == STATE_ON
@@ -1552,40 +1193,36 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_percentage(hass, "fan.test", 33)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("percentage-command-topic", "33", 0, False)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "low", 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "percentage-command-topic", "33", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_percentage(hass, "fan.test", 50)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("percentage-command-topic", "50", 0, False)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "low", 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "percentage-command-topic", "50", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_percentage(hass, "fan.test", 100)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("percentage-command-topic", "100", 0, False)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "medium", 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "percentage-command-topic", "100", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_percentage(hass, "fan.test", 0)
-    assert mqtt_mock.async_publish.call_count == 2
-    mqtt_mock.async_publish.assert_any_call("percentage-command-topic", "0", 0, False)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    mqtt_mock.async_publish.assert_any_call("speed-command-topic", "off", 0, False)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "percentage-command-topic", "0", 0, False
+    )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.state == STATE_OFF
@@ -1629,33 +1266,6 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_MEDIUM)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "medium", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_HIGH)
-    assert "not a valid speed" in caplog.text
-    caplog.clear()
-
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_OFF)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "off", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-    await common.async_set_speed(hass, "fan.test", "cUsToM")
-    assert "not a valid speed" in caplog.text
-    caplog.clear()
-
 
 async def test_attributes(hass, mqtt_mock, caplog):
     """Test attributes."""
@@ -1668,8 +1278,6 @@ async def test_attributes(hass, mqtt_mock, caplog):
                 "name": "test",
                 "command_topic": "command-topic",
                 "oscillation_command_topic": "oscillation-command-topic",
-                # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                "speed_command_topic": "speed-command-topic",
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "percentage_command_topic": "percentage-command-topic",
                 "preset_modes": [
@@ -1683,103 +1291,30 @@ async def test_attributes(hass, mqtt_mock, caplog):
 
     state = hass.states.get("fan.test")
     assert state.state == STATE_OFF
-    assert state.attributes.get(fan.ATTR_SPEED_LIST) == [
-        "low",
-        "medium",
-        "high",
-    ]
 
     await common.async_turn_on(hass, "fan.test")
     state = hass.states.get("fan.test")
     assert state.state == STATE_ON
     assert state.attributes.get(ATTR_ASSUMED_STATE)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    assert state.attributes.get(fan.ATTR_SPEED) is None
     assert state.attributes.get(fan.ATTR_OSCILLATING) is None
 
     await common.async_turn_off(hass, "fan.test")
     state = hass.states.get("fan.test")
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    assert state.attributes.get(fan.ATTR_SPEED) is None
     assert state.attributes.get(fan.ATTR_OSCILLATING) is None
 
     await common.async_oscillate(hass, "fan.test", True)
     state = hass.states.get("fan.test")
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    assert state.attributes.get(fan.ATTR_SPEED) is None
     assert state.attributes.get(fan.ATTR_OSCILLATING) is True
 
     await common.async_oscillate(hass, "fan.test", False)
     state = hass.states.get("fan.test")
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    assert state.attributes.get(fan.ATTR_SPEED) is None
     assert state.attributes.get(fan.ATTR_OSCILLATING) is False
-
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_LOW)
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-    assert state.attributes.get(fan.ATTR_SPEED) == "low"
-    assert state.attributes.get(fan.ATTR_OSCILLATING) is False
-
-    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_MEDIUM)
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-    assert state.attributes.get(fan.ATTR_SPEED) == "medium"
-    assert state.attributes.get(fan.ATTR_OSCILLATING) is False
-
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_HIGH)
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-    assert state.attributes.get(fan.ATTR_SPEED) == "high"
-    assert state.attributes.get(fan.ATTR_OSCILLATING) is False
-
-    await common.async_set_speed(hass, "fan.test", fan.SPEED_OFF)
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-    assert state.attributes.get(fan.ATTR_SPEED) == "off"
-    assert state.attributes.get(fan.ATTR_OSCILLATING) is False
-
-    await common.async_set_speed(hass, "fan.test", "cUsToM")
-    assert "not a valid speed" in caplog.text
-    caplog.clear()
-
-
-# use of speeds is deprecated, support will be removed after a quarter (2021.7)
-async def test_custom_speed_list(hass, mqtt_mock):
-    """Test optimistic mode without state topic."""
-    assert await async_setup_component(
-        hass,
-        fan.DOMAIN,
-        {
-            fan.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "oscillation_command_topic": "oscillation-command-topic",
-                "oscillation_state_topic": "oscillation-state-topic",
-                "speed_command_topic": "speed-command-topic",
-                "speed_state_topic": "speed-state-topic",
-                "speeds": ["off", "high"],
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(fan.ATTR_SPEED_LIST) == ["high"]
 
 
 async def test_supported_features(hass, mqtt_mock):
@@ -1799,29 +1334,6 @@ async def test_supported_features(hass, mqtt_mock):
                     "name": "test2",
                     "command_topic": "command-topic",
                     "oscillation_command_topic": "oscillation-command-topic",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test3a1",
-                    "command_topic": "command-topic",
-                    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                    "speed_command_topic": "speed-command-topic",
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test3a2",
-                    "command_topic": "command-topic",
-                    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                    "speed_command_topic": "speed-command-topic",
-                    "speeds": ["low"],
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test3a3",
-                    "command_topic": "command-topic",
-                    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                    "speed_command_topic": "speed-command-topic",
-                    "speeds": ["off"],
                 },
                 {
                     "platform": "mqtt",
@@ -1848,14 +1360,6 @@ async def test_supported_features(hass, mqtt_mock):
                     "command_topic": "command-topic",
                     "preset_mode_command_topic": "preset-mode-command-topic",
                     "preset_modes": ["eco", "smart", "auto"],
-                },
-                {
-                    "platform": "mqtt",
-                    "name": "test4",
-                    "command_topic": "command-topic",
-                    "oscillation_command_topic": "oscillation-command-topic",
-                    # use of speeds is deprecated, support will be removed after a quarter (2021.7)
-                    "speed_command_topic": "speed-command-topic",
                 },
                 {
                     "platform": "mqtt",
@@ -1941,19 +1445,6 @@ async def test_supported_features(hass, mqtt_mock):
     state = hass.states.get("fan.test2")
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == fan.SUPPORT_OSCILLATE
 
-    state = hass.states.get("fan.test3a1")
-    assert (
-        state.attributes.get(ATTR_SUPPORTED_FEATURES)
-        and fan.SUPPORT_SET_SPEED == fan.SUPPORT_SET_SPEED
-    )
-    state = hass.states.get("fan.test3a2")
-    assert (
-        state.attributes.get(ATTR_SUPPORTED_FEATURES)
-        and fan.SUPPORT_SET_SPEED == fan.SUPPORT_SET_SPEED
-    )
-    state = hass.states.get("fan.test3a3")
-    assert state is None
-
     state = hass.states.get("fan.test3b")
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == fan.SUPPORT_SET_SPEED
 
@@ -1964,12 +1455,6 @@ async def test_supported_features(hass, mqtt_mock):
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == fan.SUPPORT_PRESET_MODE
     state = hass.states.get("fan.test3c3")
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == fan.SUPPORT_PRESET_MODE
-
-    state = hass.states.get("fan.test4")
-    assert (
-        state.attributes.get(ATTR_SUPPORTED_FEATURES)
-        == fan.SUPPORT_OSCILLATE | fan.SUPPORT_SET_SPEED
-    )
 
     state = hass.states.get("fan.test4pcta")
     assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == fan.SUPPORT_SET_SPEED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
MQTT fan no longer supports Support for legacy speeds (OFF, LOW, MEDIUM, HIGH).
With release 2021.3 the support for legacy speeds was announced to be removed after a quater (2021.7).

With removing the legacy speeds support, integrations that rely on MQTT fan platform that still use legacy speeds would break because they can not be setup if deprecated attributes are used. This includes the MQTT auto discovery.
To prevent that these integration will fail to setup, the deprecated attributes listed here are still allowed in the config:
`payload_high_speed`, `payload_low_speed`, `payload_medium_speed`, `speed_command_topic`, `speeds`, `speed_state_topic`, `speed_value_template`


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the deprecated support for legacy speeds for the MQTT Fan platform from 2012.9.0.
We silently ignore incorrectly configured devices only telling the settings deprecated and are to be removed from the config.
To regain support for speeds users nee to implement percentage based speeds or preset modes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
