### PR TITLE
Verify that COLOR_MODE is in supported color modes

### DIFF
--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -137,13 +137,25 @@ class DeconzBaseLight(DeconzDevice, LightEntity):
     @property
     def color_mode(self) -> str:
         """Return the color mode of the light."""
-        if self._device.colormode == "ct":
+        if (
+            self._device.colormode == "ct"
+            and COLOR_MODE_COLOR_TEMP in self._attr_supported_color_modes
+        ):
             color_mode = COLOR_MODE_COLOR_TEMP
-        elif self._device.colormode == "hs":
+        elif (
+            self._device.colormode == "hs"
+            and COLOR_MODE_HS in self._attr_supported_color_modes
+        ):
             color_mode = COLOR_MODE_HS
-        elif self._device.colormode == "xy":
+        elif (
+            self._device.colormode == "xy"
+            and COLOR_MODE_XY in self._attr_supported_color_modes
+        ):
             color_mode = COLOR_MODE_XY
-        elif self._device.brightness is not None:
+        elif (
+            self._device.brightness is not None
+            and COLOR_MODE_BRIGHTNESS in self._attr_supported_color_modes
+        ):
             color_mode = COLOR_MODE_BRIGHTNESS
         else:
             color_mode = COLOR_MODE_ONOFF


### PR DESCRIPTION
* Device init creates a set of supported color modes.
* The ColorMode property now checks that the best matching color mode
is in the supported set.
* Some Sunricher devices report a wrong color mode - this fixes it.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
Some Sunricher devices report a wrong color mode, which is already handled
in the device_init (it checks for color mode + needs property data set).
The color_mode propery did not took this into account - event a list
of supported color modes was available internal. This is now fixed.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
