### PR TITLE
Only show zwave_js command classes that are on the node

### DIFF
--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -21,6 +21,7 @@ from .const import (
     ATTR_PROPERTY,
     ATTR_PROPERTY_KEY,
     ATTR_VALUE,
+    LOGGER,
 )
 from .helpers import async_get_node_from_device_id, get_zwave_value_from_config
 
@@ -193,12 +194,15 @@ async def async_get_condition_capabilities(
         return {"extra_fields": vol.Schema({vol.Required(ATTR_VALUE): value_schema})}
 
     if config[CONF_TYPE] == VALUE_TYPE:
+        cc_dict = {
+            CommandClass(cc.id).value: CommandClass(cc.id).name
+            for cc in sorted(node.command_classes, key=lambda cc: cc.name)  # type: ignore
+        }
+        LOGGER.error(cc_dict)
         return {
             "extra_fields": vol.Schema(
                 {
-                    vol.Required(ATTR_COMMAND_CLASS): vol.In(
-                        {cc.value: cc.name for cc in CommandClass}
-                    ),
+                    vol.Required(ATTR_COMMAND_CLASS): vol.In(cc_dict),
                     vol.Required(ATTR_PROPERTY): cv.string,
                     vol.Optional(ATTR_PROPERTY_KEY): cv.string,
                     vol.Optional(ATTR_ENDPOINT): cv.string,

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -199,7 +199,7 @@ async def async_get_condition_capabilities(
                     vol.Required(ATTR_COMMAND_CLASS): vol.In(
                         {
                             CommandClass(cc.id).value: CommandClass(cc.id).name
-                            for cc in sorted(node.command_classes, key=lambda cc: cc.name)  # type: ignore
+                            for cc in sorted(node.command_classes, key=lambda cc: cc.name)  # type: ignore[no-any-return]
                         }
                     ),
                     vol.Required(ATTR_PROPERTY): cv.string,

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -21,7 +21,6 @@ from .const import (
     ATTR_PROPERTY,
     ATTR_PROPERTY_KEY,
     ATTR_VALUE,
-    LOGGER,
 )
 from .helpers import async_get_node_from_device_id, get_zwave_value_from_config
 
@@ -194,15 +193,15 @@ async def async_get_condition_capabilities(
         return {"extra_fields": vol.Schema({vol.Required(ATTR_VALUE): value_schema})}
 
     if config[CONF_TYPE] == VALUE_TYPE:
-        cc_dict = {
-            CommandClass(cc.id).value: CommandClass(cc.id).name
-            for cc in sorted(node.command_classes, key=lambda cc: cc.name)  # type: ignore
-        }
-        LOGGER.error(cc_dict)
         return {
             "extra_fields": vol.Schema(
                 {
-                    vol.Required(ATTR_COMMAND_CLASS): vol.In(cc_dict),
+                    vol.Required(ATTR_COMMAND_CLASS): vol.In(
+                        {
+                            CommandClass(cc.id).value: CommandClass(cc.id).name
+                            for cc in sorted(node.command_classes, key=lambda cc: cc.name)  # type: ignore
+                        }
+                    ),
                     vol.Required(ATTR_PROPERTY): cv.string,
                     vol.Optional(ATTR_PROPERTY_KEY): cv.string,
                     vol.Optional(ATTR_ENDPOINT): cv.string,

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -430,7 +430,18 @@ async def test_get_condition_capabilities_value(
     )
     assert capabilities and "extra_fields" in capabilities
 
-    cc_options = [(cc.value, cc.name) for cc in CommandClass]
+    cc_options = [
+        (133, "ASSOCIATION"),
+        (128, "BATTERY"),
+        (112, "CONFIGURATION"),
+        (98, "DOOR_LOCK"),
+        (122, "FIRMWARE_UPDATE_MD"),
+        (114, "MANUFACTURER_SPECIFIC"),
+        (113, "ALARM"),
+        (152, "SECURITY"),
+        (99, "USER_CODE"),
+        (134, "VERSION"),
+    ]
 
     assert voluptuous_serialize.convert(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer


### PR DESCRIPTION
## Proposed change
For device conditions on any zwave value, we previously would list all CCs. But since we have the node, we can filter that list down to CC's that the node actually has.

And heres the type error I decided to ignore:
homeassistant/components/zwave_js/device_condition.py:199: error: Returning Any from function declared to return "SupportsLessThan"  [no-any-return]
Found 1 error in 1 file (checked 1 source file)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
