### PR TITLE
Add support for logger info in fronius integration

### DIFF
--- a/homeassistant/components/fronius/manifest.json
+++ b/homeassistant/components/fronius/manifest.json
@@ -2,7 +2,7 @@
   "domain": "fronius",
   "name": "Fronius",
   "documentation": "https://www.home-assistant.io/integrations/fronius",
-  "requirements": ["pyfronius==0.5.5"],
+  "requirements": ["pyfronius==0.6.0"],
   "codeowners": ["@nielstron"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import copy
 from datetime import timedelta
 import logging
+from typing import Any
 
 from pyfronius import Fronius
 import voluptuous as vol
@@ -159,16 +160,16 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class FroniusAdapter:
     """The Fronius sensor fetching component."""
 
-    def __init__(self, bridge: Fronius, name, device, add_entities):
+    def __init__(self, bridge, name, device, add_entities):
         """Initialize the sensor."""
-        self.bridge = bridge
-        self._name = name
-        self._device = device
-        self._fetched: dict = {}
+        self.bridge: Fronius = bridge
+        self._name: str = name
+        self._device: int = device
+        self._fetched: dict[str, Any] = {}
         self._available = True
 
-        self.sensors: set = set()
-        self._registered_sensors: set = set()
+        self.sensors: set[str] = set()
+        self._registered_sensors: set[SensorEntity] = set()
         self._add_entities = add_entities
 
     @property
@@ -233,7 +234,7 @@ class FroniusAdapter:
         """Return values of interest."""
 
     @callback
-    def register(self, sensor: SensorEntity):
+    def register(self, sensor):
         """Register child sensor for update subscriptions."""
         self._registered_sensors.add(sensor)
         return lambda: self._registered_sensors.remove(sensor)

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -164,11 +164,11 @@ class FroniusAdapter:
         self.bridge = bridge
         self._name = name
         self._device = device
-        self._fetched = {}
+        self._fetched: dict = {}
         self._available = True
 
-        self.sensors = set()
-        self._registered_sensors = set()
+        self.sensors: set = set()
+        self._registered_sensors: set = set()
         self._add_entities = add_entities
 
     @property
@@ -233,7 +233,7 @@ class FroniusAdapter:
         """Return values of interest."""
 
     @callback
-    def register(self, sensor):
+    def register(self, sensor: SensorEntity):
         """Register child sensor for update subscriptions."""
         self._registered_sensors.add(sensor)
         return lambda: self._registered_sensors.remove(sensor)

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt
 
@@ -160,7 +161,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class FroniusAdapter:
     """The Fronius sensor fetching component."""
 
-    def __init__(self, bridge, name, device, add_entities):
+    def __init__(
+        self, bridge: Fronius, name: str, device: int, add_entities: AddEntitiesCallback
+    ) -> None:
         """Initialize the sensor."""
         self.bridge: Fronius = bridge
         self._name: str = name

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -42,6 +42,7 @@ TYPE_INVERTER = "inverter"
 TYPE_STORAGE = "storage"
 TYPE_METER = "meter"
 TYPE_POWER_FLOW = "power_flow"
+TYPE_LOGGER_INFO = "logger_info"
 SCOPE_DEVICE = "device"
 SCOPE_SYSTEM = "system"
 
@@ -50,7 +51,13 @@ DEFAULT_DEVICE = 0
 DEFAULT_INVERTER = 1
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 
-SENSOR_TYPES = [TYPE_INVERTER, TYPE_STORAGE, TYPE_METER, TYPE_POWER_FLOW]
+SENSOR_TYPES = [
+    TYPE_INVERTER,
+    TYPE_STORAGE,
+    TYPE_METER,
+    TYPE_POWER_FLOW,
+    TYPE_LOGGER_INFO,
+]
 SCOPE_TYPES = [SCOPE_DEVICE, SCOPE_SYSTEM]
 
 PREFIX_DEVICE_CLASS_MAPPING = [
@@ -127,6 +134,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 adapter_cls = FroniusMeterDevice
         elif sensor_type == TYPE_POWER_FLOW:
             adapter_cls = FroniusPowerFlow
+        elif sensor_type == TYPE_LOGGER_INFO:
+            adapter_cls = FroniusLoggerInfo
         else:
             adapter_cls = FroniusStorage
 
@@ -150,7 +159,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class FroniusAdapter:
     """The Fronius sensor fetching component."""
 
-    def __init__(self, bridge, name, device, add_entities):
+    def __init__(self, bridge: Fronius, name, device, add_entities):
         """Initialize the sensor."""
         self.bridge = bridge
         self._name = name
@@ -276,6 +285,14 @@ class FroniusPowerFlow(FroniusAdapter):
     async def _update(self):
         """Get the values for the current state."""
         return await self.bridge.current_power_flow()
+
+
+class FroniusLoggerInfo(FroniusAdapter):
+    """Adapter for the fronius power flow."""
+
+    async def _update(self):
+        """Get the values for the current state."""
+        return await self.bridge.current_logger_info()
 
 
 class FroniusTemplateSensor(SensorEntity):

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -165,9 +165,9 @@ class FroniusAdapter:
         self, bridge: Fronius, name: str, device: int, add_entities: AddEntitiesCallback
     ) -> None:
         """Initialize the sensor."""
-        self.bridge: Fronius = bridge
-        self._name: str = name
-        self._device: int = device
+        self.bridge = bridge
+        self._name = name
+        self._device = device
         self._fetched: dict[str, Any] = {}
         self._available = True
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1469,7 +1469,7 @@ pyfreedompro==1.1.0
 pyfritzhome==0.6.2
 
 # homeassistant.components.fronius
-pyfronius==0.5.5
+pyfronius==0.6.0
 
 # homeassistant.components.ifttt
 pyfttt==0.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the option to track the costs and returns of energy of the fronius inverter.
The newly added sensors "cash factor" and "delivery factor" track the current price for bought and sold energy in currency/kWh.

This is a feature of a newer version of pyfronius and hence requires a dependency upgrade.

New Release: https://github.com/nielstron/pyfronius/releases/tag/release-0.6.0

Diff: https://github.com/nielstron/pyfronius/compare/release-0.5.5...release-0.6.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18978

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] (TODO)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
