### PR TITLE
Fix TPLink emeter reset not updating

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -269,7 +269,7 @@ class SmartPlugDataUpdateCoordinator(DataUpdateCoordinator):
                 }
                 emeter_statics = self.smartplug.get_emeter_daily()
                 last_reset = datetime.now() - get_time_offset(self.smartplug)
-                last_reset_local = as_local(last_reset.replace(microsecond=0))
+                last_reset_local = as_local(last_reset.replace(second=0, microsecond=0))
                 _LOGGER.debug(
                     "%s last reset time as local to server is %s"
                     % (

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -1,6 +1,7 @@
 """Common code for tplink."""
 from __future__ import annotations
 
+from datetime import timedelta
 import logging
 from typing import Callable
 
@@ -184,3 +185,18 @@ def add_available_devices(
 
     hass.data[TPLINK_DOMAIN][f"{device_type}_remaining"] = devices_unavailable
     return entities_ready
+
+
+def get_time_offset(device: SmartDevice) -> timedelta:
+    """Get the time offset since last device reset (local midnight)."""
+    device_time = device.time.replace(microsecond=0)
+    offset = device_time - device_time.replace(hour=0, minute=0, second=0)
+    _LOGGER.debug(
+        "%s local time is %s, offset from midnight is %s"
+        % (
+            device.alias,
+            device_time.strftime("%Y/%m/%d %H:%M:%S"),
+            str(offset),
+        )
+    )
+    return offset

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -1,6 +1,7 @@
 """Support for TPLink HS100/HS110/HS200 smart switch energy sensors."""
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Final
 
 from pyHS100 import SmartPlug
@@ -153,3 +154,10 @@ class SmartPlugSensor(CoordinatorEntity, SensorEntity):
             "connections": {(dr.CONNECTION_NETWORK_MAC, self.data[CONF_MAC])},
             "sw_version": self.data[CONF_SW_VERSION],
         }
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the  last reset time for emeter."""
+        return self.data[CONF_EMETER_PARAMS][ATTR_LAST_RESET].get(
+            self.entity_description.key
+        )

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -1,6 +1,7 @@
 """Tests for the TP-Link component."""
 from __future__ import annotations
 
+from datetime import datetime
 import time
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -222,6 +223,11 @@ async def test_platforms_are_initialized(hass: HomeAssistant):
     ), patch(
         "homeassistant.components.tplink.common.SmartPlug.is_dimmable",
         False,
+    ), patch(
+        "homeassistant.components.tplink.get_time_offset",
+        return_value=(
+            datetime.now() - datetime.now().replace(hour=0, minute=0, second=0)
+        ),
     ):
 
         light = SmartBulb("123.123.123.123")
@@ -412,7 +418,12 @@ async def test_unload(hass, platform):
     ), patch(
         f"homeassistant.components.tplink.{platform}.async_setup_entry",
         return_value=mock_coro(True),
-    ) as async_setup_entry:
+    ) as async_setup_entry, patch(
+        "homeassistant.components.tplink.get_time_offset",
+        return_value=(
+            datetime.now() - datetime.now().replace(hour=0, minute=0, second=0)
+        ),
+    ):
         config = {
             tplink.DOMAIN: {
                 platform: [{CONF_HOST: "123.123.123.123"}],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes the daily consumption on TP link energy monitoring plugs not resetting properly since `LAST_RESET` was only being set in the `init` and was then never updated. It also takes a stab at handling the local time of the plug being different to Home Assistant (imagine where plug is not allowed internet access and is hours out). This is NOT resilient against day light savings but is not expected to be around more than two weeks in release.

*Note*: To address merge conflicts this PR also has to revert #54723 which is in dev but contains code requiring 2021.9. That PR should be remerged after this PR if this PR is accepted. Of course this change should be redundant with 2021.9

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54309
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
