### PR TITLE
Remove last_reset attribute and set state class to total_increasing for Integration sensors

### DIFF
--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -5,11 +5,10 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
-    ATTR_LAST_RESET,
     DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_POWER,
     PLATFORM_SCHEMA,
-    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
 )
 from homeassistant.const import (
@@ -28,7 +27,6 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.util import dt as dt_util
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
@@ -124,25 +122,18 @@ class IntegrationSensor(RestoreEntity, SensorEntity):
 
         self._unit_prefix = UNIT_PREFIXES[unit_prefix]
         self._unit_time = UNIT_TIME[unit_time]
-        self._attr_state_class = STATE_CLASS_MEASUREMENT
+        self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
         await super().async_added_to_hass()
         state = await self.async_get_last_state()
-        self._attr_last_reset = dt_util.utcnow()
         if state:
             try:
                 self._state = Decimal(state.state)
             except (DecimalException, ValueError) as err:
                 _LOGGER.warning("Could not restore last state: %s", err)
             else:
-                last_reset = dt_util.parse_datetime(
-                    state.attributes.get(ATTR_LAST_RESET, "")
-                )
-                self._attr_last_reset = (
-                    last_reset if last_reset else dt_util.utc_from_timestamp(0)
-                )
                 self._attr_device_class = state.attributes.get(ATTR_DEVICE_CLASS)
 
                 self._unit_of_measurement = state.attributes.get(

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
+from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING
 from homeassistant.const import (
     DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_POWER,
@@ -40,7 +40,7 @@ async def test_state(hass) -> None:
     state = hass.states.get("sensor.integration")
     assert state is not None
     assert state.attributes.get("last_reset") == now.isoformat()
-    assert state.attributes.get("state_class") == STATE_CLASS_MEASUREMENT
+    assert state.attributes.get("state_class") == STATE_CLASS_TOTAL_INCREASING
     assert "device_class" not in state.attributes
 
     future_now = dt_util.utcnow() + timedelta(seconds=3600)
@@ -58,7 +58,7 @@ async def test_state(hass) -> None:
 
     assert state.attributes.get("unit_of_measurement") == ENERGY_KILO_WATT_HOUR
     assert state.attributes.get("device_class") == DEVICE_CLASS_ENERGY
-    assert state.attributes.get("state_class") == STATE_CLASS_MEASUREMENT
+    assert state.attributes.get("state_class") == STATE_CLASS_TOTAL_INCREASING
     assert state.attributes.get("last_reset") == now.isoformat()
 
 
@@ -97,7 +97,6 @@ async def test_restore_state(hass: HomeAssistant) -> None:
     assert state.state == "100.00"
     assert state.attributes.get("unit_of_measurement") == ENERGY_KILO_WATT_HOUR
     assert state.attributes.get("device_class") == DEVICE_CLASS_ENERGY
-    assert state.attributes.get("last_reset") == "2019-10-06T21:00:00"
 
 
 async def test_restore_state_failed(hass: HomeAssistant) -> None:
@@ -131,7 +130,7 @@ async def test_restore_state_failed(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "0"
     assert state.attributes.get("unit_of_measurement") == ENERGY_KILO_WATT_HOUR
-    assert state.attributes.get("state_class") == STATE_CLASS_MEASUREMENT
+    assert state.attributes.get("state_class") == STATE_CLASS_TOTAL_INCREASING
     assert state.attributes.get("last_reset") != "2019-10-06T21:00:00"
     assert "device_class" not in state.attributes
 

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -39,7 +39,6 @@ async def test_state(hass) -> None:
 
     state = hass.states.get("sensor.integration")
     assert state is not None
-    assert state.attributes.get("last_reset") == now.isoformat()
     assert state.attributes.get("state_class") == STATE_CLASS_TOTAL_INCREASING
     assert "device_class" not in state.attributes
 
@@ -59,7 +58,6 @@ async def test_state(hass) -> None:
     assert state.attributes.get("unit_of_measurement") == ENERGY_KILO_WATT_HOUR
     assert state.attributes.get("device_class") == DEVICE_CLASS_ENERGY
     assert state.attributes.get("state_class") == STATE_CLASS_TOTAL_INCREASING
-    assert state.attributes.get("last_reset") == now.isoformat()
 
 
 async def test_restore_state(hass: HomeAssistant) -> None:
@@ -71,7 +69,6 @@ async def test_restore_state(hass: HomeAssistant) -> None:
                 "sensor.integration",
                 "100.0",
                 {
-                    "last_reset": "2019-10-06T21:00:00",
                     "device_class": DEVICE_CLASS_ENERGY,
                     "unit_of_measurement": ENERGY_KILO_WATT_HOUR,
                 },
@@ -107,9 +104,7 @@ async def test_restore_state_failed(hass: HomeAssistant) -> None:
             State(
                 "sensor.integration",
                 "INVALID",
-                {
-                    "last_reset": "2019-10-06T21:00:00.000000",
-                },
+                {},
             ),
         ),
     )
@@ -131,7 +126,6 @@ async def test_restore_state_failed(hass: HomeAssistant) -> None:
     assert state.state == "0"
     assert state.attributes.get("unit_of_measurement") == ENERGY_KILO_WATT_HOUR
     assert state.attributes.get("state_class") == STATE_CLASS_TOTAL_INCREASING
-    assert state.attributes.get("last_reset") != "2019-10-06T21:00:00"
     assert "device_class" not in state.attributes
 
 


### PR DESCRIPTION

Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove last_reset attribute and set state class to total_increasing for Integration sensors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
