### PR TITLE
Convert template/vacuum to pytest with fixtures

### DIFF
--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -13,13 +13,13 @@ def calls(hass):
 
 
 @pytest.fixture
-async def start_ha(hass, do_count, do_domain, do_config, caplog):
+async def start_ha(hass, count, domain, config, caplog):
     """Do setup of integration."""
-    with assert_setup_component(do_count, do_domain):
+    with assert_setup_component(count, domain):
         assert await async_setup_component(
             hass,
-            do_domain,
-            do_config,
+            domain,
+            config,
         )
 
     await hass.async_block_till_done()

--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -1,2 +1,27 @@
 """template conftest."""
-from tests.components.light.conftest import mock_light_profiles  # noqa: F401
+import pytest
+
+from homeassistant.setup import async_setup_component
+
+from tests.common import assert_setup_component, async_mock_service
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
+
+
+@pytest.fixture
+async def start_ha(hass, do_count, do_domain, do_config, caplog):
+    """Do setup of integration."""
+    with assert_setup_component(do_count, do_domain):
+        assert await async_setup_component(
+            hass,
+            do_domain,
+            do_config,
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -12,7 +12,7 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 
-from tests.common import assert_setup_component, async_mock_service
+from tests.common import assert_setup_component
 from tests.components.vacuum import common
 
 _TEST_VACUUM = "vacuum.test_vacuum"
@@ -23,18 +23,14 @@ _FAN_SPEED_INPUT_SELECT = "input_select.fan_speed"
 _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
 
 
-@pytest.fixture
-def calls(hass):
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
-
-
-# Configuration tests #
-async def test_missing_optional_config(hass, calls):
-    """Test: missing optional template is ok."""
-    with assert_setup_component(1, "vacuum"):
-        assert await setup.async_setup_component(
-            hass,
+@pytest.mark.parametrize(
+    "do_len,do_count,do_parm1,do_parm2,do_domain,do_config",
+    [
+        (
+            1,
+            1,
+            STATE_UNKNOWN,
+            None,
             "vacuum",
             {
                 "vacuum": {
@@ -44,20 +40,12 @@ async def test_missing_optional_config(hass, calls):
                     },
                 }
             },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    _verify(hass, STATE_UNKNOWN, None)
-
-
-async def test_missing_start_config(hass, calls):
-    """Test: missing 'start' will fail."""
-    with assert_setup_component(0, "vacuum"):
-        assert await setup.async_setup_component(
-            hass,
+        ),
+        (
+            0,
+            0,
+            None,
+            None,
             "vacuum",
             {
                 "vacuum": {
@@ -65,20 +53,12 @@ async def test_missing_start_config(hass, calls):
                     "vacuums": {"test_vacuum": {"value_template": "{{ 'on' }}"}},
                 }
             },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert hass.states.async_all() == []
-
-
-async def test_invalid_config(hass, calls):
-    """Test: invalid config structure will fail."""
-    with assert_setup_component(0, "vacuum"):
-        assert await setup.async_setup_component(
-            hass,
+        ),
+        (
+            0,
+            0,
+            None,
+            None,
             "vacuum",
             {
                 "platform": "template",
@@ -86,57 +66,12 @@ async def test_invalid_config(hass, calls):
                     "test_vacuum": {"start": {"service": "script.vacuum_start"}}
                 },
             },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert hass.states.async_all() == []
-
-
-# End of configuration tests #
-
-
-# Template tests #
-async def test_templates_with_entities(hass, calls):
-    """Test templates with values from other entities."""
-    with assert_setup_component(1, "vacuum"):
-        assert await setup.async_setup_component(
-            hass,
-            "vacuum",
-            {
-                "vacuum": {
-                    "platform": "template",
-                    "vacuums": {
-                        "test_vacuum": {
-                            "value_template": "{{ states('input_select.state') }}",
-                            "battery_level_template": "{{ states('input_number.battery_level') }}",
-                            "start": {"service": "script.vacuum_start"},
-                        }
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    _verify(hass, STATE_UNKNOWN, None)
-
-    hass.states.async_set(_STATE_INPUT_SELECT, STATE_CLEANING)
-    hass.states.async_set(_BATTERY_LEVEL_INPUT_NUMBER, 100)
-    await hass.async_block_till_done()
-
-    _verify(hass, STATE_CLEANING, 100)
-
-
-async def test_templates_with_valid_values(hass, calls):
-    """Test templates with valid values."""
-    with assert_setup_component(1, "vacuum"):
-        assert await setup.async_setup_component(
-            hass,
+        ),
+        (
+            1,
+            1,
+            STATE_CLEANING,
+            100,
             "vacuum",
             {
                 "vacuum": {
@@ -150,20 +85,12 @@ async def test_templates_with_valid_values(hass, calls):
                     },
                 }
             },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    _verify(hass, STATE_CLEANING, 100)
-
-
-async def test_templates_invalid_values(hass, calls):
-    """Test templates with invalid values."""
-    with assert_setup_component(1, "vacuum"):
-        assert await setup.async_setup_component(
-            hass,
+        ),
+        (
+            1,
+            1,
+            STATE_UNKNOWN,
+            None,
             "vacuum",
             {
                 "vacuum": {
@@ -177,20 +104,12 @@ async def test_templates_invalid_values(hass, calls):
                     },
                 }
             },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    _verify(hass, STATE_UNKNOWN, None)
-
-
-async def test_invalid_templates(hass, calls):
-    """Test invalid templates."""
-    with assert_setup_component(1, "vacuum"):
-        assert await setup.async_setup_component(
-            hass,
+        ),
+        (
+            1,
+            1,
+            STATE_UNKNOWN,
+            None,
             "vacuum",
             {
                 "vacuum": {
@@ -205,37 +124,69 @@ async def test_invalid_templates(hass, calls):
                     },
                 }
             },
+        ),
+    ],
+)
+async def test_configs(hass, do_len, do_parm1, do_parm2, start_ha):
+    """Test: configs."""
+    assert len(hass.states.async_all()) == do_len
+    if do_len:
+        _verify(hass, do_parm1, do_parm2)
+
+
+@pytest.mark.parametrize(
+    "do_count,do_domain,do_config",
+    [
+        (
+            1,
+            "vacuum",
+            {
+                "vacuum": {
+                    "platform": "template",
+                    "vacuums": {
+                        "test_vacuum": {
+                            "value_template": "{{ states('input_select.state') }}",
+                            "battery_level_template": "{{ states('input_number.battery_level') }}",
+                            "start": {"service": "script.vacuum_start"},
+                        }
+                    },
+                }
+            },
         )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+    ],
+)
+async def test_templates_with_entities(hass, start_ha):
+    """Test templates with values from other entities."""
     _verify(hass, STATE_UNKNOWN, None)
 
+    hass.states.async_set(_STATE_INPUT_SELECT, STATE_CLEANING)
+    hass.states.async_set(_BATTERY_LEVEL_INPUT_NUMBER, 100)
+    await hass.async_block_till_done()
+    _verify(hass, STATE_CLEANING, 100)
 
-async def test_available_template_with_entities(hass, calls):
+
+@pytest.mark.parametrize(
+    "do_count,do_domain,do_config",
+    [
+        (
+            1,
+            "vacuum",
+            {
+                "vacuum": {
+                    "platform": "template",
+                    "vacuums": {
+                        "test_template_vacuum": {
+                            "availability_template": "{{ is_state('availability_state.state', 'on') }}",
+                            "start": {"service": "script.vacuum_start"},
+                        }
+                    },
+                }
+            },
+        )
+    ],
+)
+async def test_available_template_with_entities(hass, start_ha):
     """Test availability templates with values from other entities."""
-
-    assert await setup.async_setup_component(
-        hass,
-        "vacuum",
-        {
-            "vacuum": {
-                "platform": "template",
-                "vacuums": {
-                    "test_template_vacuum": {
-                        "availability_template": "{{ is_state('availability_state.state', 'on') }}",
-                        "start": {"service": "script.vacuum_start"},
-                    }
-                },
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
 
     # When template returns true..
     hass.states.async_set("availability_state.state", STATE_ON)
@@ -252,57 +203,60 @@ async def test_available_template_with_entities(hass, calls):
     assert hass.states.get("vacuum.test_template_vacuum").state == STATE_UNAVAILABLE
 
 
-async def test_invalid_availability_template_keeps_component_available(hass, caplog):
+@pytest.mark.parametrize(
+    "do_count,do_domain,do_config",
+    [
+        (
+            1,
+            "vacuum",
+            {
+                "vacuum": {
+                    "platform": "template",
+                    "vacuums": {
+                        "test_template_vacuum": {
+                            "availability_template": "{{ x - 12 }}",
+                            "start": {"service": "script.vacuum_start"},
+                        }
+                    },
+                }
+            },
+        )
+    ],
+)
+async def test_invalid_availability_template_keeps_component_available(
+    hass, caplog, start_ha
+):
     """Test that an invalid availability keeps the device available."""
-    assert await setup.async_setup_component(
-        hass,
-        "vacuum",
-        {
-            "vacuum": {
-                "platform": "template",
-                "vacuums": {
-                    "test_template_vacuum": {
-                        "availability_template": "{{ x - 12 }}",
-                        "start": {"service": "script.vacuum_start"},
-                    }
-                },
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
     assert hass.states.get("vacuum.test_template_vacuum") != STATE_UNAVAILABLE
-    assert ("UndefinedError: 'x' is undefined") in caplog.text
+    text = str([x.getMessage() for x in caplog.get_records("setup")])
+    assert ("UndefinedError: \\'x\\' is undefined") in text
 
 
-async def test_attribute_templates(hass, calls):
+@pytest.mark.parametrize(
+    "do_count,do_domain,do_config",
+    [
+        (
+            1,
+            "vacuum",
+            {
+                "vacuum": {
+                    "platform": "template",
+                    "vacuums": {
+                        "test_template_vacuum": {
+                            "value_template": "{{ 'cleaning' }}",
+                            "start": {"service": "script.vacuum_start"},
+                            "attribute_templates": {
+                                "test_attribute": "It {{ states.sensor.test_state.state }}."
+                            },
+                        }
+                    },
+                }
+            },
+        )
+    ],
+)
+async def test_attribute_templates(hass, start_ha):
     """Test attribute_templates template."""
-    assert await setup.async_setup_component(
-        hass,
-        "vacuum",
-        {
-            "vacuum": {
-                "platform": "template",
-                "vacuums": {
-                    "test_template_vacuum": {
-                        "value_template": "{{ 'cleaning' }}",
-                        "start": {"service": "script.vacuum_start"},
-                        "attribute_templates": {
-                            "test_attribute": "It {{ states.sensor.test_state.state }}."
-                        },
-                    }
-                },
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
     state = hass.states.get("vacuum.test_template_vacuum")
     assert state.attributes["test_attribute"] == "It ."
 
@@ -315,41 +269,101 @@ async def test_attribute_templates(hass, calls):
     assert state.attributes["test_attribute"] == "It Works."
 
 
-async def test_invalid_attribute_template(hass, caplog):
+@pytest.mark.parametrize(
+    "do_count,do_domain,do_config",
+    [
+        (
+            1,
+            "vacuum",
+            {
+                "vacuum": {
+                    "platform": "template",
+                    "vacuums": {
+                        "invalid_template": {
+                            "value_template": "{{ states('input_select.state') }}",
+                            "start": {"service": "script.vacuum_start"},
+                            "attribute_templates": {
+                                "test_attribute": "{{ this_function_does_not_exist() }}"
+                            },
+                        }
+                    },
+                }
+            },
+        )
+    ],
+)
+async def test_invalid_attribute_template(hass, caplog, start_ha):
     """Test that errors are logged if rendering template fails."""
-    assert await setup.async_setup_component(
-        hass,
-        "vacuum",
-        {
-            "vacuum": {
-                "platform": "template",
-                "vacuums": {
-                    "invalid_template": {
-                        "value_template": "{{ states('input_select.state') }}",
-                        "start": {"service": "script.vacuum_start"},
-                        "attribute_templates": {
-                            "test_attribute": "{{ this_function_does_not_exist() }}"
-                        },
-                    }
-                },
-            }
-        },
-    )
-    await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 1
 
-    await hass.async_start()
+    text = str([x.getMessage() for x in caplog.get_records("setup")])
+    assert "test_attribute" in text
+    assert "TemplateError" in text
+
+
+@pytest.mark.parametrize(
+    "do_count,do_domain,do_config",
+    [
+        (
+            1,
+            "vacuum",
+            {
+                "vacuum": {
+                    "platform": "template",
+                    "vacuums": {
+                        "test_template_vacuum_01": {
+                            "unique_id": "not-so-unique-anymore",
+                            "value_template": "{{ true }}",
+                            "start": {"service": "script.vacuum_start"},
+                        },
+                        "test_template_vacuum_02": {
+                            "unique_id": "not-so-unique-anymore",
+                            "value_template": "{{ false }}",
+                            "start": {"service": "script.vacuum_start"},
+                        },
+                    },
+                }
+            },
+        ),
+    ],
+)
+async def test_unique_id(hass, start_ha):
+    """Test unique_id option only creates one vacuum per id."""
+    assert len(hass.states.async_all()) == 1
+
+
+async def test_unused_services(hass):
+    """Test calling unused services should not crash."""
+    await _register_basic_vacuum(hass)
+
+    # Pause vacuum
+    await common.async_pause(hass, _TEST_VACUUM)
     await hass.async_block_till_done()
 
-    assert "test_attribute" in caplog.text
-    assert "TemplateError" in caplog.text
+    # Stop vacuum
+    await common.async_stop(hass, _TEST_VACUUM)
+    await hass.async_block_till_done()
+
+    # Return vacuum to base
+    await common.async_return_to_base(hass, _TEST_VACUUM)
+    await hass.async_block_till_done()
+
+    # Spot cleaning
+    await common.async_clean_spot(hass, _TEST_VACUUM)
+    await hass.async_block_till_done()
+
+    # Locate vacuum
+    await common.async_locate(hass, _TEST_VACUUM)
+    await hass.async_block_till_done()
+
+    # Set fan's speed
+    await common.async_set_fan_speed(hass, "medium", _TEST_VACUUM)
+    await hass.async_block_till_done()
+
+    _verify(hass, STATE_UNKNOWN, None)
 
 
-# End of template tests #
-
-
-# Function tests #
-async def test_state_services(hass, calls):
+async def test_state_services(hass):
     """Test state services."""
     await _register_components(hass)
 
@@ -386,38 +400,7 @@ async def test_state_services(hass, calls):
     _verify(hass, STATE_RETURNING, None)
 
 
-async def test_unused_services(hass, calls):
-    """Test calling unused services should not crash."""
-    await _register_basic_vacuum(hass)
-
-    # Pause vacuum
-    await common.async_pause(hass, _TEST_VACUUM)
-    await hass.async_block_till_done()
-
-    # Stop vacuum
-    await common.async_stop(hass, _TEST_VACUUM)
-    await hass.async_block_till_done()
-
-    # Return vacuum to base
-    await common.async_return_to_base(hass, _TEST_VACUUM)
-    await hass.async_block_till_done()
-
-    # Spot cleaning
-    await common.async_clean_spot(hass, _TEST_VACUUM)
-    await hass.async_block_till_done()
-
-    # Locate vacuum
-    await common.async_locate(hass, _TEST_VACUUM)
-    await hass.async_block_till_done()
-
-    # Set fan's speed
-    await common.async_set_fan_speed(hass, "medium", _TEST_VACUUM)
-    await hass.async_block_till_done()
-
-    _verify(hass, STATE_UNKNOWN, None)
-
-
-async def test_clean_spot_service(hass, calls):
+async def test_clean_spot_service(hass):
     """Test clean spot service."""
     await _register_components(hass)
 
@@ -429,7 +412,7 @@ async def test_clean_spot_service(hass, calls):
     assert hass.states.get(_SPOT_CLEANING_INPUT_BOOLEAN).state == STATE_ON
 
 
-async def test_locate_service(hass, calls):
+async def test_locate_service(hass):
     """Test locate service."""
     await _register_components(hass)
 
@@ -441,7 +424,7 @@ async def test_locate_service(hass, calls):
     assert hass.states.get(_LOCATING_INPUT_BOOLEAN).state == STATE_ON
 
 
-async def test_set_fan_speed(hass, calls):
+async def test_set_fan_speed(hass):
     """Test set valid fan speed."""
     await _register_components(hass)
 
@@ -460,7 +443,7 @@ async def test_set_fan_speed(hass, calls):
     assert hass.states.get(_FAN_SPEED_INPUT_SELECT).state == "medium"
 
 
-async def test_set_invalid_fan_speed(hass, calls):
+async def test_set_invalid_fan_speed(hass):
     """Test set invalid fan speed when fan has valid speed."""
     await _register_components(hass)
 
@@ -611,34 +594,3 @@ async def _register_components(hass):
     await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
-
-
-async def test_unique_id(hass):
-    """Test unique_id option only creates one vacuum per id."""
-    await setup.async_setup_component(
-        hass,
-        "vacuum",
-        {
-            "vacuum": {
-                "platform": "template",
-                "vacuums": {
-                    "test_template_vacuum_01": {
-                        "unique_id": "not-so-unique-anymore",
-                        "value_template": "{{ true }}",
-                        "start": {"service": "script.vacuum_start"},
-                    },
-                    "test_template_vacuum_02": {
-                        "unique_id": "not-so-unique-anymore",
-                        "value_template": "{{ false }}",
-                        "start": {"service": "script.vacuum_start"},
-                    },
-                },
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 1

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -24,7 +24,7 @@ _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
 
 
 @pytest.mark.parametrize(
-    "do_len,do_count,do_parm1,do_parm2,do_domain,do_config",
+    "length,count,parm1,parm2,domain,config",
     [
         (
             1,
@@ -127,15 +127,15 @@ _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
         ),
     ],
 )
-async def test_configs(hass, do_len, do_parm1, do_parm2, start_ha):
+async def test_configs(hass, length, parm1, parm2, start_ha):
     """Test: configs."""
-    assert len(hass.states.async_all()) == do_len
-    if do_len:
-        _verify(hass, do_parm1, do_parm2)
+    assert len(hass.states.async_all()) == length
+    if length:
+        _verify(hass, parm1, parm2)
 
 
 @pytest.mark.parametrize(
-    "do_count,do_domain,do_config",
+    "count,domain,config",
     [
         (
             1,
@@ -166,7 +166,7 @@ async def test_templates_with_entities(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "do_count,do_domain,do_config",
+    "count,domain,config",
     [
         (
             1,
@@ -204,7 +204,7 @@ async def test_available_template_with_entities(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "do_count,do_domain,do_config",
+    "count,domain,config",
     [
         (
             1,
@@ -233,7 +233,7 @@ async def test_invalid_availability_template_keeps_component_available(
 
 
 @pytest.mark.parametrize(
-    "do_count,do_domain,do_config",
+    "count,domain,config",
     [
         (
             1,
@@ -270,7 +270,7 @@ async def test_attribute_templates(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "do_count,do_domain,do_config",
+    "count,domain,config",
     [
         (
             1,
@@ -302,7 +302,7 @@ async def test_invalid_attribute_template(hass, caplog, start_ha):
 
 
 @pytest.mark.parametrize(
-    "do_count,do_domain,do_config",
+    "count,domain,config",
     [
         (
             1,

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -23,15 +23,13 @@ _FAN_SPEED_INPUT_SELECT = "input_select.fan_speed"
 _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
 
 
+@pytest.mark.parametrize("count,domain", [(1, "vacuum")])
 @pytest.mark.parametrize(
-    "length,count,parm1,parm2,domain,config",
+    "parm1,parm2,config",
     [
         (
-            1,
-            1,
             STATE_UNKNOWN,
             None,
-            "vacuum",
             {
                 "vacuum": {
                     "platform": "template",
@@ -42,37 +40,8 @@ _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
             },
         ),
         (
-            0,
-            0,
-            None,
-            None,
-            "vacuum",
-            {
-                "vacuum": {
-                    "platform": "template",
-                    "vacuums": {"test_vacuum": {"value_template": "{{ 'on' }}"}},
-                }
-            },
-        ),
-        (
-            0,
-            0,
-            None,
-            None,
-            "vacuum",
-            {
-                "platform": "template",
-                "vacuums": {
-                    "test_vacuum": {"start": {"service": "script.vacuum_start"}}
-                },
-            },
-        ),
-        (
-            1,
-            1,
             STATE_CLEANING,
             100,
-            "vacuum",
             {
                 "vacuum": {
                     "platform": "template",
@@ -87,11 +56,8 @@ _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
             },
         ),
         (
-            1,
-            1,
             STATE_UNKNOWN,
             None,
-            "vacuum",
             {
                 "vacuum": {
                     "platform": "template",
@@ -106,11 +72,8 @@ _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
             },
         ),
         (
-            1,
-            1,
             STATE_UNKNOWN,
             None,
-            "vacuum",
             {
                 "vacuum": {
                     "platform": "template",
@@ -127,11 +90,31 @@ _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
         ),
     ],
 )
-async def test_configs(hass, length, parm1, parm2, start_ha):
+async def test_valid_configs(hass, count, parm1, parm2, start_ha):
     """Test: configs."""
-    assert len(hass.states.async_all()) == length
-    if length:
-        _verify(hass, parm1, parm2)
+    assert len(hass.states.async_all()) == count
+    _verify(hass, parm1, parm2)
+
+
+@pytest.mark.parametrize("count,domain", [(0, "vacuum")])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "vacuum": {
+                "platform": "template",
+                "vacuums": {"test_vacuum": {"value_template": "{{ 'on' }}"}},
+            }
+        },
+        {
+            "platform": "template",
+            "vacuums": {"test_vacuum": {"start": {"service": "script.vacuum_start"}}},
+        },
+    ],
+)
+async def test_invalid_configs(hass, count, start_ha):
+    """Test: configs."""
+    assert len(hass.states.async_all()) == count
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
template/vacuum did use pytest, but not very efficient. Added use of fixtures, that can be used for the other entities as well.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
#40899
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
