### PR TITLE
Add config flow to Rainforest EAGLE-200

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -838,6 +838,8 @@ omit =
     homeassistant/components/rainmachine/binary_sensor.py
     homeassistant/components/rainmachine/sensor.py
     homeassistant/components/rainmachine/switch.py
+    homeassistant/components/rainforest_eagle/__init__.py
+    homeassistant/components/rainforest_eagle/data.py
     homeassistant/components/rainforest_eagle/sensor.py
     homeassistant/components/raspihats/*
     homeassistant/components/raspyrfm/*

--- a/homeassistant/components/rainforest_eagle/__init__.py
+++ b/homeassistant/components/rainforest_eagle/__init__.py
@@ -1,1 +1,34 @@
-"""The rainforest_eagle component."""
+"""The Rainforest Eagle-200 integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TYPE
+from homeassistant.core import HomeAssistant
+
+from . import data
+from .const import CONF_CLOUD_ID, CONF_INSTALL_CODE, DOMAIN
+
+PLATFORMS = ("sensor",)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Rainforest Eagle-200 from a config entry."""
+    coordinator = data.EagleDataCoordinator(
+        hass,
+        entry.data[CONF_TYPE],
+        entry.data[CONF_CLOUD_ID],
+        entry.data[CONF_INSTALL_CODE],
+    )
+    await coordinator.async_config_entry_first_refresh()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/rainforest_eagle/__init__.py
+++ b/homeassistant/components/rainforest_eagle/__init__.py
@@ -11,7 +11,7 @@ PLATFORMS = ("sensor",)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Rainforest Eagle-200 from a config entry."""
+    """Set up Rainforest Eagle from a config entry."""
     coordinator = data.EagleDataCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator

--- a/homeassistant/components/rainforest_eagle/__init__.py
+++ b/homeassistant/components/rainforest_eagle/__init__.py
@@ -1,24 +1,18 @@
-"""The Rainforest Eagle-200 integration."""
+"""The Rainforest Eagle integration."""
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_TYPE
 from homeassistant.core import HomeAssistant
 
 from . import data
-from .const import CONF_CLOUD_ID, CONF_INSTALL_CODE, DOMAIN
+from .const import DOMAIN
 
 PLATFORMS = ("sensor",)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Rainforest Eagle-200 from a config entry."""
-    coordinator = data.EagleDataCoordinator(
-        hass,
-        entry.data[CONF_TYPE],
-        entry.data[CONF_CLOUD_ID],
-        entry.data[CONF_INSTALL_CODE],
-    )
+    coordinator = data.EagleDataCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/rainforest_eagle/config_flow.py
+++ b/homeassistant/components/rainforest_eagle/config_flow.py
@@ -1,0 +1,68 @@
+"""Config flow for Rainforest Eagle-200 integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_TYPE
+from homeassistant.data_entry_flow import FlowResult
+
+from . import data
+from .const import CONF_CLOUD_ID, CONF_INSTALL_CODE, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CLOUD_ID): str,
+        vol.Required(CONF_INSTALL_CODE): str,
+    }
+)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Rainforest Eagle-200."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+
+        errors = {}
+
+        try:
+            eagle_type = await self.hass.async_add_executor_job(
+                data.get_type, user_input[CONF_CLOUD_ID], user_input[CONF_INSTALL_CODE]
+            )
+        except data.CannotConnect:
+            errors["base"] = "cannot_connect"
+        except data.InvalidAuth:
+            errors["base"] = "invalid_auth"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            await self.async_set_unique_id(user_input[CONF_CLOUD_ID])
+            user_input[CONF_TYPE] = eagle_type
+            return self.async_create_entry(
+                title=user_input[CONF_CLOUD_ID], data=user_input
+            )
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
+        """Handle the import step."""
+        await self.async_set_unique_id(user_input[CONF_CLOUD_ID])
+        self._abort_if_unique_id_configured()
+        return await self.async_step_user(user_input)

--- a/homeassistant/components/rainforest_eagle/config_flow.py
+++ b/homeassistant/components/rainforest_eagle/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Rainforest Eagle-200 integration."""
+"""Config flow for Rainforest Eagle integration."""
 from __future__ import annotations
 
 import logging
@@ -24,7 +24,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Rainforest Eagle-200."""
+    """Handle a config flow for Rainforest Eagle."""
 
     VERSION = 1
 

--- a/homeassistant/components/rainforest_eagle/const.py
+++ b/homeassistant/components/rainforest_eagle/const.py
@@ -1,0 +1,8 @@
+"""Constants for the Rainforest Eagle-200 integration."""
+
+DOMAIN = "rainforest_eagle"
+CONF_CLOUD_ID = "cloud_id"
+CONF_INSTALL_CODE = "install_code"
+
+TYPE_LEGACY = "legacy"
+TYPE_EAGLE_200 = "eagle-200"

--- a/homeassistant/components/rainforest_eagle/const.py
+++ b/homeassistant/components/rainforest_eagle/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Rainforest Eagle-200 integration."""
+"""Constants for the Rainforest Eagle integration."""
 
 DOMAIN = "rainforest_eagle"
 CONF_CLOUD_ID = "cloud_id"

--- a/homeassistant/components/rainforest_eagle/const.py
+++ b/homeassistant/components/rainforest_eagle/const.py
@@ -3,6 +3,7 @@
 DOMAIN = "rainforest_eagle"
 CONF_CLOUD_ID = "cloud_id"
 CONF_INSTALL_CODE = "install_code"
+CONF_HARDWARE_ADDRESS = "hardware_address"
 
-TYPE_LEGACY = "legacy"
+TYPE_EAGLE_100 = "eagle-100"
 TYPE_EAGLE_200 = "eagle-200"

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -92,7 +92,7 @@ class EagleDataCoordinator(DataUpdateCoordinator):
     eagle100_reader: Eagle100Reader | None = None
     eagle200_meter: aioeagle.ElectricMeter | None = None
 
-    def __init__(self, hass, entry: ConfigEntry):
+    def __init__(self, hass: HomeAssistant , entry: ConfigEntry) -> None:
         """Initialize the data object."""
         self.entry = entry
         if self.type == TYPE_EAGLE_100:

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -139,9 +139,7 @@ class EagleDataCoordinator(DataUpdateCoordinator):
 
         try:
             async with async_timeout.timeout(30):
-                data = await self.eagle200_meter.get_device_query(
-                    self.eagle200_meter.ENERGY_AND_POWER_VARIABLES
-                )
+                data = await self.eagle200_meter.get_device_query()
         except aioeagle.BadAuth as error:
             raise ConfigEntryAuthFailed from error
 

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -88,7 +88,7 @@ async def async_get_type(hass, cloud_id, install_code):
 
 
 class EagleDataCoordinator(DataUpdateCoordinator):
-    """Get the latest data from the Eagle-200 device."""
+    """Get the latest data from the Eagle device."""
 
     eagle100_reader: Eagle100Reader | None = None
     eagle200_meter: aioeagle.ElectricMeter | None = None
@@ -145,7 +145,7 @@ class EagleDataCoordinator(DataUpdateCoordinator):
         return {var["Name"]: var["Value"] for var in data.values()}
 
     async def _async_update_data_100(self):
-        """Get the latest data from the Eagle-200 device."""
+        """Get the latest data from the Eagle-100 device."""
         try:
             data = await self.hass.async_add_executor_job(self._fetch_data)
         except UPDATE_100_ERRORS as error:

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -41,14 +41,14 @@ def get_type(cloud_id, install_code):
     # Branch to test if target is Legacy Model
     if (
         "NetworkInfo" in response
-        and response["NetworkInfo"].get("ModelId", None) == "Z109-EAGLE"
+        and response["NetworkInfo"].get("ModelId") == "Z109-EAGLE"
     ):
         return TYPE_LEGACY
 
     # Branch to test if target is Eagle-200 Model
     if (
         "Response" in response
-        and response["Response"].get("Command", None) == "get_network_info"
+        and response["Response"].get("Command") == "get_network_info"
     ):
         return TYPE_EAGLE_200
 

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -1,0 +1,119 @@
+"""Rainforest data."""
+from datetime import timedelta
+import logging
+
+from eagle200_reader import EagleReader
+from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
+from uEagle import Eagle as LegacyReader
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import TYPE_EAGLE_200, TYPE_LEGACY
+
+_LOGGER = logging.getLogger(__name__)
+
+UPDATE_ERRORS = (ConnectError, HTTPError, Timeout, ValueError)
+
+
+class RainforestError(HomeAssistantError):
+    """Base error."""
+
+
+class CannotConnect(RainforestError):
+    """Error to indicate a request failed."""
+
+
+class InvalidAuth(RainforestError):
+    """Error to indicate bad auth."""
+
+
+def get_type(cloud_id, install_code):
+    """Try API call 'get_network_info' to see if target device is Legacy or Eagle-200."""
+    reader = FixedLegacyReader(cloud_id, install_code)
+
+    try:
+        response = reader.get_network_info()
+    except UPDATE_ERRORS as error:
+        _LOGGER.error("Failed to connect during setup: %s", error)
+        raise CannotConnect from error
+
+    # Branch to test if target is Legacy Model
+    if (
+        "NetworkInfo" in response
+        and response["NetworkInfo"].get("ModelId", None) == "Z109-EAGLE"
+    ):
+        return TYPE_LEGACY
+
+    # Branch to test if target is Eagle-200 Model
+    if (
+        "Response" in response
+        and response["Response"].get("Command", None) == "get_network_info"
+    ):
+        return TYPE_EAGLE_200
+
+    # Catch-all if hardware ID tests fail
+    return None
+
+
+class FixedLegacyReader(LegacyReader):
+    """Wraps uEagle to make it behave like eagle_reader, offering update()."""
+
+    def update(self):
+        """Fetch and return the four sensor values in a dict."""
+        out = {}
+
+        resp = self.get_instantaneous_demand()["InstantaneousDemand"]
+        out["instantanous_demand"] = resp["Demand"]
+
+        resp = self.get_current_summation()["CurrentSummation"]
+        out["summation_delivered"] = resp["SummationDelivered"]
+        out["summation_received"] = resp["SummationReceived"]
+        out["summation_total"] = out["summation_delivered"] - out["summation_received"]
+
+        return out
+
+
+class FixedEagleReader(EagleReader):
+    """Wraps EagleReader to avoid updating in constructor."""
+
+    # pylint: disable=super-init-not-called
+    def __init__(self, ip_addr, cloud_id, install_code):
+        """Initialize eagle reader.
+
+        We don't call super() because it fetches data.
+        """
+        self.ip_addr = ip_addr
+        self.cloud_id = cloud_id
+        self.install_code = install_code
+
+        self.instantanous_demand_value = 0.0
+        self.summation_delivered_value = 0.0
+        self.summation_received_value = 0.0
+        self.summation_total_value = 0.0
+
+
+class EagleDataCoordinator(DataUpdateCoordinator):
+    """Get the latest data from the Eagle-200 device."""
+
+    def __init__(self, hass, reader_type, cloud_id, install_code):
+        """Initialize the data object."""
+        super().__init__(
+            hass, _LOGGER, name=cloud_id, update_interval=timedelta(seconds=30)
+        )
+        self.cloud_id = cloud_id
+        if reader_type == TYPE_LEGACY:
+            self._eagle_reader = FixedLegacyReader(cloud_id, install_code)
+        else:
+            self._eagle_reader = FixedEagleReader(
+                f"eagle-{cloud_id}.local", cloud_id, install_code
+            )
+
+    async def _async_update_data(self):
+        """Get the latest data from the Eagle-200 device."""
+        try:
+            data = await self.hass.async_add_executor_job(self._eagle_reader.update)
+            _LOGGER.debug("API data: %s", data)
+            return data
+        except UPDATE_ERRORS as error:
+            raise UpdateFailed from error

--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -5,6 +5,7 @@
   "requirements": ["eagle200_reader==0.2.4", "uEagle==0.0.2"],
   "codeowners": ["@gtdiehl", "@jcalbert"],
   "iot_class": "local_polling",
+  "config_flow": true,
   "dhcp": [
     {
       "macaddress": "D8D5B9*"

--- a/homeassistant/components/rainforest_eagle/manifest.json
+++ b/homeassistant/components/rainforest_eagle/manifest.json
@@ -1,8 +1,8 @@
 {
   "domain": "rainforest_eagle",
-  "name": "Rainforest Eagle-200",
+  "name": "Rainforest Eagle",
   "documentation": "https://www.home-assistant.io/integrations/rainforest_eagle",
-  "requirements": ["eagle200_reader==0.2.4", "uEagle==0.0.2"],
+  "requirements": ["aioeagle==1.1.0", "uEagle==0.0.2"],
   "codeowners": ["@gtdiehl", "@jcalbert"],
   "iot_class": "local_polling",
   "config_flow": true,

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -9,7 +9,6 @@ import voluptuous as vol
 from homeassistant.components.sensor import (
     DEVICE_CLASS_ENERGY,
     PLATFORM_SCHEMA,
-    STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
     SensorEntityDescription,
@@ -20,6 +19,7 @@ from homeassistant.const import (
     CONF_IP_ADDRESS,
     DEVICE_CLASS_POWER,
     ENERGY_KILO_WATT_HOUR,
+    POWER_KILO_WATT,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
@@ -33,36 +33,26 @@ from .data import EagleDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-POWER_KILO_WATT = "kW"
-
 SENSORS = (
     SensorEntityDescription(
-        key="instantanous_demand",
+        key="zigbee:InstantaneousDemand",
         name="Meter Power Demand",
         native_unit_of_measurement=POWER_KILO_WATT,
         device_class=DEVICE_CLASS_POWER,
     ),
     SensorEntityDescription(
-        key="summation_delivered",
+        key="zigbee:CurrentSummationDelivered",
         name="Total Meter Energy Delivered",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     SensorEntityDescription(
-        key="summation_received",
+        key="zigbee:CurrentSummationReceived",
         name="Total Meter Energy Received",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
-    ),
-    SensorEntityDescription(
-        key="summation_total",
-        name="Net Meter Energy (Delivered minus Received)",
-        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
-        device_class=DEVICE_CLASS_ENERGY,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_registry_enabled_default=False,
     ),
 )
 
@@ -132,8 +122,8 @@ class EagleSensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> DeviceInfo | None:
         """Return device info."""
         return {
-            "name": "EAGLE-200",
+            "name": self.coordinator.model,
             "identifiers": {(DOMAIN, self.coordinator.cloud_id)},
             "manufacturer": "Rainforest Automation",
-            "model": "EAGLE-200",
+            "model": self.coordinator.model,
         }

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -1,4 +1,4 @@
-"""Support for the Rainforest Eagle-200 energy monitor."""
+"""Support for the Rainforest Eagle energy monitor."""
 from __future__ import annotations
 
 import logging
@@ -73,8 +73,8 @@ async def async_setup_platform(
 ):
     """Import config as config entry."""
     _LOGGER.warning(
-        "Configuration of the EAGLE-200 platform in YAML is deprecated and will be "
-        "removed in Home Assistant 2021.11; Your existing configuration "
+        "Configuration of the rainforest_eagle platform in YAML is deprecated "
+        "and will be removed in Home Assistant 2021.11; Your existing configuration "
         "has been imported into the UI automatically and can be safely removed "
         "from your configuration.yaml file"
     )
@@ -99,7 +99,7 @@ async def async_setup_entry(
 
 
 class EagleSensor(CoordinatorEntity, SensorEntity):
-    """Implementation of the Rainforest Eagle-200 sensor."""
+    """Implementation of the Rainforest Eagle sensor."""
 
     coordinator: EagleDataCoordinator
 

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -1,13 +1,9 @@
 """Support for the Rainforest Eagle-200 energy monitor."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import timedelta
 import logging
+from typing import Any
 
-from eagle200_reader import EagleReader
-from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
-from uEagle import Eagle as LegacyReader
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
@@ -16,59 +12,59 @@ from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
+    SensorEntityDescription,
+    StateType,
 )
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_IP_ADDRESS,
     DEVICE_CLASS_POWER,
     ENERGY_KILO_WATT_HOUR,
 )
-import homeassistant.helpers.config_validation as cv
-from homeassistant.util import Throttle
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-CONF_CLOUD_ID = "cloud_id"
-CONF_INSTALL_CODE = "install_code"
-POWER_KILO_WATT = "kW"
+from .const import CONF_CLOUD_ID, CONF_INSTALL_CODE, DOMAIN
+from .data import EagleDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-MIN_SCAN_INTERVAL = timedelta(seconds=30)
+POWER_KILO_WATT = "kW"
 
-
-@dataclass
-class SensorType:
-    """Rainforest sensor type."""
-
-    name: str
-    unit_of_measurement: str
-    device_class: str | None = None
-    state_class: str | None = None
-
-
-SENSORS = {
-    "instantanous_demand": SensorType(
-        name="Eagle-200 Meter Power Demand",
-        unit_of_measurement=POWER_KILO_WATT,
+SENSORS = (
+    SensorEntityDescription(
+        key="instantanous_demand",
+        name="Meter Power Demand",
+        native_unit_of_measurement=POWER_KILO_WATT,
         device_class=DEVICE_CLASS_POWER,
     ),
-    "summation_delivered": SensorType(
-        name="Eagle-200 Total Meter Energy Delivered",
-        unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+    SensorEntityDescription(
+        key="summation_delivered",
+        name="Total Meter Energy Delivered",
+        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
-    "summation_received": SensorType(
-        name="Eagle-200 Total Meter Energy Received",
-        unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+    SensorEntityDescription(
+        key="summation_received",
+        name="Total Meter Energy Received",
+        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
-    "summation_total": SensorType(
-        name="Eagle-200 Net Meter Energy (Delivered minus Received)",
-        unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+    SensorEntityDescription(
+        key="summation_total",
+        name="Net Meter Energy (Delivered minus Received)",
+        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
-}
+)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -79,104 +75,65 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def hwtest(cloud_id, install_code, ip_address):
-    """Try API call 'get_network_info' to see if target device is Legacy or Eagle-200."""
-    reader = LeagleReader(cloud_id, install_code, ip_address)
-    response = reader.get_network_info()
-
-    # Branch to test if target is Legacy Model
-    if (
-        "NetworkInfo" in response
-        and response["NetworkInfo"].get("ModelId", None) == "Z109-EAGLE"
-    ):
-        return reader
-
-    # Branch to test if target is Eagle-200 Model
-    if (
-        "Response" in response
-        and response["Response"].get("Command", None) == "get_network_info"
-    ):
-        return EagleReader(ip_address, cloud_id, install_code)
-
-    # Catch-all if hardware ID tests fail
-    raise ValueError("Couldn't determine device model.")
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Create the Eagle-200 sensor."""
-    ip_address = config[CONF_IP_ADDRESS]
-    cloud_id = config[CONF_CLOUD_ID]
-    install_code = config[CONF_INSTALL_CODE]
-
-    try:
-        eagle_reader = hwtest(cloud_id, install_code, ip_address)
-    except (ConnectError, HTTPError, Timeout, ValueError) as error:
-        _LOGGER.error("Failed to connect during setup: %s", error)
-        return
-
-    eagle_data = EagleData(eagle_reader)
-    eagle_data.update()
-
-    add_entities(EagleSensor(eagle_data, condition) for condition in SENSORS)
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: dict[str, Any] | None = None,
+):
+    """Import config as config entry."""
+    _LOGGER.warning(
+        "Configuration of the EAGLE-200 platform in YAML is deprecated and will be "
+        "removed in Home Assistant 2021.11; Your existing configuration "
+        "has been imported into the UI automatically and can be safely removed "
+        "from your configuration.yaml file"
+    )
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={
+                CONF_CLOUD_ID: config[CONF_CLOUD_ID],
+                CONF_INSTALL_CODE: config[CONF_INSTALL_CODE],
+            },
+        )
+    )
 
 
-class EagleSensor(SensorEntity):
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(EagleSensor(coordinator, description) for description in SENSORS)
+
+
+class EagleSensor(CoordinatorEntity, SensorEntity):
     """Implementation of the Rainforest Eagle-200 sensor."""
 
-    def __init__(self, eagle_data, sensor_type):
+    coordinator: EagleDataCoordinator
+
+    def __init__(self, coordinator, entity_description):
         """Initialize the sensor."""
-        self.eagle_data = eagle_data
-        self._type = sensor_type
-        sensor_info = SENSORS[sensor_type]
-        self._attr_name = sensor_info.name
-        self._attr_native_unit_of_measurement = sensor_info.unit_of_measurement
-        self._attr_device_class = sensor_info.device_class
-        self._attr_state_class = sensor_info.state_class
+        super().__init__(coordinator)
+        self.entity_description = entity_description
 
-    def update(self):
-        """Get the energy information from the Rainforest Eagle."""
-        self.eagle_data.update()
-        self._attr_native_value = self.eagle_data.get_state(self._type)
+    @property
+    def unique_id(self) -> str | None:
+        """Return unique ID of entity."""
+        return f"{self.coordinator.cloud_id}-{self.entity_description.key}"
 
+    @property
+    def native_value(self) -> StateType:
+        """Return native value of the sensor."""
+        return self.coordinator.data.get(self.entity_description.key)
 
-class EagleData:
-    """Get the latest data from the Eagle-200 device."""
-
-    def __init__(self, eagle_reader):
-        """Initialize the data object."""
-        self._eagle_reader = eagle_reader
-        self.data = {}
-
-    @Throttle(MIN_SCAN_INTERVAL)
-    def update(self):
-        """Get the latest data from the Eagle-200 device."""
-        try:
-            self.data = self._eagle_reader.update()
-            _LOGGER.debug("API data: %s", self.data)
-        except (ConnectError, HTTPError, Timeout, ValueError) as error:
-            _LOGGER.error("Unable to connect during update: %s", error)
-            self.data = {}
-
-    def get_state(self, sensor_type):
-        """Get the sensor value from the dictionary."""
-        state = self.data.get(sensor_type)
-        _LOGGER.debug("Updating: %s - %s", sensor_type, state)
-        return state
-
-
-class LeagleReader(LegacyReader, SensorEntity):
-    """Wraps uEagle to make it behave like eagle_reader, offering update()."""
-
-    def update(self):
-        """Fetch and return the four sensor values in a dict."""
-        out = {}
-
-        resp = self.get_instantaneous_demand()["InstantaneousDemand"]
-        out["instantanous_demand"] = resp["Demand"]
-
-        resp = self.get_current_summation()["CurrentSummation"]
-        out["summation_delivered"] = resp["SummationDelivered"]
-        out["summation_received"] = resp["SummationReceived"]
-        out["summation_total"] = out["summation_delivered"] - out["summation_received"]
-
-        return out
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return device info."""
+        return {
+            "name": "EAGLE-200",
+            "identifiers": {(DOMAIN, self.coordinator.cloud_id)},
+            "manufacturer": "Rainforest Automation",
+            "model": "EAGLE-200",
+        }

--- a/homeassistant/components/rainforest_eagle/strings.json
+++ b/homeassistant/components/rainforest_eagle/strings.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "cloud_id": "Cloud ID",
+          "install_code": "Installation Code"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/rainforest_eagle/translations/en.json
+++ b/homeassistant/components/rainforest_eagle/translations/en.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "password": "Password",
+                    "username": "Username"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/components/rainforest_eagle/translations/en.json
+++ b/homeassistant/components/rainforest_eagle/translations/en.json
@@ -11,9 +11,8 @@
         "step": {
             "user": {
                 "data": {
-                    "host": "Host",
-                    "password": "Password",
-                    "username": "Username"
+                    "cloud_id": "Cloud ID",
+                    "install_code": "Installation Code"
                 }
             }
         }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -215,6 +215,7 @@ FLOWS = [
     "ps4",
     "pvpc_hourly_pricing",
     "rachio",
+    "rainforest_eagle",
     "rainmachine",
     "recollect_waste",
     "renault",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -162,6 +162,10 @@ DHCP = [
         "macaddress": "74C63B*"
     },
     {
+        "domain": "rainforest_eagle",
+        "macaddress": "D8D5B9*"
+    },
+    {
         "domain": "ring",
         "hostname": "ring*",
         "macaddress": "0CAE7D*"

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -254,9 +254,10 @@ class DataUpdateCoordinator(Generic[T]):
 
         finally:
             self.logger.debug(
-                "Finished fetching %s data in %.3f seconds",
+                "Finished fetching %s data in %.3f seconds (success: %s)",
                 self.name,
                 monotonic() - start,
+                self.last_update_success,
             )
             if not auth_failed and self._listeners and not self.hass.is_stopping:
                 self._schedule_refresh()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -160,6 +160,9 @@ aiodns==3.0.0
 # homeassistant.components.eafm
 aioeafm==0.1.2
 
+# homeassistant.components.rainforest_eagle
+aioeagle==1.1.0
+
 # homeassistant.components.emonitor
 aioemonitor==1.0.5
 
@@ -541,9 +544,6 @@ dweepy==0.3.0
 
 # homeassistant.components.dynalite
 dynalite_devices==0.1.46
-
-# homeassistant.components.rainforest_eagle
-eagle200_reader==0.2.4
 
 # homeassistant.components.ebusd
 ebusdpy==0.0.16

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -311,6 +311,9 @@ dsmr_parser==0.29
 # homeassistant.components.dynalite
 dynalite_devices==0.1.46
 
+# homeassistant.components.rainforest_eagle
+eagle200_reader==0.2.4
+
 # homeassistant.components.elgato
 elgato==2.1.1
 
@@ -1276,6 +1279,9 @@ twilio==6.32.0
 
 # homeassistant.components.twinkly
 twinkly-client==0.0.2
+
+# homeassistant.components.rainforest_eagle
+uEagle==0.0.2
 
 # homeassistant.components.upb
 upb_lib==0.4.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -99,6 +99,9 @@ aiodns==3.0.0
 # homeassistant.components.eafm
 aioeafm==0.1.2
 
+# homeassistant.components.rainforest_eagle
+aioeagle==1.1.0
+
 # homeassistant.components.emonitor
 aioemonitor==1.0.5
 
@@ -310,9 +313,6 @@ dsmr_parser==0.29
 
 # homeassistant.components.dynalite
 dynalite_devices==0.1.46
-
-# homeassistant.components.rainforest_eagle
-eagle200_reader==0.2.4
 
 # homeassistant.components.elgato
 elgato==2.1.1

--- a/script/scaffold/templates/config_flow/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow/tests/test_config_flow.py
@@ -15,7 +15,7 @@ async def test_form(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == RESULT_TYPE_FORM
-    assert result["errors"] == {}
+    assert result["errors"] is None
 
     with patch(
         "homeassistant.components.NEW_DOMAIN.config_flow.PlaceholderHub.authenticate",

--- a/tests/components/rainforest_eagle/__init__.py
+++ b/tests/components/rainforest_eagle/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Rainforest Eagle-200 integration."""

--- a/tests/components/rainforest_eagle/__init__.py
+++ b/tests/components/rainforest_eagle/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for the Rainforest Eagle-200 integration."""
+"""Tests for the Rainforest Eagle integration."""

--- a/tests/components/rainforest_eagle/test_config_flow.py
+++ b/tests/components/rainforest_eagle/test_config_flow.py
@@ -1,0 +1,126 @@
+"""Test the Rainforest Eagle-200 config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.rainforest_eagle.const import (
+    CONF_CLOUD_ID,
+    CONF_INSTALL_CODE,
+    DOMAIN,
+    TYPE_EAGLE_200,
+)
+from homeassistant.components.rainforest_eagle.data import CannotConnect, InvalidAuth
+from homeassistant.const import CONF_TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.rainforest_eagle.data.get_type",
+        return_value=TYPE_EAGLE_200,
+    ), patch(
+        "homeassistant.components.rainforest_eagle.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_CLOUD_ID: "abcdef", CONF_INSTALL_CODE: "123456"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "abcdef"
+    assert result2["data"] == {
+        CONF_TYPE: TYPE_EAGLE_200,
+        CONF_CLOUD_ID: "abcdef",
+        CONF_INSTALL_CODE: "123456",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.rainforest_eagle.data.get_type",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_CLOUD_ID: "abcdef", CONF_INSTALL_CODE: "123456"},
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.rainforest_eagle.data.get_type",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_CLOUD_ID: "abcdef", CONF_INSTALL_CODE: "123456"},
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_import(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch(
+        "homeassistant.components.rainforest_eagle.data.get_type",
+        return_value=TYPE_EAGLE_200,
+    ), patch(
+        "homeassistant.components.rainforest_eagle.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data={CONF_CLOUD_ID: "abcdef", CONF_INSTALL_CODE: "123456"},
+            context={"source": config_entries.SOURCE_IMPORT},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "abcdef"
+    assert result["data"] == {
+        CONF_TYPE: TYPE_EAGLE_200,
+        CONF_CLOUD_ID: "abcdef",
+        CONF_INSTALL_CODE: "123456",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    # Second time we should get already_configured
+    result2 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data={CONF_CLOUD_ID: "abcdef", CONF_INSTALL_CODE: "123456"},
+        context={"source": config_entries.SOURCE_IMPORT},
+    )
+
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "already_configured"

--- a/tests/components/rainforest_eagle/test_config_flow.py
+++ b/tests/components/rainforest_eagle/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from homeassistant import config_entries, setup
 from homeassistant.components.rainforest_eagle.const import (
     CONF_CLOUD_ID,
+    CONF_HARDWARE_ADDRESS,
     CONF_INSTALL_CODE,
     DOMAIN,
     TYPE_EAGLE_200,
@@ -28,8 +29,8 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result["errors"] is None
 
     with patch(
-        "homeassistant.components.rainforest_eagle.data.get_type",
-        return_value=TYPE_EAGLE_200,
+        "homeassistant.components.rainforest_eagle.data.async_get_type",
+        return_value=(TYPE_EAGLE_200, "mock-hw"),
     ), patch(
         "homeassistant.components.rainforest_eagle.async_setup_entry",
         return_value=True,
@@ -46,6 +47,7 @@ async def test_form(hass: HomeAssistant) -> None:
         CONF_TYPE: TYPE_EAGLE_200,
         CONF_CLOUD_ID: "abcdef",
         CONF_INSTALL_CODE: "123456",
+        CONF_HARDWARE_ADDRESS: "mock-hw",
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -57,7 +59,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.rainforest_eagle.data.get_type",
+        "homeassistant.components.rainforest_eagle.data.Eagle100Reader.get_network_info",
         side_effect=InvalidAuth,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -76,7 +78,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.rainforest_eagle.data.get_type",
+        "homeassistant.components.rainforest_eagle.data.Eagle100Reader.get_network_info",
         side_effect=CannotConnect,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -93,8 +95,8 @@ async def test_import(hass: HomeAssistant) -> None:
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
-        "homeassistant.components.rainforest_eagle.data.get_type",
-        return_value=TYPE_EAGLE_200,
+        "homeassistant.components.rainforest_eagle.data.async_get_type",
+        return_value=(TYPE_EAGLE_200, "mock-hw"),
     ), patch(
         "homeassistant.components.rainforest_eagle.async_setup_entry",
         return_value=True,
@@ -112,6 +114,7 @@ async def test_import(hass: HomeAssistant) -> None:
         CONF_TYPE: TYPE_EAGLE_200,
         CONF_CLOUD_ID: "abcdef",
         CONF_INSTALL_CODE: "123456",
+        CONF_HARDWARE_ADDRESS: "mock-hw",
     }
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/rainforest_eagle/test_config_flow.py
+++ b/tests/components/rainforest_eagle/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Test the Rainforest Eagle-200 config flow."""
+"""Test the Rainforest Eagle config flow."""
 from unittest.mock import patch
 
 from homeassistant import config_entries, setup


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Rainforest Eagle is now set up via the UI. Your existing platform configuration has been imported and can safely be removed.

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a config flow to Rainforest EAGLE-200. 

The Rainforest EAGLE-200 supports 2 protocols and this was all put in a single sensor platform file. I made the following changes, hopefully easy to follow:

 - Use [aioeagle](https://github.com/home-assistant-libs/aioeagle) to fetch EAGLE-200 data
 - Move data fetching to `data.py`
 - Split "detect device type" from fetching data
 - Convert fetching data to update coordinator
 - Migrate sensor from custom entity description to native entity description
 - Add config flow

Note that it contains invalid auth error handling but we don't support that yet. Waiting for https://github.com/gtdiehl/eagle200_reader/pull/8 to be merged. Although I might consider rewriting it to be my own async lib.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
