### PR TITLE
Add missing id to yeelights that were setup manually

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -248,7 +248,7 @@ def _async_normalize_config_entry(hass: HomeAssistant, entry: ConfigEntry) -> No
                 ),
             },
         )
-    if entry.unique_id and not entry.data.get(CONF_ID):
+    elif entry.unique_id and not entry.data.get(CONF_ID):
         hass.config_entries.async_update_entry(
             entry,
             data={CONF_HOST: entry.data.get(CONF_HOST), CONF_ID: entry.unique_id},

--- a/homeassistant/components/yeelight/config_flow.py
+++ b/homeassistant/components/yeelight/config_flow.py
@@ -118,7 +118,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
-                    title=f"{model} {self.unique_id}", data=user_input
+                    title=f"{model} {self.unique_id}",
+                    data={
+                        CONF_HOST: user_input[CONF_HOST],
+                        CONF_ID: self.unique_id,
+                    },
                 )
 
         user_input = user_input or {}

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -215,7 +215,7 @@ async def test_manual(hass: HomeAssistant):
         await hass.async_block_till_done()
     assert result4["type"] == "create_entry"
     assert result4["title"] == "color 0x000000000015243f"
-    assert result4["data"] == {CONF_HOST: IP_ADDRESS}
+    assert result4["data"] == {CONF_HOST: IP_ADDRESS, CONF_ID: "0x000000000015243f"}
 
     # Duplicate
     result = await hass.config_entries.flow.async_init(
@@ -298,7 +298,7 @@ async def test_manual_no_capabilities(hass: HomeAssistant):
             result["flow_id"], {CONF_HOST: IP_ADDRESS}
         )
     assert result["type"] == "create_entry"
-    assert result["data"] == {CONF_HOST: IP_ADDRESS}
+    assert result["data"] == {CONF_HOST: IP_ADDRESS, CONF_ID: None}
 
 
 async def test_discovered_by_homekit_and_dhcp(hass):

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -284,7 +284,10 @@ async def test_async_listen_error_has_host_without_id(hass: HomeAssistant):
 async def test_async_setup_with_missing_id(hass: HomeAssistant):
     """Test that setting adds the missing CONF_ID from unique_id."""
     config_entry = MockConfigEntry(
-        domain=DOMAIN, unique_id=ID, data={CONF_HOST: "127.0.0.1"}
+        domain=DOMAIN,
+        unique_id=ID,
+        data={CONF_HOST: "127.0.0.1"},
+        options={CONF_NAME: "Test name"},
     )
     config_entry.add_to_hass(hass)
 

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -155,6 +155,9 @@ async def test_setup_import(hass: HomeAssistant):
     assert hass.states.get(f"binary_sensor.{name}_nightlight") is not None
     assert hass.states.get(f"light.{name}") is not None
     assert hass.states.get(f"light.{name}_nightlight") is not None
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.unique_id == "0x000000000015243f"
+    assert entry.data[CONF_ID] == "0x000000000015243f"
 
 
 async def test_unique_ids_device(hass: HomeAssistant):

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -279,3 +279,19 @@ async def test_async_listen_error_has_host_without_id(hass: HomeAssistant):
         await hass.config_entries.async_setup(config_entry.entry_id)
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_async_setup_with_missing_id(hass: HomeAssistant):
+    """Test that setting adds the missing CONF_ID from unique_id."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, unique_id=ID, data={CONF_HOST: "127.0.0.1"}
+    )
+    config_entry.add_to_hass(hass)
+
+    with _patch_discovery(), _patch_discovery_timeout(), _patch_discovery_interval(), patch(
+        f"{MODULE}.AsyncBulb", return_value=_mocked_bulb(cannot_connect=True)
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.data[CONF_ID] == ID


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add missing id to yeelights that were setup manually

yeelight was creating entries that were missing the ID field.  If the IP address of the yeelight changed, the user had no way to recover besides delete and recreate the entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
