### PR TITLE
Make log rollover at startup

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -335,14 +335,14 @@ def async_enable_logging(
         err_handler: logging.FileHandler
         if log_rotate_days:
             err_handler = logging.handlers.TimedRotatingFileHandler(
-                err_log_path, when="midnight", backupCount=log_rotate_days, delay=True
+                err_log_path, when="midnight", backupCount=log_rotate_days
             )
         else:
             err_handler = logging.handlers.RotatingFileHandler(
-                err_log_path, backupCount=1, delay=True
+                err_log_path, backupCount=1
             )
 
-        err_handler.rotate(err_log_path, f"{err_log_path}.bak")
+        err_handler.rotate(err_log_path, f"{err_log_path}.previous")
         err_handler.setLevel(logging.INFO if verbose else logging.WARNING)
         err_handler.setFormatter(logging.Formatter(fmt, datefmt=datefmt))
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -332,15 +332,17 @@ def async_enable_logging(
         not err_path_exists and os.access(err_dir, os.W_OK)
     ):
 
+        err_handler: logging.FileHandler
         if log_rotate_days:
-            err_handler: logging.FileHandler = (
-                logging.handlers.TimedRotatingFileHandler(
-                    err_log_path, when="midnight", backupCount=log_rotate_days
-                )
+            err_handler = logging.handlers.TimedRotatingFileHandler(
+                err_log_path, when="midnight", backupCount=log_rotate_days, delay=True
             )
         else:
-            err_handler = logging.FileHandler(err_log_path, mode="w", delay=True)
+            err_handler = logging.handlers.RotatingFileHandler(
+                err_log_path, backupCount=1, delay=True
+            )
 
+        err_handler.rotate(err_log_path, f"{err_log_path}.bak")
         err_handler.setLevel(logging.INFO if verbose else logging.WARNING)
         err_handler.setFormatter(logging.Formatter(fmt, datefmt=datefmt))
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -342,7 +342,7 @@ def async_enable_logging(
                 err_log_path, backupCount=1
             )
 
-        err_handler.rotate(err_log_path, f"{err_log_path}.previous")
+        err_handler.rotate(err_log_path, f"{err_log_path[:-4]}.previous.log")
         err_handler.setLevel(logging.INFO if verbose else logging.WARNING)
         err_handler.setFormatter(logging.Formatter(fmt, datefmt=datefmt))
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -62,6 +62,13 @@ async def test_async_enable_logging(hass):
     ) as mock_async_activate_log_queue_handler:
         bootstrap.async_enable_logging(hass)
         mock_async_activate_log_queue_handler.assert_called_once()
+        mock_async_activate_log_queue_handler.reset_mock()
+        bootstrap.async_enable_logging(
+            hass,
+            log_rotate_days=5,
+            log_file="test.log",
+        )
+        mock_async_activate_log_queue_handler.assert_called_once()
 
 
 async def test_load_hassio(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR solves 2 problems:
a) when using "--log-rotate-days" delay=True was missing, leading to a slower (in load conditions) handling
b) whenever hass is started home-assistant.log is cleared and all information gone, this is especially true when running hass as a daemon with an automatic restart.

Changed logging.FileHandler to logging.handlers.RotatingFileHandler, and then call .rotate in order to create 1 file: home-assistant.log.bak in order to preserve the old log.

Having either logging.handlers.RotatingFileHandler or logging.handlers.TimedRotatingFileHandler (already in place), allows a future PR to extend the developer tools with a new command ("change log") to secure the log.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I could not find a place in homeassistant.io that talks about how logging works (e.g. use of --log-rotate-days).

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
