### PR TITLE
Generate statistics for all sensors with a supported state_class

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -222,10 +222,13 @@ def get_metadata(
     hass: HomeAssistant,
     statistic_id: str,
 ) -> dict[str, str] | None:
-    """Return the last number_of_stats statistics for a statistic_id."""
+    """Return metadata for a statistic_id."""
     statistic_ids = [statistic_id]
     with session_scope(hass=hass) as session:
-        return _get_metadata(hass, session, statistic_ids, None).get(statistic_id)
+        metadata_ids = _get_metadata_ids(hass, session, [statistic_id])
+        if not metadata_ids:
+            return None
+        return _get_metadata(hass, session, statistic_ids, None).get(metadata_ids[0])
 
 
 def _configured_unit(unit: str, units: UnitSystem) -> str:

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -218,6 +218,16 @@ def _get_metadata(
     return metadata
 
 
+def get_metadata(
+    hass: HomeAssistant,
+    statistic_id: str,
+) -> dict[str, str] | None:
+    """Return the last number_of_stats statistics for a statistic_id."""
+    statistic_ids = [statistic_id]
+    with session_scope(hass=hass) as session:
+        return _get_metadata(hass, session, statistic_ids, None).get(statistic_id)
+
+
 def _configured_unit(unit: str, units: UnitSystem) -> str:
     """Return the pressure and temperature units configured by the user."""
     if unit == PRESSURE_PA:

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -208,7 +208,7 @@ def _normalize_states(
                 if entity_id not in hass.data[WARN_UNSTABLE_UNIT]:
                     hass.data[WARN_UNSTABLE_UNIT].add(entity_id)
                     _LOGGER.warning(
-                        "The unit of %s is changing, got %s. Generation of long term "
+                        "The unit of %s is changing, got %s, generation of long term "
                         "statistics will be suppressed unless the unit is stable",
                         entity_id,
                         all_units,

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -26,7 +26,6 @@ from homeassistant.const import (
     DEVICE_CLASS_POWER,
     ENERGY_KILO_WATT_HOUR,
     ENERGY_WATT_HOUR,
-    PERCENTAGE,
     POWER_KILO_WATT,
     POWER_WATT,
     PRESSURE_BAR,
@@ -50,14 +49,14 @@ from . import ATTR_LAST_RESET, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-DEVICE_CLASS_OR_UNIT_STATISTICS = {
+DEVICE_CLASS_STATISTICS = {
     STATE_CLASS_MEASUREMENT: {
         DEVICE_CLASS_BATTERY: {"mean", "min", "max"},
         DEVICE_CLASS_HUMIDITY: {"mean", "min", "max"},
         DEVICE_CLASS_POWER: {"mean", "min", "max"},
         DEVICE_CLASS_PRESSURE: {"mean", "min", "max"},
         DEVICE_CLASS_TEMPERATURE: {"mean", "min", "max"},
-        PERCENTAGE: {"mean", "min", "max"},
+        None: {"mean", "min", "max"},
         # Deprecated, support will be removed in Home Assistant 2021.11
         DEVICE_CLASS_ENERGY: {"sum"},
         DEVICE_CLASS_GAS: {"sum"},
@@ -67,6 +66,7 @@ DEVICE_CLASS_OR_UNIT_STATISTICS = {
         DEVICE_CLASS_ENERGY: {"sum"},
         DEVICE_CLASS_GAS: {"sum"},
         DEVICE_CLASS_MONETARY: {"sum"},
+        None: {"sum"},
     },
 }
 
@@ -116,30 +116,22 @@ UNIT_CONVERSIONS: dict[str, dict[str, Callable]] = {
 
 # Keep track of entities for which a warning about unsupported unit has been logged
 WARN_UNSUPPORTED_UNIT = set()
+WARN_UNSTABLE_UNIT = set()
 
 
-def _get_entities(hass: HomeAssistant) -> list[tuple[str, str, str]]:
-    """Get (entity_id, state_class, key) of all sensors for which to compile statistics.
-
-    Key is either a device class or a unit and is used to index the
-    DEVICE_CLASS_OR_UNIT_STATISTICS map.
-    """
+def _get_entities(hass: HomeAssistant) -> list[tuple[str, str, str | None]]:
+    """Get (entity_id, state_class, device_class) of all sensors for which to compile statistics."""
     all_sensors = hass.states.all(DOMAIN)
     entity_ids = []
 
     for state in all_sensors:
         if (state_class := state.attributes.get(ATTR_STATE_CLASS)) not in STATE_CLASSES:
             continue
-
         if (
-            key := state.attributes.get(ATTR_DEVICE_CLASS)
-        ) in DEVICE_CLASS_OR_UNIT_STATISTICS[state_class]:
-            entity_ids.append((state.entity_id, state_class, key))
-
-        if (
-            key := state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        ) in DEVICE_CLASS_OR_UNIT_STATISTICS[state_class]:
-            entity_ids.append((state.entity_id, state_class, key))
+            device_class := state.attributes.get(ATTR_DEVICE_CLASS)
+        ) not in DEVICE_CLASS_STATISTICS[state_class]:
+            device_class = None
+        entity_ids.append((state.entity_id, state_class, device_class))
 
     return entity_ids
 
@@ -189,18 +181,31 @@ def _time_weighted_average(
     return accumulated / (end - start).total_seconds()
 
 
+def _units_same(fstates: list[tuple[float, State]]) -> bool:
+    """Return True if all states have the same unit."""
+    states = next(itertools.islice(zip(*fstates), 1, 2))
+    units = iter(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) for state in states)
+    first = next(units)
+    return all(first == x for x in units)
+
+
 def _normalize_states(
-    entity_history: list[State], key: str, entity_id: str
+    entity_history: list[State], device_class: str | None, entity_id: str
 ) -> tuple[str | None, list[tuple[float, State]]]:
     """Normalize units."""
     unit = None
 
-    if key not in UNIT_CONVERSIONS:
+    if device_class not in UNIT_CONVERSIONS:
         # We're not normalizing this device class, return the state as they are
         fstates = [
             (float(el.state), el) for el in entity_history if _is_number(el.state)
         ]
         if fstates:
+            if not _units_same(fstates):
+                if entity_id not in WARN_UNSTABLE_UNIT:
+                    _LOGGER.warning("The unit of %s is not stable", entity_id)
+                    WARN_UNSTABLE_UNIT.add(entity_id)
+                return None, []
             unit = fstates[0][1].attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         return unit, fstates
 
@@ -214,15 +219,15 @@ def _normalize_states(
         fstate = float(state.state)
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         # Exclude unsupported units from statistics
-        if unit not in UNIT_CONVERSIONS[key]:
+        if unit not in UNIT_CONVERSIONS[device_class]:
             if entity_id not in WARN_UNSUPPORTED_UNIT:
                 WARN_UNSUPPORTED_UNIT.add(entity_id)
                 _LOGGER.warning("%s has unknown unit %s", entity_id, unit)
             continue
 
-        fstates.append((UNIT_CONVERSIONS[key][unit](fstate), state))
+        fstates.append((UNIT_CONVERSIONS[device_class][unit](fstate), state))
 
-    return DEVICE_CLASS_UNITS[key], fstates
+    return DEVICE_CLASS_UNITS[device_class], fstates
 
 
 def compile_statistics(
@@ -241,17 +246,25 @@ def compile_statistics(
         hass, start - datetime.timedelta.resolution, end, [i[0] for i in entities]
     )
 
-    for entity_id, state_class, key in entities:
-        wanted_statistics = DEVICE_CLASS_OR_UNIT_STATISTICS[state_class][key]
+    for entity_id, state_class, device_class in entities:
+        wanted_statistics = DEVICE_CLASS_STATISTICS[state_class][device_class]
 
         if entity_id not in history_list:
             continue
 
         entity_history = history_list[entity_id]
-        unit, fstates = _normalize_states(entity_history, key, entity_id)
+        unit, fstates = _normalize_states(entity_history, device_class, entity_id)
 
         if not fstates:
             continue
+
+        # Check metadata
+        if old_metadata := statistics.get_metadata(hass, entity_id):
+            if old_metadata["unit_of_measurement"] != unit:
+                if entity_id not in WARN_UNSTABLE_UNIT:
+                    _LOGGER.warning("The unit of %s is not stable", entity_id)
+                    WARN_UNSTABLE_UNIT.add(entity_id)
+                continue
 
         result[entity_id] = {}
 
@@ -333,8 +346,8 @@ def list_statistic_ids(hass: HomeAssistant, statistic_type: str | None = None) -
 
     statistic_ids = {}
 
-    for entity_id, state_class, key in entities:
-        provided_statistics = DEVICE_CLASS_OR_UNIT_STATISTICS[state_class][key]
+    for entity_id, state_class, device_class in entities:
+        provided_statistics = DEVICE_CLASS_STATISTICS[state_class][device_class]
 
         if statistic_type is not None and statistic_type not in provided_statistics:
             continue
@@ -351,14 +364,14 @@ def list_statistic_ids(hass: HomeAssistant, statistic_type: str | None = None) -
 
         native_unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
 
-        if key not in UNIT_CONVERSIONS:
+        if device_class not in UNIT_CONVERSIONS:
             statistic_ids[entity_id] = native_unit
             continue
 
-        if native_unit not in UNIT_CONVERSIONS[key]:
+        if native_unit not in UNIT_CONVERSIONS[device_class]:
             continue
 
-        statistics_unit = DEVICE_CLASS_UNITS[key]
+        statistics_unit = DEVICE_CLASS_UNITS[device_class]
         statistic_ids[entity_id] = statistics_unit
 
     return statistic_ids

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -209,7 +209,7 @@ def _normalize_states(
                     hass.data[WARN_UNSTABLE_UNIT].add(entity_id)
                     _LOGGER.warning(
                         "The unit of %s is changing, got %s. Generation of long term "
-                        "statistics will be suppressed unless the unit is stable.",
+                        "statistics will be suppressed unless the unit is stable",
                         entity_id,
                         all_units,
                     )
@@ -271,7 +271,6 @@ def compile_statistics(
         # Check metadata
         if old_metadata := statistics.get_metadata(hass, entity_id):
             if old_metadata["unit_of_measurement"] != unit:
-                _LOGGER.warning("type: %s", type(WARN_UNSTABLE_UNIT))
                 if WARN_UNSTABLE_UNIT not in hass.data:
                     hass.data[WARN_UNSTABLE_UNIT] = set()
                 if entity_id not in hass.data[WARN_UNSTABLE_UNIT]:
@@ -279,7 +278,7 @@ def compile_statistics(
                     _LOGGER.warning(
                         "The unit of %s (%s) does not match the unit of already "
                         "compiled statistics (%s). Generation of long term statistics "
-                        "will be suppressed unless the unit changes back to %s.",
+                        "will be suppressed unless the unit changes back to %s",
                         entity_id,
                         unit,
                         old_metadata["unit_of_measurement"],

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -262,7 +262,10 @@ def compile_statistics(
         if old_metadata := statistics.get_metadata(hass, entity_id):
             if old_metadata["unit_of_measurement"] != unit:
                 if entity_id not in WARN_UNSTABLE_UNIT:
-                    _LOGGER.warning("The unit of %s is not stable", entity_id)
+                    _LOGGER.warning(
+                        "The unit of %s does not match the unit of statistics",
+                        entity_id,
+                    )
                     WARN_UNSTABLE_UNIT.add(entity_id)
                 continue
 
@@ -362,7 +365,11 @@ def list_statistic_ids(hass: HomeAssistant, statistic_type: str | None = None) -
         ):
             continue
 
-        native_unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        metadata = statistics.get_metadata(hass, entity_id)
+        if metadata:
+            native_unit: str | None = metadata["unit_of_measurement"]
+        else:
+            native_unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
 
         if device_class not in UNIT_CONVERSIONS:
             statistic_ids[entity_id] = native_unit

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -911,11 +911,7 @@ def test_compile_hourly_statistics_changing_units_2(
 
     recorder.do_adhoc_statistics(period="hourly", start=zero + timedelta(minutes=30))
     wait_recording_done(hass)
-    assert (
-        f"The unit of sensor.test1 is changing, got {{'{unit}', 'cats'}}" in caplog.text
-        or f"The unit of sensor.test1 is changing, got {{'cats', '{unit}'}}"
-        in caplog.text
-    )
+    assert "The unit of sensor.test1 is changing" in caplog.text
     statistic_ids = list_statistic_ids(hass)
     assert statistic_ids == [
         {"statistic_id": "sensor.test1", "unit_of_measurement": "cats"}

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -167,6 +167,7 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
                 "mean": approx(16.440677966101696),
                 "min": approx(10.0),
                 "max": approx(30.0),
+                "last_reset": None,
                 "state": None,
                 "sum": None,
             }
@@ -178,6 +179,7 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
                 "mean": approx(16.440677966101696),
                 "min": approx(10.0),
                 "max": approx(30.0),
+                "last_reset": None,
                 "state": None,
                 "sum": None,
             }
@@ -845,6 +847,7 @@ def test_compile_hourly_statistics_changing_units_1(
                 "mean": approx(mean),
                 "min": approx(min),
                 "max": approx(max),
+                "last_reset": None,
                 "state": None,
                 "sum": None,
             }
@@ -870,6 +873,7 @@ def test_compile_hourly_statistics_changing_units_1(
                 "mean": approx(mean),
                 "min": approx(min),
                 "max": approx(max),
+                "last_reset": None,
                 "state": None,
                 "sum": None,
             }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Generate statistics for all sensors with a supported `state_class`:
 - For explicitly supported device classes, long term statistics will only be generated if the sensor's unit is supported for normalization
 - For other device classes, or sensors with no device class, long term  statistics is always generated
 - If the `unit_of_measurement` of a sensor changes, statistics will no longer be generated and a warning will be logged

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
