### PR TITLE
Fix Google Calendar auth user code expire time comparison

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -1,5 +1,5 @@
 """Support for Google - Calendar Event Devices."""
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 import logging
 import os
@@ -27,8 +27,8 @@ from homeassistant.const import (
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import generate_entity_id
-from homeassistant.helpers.event import track_time_change
-from homeassistant.util import convert, dt
+from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.util import convert
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -188,7 +188,12 @@ def do_authentication(hass, hass_config, config):
 
     def step2_exchange(now):
         """Keep trying to validate the user_code until it expires."""
-        if now >= dt.as_local(dev_flow.user_code_expiry):
+
+        # For some reason, oauth.step1_get_device_and_user_codes() returns a datetime
+        # object without tzinfo. For the comparison below to work, it needs one.
+        user_code_expiry = dev_flow.user_code_expiry.replace(tzinfo=timezone.utc)
+
+        if now >= user_code_expiry:
             hass.components.persistent_notification.create(
                 "Authentication code expired, please restart "
                 "Home-Assistant and try again",
@@ -216,7 +221,7 @@ def do_authentication(hass, hass_config, config):
             notification_id=NOTIFICATION_ID,
         )
 
-    listener = track_time_change(
+    listener = track_utc_time_change(
         hass, step2_exchange, second=range(0, 60, dev_flow.interval)
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The OAuth flow for the Google Calendar API is broken if the time zone in Home Assistant is GMT+1 or more, as described in #51490, https://community.home-assistant.io/t/google-calendar-issue-authentication-code-expired-please-restart-home-assistant-and-try-again/313227/25 and https://community.home-assistant.io/t/google-calendar-setup-authentication-code-expired/315621.

With thelp of some debug logging, it turned out that the `dev_flow.user_code_expiry` `datetime` object returned by `oauth.step1_get_device_and_user_codes()` is in UTC, but its `tzinfo` property is set to `None`. This means that calling `dt.as_local(dev_flow.user_code_expiry)` will return the same instance, because `as_local` assumes that the `datetime` already is in the _current_ timezone if `tzinfo is None`.

```
2021-08-19 22:31:11 WARNING (SyncWorker_3) [homeassistant.components.google] type(dev_flow.user_code_expiry): <class 'datetime.datetime'>
2021-08-19 22:31:11 WARNING (SyncWorker_3) [homeassistant.components.google] dev_flow.user_code_expiry.tzinfo: None
2021-08-19 22:31:11 WARNING (SyncWorker_3) [homeassistant.components.google] now.tzinfo: Europe/Helsinki
2021-08-19 22:31:11 WARNING (SyncWorker_3) [homeassistant.components.google] dev_flow.user_code_expiry: 2021-08-19 20:01:06.370063
2021-08-19 22:31:11 WARNING (SyncWorker_3) [homeassistant.components.google] dt.as_local(dev_flow.user_code_expiry): 2021-08-19 20:01:06.370063+03:00
2021-08-19 22:31:11 WARNING (SyncWorker_3) [homeassistant.components.google] now: 2021-08-19 22:31:11.213553+03:00
```

Explicitly setting `tzinfo` to UTC before passing it on to `dt.as_local()` solves the issue, and the "Authentication code expired" message stops appearing after every Home Assistant restart.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51490
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
