### PR TITLE
Add support to a different unit of measurement(mmol/L) on Nightscout

### DIFF
--- a/homeassistant/components/nightscout/__init__.py
+++ b/homeassistant/components/nightscout/__init__.py
@@ -5,14 +5,14 @@ from aiohttp import ClientError
 from py_nightscout import Api as NightscoutAPI
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, CONF_URL
+from homeassistant.const import CONF_API_KEY, CONF_UNIT_OF_MEASUREMENT, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import SLOW_UPDATE_WARNING
 
-from .const import DOMAIN
+from .const import DOMAIN, MG_DL
 
 PLATFORMS = ["sensor"]
 _API_TIMEOUT = SLOW_UPDATE_WARNING - 1
@@ -28,6 +28,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         status = await api.get_server_status()
     except (ClientError, AsyncIOTimeoutError, OSError) as error:
         raise ConfigEntryNotReady from error
+
+    if not entry.options:
+        hass.config_entries.async_update_entry(
+            entry, options={CONF_UNIT_OF_MEASUREMENT: MG_DL}
+        )
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = api

--- a/homeassistant/components/nightscout/config_flow.py
+++ b/homeassistant/components/nightscout/config_flow.py
@@ -7,9 +7,10 @@ from py_nightscout import Api as NightscoutAPI
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
-from homeassistant.const import CONF_API_KEY, CONF_URL
+from homeassistant.const import CONF_API_KEY, CONF_UNIT_OF_MEASUREMENT, CONF_URL
+from homeassistant.core import callback
 
-from .const import DOMAIN
+from .const import DOMAIN, MG_DL, MMOL_L
 from .utils import hash_from_url
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,6 +62,37 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return NightscoutOptionsFlowHandler(config_entry)
+
+
+class NightscoutOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a option flow for Nightscout."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Handle options flow."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_UNIT_OF_MEASUREMENT,
+                    default=self.config_entry.options.get(
+                        CONF_UNIT_OF_MEASUREMENT, MG_DL
+                    ),
+                ): vol.In({MG_DL, MMOL_L}),
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=data_schema)
 
 
 class InputValidationError(exceptions.HomeAssistantError):

--- a/homeassistant/components/nightscout/const.py
+++ b/homeassistant/components/nightscout/const.py
@@ -2,6 +2,10 @@
 
 DOMAIN = "nightscout"
 
+MMOL_L = "mmol/L"
+MG_DL = "mg/dL"
+
 ATTR_DEVICE = "device"
+ATTR_SGV = "sgv"
 ATTR_DELTA = "delta"
 ATTR_DIRECTION = "direction"

--- a/homeassistant/components/nightscout/strings.json
+++ b/homeassistant/components/nightscout/strings.json
@@ -18,5 +18,14 @@
         "abort": {
             "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
         }
+    },
+    "options": {
+      "step": {
+        "init": {
+          "data": {
+            "unit_of_measurement": "Unit of measurement"
+          }
+        }
+      }
     }
 }

--- a/homeassistant/components/nightscout/translations/en.json
+++ b/homeassistant/components/nightscout/translations/en.json
@@ -19,5 +19,14 @@
                 "title": "Enter your Nightscout server information."
             }
         }
+    },
+    "options": {
+      "step": {
+        "init": {
+          "data": {
+            "unit_of_measurement": "Unit of measurement"
+          }
+        }
+      }
     }
 }

--- a/homeassistant/components/nightscout/translations/pt-BR.json
+++ b/homeassistant/components/nightscout/translations/pt-BR.json
@@ -14,5 +14,14 @@
                 }
             }
         }
-    }
+    },
+    "options": {
+        "step": {
+          "init": {
+            "data": {
+              "unit_of_measurement": "Unidade de medida"
+            }
+          }
+        }
+      }
 }

--- a/homeassistant/components/nightscout/translations/pt.json
+++ b/homeassistant/components/nightscout/translations/pt.json
@@ -16,5 +16,14 @@
                 }
             }
         }
-    }
+    },
+    "options": {
+        "step": {
+          "init": {
+            "data": {
+              "unit_of_measurement": "Unidade de medida"
+            }
+          }
+        }
+      }
 }

--- a/tests/components/nightscout/__init__.py
+++ b/tests/components/nightscout/__init__.py
@@ -5,8 +5,13 @@ from unittest.mock import patch
 from aiohttp import ClientConnectionError
 from py_nightscout.models import SGV, ServerStatus
 
-from homeassistant.components.nightscout.const import DOMAIN
-from homeassistant.const import CONF_URL
+from homeassistant.components.nightscout.const import (
+    ATTR_DELTA,
+    ATTR_SGV,
+    DOMAIN,
+    MG_DL,
+)
+from homeassistant.const import CONF_UNIT_OF_MEASUREMENT, CONF_URL
 
 from tests.common import MockConfigEntry
 
@@ -17,6 +22,9 @@ GLUCOSE_READINGS = [
         )
     )
 ]
+
+CONVERTED_MMOL_VALUES = {ATTR_SGV: 9.4, ATTR_DELTA: -0.3}
+
 SERVER_STATUS = ServerStatus.new_from_json_dict(
     json.loads(
         '{"status":"ok","name":"nightscout","version":"13.0.1","serverTime":"2020-08-05T18:14:02.032Z","serverTimeEpoch":1596651242032,"apiEnabled":true,"careportalEnabled":true,"boluscalcEnabled":true,"settings":{},"extendedSettings":{},"authorized":null}'
@@ -29,11 +37,16 @@ SERVER_STATUS_STATUS_ONLY = ServerStatus.new_from_json_dict(
 )
 
 
-async def init_integration(hass) -> MockConfigEntry:
+async def init_integration(hass, unit_of_measurement=MG_DL) -> MockConfigEntry:
     """Set up the Nightscout integration in Home Assistant."""
+    options = {}
+    if unit_of_measurement:
+        options[CONF_UNIT_OF_MEASUREMENT] = unit_of_measurement
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_URL: "https://some.url:1234"},
+        options=options,
     )
     with patch(
         "homeassistant.components.nightscout.NightscoutAPI.get_sgvs",

--- a/tests/components/nightscout/test_sensor.py
+++ b/tests/components/nightscout/test_sensor.py
@@ -4,10 +4,13 @@ from homeassistant.components.nightscout.const import (
     ATTR_DELTA,
     ATTR_DEVICE,
     ATTR_DIRECTION,
+    ATTR_SGV,
+    MMOL_L,
 )
 from homeassistant.const import ATTR_DATE, ATTR_ICON, STATE_UNAVAILABLE
 
 from tests.components.nightscout import (
+    CONVERTED_MMOL_VALUES,
     GLUCOSE_READINGS,
     init_integration,
     init_integration_empty_response,
@@ -23,6 +26,14 @@ async def test_sensor_state(hass):
     assert test_glucose_sensor.state == str(
         GLUCOSE_READINGS[0].sgv  # pylint: disable=maybe-no-member
     )
+
+
+async def test_sensor_state_options_changed(hass):
+    """Test sensor state data with options changed."""
+    await init_integration(hass, MMOL_L)
+
+    test_glucose_sensor = hass.states.get("sensor.blood_sugar")
+    assert test_glucose_sensor.state == str(CONVERTED_MMOL_VALUES[ATTR_SGV])
 
 
 async def test_sensor_error(hass):
@@ -52,6 +63,22 @@ async def test_sensor_attributes(hass):
     attr = test_glucose_sensor.attributes
     assert attr[ATTR_DATE] == reading.date  # pylint: disable=maybe-no-member
     assert attr[ATTR_DELTA] == reading.delta  # pylint: disable=maybe-no-member
+    assert attr[ATTR_DEVICE] == reading.device  # pylint: disable=maybe-no-member
+    assert attr[ATTR_DIRECTION] == reading.direction  # pylint: disable=maybe-no-member
+    assert attr[ATTR_ICON] == "mdi:arrow-bottom-right"
+
+
+async def test_sensor_attributes_options_changed(hass):
+    """Test sensor attributes."""
+    await init_integration(hass, MMOL_L)
+
+    test_glucose_sensor = hass.states.get("sensor.blood_sugar")
+    reading = GLUCOSE_READINGS[0]
+    assert reading is not None
+
+    attr = test_glucose_sensor.attributes
+    assert attr[ATTR_DATE] == reading.date  # pylint: disable=maybe-no-member
+    assert attr[ATTR_DELTA] == CONVERTED_MMOL_VALUES[ATTR_DELTA]
     assert attr[ATTR_DEVICE] == reading.device  # pylint: disable=maybe-no-member
     assert attr[ATTR_DIRECTION] == reading.direction  # pylint: disable=maybe-no-member
     assert attr[ATTR_ICON] == "mdi:arrow-bottom-right"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The existing Nightscout integration only supports one unit of measurement for blood glucose values(mg/dL). Most countries in Europe and Oceania use a different unit of measurement(mmol/L).

This PR introduces an option to chose which unit of measurement the user wants for the Nightscout integration.

![nightscout_configuration_01](https://user-images.githubusercontent.com/1175432/130155661-6b04b82e-07c0-4f58-86bd-1606a28fe1aa.png)
![nightscout_configuration_02](https://user-images.githubusercontent.com/1175432/130155659-0c12940f-f601-4fb5-8289-c15814faf845.png)

I worked on this feature, but during the creation of the PR I noticed that someone else attempted to do the same thing a while ago on #41382 but it ended up being automatically closed due to inactivity. My changes are similar to the ones proposed on the other PR, but still slightly different.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
  - #45002
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
