### PR TITLE
Bump zwave-js-server-python to 0.29.0

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -10,7 +10,7 @@ from aiohttp import hdrs, web, web_exceptions, web_request
 import voluptuous as vol
 from zwave_js_server import dump
 from zwave_js_server.client import Client
-from zwave_js_server.const import CommandClass, LogLevel
+from zwave_js_server.const import CommandClass, InclusionStrategy, LogLevel
 from zwave_js_server.exceptions import (
     BaseZwaveJSServerError,
     FailedCommand,
@@ -386,7 +386,11 @@ async def websocket_add_node(
 ) -> None:
     """Add a node to the Z-Wave network."""
     controller = client.driver.controller
-    include_non_secure = not msg[SECURE]
+
+    if msg[SECURE]:
+        inclusion_strategy = InclusionStrategy.SECURITY_S0
+    else:
+        inclusion_strategy = InclusionStrategy.INSECURE
 
     @callback
     def async_cleanup() -> None:
@@ -454,7 +458,7 @@ async def websocket_add_node(
         ),
     ]
 
-    result = await controller.async_begin_inclusion(include_non_secure)
+    result = await controller.async_begin_inclusion(inclusion_strategy)
     connection.send_result(
         msg[ID],
         result,
@@ -594,8 +598,12 @@ async def websocket_replace_failed_node(
 ) -> None:
     """Replace a failed node with a new node."""
     controller = client.driver.controller
-    include_non_secure = not msg[SECURE]
     node_id = msg[NODE_ID]
+
+    if msg[SECURE]:
+        inclusion_strategy = InclusionStrategy.SECURITY_S0
+    else:
+        inclusion_strategy = InclusionStrategy.INSECURE
 
     @callback
     def async_cleanup() -> None:
@@ -677,7 +685,7 @@ async def websocket_replace_failed_node(
         ),
     ]
 
-    result = await controller.async_replace_failed_node(node_id, include_non_secure)
+    result = await controller.async_replace_failed_node(node_id, inclusion_strategy)
     connection.send_result(
         msg[ID],
         result,

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave JS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["zwave-js-server-python==0.28.0"],
+  "requirements": ["zwave-js-server-python==0.29.0"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["http", "websocket_api"],
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2477,4 +2477,4 @@ zigpy==0.36.1
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.28.0
+zwave-js-server-python==0.29.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1385,4 +1385,4 @@ zigpy-znp==0.5.3
 zigpy==0.36.1
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.28.0
+zwave-js-server-python==0.29.0

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -437,7 +437,7 @@ async def test_get_condition_capabilities_value(
         (98, "DOOR_LOCK"),
         (122, "FIRMWARE_UPDATE_MD"),
         (114, "MANUFACTURER_SPECIFIC"),
-        (113, "ALARM"),
+        (113, "NOTIFICATION"),
         (152, "SECURITY"),
         (99, "USER_CODE"),
         (134, "VERSION"),


### PR DESCRIPTION
## Proposed change
Changelog: https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.29.0

Backwards incompatible changes have been addressed


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
