### PR TITLE
Add support for USB discovery to ZHA

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -145,7 +145,7 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if (
             vid == "10C4"
             and pid == "8A2A"
-            and "ZigBee" not in discovery_info["description"]
+            and "ZigBee" not in description
         ):
             return self.async_abort(reason="not_zha_device")
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -35,17 +35,16 @@ def _format_port_human_readable(
     vid: str | None,
     pid: str | None,
 ) -> str:
+    extended_details = (f" - {manufacturer}" if manufacturer else "") + (
+        f" - {vid}:{pid}" if vid else ""
+    )
+
     if description:
         return (
             f"{description[:26]} - {device}, s/n: {serial_number or 'n/a'}"
-            + (f" - {manufacturer}" if manufacturer else "")
-            + (f" - {vid}:{pid}" if vid else "")
+            + extended_details
         )
-    return (
-        f"{device}, s/n: {serial_number or 'n/a'}"
-        + (f" - {manufacturer}" if manufacturer else "")
-        + (f" - {vid}:{pid}" if vid else "")
-    )
+    return f"{device}, s/n: {serial_number or 'n/a'}" + extended_details
 
 
 class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -27,6 +27,27 @@ SUPPORTED_PORT_SETTINGS = (
 )
 
 
+def _format_port_human_readable(
+    device: str,
+    serial_number: str | None,
+    manufacturer: str | None,
+    description: str | None,
+    vid: str | None,
+    pid: str | None,
+) -> str:
+    if description:
+        return (
+            f"{description[:26]} - {device}, s/n: {serial_number or 'n/a'}"
+            + (f" - {manufacturer}" if manufacturer else "")
+            + (f" - {vid}:{pid}" if vid else "")
+        )
+    return (
+        f"{device}, s/n: {serial_number or 'n/a'}"
+        + (f" - {manufacturer}" if manufacturer else "")
+        + (f" - {vid}:{pid}" if vid else "")
+    )
+
+
 class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
@@ -36,6 +57,8 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize flow instance."""
         self._device_path = None
         self._radio_type = None
+        self._auto_detected_data = None
+        self._title = None
 
     async def async_step_user(self, user_input=None):
         """Handle a zha config flow start."""
@@ -90,6 +113,74 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="pick_radio",
             data_schema=vol.Schema(schema),
+        )
+
+    async def async_step_usb(self, discovery_info: DiscoveryInfoType):
+        """Handle usb discovery."""
+        vid = discovery_info["vid"]
+        pid = discovery_info["pid"]
+        serial_number = discovery_info["serial_number"]
+        device = discovery_info["device"]
+        manufacturer = discovery_info["manufacturer"]
+        description = discovery_info["description"]
+        await self.async_set_unique_id(
+            f"{vid}:{pid}_{serial_number}_{manufacturer}_{description}"
+        )
+        self._abort_if_unique_id_configured(
+            updates={
+                CONF_DEVICE: {CONF_DEVICE_PATH: self._device_path},
+            }
+        )
+        # Check if already configured
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        # If they already have a discovery for deconz
+        # we ignore the usb discovery as they probably
+        # want to use it there instead
+        for flow in self.hass.config_entries.flow.async_progress():
+            if flow["handler"] == "deconz":
+                return self.async_abort(reason="not_zha_device")
+
+        # The Nortek sticks are a special case since they
+        # have a Z-Wave and a Zigbee radio. We need to reject
+        # the Z-Wave radio.
+        if (
+            vid == "10C4"
+            and pid == "8A2A"
+            and "ZigBee" not in discovery_info["description"]
+        ):
+            return self.async_abort(reason="not_zha_device")
+
+        dev_path = await self.hass.async_add_executor_job(get_serial_by_id, device)
+        self._auto_detected_data = await detect_radios(dev_path)
+        if self._auto_detected_data is None:
+            return self.async_abort(reason="not_zha_device")
+        self._device_path = dev_path
+        self._title = _format_port_human_readable(
+            dev_path,
+            serial_number,
+            manufacturer,
+            description,
+            vid,
+            pid,
+        )
+        self._set_confirm_only()
+        self.context["title_placeholders"] = {CONF_NAME: self._title}
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(self, user_input=None):
+        """Confirm a discovery."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self._title,
+                data=self._auto_detected_data,
+            )
+
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders={CONF_NAME: self._title},
+            data_schema=vol.Schema({}),
         )
 
     async def async_step_zeroconf(self, discovery_info: DiscoveryInfoType):

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -35,16 +35,14 @@ def _format_port_human_readable(
     vid: str | None,
     pid: str | None,
 ) -> str:
-    extended_details = (f" - {manufacturer}" if manufacturer else "") + (
-        f" - {vid}:{pid}" if vid else ""
-    )
+    device_details = f"{device}, s/n: {serial_number or 'n/a'}"
+    manufacturer_details = f" - {manufacturer}" if manufacturer else ""
+    vendor_details = f" - {vid}:{pid}" if vid else ""
+    full_details = f"{device_details}{manufacturer_details}{vendor_details}"
 
-    if description:
-        return (
-            f"{description[:26]} - {device}, s/n: {serial_number or 'n/a'}"
-            + extended_details
-        )
-    return f"{device}, s/n: {serial_number or 'n/a'}" + extended_details
+    if not description:
+        return full_details
+    return f"{description[:26]} - {full_details}"
 
 
 class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -142,11 +142,7 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # The Nortek sticks are a special case since they
         # have a Z-Wave and a Zigbee radio. We need to reject
         # the Z-Wave radio.
-        if (
-            vid == "10C4"
-            and pid == "8A2A"
-            and "ZigBee" not in description
-        ):
+        if vid == "10C4" and pid == "8A2A" and "ZigBee" not in description:
             return self.async_abort(reason="not_zha_device")
 
         dev_path = await self.hass.async_add_executor_job(get_serial_by_id, device)

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -15,6 +15,12 @@
     "zigpy-zigate==0.7.3",
     "zigpy-znp==0.5.3"
   ],
+  "usb": [
+   {"vid":"10C4","pid":"EA60"},
+   {"vid":"1CF1","pid":"0030"},
+   {"vid":"1A86","pid":"7523"},
+   {"vid":"10C4","pid":"8A2A"}
+  ],
   "codeowners": ["@dmulcahey", "@adminiuga"],
   "zeroconf": [
     {

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -7,6 +7,9 @@
         "data": { "path": "Serial Device Path" },
         "description": "Select serial port for Zigbee radio"
       },
+      "confirm": {
+        "description": "Do you want to setup {name}?"
+      },
       "pick_radio": {
         "data": { "radio_type": "Radio Type" },
         "title": "Radio Type",
@@ -26,7 +29,8 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "not_zha_device": "This device is not a zha device"
     }
   },
   "config_panel": {

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -1,6 +1,7 @@
 {
     "config": {
         "abort": {
+            "not_zha_device": "This device is not a zha device",
             "single_instance_allowed": "Already configured. Only a single configuration possible."
         },
         "error": {
@@ -8,6 +9,9 @@
         },
         "flow_title": "{name}",
         "step": {
+            "confirm": {
+                "description": "Do you want to setup {name}?"
+            },
             "pick_radio": {
                 "data": {
                     "radio_type": "Radio Type"

--- a/homeassistant/generated/usb.py
+++ b/homeassistant/generated/usb.py
@@ -5,4 +5,25 @@ To update, run python3 -m script.hassfest
 
 # fmt: off
 
-USB = []  # type: ignore
+USB = [
+    {
+        "domain": "zha",
+        "vid": "10C4",
+        "pid": "EA60"
+    },
+    {
+        "domain": "zha",
+        "vid": "1CF1",
+        "pid": "0030"
+    },
+    {
+        "domain": "zha",
+        "vid": "1A86",
+        "pid": "7523"
+    },
+    {
+        "domain": "zha",
+        "vid": "10C4",
+        "pid": "8A2A"
+    }
+]

--- a/script/hassfest/usb.py
+++ b/script/hassfest/usb.py
@@ -13,7 +13,7 @@ To update, run python3 -m script.hassfest
 
 # fmt: off
 
-USB = {}  # type: ignore
+USB = {}
 """.strip()
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

<img width="330" alt="Screen Shot 2021-08-20 at 8 04 52 PM" src="https://user-images.githubusercontent.com/663432/130305713-8e37af96-76f0-42b2-bd99-74593c316787.png">
<img width="591" alt="Screen Shot 2021-08-20 at 8 05 01 PM" src="https://user-images.githubusercontent.com/663432/130305714-3f67f0c4-9c6f-4d46-bfaf-c564f16c7962.png">
<img width="583" alt="Screen Shot 2021-08-20 at 8 05 13 PM" src="https://user-images.githubusercontent.com/663432/130305716-0ea18283-ecba-4e70-b419-68964b45163f.png">




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19022

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
