### PR TITLE
Add support for USB discovery to zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -353,6 +353,9 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
             and "Z-Wave" not in discovery_info["description"]
         ):
             return self.async_abort(reason="not_zwave_device")
+        # Zooz uses this vid/pid, but so do 2652 sticks
+        if vid == "10C4" and pid == "EA60" and "2652" in discovery_info["description"]:
+            return self.async_abort(reason="not_zwave_device")
 
         addon_info = await self._async_get_addon_info()
         if addon_info.state not in (AddonState.NOT_INSTALLED, AddonState.NOT_RUNNING):

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -333,8 +333,10 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
         """Handle USB Discovery."""
         if not is_hassio(self.hass):
             return self.async_abort(reason="discovery_requires_supervisor")
-        if self._async_in_progress() or self._async_current_entries():
+        if self._async_current_entries():
             return self.async_abort(reason="already_configured")
+        if self._async_in_progress():
+            return self.async_abort(reason="already_in_progress")
 
         vid = discovery_info["vid"]
         pid = discovery_info["pid"]
@@ -433,7 +435,7 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
         This flow is triggered by the Z-Wave JS add-on.
         """
         if self._async_in_progress():
-            return self.async_abort(reason="already_configured")
+            return self.async_abort(reason="already_in_progress")
 
         self.ws_address = f"ws://{discovery_info['host']}:{discovery_info['port']}"
         try:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -389,10 +389,7 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
                 data_schema=vol.Schema({}),
             )
 
-        addon_info = await self._async_get_addon_info()
-        if addon_info.state == AddonState.NOT_INSTALLED:
-            return await self.async_step_install_addon()
-        return await self.async_step_configure_addon()
+        return await self.async_step_on_supervisor({CONF_USE_ADDON: True})
 
     async def async_step_manual(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -354,7 +354,7 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
         ):
             return self.async_abort(reason="not_zwave_device")
         # Zooz uses this vid/pid, but so do 2652 sticks
-        if vid == "10C4" and pid == "EA60" and "2652" in discovery_info["description"]:
+        if vid == "10C4" and pid == "EA60" and "2652" in description:
             return self.async_abort(reason="not_zwave_device")
 
         addon_info = await self._async_get_addon_info()

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -347,11 +347,7 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
         # The Nortek sticks are a special case since they
         # have a Z-Wave and a Zigbee radio. We need to reject
         # the Zigbee radio.
-        if (
-            vid == "10C4"
-            and pid == "8A2A"
-            and "Z-Wave" not in description
-        ):
+        if vid == "10C4" and pid == "8A2A" and "Z-Wave" not in description:
             return self.async_abort(reason="not_zwave_device")
         # Zooz uses this vid/pid, but so do 2652 sticks
         if vid == "10C4" and pid == "EA60" and "2652" in description:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -350,7 +350,7 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
         if (
             vid == "10C4"
             and pid == "8A2A"
-            and "Z-Wave" not in discovery_info["description"]
+            and "Z-Wave" not in description
         ):
             return self.async_abort(reason="not_zwave_device")
         # Zooz uses this vid/pid, but so do 2652 sticks

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -75,17 +75,14 @@ def _format_port_human_readable(
     vid: str | None,
     pid: str | None,
 ) -> str:
-    if description:
-        return (
-            f"{description[:26]} - {device}, s/n: {serial_number or 'n/a'}"
-            + (f" - {manufacturer}" if manufacturer else "")
-            + (f" - {vid}:{pid}" if vid else "")
-        )
-    return (
-        f"{device}, s/n: {serial_number or 'n/a'}"
-        + (f" - {manufacturer}" if manufacturer else "")
-        + (f" - {vid}:{pid}" if vid else "")
-    )
+    device_details = f"{device}, s/n: {serial_number or 'n/a'}"
+    manufacturer_details = f" - {manufacturer}" if manufacturer else ""
+    vendor_details = f" - {vid}:{pid}" if vid else ""
+    full_details = f"{device_details}{manufacturer_details}{vendor_details}"
+
+    if not description:
+        return full_details
+    return f"{description[:26]} - {full_details}"
 
 
 def get_manual_schema(user_input: dict[str, Any]) -> vol.Schema:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -371,9 +371,22 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
             pid,
         )
         self.context["title_placeholders"] = {CONF_NAME: self._title}
+        return await self.async_step_usb_confirm()
+
+    async def async_step_usb_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle USB Discovery confirmation."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="usb_confirm",
+                description_placeholders={CONF_NAME: self._title},
+                data_schema=vol.Schema({}),
+            )
+
+        addon_info = await self._async_get_addon_info()
         if addon_info.state == AddonState.NOT_INSTALLED:
             return await self.async_step_install_addon()
-
         return await self.async_step_configure_addon()
 
     async def async_step_manual(
@@ -456,8 +469,6 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_manual()
 
         self.use_addon = True
-        if self._title:
-            self.context["title_placeholders"] = {CONF_NAME: self._title}
 
         addon_info = await self._async_get_addon_info()
 

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -6,5 +6,10 @@
   "requirements": ["zwave-js-server-python==0.29.0"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["http", "websocket_api"],
-  "iot_class": "local_push"
+  "iot_class": "local_push",
+  "usb": [
+   {"vid":"0658","pid":"0200"},
+   {"vid":"1A86","pid":"7523"},
+   {"vid":"10C4","pid":"EA60"}
+  ]
 }

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "usb": [
    {"vid":"0658","pid":"0200"},
-   {"vid":"1A86","pid":"7523"},
+   {"vid":"10C4","pid":"8A2A"},
    {"vid":"10C4","pid":"EA60"}
   ]
 }

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
   "requirements": ["zwave-js-server-python==0.29.0"],
   "codeowners": ["@home-assistant/z-wave"],
-  "dependencies": ["http", "websocket_api"],
+  "dependencies": ["usb", "http", "websocket_api"],
   "iot_class": "local_push",
   "usb": [
    {"vid":"0658","pid":"0200"},

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "{name}",
     "step": {
       "manual": {
         "data": {
@@ -44,7 +45,9 @@
       "addon_set_config_failed": "Failed to set Z-Wave JS configuration.",
       "addon_start_failed": "Failed to start the Z-Wave JS add-on.",
       "addon_get_discovery_info_failed": "Failed to get Z-Wave JS add-on discovery info.",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "discovery_requires_supervisor": "Discovery requires the supervisor.",
+      "not_zwave_device": "Discovered device is not a Z-Wave device."
     },
     "progress": {
       "install_addon": "Please wait while the Z-Wave JS add-on installation finishes. This can take several minutes.",

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -7,6 +7,9 @@
           "url": "[%key:common::config_flow::data::url%]"
         }
       },
+      "usb_confirm": {
+        "description": "Do you want to setup {name} with the Z-Wave JS add-on?"
+      },
       "on_supervisor": {
         "title": "Select connection method",
         "description": "Do you want to use the Z-Wave JS Supervisor add-on?",

--- a/homeassistant/components/zwave_js/translations/en.json
+++ b/homeassistant/components/zwave_js/translations/en.json
@@ -8,7 +8,9 @@
             "addon_start_failed": "Failed to start the Z-Wave JS add-on.",
             "already_configured": "Device is already configured",
             "already_in_progress": "Configuration flow is already in progress",
-            "cannot_connect": "Failed to connect"
+            "cannot_connect": "Failed to connect",
+            "discovery_requires_supervisor": "Discovery requires the supervisor.",
+            "not_zwave_device": "Discovered device is not a Z-Wave device."
         },
         "error": {
             "addon_start_failed": "Failed to start the Z-Wave JS add-on. Check the configuration.",
@@ -16,6 +18,7 @@
             "invalid_ws_url": "Invalid websocket URL",
             "unknown": "Unexpected error"
         },
+        "flow_title": "{name}",
         "progress": {
             "install_addon": "Please wait while the Z-Wave JS add-on installation finishes. This can take several minutes.",
             "start_addon": "Please wait while the Z-Wave JS add-on start completes. This may take some seconds."

--- a/homeassistant/components/zwave_js/translations/en.json
+++ b/homeassistant/components/zwave_js/translations/en.json
@@ -51,6 +51,9 @@
             },
             "start_addon": {
                 "title": "The Z-Wave JS add-on is starting."
+            },
+            "usb_confirm": {
+                "description": "Do you want to setup {name} with the Z-Wave JS add-on?"
             }
         }
     },

--- a/homeassistant/generated/usb.py
+++ b/homeassistant/generated/usb.py
@@ -33,8 +33,8 @@ USB = [
     },
     {
         "domain": "zwave_js",
-        "vid": "1A86",
-        "pid": "7523"
+        "vid": "10C4",
+        "pid": "8A2A"
     },
     {
         "domain": "zwave_js",

--- a/homeassistant/generated/usb.py
+++ b/homeassistant/generated/usb.py
@@ -25,5 +25,20 @@ USB = [
         "domain": "zha",
         "vid": "10C4",
         "pid": "8A2A"
+    },
+    {
+        "domain": "zwave_js",
+        "vid": "0658",
+        "pid": "0200"
+    },
+    {
+        "domain": "zwave_js",
+        "vid": "1A86",
+        "pid": "7523"
+    },
+    {
+        "domain": "zwave_js",
+        "vid": "10C4",
+        "pid": "EA60"
     }
 ]

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1,7 +1,6 @@
 """Test the Z-Wave JS config flow."""
 import asyncio
-import os
-from unittest.mock import DEFAULT, MagicMock, call, patch, sentinel
+from unittest.mock import DEFAULT, call, patch
 
 import aiohttp
 import pytest
@@ -9,7 +8,6 @@ from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries, setup
 from homeassistant.components.hassio.handler import HassioAPIError
-from homeassistant.components.zwave_js import config_flow
 from homeassistant.components.zwave_js.config_flow import SERVER_VERSION_TIMEOUT, TITLE
 from homeassistant.components.zwave_js.const import DOMAIN
 
@@ -1922,52 +1920,3 @@ async def test_options_addon_not_installed(
     assert entry.data["integration_created_addon"] is True
     assert client.connect.call_count == 2
     assert client.disconnect.call_count == 1
-
-
-# Lifted from the zha tests
-def test_get_serial_by_id_no_dir():
-    """Test serial by id conversion if there's no /dev/serial/by-id."""
-    p1 = patch("os.path.isdir", MagicMock(return_value=False))
-    p2 = patch("os.scandir")
-    with p1 as is_dir_mock, p2 as scan_mock:
-        res = config_flow.get_serial_by_id(sentinel.path)
-        assert res is sentinel.path
-        assert is_dir_mock.call_count == 1
-        assert scan_mock.call_count == 0
-
-
-# Lifted from the zha tests
-def test_get_serial_by_id():
-    """Test serial by id conversion."""
-    p1 = patch("os.path.isdir", MagicMock(return_value=True))
-    p2 = patch("os.scandir")
-
-    def _realpath(path):
-        if path is sentinel.matched_link:
-            return sentinel.path
-        return sentinel.serial_link_path
-
-    p3 = patch("os.path.realpath", side_effect=_realpath)
-    with p1 as is_dir_mock, p2 as scan_mock, p3:
-        res = config_flow.get_serial_by_id(sentinel.path)
-        assert res is sentinel.path
-        assert is_dir_mock.call_count == 1
-        assert scan_mock.call_count == 1
-
-        entry1 = MagicMock(spec_set=os.DirEntry)
-        entry1.is_symlink.return_value = True
-        entry1.path = sentinel.some_path
-
-        entry2 = MagicMock(spec_set=os.DirEntry)
-        entry2.is_symlink.return_value = False
-        entry2.path = sentinel.other_path
-
-        entry3 = MagicMock(spec_set=os.DirEntry)
-        entry3.is_symlink.return_value = True
-        entry3.path = sentinel.matched_link
-
-        scan_mock.return_value = [entry1, entry2, entry3]
-        res = config_flow.get_serial_by_id(sentinel.path)
-        assert res is sentinel.matched_link
-        assert is_dir_mock.call_count == 2
-        assert scan_mock.call_count == 2

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -415,7 +415,6 @@ async def test_abort_hassio_discovery_with_existing_flow(
     hass, supervisor, addon_options
 ):
     """Test hassio discovery flow is aborted when another discovery has happened."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USB},
@@ -444,7 +443,6 @@ async def test_usb_discovery(
     start_addon,
 ):
     """Test usb discovery success path."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USB},
@@ -632,8 +630,6 @@ async def test_discovery_addon_not_installed(
 
 async def test_abort_usb_discovery_with_existing_flow(hass, supervisor, addon_options):
     """Test usb discovery flow is aborted when another discovery has happened."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
@@ -654,8 +650,6 @@ async def test_abort_usb_discovery_with_existing_flow(hass, supervisor, addon_op
 
 async def test_abort_usb_discovery_already_configured(hass, supervisor, addon_options):
     """Test usb discovery flow is aborted when there is an existing entry."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     entry = MockConfigEntry(
         domain=DOMAIN, data={"url": "ws://localhost:3000"}, title=TITLE, unique_id=1234
     )
@@ -672,8 +666,6 @@ async def test_abort_usb_discovery_already_configured(hass, supervisor, addon_op
 
 async def test_usb_discovery_requires_supervisor(hass):
     """Test usb discovery flow is aborted when there is no supervisor."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USB},
@@ -685,8 +677,6 @@ async def test_usb_discovery_requires_supervisor(hass):
 
 async def test_usb_discovery_already_running(hass, supervisor, addon_running):
     """Test usb discovery flow is aborted when the addon is running."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USB},
@@ -707,8 +697,6 @@ async def test_abort_usb_discovery_aborts_specific_devices(
     hass, supervisor, addon_options, discovery_info
 ):
     """Test usb discovery flow is aborted on specific devices."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USB},

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -587,6 +587,19 @@ async def test_abort_usb_discovery_already_configured(hass, supervisor, addon_op
     assert result["reason"] == "already_configured"
 
 
+async def test_usb_discovery_requires_supervisor(hass):
+    """Test usb discovery flow is aborted when there is no supervisor."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USB},
+        data=USB_DISCOVERY_INFO,
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "discovery_requires_supervisor"
+
+
 async def test_not_addon(hass, supervisor):
     """Test opting out of add-on on Supervisor."""
     await setup.async_setup_component(hass, "persistent_notification", {})

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -31,6 +31,24 @@ USB_DISCOVERY_INFO = {
     "manufacturer": "test",
 }
 
+NORTEK_ZIGBEE_DISCOVERY_INFO = {
+    "device": "/dev/zigbee",
+    "pid": "8A2A",
+    "vid": "10C4",
+    "serial_number": "1234",
+    "description": "nortek zigbee radio",
+    "manufacturer": "nortek",
+}
+
+CP2652_ZIGBEE_DISCOVERY_INFO = {
+    "device": "/dev/zigbee",
+    "pid": "EA60",
+    "vid": "10C4",
+    "serial_number": "",
+    "description": "cp2652",
+    "manufacturer": "generic",
+}
+
 
 @pytest.fixture(name="persistent_notification", autouse=True)
 async def setup_persistent_notification(hass):
@@ -598,6 +616,28 @@ async def test_usb_discovery_requires_supervisor(hass):
     )
     assert result["type"] == "abort"
     assert result["reason"] == "discovery_requires_supervisor"
+
+
+@pytest.mark.parametrize(
+    "discovery_info",
+    [
+        NORTEK_ZIGBEE_DISCOVERY_INFO,
+        CP2652_ZIGBEE_DISCOVERY_INFO,
+    ],
+)
+async def test_abort_usb_discovery_aborts_specific_devices(
+    hass, supervisor, addon_options, discovery_info
+):
+    """Test usb discovery flow is aborted on specific devices."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USB},
+        data=discovery_info,
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "not_zwave_device"
 
 
 async def test_not_addon(hass, supervisor):

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -455,10 +455,6 @@ async def test_usb_discovery(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    import pprint
-
-    pprint.pprint(result)
-
     assert result["type"] == "progress"
     assert result["step_id"] == "install_addon"
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for USB discovery to zwave_js

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19023

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
- On linux, devices are detected as soon as they are plugged in

- On windows and mac, devices are detected at startup and
  hourly