### PR TITLE
OVO Energy - Sensor Entity Descriptions

### DIFF
--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -99,37 +99,10 @@ class OVOEnergyEntity(CoordinatorEntity):
         self,
         coordinator: DataUpdateCoordinator,
         client: OVOEnergy,
-        key: str,
-        name: str,
-        icon: str,
     ) -> None:
         """Initialize the OVO Energy entity."""
         super().__init__(coordinator)
         self._client = client
-        self._key = key
-        self._name = name
-        self._icon = icon
-        self._available = True
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique ID for this sensor."""
-        return self._key
-
-    @property
-    def name(self) -> str:
-        """Return the name of the entity."""
-        return self._name
-
-    @property
-    def icon(self) -> str:
-        """Return the mdi icon of the entity."""
-        return self._icon
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.coordinator.last_update_success and self._available
 
 
 class OVOEnergyDeviceEntity(OVOEnergyEntity):

--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -99,10 +99,12 @@ class OVOEnergyEntity(CoordinatorEntity):
         self,
         coordinator: DataUpdateCoordinator,
         client: OVOEnergy,
+        key: str,
     ) -> None:
         """Initialize the OVO Energy entity."""
         super().__init__(coordinator)
         self._client = client
+        self._attr_unique_id = key
 
 
 class OVOEnergyDeviceEntity(OVOEnergyEntity):

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -91,7 +91,6 @@ SENSOR_TYPES_GAS: tuple[OVOEnergySensorEntityDescription, ...] = (
         name="OVO Last Gas Cost",
         device_class=DEVICE_CLASS_MONETARY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
-        # native_unit_of_measurement=coordinator.data.gas[-1].cost.currency_unit,
         icon="mdi:cash-multiple",
         value=lambda usage: usage.gas[-1].consumption,
     ),

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -52,118 +52,122 @@ async def async_setup_entry(
 
     if coordinator.data:
         if coordinator.data.electricity:
-            entities = [
-                *entities,
-                OVOEnergySensor(
-                    coordinator,
-                    OVOEnergySensorEntityDescription(
-                        key=f"{DOMAIN}_{client.account_id}_last_electricity_reading",
-                        name="OVO Last Electricity Reading",
-                        device_class=DEVICE_CLASS_ENERGY,
-                        state_class=STATE_CLASS_TOTAL_INCREASING,
-                        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
-                        value=lambda usage: usage.electricity[-1].consumption,
-                    ),
-                    client,
-                ),
-                OVOEnergySensor(
-                    coordinator,
-                    OVOEnergySensorEntityDescription(
-                        key=f"{DOMAIN}_{client.account_id}_last_electricity_cost",
-                        name="OVO Last Electricity Cost",
-                        device_class=DEVICE_CLASS_MONETARY,
-                        state_class=STATE_CLASS_TOTAL_INCREASING,
-                        native_unit_of_measurement=coordinator.data.electricity[
-                            -1
-                        ].cost.currency_unit,
-                        icon="mdi:cash-multiple",
-                        value=lambda usage: usage.electricity[-1].consumption,
-                    ),
-                    client,
-                ),
-                OVOEnergySensor(
-                    coordinator,
-                    OVOEnergySensorEntityDescription(
-                        key=f"{DOMAIN}_{client.account_id}_last_electricity_start_time",
-                        name="OVO Last Electricity Start Time",
-                        entity_registry_enabled_default=False,
-                        device_class=DEVICE_CLASS_TIMESTAMP,
-                        value=lambda usage: dt_util.as_utc(
-                            usage.electricity[-1].interval.start
+            entities.extend(
+                [
+                    OVOEnergySensor(
+                        coordinator,
+                        OVOEnergySensorEntityDescription(
+                            key=f"{DOMAIN}_{client.account_id}_last_electricity_reading",
+                            name="OVO Last Electricity Reading",
+                            device_class=DEVICE_CLASS_ENERGY,
+                            state_class=STATE_CLASS_TOTAL_INCREASING,
+                            native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+                            value=lambda usage: usage.electricity[-1].consumption,
                         ),
+                        client,
                     ),
-                    client,
-                ),
-                OVOEnergySensor(
-                    coordinator,
-                    OVOEnergySensorEntityDescription(
-                        key=f"{DOMAIN}_{client.account_id}_last_electricity_end_time",
-                        name="OVO Last Electricity End Time",
-                        entity_registry_enabled_default=False,
-                        device_class=DEVICE_CLASS_TIMESTAMP,
-                        value=lambda usage: dt_util.as_utc(
-                            usage.electricity[-1].interval.end
+                    OVOEnergySensor(
+                        coordinator,
+                        OVOEnergySensorEntityDescription(
+                            key=f"{DOMAIN}_{client.account_id}_last_electricity_cost",
+                            name="OVO Last Electricity Cost",
+                            device_class=DEVICE_CLASS_MONETARY,
+                            state_class=STATE_CLASS_TOTAL_INCREASING,
+                            native_unit_of_measurement=coordinator.data.electricity[
+                                -1
+                            ].cost.currency_unit,
+                            icon="mdi:cash-multiple",
+                            value=lambda usage: usage.electricity[-1].consumption,
                         ),
+                        client,
                     ),
-                    client,
-                ),
-            ]
+                    OVOEnergySensor(
+                        coordinator,
+                        OVOEnergySensorEntityDescription(
+                            key=f"{DOMAIN}_{client.account_id}_last_electricity_start_time",
+                            name="OVO Last Electricity Start Time",
+                            entity_registry_enabled_default=False,
+                            device_class=DEVICE_CLASS_TIMESTAMP,
+                            value=lambda usage: dt_util.as_utc(
+                                usage.electricity[-1].interval.start
+                            ),
+                        ),
+                        client,
+                    ),
+                    OVOEnergySensor(
+                        coordinator,
+                        OVOEnergySensorEntityDescription(
+                            key=f"{DOMAIN}_{client.account_id}_last_electricity_end_time",
+                            name="OVO Last Electricity End Time",
+                            entity_registry_enabled_default=False,
+                            device_class=DEVICE_CLASS_TIMESTAMP,
+                            value=lambda usage: dt_util.as_utc(
+                                usage.electricity[-1].interval.end
+                            ),
+                        ),
+                        client,
+                    ),
+                ]
+            )
         if coordinator.data.gas:
-            entities = [
-                *entities,
-                OVOEnergySensor(
-                    coordinator,
-                    OVOEnergySensorEntityDescription(
-                        key=f"{DOMAIN}_{client.account_id}_last_gas_reading",
-                        name="OVO Last Gas Reading",
-                        device_class=DEVICE_CLASS_ENERGY,
-                        state_class=STATE_CLASS_TOTAL_INCREASING,
-                        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
-                        icon="mdi:gas-cylinder",
-                        value=lambda usage: usage.gas[-1].consumption,
-                    ),
-                    client,
-                ),
-                OVOEnergySensor(
-                    coordinator,
-                    OVOEnergySensorEntityDescription(
-                        key=f"{DOMAIN}_{client.account_id}_last_gas_cost",
-                        name="OVO Last Gas Cost",
-                        device_class=DEVICE_CLASS_MONETARY,
-                        state_class=STATE_CLASS_TOTAL_INCREASING,
-                        native_unit_of_measurement=coordinator.data.gas[
-                            -1
-                        ].cost.currency_unit,
-                        icon="mdi:cash-multiple",
-                        value=lambda usage: usage.gas[-1].consumption,
-                    ),
-                    client,
-                ),
-                OVOEnergySensor(
-                    coordinator,
-                    OVOEnergySensorEntityDescription(
-                        key=f"{DOMAIN}_{client.account_id}_last_gas_start_time",
-                        name="OVO Last Gas Start Time",
-                        entity_registry_enabled_default=False,
-                        device_class=DEVICE_CLASS_TIMESTAMP,
-                        value=lambda usage: dt_util.as_utc(
-                            usage.gas[-1].interval.start
+            entities.extend(
+                [
+                    OVOEnergySensor(
+                        coordinator,
+                        OVOEnergySensorEntityDescription(
+                            key=f"{DOMAIN}_{client.account_id}_last_gas_reading",
+                            name="OVO Last Gas Reading",
+                            device_class=DEVICE_CLASS_ENERGY,
+                            state_class=STATE_CLASS_TOTAL_INCREASING,
+                            native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+                            icon="mdi:gas-cylinder",
+                            value=lambda usage: usage.gas[-1].consumption,
                         ),
+                        client,
                     ),
-                    client,
-                ),
-                OVOEnergySensor(
-                    coordinator,
-                    OVOEnergySensorEntityDescription(
-                        key=f"{DOMAIN}_{client.account_id}_last_gas_end_time",
-                        name="OVO Last Gas End Time",
-                        entity_registry_enabled_default=False,
-                        device_class=DEVICE_CLASS_TIMESTAMP,
-                        value=lambda usage: dt_util.as_utc(usage.gas[-1].interval.end),
+                    OVOEnergySensor(
+                        coordinator,
+                        OVOEnergySensorEntityDescription(
+                            key=f"{DOMAIN}_{client.account_id}_last_gas_cost",
+                            name="OVO Last Gas Cost",
+                            device_class=DEVICE_CLASS_MONETARY,
+                            state_class=STATE_CLASS_TOTAL_INCREASING,
+                            native_unit_of_measurement=coordinator.data.gas[
+                                -1
+                            ].cost.currency_unit,
+                            icon="mdi:cash-multiple",
+                            value=lambda usage: usage.gas[-1].consumption,
+                        ),
+                        client,
                     ),
-                    client,
-                ),
-            ]
+                    OVOEnergySensor(
+                        coordinator,
+                        OVOEnergySensorEntityDescription(
+                            key=f"{DOMAIN}_{client.account_id}_last_gas_start_time",
+                            name="OVO Last Gas Start Time",
+                            entity_registry_enabled_default=False,
+                            device_class=DEVICE_CLASS_TIMESTAMP,
+                            value=lambda usage: dt_util.as_utc(
+                                usage.gas[-1].interval.start
+                            ),
+                        ),
+                        client,
+                    ),
+                    OVOEnergySensor(
+                        coordinator,
+                        OVOEnergySensorEntityDescription(
+                            key=f"{DOMAIN}_{client.account_id}_last_gas_end_time",
+                            name="OVO Last Gas End Time",
+                            entity_registry_enabled_default=False,
+                            device_class=DEVICE_CLASS_TIMESTAMP,
+                            value=lambda usage: dt_util.as_utc(
+                                usage.gas[-1].interval.end
+                            ),
+                        ),
+                        client,
+                    ),
+                ]
+            )
 
     async_add_entities(entities, True)
 

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -1,22 +1,42 @@
 """Support for OVO Energy sensors."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import timedelta
+from typing import Callable, cast
 
 from ovoenergy import OVODailyUsage
 from ovoenergy.ovoenergy import OVOEnergy
 
-from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING, SensorEntity
+from homeassistant.components.sensor import (
+    STATE_CLASS_TOTAL_INCREASING,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DEVICE_CLASS_ENERGY, DEVICE_CLASS_MONETARY
+from homeassistant.const import (
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_MONETARY,
+    DEVICE_CLASS_TIMESTAMP,
+    ENERGY_KILO_WATT_HOUR,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from . import OVOEnergyDeviceEntity
 from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
 
 SCAN_INTERVAL = timedelta(seconds=300)
 PARALLEL_UPDATES = 4
+
+
+@dataclass
+class OVOEnergySensorEntityDescription(SensorEntityDescription):
+    """Class describing System Bridge sensor entities."""
+
+    value: Callable = round
 
 
 async def async_setup_entry(
@@ -32,199 +52,148 @@ async def async_setup_entry(
 
     if coordinator.data:
         if coordinator.data.electricity:
-            entities.append(OVOEnergyLastElectricityReading(coordinator, client))
-            entities.append(
-                OVOEnergyLastElectricityCost(
+            entities = [
+                *entities,
+                OVOEnergySensor(
                     coordinator,
+                    OVOEnergySensorEntityDescription(
+                        key=f"{DOMAIN}_{client.account_id}_last_electricity_reading",
+                        name="OVO Last Electricity Reading",
+                        device_class=DEVICE_CLASS_ENERGY,
+                        state_class=STATE_CLASS_TOTAL_INCREASING,
+                        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+                        value=lambda usage: usage.electricity[-1].consumption,
+                    ),
                     client,
-                    coordinator.data.electricity[
-                        len(coordinator.data.electricity) - 1
-                    ].cost.currency_unit,
-                )
-            )
+                ),
+                OVOEnergySensor(
+                    coordinator,
+                    OVOEnergySensorEntityDescription(
+                        key=f"{DOMAIN}_{client.account_id}_last_electricity_cost",
+                        name="OVO Last Electricity Cost",
+                        device_class=DEVICE_CLASS_MONETARY,
+                        state_class=STATE_CLASS_TOTAL_INCREASING,
+                        native_unit_of_measurement=coordinator.data.electricity[
+                            -1
+                        ].cost.currency_unit,
+                        icon="mdi:cash-multiple",
+                        value=lambda usage: usage.electricity[-1].consumption,
+                    ),
+                    client,
+                ),
+                OVOEnergySensor(
+                    coordinator,
+                    OVOEnergySensorEntityDescription(
+                        key=f"{DOMAIN}_{client.account_id}_last_electricity_start_time",
+                        name="OVO Last Electricity Start Time",
+                        entity_registry_enabled_default=False,
+                        device_class=DEVICE_CLASS_TIMESTAMP,
+                        value=lambda usage: dt_util.as_utc(
+                            usage.electricity[-1].interval.start
+                        ),
+                    ),
+                    client,
+                ),
+                OVOEnergySensor(
+                    coordinator,
+                    OVOEnergySensorEntityDescription(
+                        key=f"{DOMAIN}_{client.account_id}_last_electricity_end_time",
+                        name="OVO Last Electricity End Time",
+                        entity_registry_enabled_default=False,
+                        device_class=DEVICE_CLASS_TIMESTAMP,
+                        value=lambda usage: dt_util.as_utc(
+                            usage.electricity[-1].interval.end
+                        ),
+                    ),
+                    client,
+                ),
+            ]
         if coordinator.data.gas:
-            entities.append(OVOEnergyLastGasReading(coordinator, client))
-            entities.append(
-                OVOEnergyLastGasCost(
+            entities = [
+                *entities,
+                OVOEnergySensor(
                     coordinator,
+                    OVOEnergySensorEntityDescription(
+                        key=f"{DOMAIN}_{client.account_id}_last_gas_reading",
+                        name="OVO Last Gas Reading",
+                        device_class=DEVICE_CLASS_ENERGY,
+                        state_class=STATE_CLASS_TOTAL_INCREASING,
+                        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+                        icon="mdi:gas-cylinder",
+                        value=lambda usage: usage.gas[-1].consumption,
+                    ),
                     client,
-                    coordinator.data.gas[
-                        len(coordinator.data.gas) - 1
-                    ].cost.currency_unit,
-                )
-            )
+                ),
+                OVOEnergySensor(
+                    coordinator,
+                    OVOEnergySensorEntityDescription(
+                        key=f"{DOMAIN}_{client.account_id}_last_gas_cost",
+                        name="OVO Last Gas Cost",
+                        device_class=DEVICE_CLASS_MONETARY,
+                        state_class=STATE_CLASS_TOTAL_INCREASING,
+                        native_unit_of_measurement=coordinator.data.gas[
+                            -1
+                        ].cost.currency_unit,
+                        icon="mdi:cash-multiple",
+                        value=lambda usage: usage.gas[-1].consumption,
+                    ),
+                    client,
+                ),
+                OVOEnergySensor(
+                    coordinator,
+                    OVOEnergySensorEntityDescription(
+                        key=f"{DOMAIN}_{client.account_id}_last_gas_start_time",
+                        name="OVO Last Gas Start Time",
+                        entity_registry_enabled_default=False,
+                        device_class=DEVICE_CLASS_TIMESTAMP,
+                        value=lambda usage: dt_util.as_utc(
+                            usage.gas[-1].interval.start
+                        ),
+                    ),
+                    client,
+                ),
+                OVOEnergySensor(
+                    coordinator,
+                    OVOEnergySensorEntityDescription(
+                        key=f"{DOMAIN}_{client.account_id}_last_gas_end_time",
+                        name="OVO Last Gas End Time",
+                        entity_registry_enabled_default=False,
+                        device_class=DEVICE_CLASS_TIMESTAMP,
+                        value=lambda usage: dt_util.as_utc(usage.gas[-1].interval.end),
+                    ),
+                    client,
+                ),
+            ]
 
     async_add_entities(entities, True)
 
 
 class OVOEnergySensor(OVOEnergyDeviceEntity, SensorEntity):
-    """Defines a OVO Energy sensor."""
+    """Define a OVO Energy sensor."""
 
-    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+    coordinator: DataUpdateCoordinator
+    entity_description: OVOEnergySensorEntityDescription
 
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
+        description: OVOEnergySensorEntityDescription,
         client: OVOEnergy,
-        key: str,
-        name: str,
-        icon: str,
-        device_class: str | None,
-        unit_of_measurement: str | None,
     ) -> None:
-        """Initialize OVO Energy sensor."""
-        self._attr_device_class = device_class
-        self._unit_of_measurement = unit_of_measurement
-
-        super().__init__(coordinator, client, key, name, icon)
+        """Initialize."""
+        super().__init__(coordinator, client)
+        self.entity_description = description
 
     @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit this state is expressed in."""
-        return self._unit_of_measurement
-
-
-class OVOEnergyLastElectricityReading(OVOEnergySensor):
-    """Defines a OVO Energy last reading sensor."""
-
-    def __init__(self, coordinator: DataUpdateCoordinator, client: OVOEnergy) -> None:
-        """Initialize OVO Energy sensor."""
-
-        super().__init__(
-            coordinator,
-            client,
-            f"{client.account_id}_last_electricity_reading",
-            "OVO Last Electricity Reading",
-            "mdi:flash",
-            DEVICE_CLASS_ENERGY,
-            "kWh",
-        )
+    def unique_id(self) -> str:
+        """Return the unique ID for this entity."""
+        return self.entity_description.key
 
     @property
-    def native_value(self) -> str:
-        """Return the state of the sensor."""
+    def native_value(self) -> StateType:
+        """Return the state."""
         usage: OVODailyUsage = self.coordinator.data
-        if usage is None or not usage.electricity:
+        try:
+            return cast(StateType, self.entity_description.value(usage))
+        except TypeError:
             return None
-        return usage.electricity[-1].consumption
-
-    @property
-    def extra_state_attributes(self) -> object:
-        """Return the attributes of the sensor."""
-        usage: OVODailyUsage = self.coordinator.data
-        if usage is None or not usage.electricity:
-            return None
-        return {
-            "start_time": usage.electricity[-1].interval.start,
-            "end_time": usage.electricity[-1].interval.end,
-        }
-
-
-class OVOEnergyLastGasReading(OVOEnergySensor):
-    """Defines a OVO Energy last reading sensor."""
-
-    def __init__(self, coordinator: DataUpdateCoordinator, client: OVOEnergy) -> None:
-        """Initialize OVO Energy sensor."""
-
-        super().__init__(
-            coordinator,
-            client,
-            f"{DOMAIN}_{client.account_id}_last_gas_reading",
-            "OVO Last Gas Reading",
-            "mdi:gas-cylinder",
-            DEVICE_CLASS_ENERGY,
-            "kWh",
-        )
-
-    @property
-    def native_value(self) -> str:
-        """Return the state of the sensor."""
-        usage: OVODailyUsage = self.coordinator.data
-        if usage is None or not usage.gas:
-            return None
-        return usage.gas[-1].consumption
-
-    @property
-    def extra_state_attributes(self) -> object:
-        """Return the attributes of the sensor."""
-        usage: OVODailyUsage = self.coordinator.data
-        if usage is None or not usage.gas:
-            return None
-        return {
-            "start_time": usage.gas[-1].interval.start,
-            "end_time": usage.gas[-1].interval.end,
-        }
-
-
-class OVOEnergyLastElectricityCost(OVOEnergySensor):
-    """Defines a OVO Energy last cost sensor."""
-
-    def __init__(
-        self, coordinator: DataUpdateCoordinator, client: OVOEnergy, currency: str
-    ) -> None:
-        """Initialize OVO Energy sensor."""
-        super().__init__(
-            coordinator,
-            client,
-            f"{DOMAIN}_{client.account_id}_last_electricity_cost",
-            "OVO Last Electricity Cost",
-            "mdi:cash-multiple",
-            DEVICE_CLASS_MONETARY,
-            currency,
-        )
-
-    @property
-    def native_value(self) -> str:
-        """Return the state of the sensor."""
-        usage: OVODailyUsage = self.coordinator.data
-        if usage is None or not usage.electricity:
-            return None
-        return usage.electricity[-1].cost.amount
-
-    @property
-    def extra_state_attributes(self) -> object:
-        """Return the attributes of the sensor."""
-        usage: OVODailyUsage = self.coordinator.data
-        if usage is None or not usage.electricity:
-            return None
-        return {
-            "start_time": usage.electricity[-1].interval.start,
-            "end_time": usage.electricity[-1].interval.end,
-        }
-
-
-class OVOEnergyLastGasCost(OVOEnergySensor):
-    """Defines a OVO Energy last cost sensor."""
-
-    def __init__(
-        self, coordinator: DataUpdateCoordinator, client: OVOEnergy, currency: str
-    ) -> None:
-        """Initialize OVO Energy sensor."""
-        super().__init__(
-            coordinator,
-            client,
-            f"{DOMAIN}_{client.account_id}_last_gas_cost",
-            "OVO Last Gas Cost",
-            "mdi:cash-multiple",
-            DEVICE_CLASS_MONETARY,
-            currency,
-        )
-
-    @property
-    def native_value(self) -> str:
-        """Return the state of the sensor."""
-        usage: OVODailyUsage = self.coordinator.data
-        if usage is None or not usage.gas:
-            return None
-        return usage.gas[-1].cost.amount
-
-    @property
-    def extra_state_attributes(self) -> object:
-        """Return the attributes of the sensor."""
-        usage: OVODailyUsage = self.coordinator.data
-        if usage is None or not usage.gas:
-            return None
-        return {
-            "start_time": usage.gas[-1].interval.start,
-            "end_time": usage.gas[-1].interval.end,
-        }

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -36,7 +36,7 @@ PARALLEL_UPDATES = 4
 class OVOEnergySensorEntityDescription(SensorEntityDescription):
     """Class describing System Bridge sensor entities."""
 
-    value: Callable = round
+    value: Callable[[OVODailyUsage], StateType] = round
 
 
 async def async_setup_entry(

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -125,19 +125,19 @@ async def async_setup_entry(
 
     if coordinator.data:
         if coordinator.data.electricity:
-            entities.extend(
-                [
-                    OVOEnergySensor(coordinator, description, client)
-                    for description in SENSOR_TYPES_ELECTRICITY
-                ]
-            )
+            for description in SENSOR_TYPES_ELECTRICITY:
+                if description.key == KEY_LAST_ELECTRICITY_COST:
+                    description.native_unit_of_measurement = (
+                        coordinator.data.electricity[-1].cost.currency_unit
+                    )
+                entities.append(OVOEnergySensor(coordinator, description, client))
         if coordinator.data.gas:
-            entities.extend(
-                [
-                    OVOEnergySensor(coordinator, description, client)
-                    for description in SENSOR_TYPES_GAS
-                ]
-            )
+            for description in SENSOR_TYPES_GAS:
+                if description.key == KEY_LAST_GAS_COST:
+                    description.native_unit_of_measurement = coordinator.data.gas[
+                        -1
+                    ].cost.currency_unit
+                entities.append(OVOEnergySensor(coordinator, description, client))
 
     async_add_entities(entities, True)
 
@@ -155,15 +155,6 @@ class OVOEnergySensor(OVOEnergyDeviceEntity, SensorEntity):
         client: OVOEnergy,
     ) -> None:
         """Initialize."""
-        if description.key == KEY_LAST_ELECTRICITY_COST:
-            description.native_unit_of_measurement = coordinator.data.electricity[
-                -1
-            ].cost.currency_unit
-        elif description.key == KEY_LAST_GAS_COST:
-            description.native_unit_of_measurement = coordinator.data.gas[
-                -1
-            ].cost.currency_unit
-
         super().__init__(
             coordinator,
             client,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
These attributes have been  removed and replaced with full sensors for both gas and electricity:

- `start_time`
- `end_time`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Converts OVO Energy sensors to use entity descriptions. Also adds times for usage instead of adding them as attributes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
-->

- [x] Code quality improvements to existing code or addition of tests

<!--
## Additional information
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

<!--
If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
-->

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!

- [ ] No score or internal
-->
- [x] 🥈 Silver
<!--
- [ ] 🥇 Gold
- [ ] 🏆 Platinum
-->

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
