### PR TITLE
Switch periodic USB scanning to on-demand websocket when observer is not available

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -2,29 +2,28 @@
 from __future__ import annotations
 
 import dataclasses
-import datetime
 import logging
 import os
 import sys
 
 from serial.tools.list_ports import comports
 from serial.tools.list_ports_common import ListPortInfo
+import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components import websocket_api
+from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_usb
 
+from .const import DOMAIN
 from .flow import FlowDispatcher, USBFlow
 from .models import USBDevice
 from .utils import usb_device_from_port
 
 _LOGGER = logging.getLogger(__name__)
-
-# Perodic scanning only happens on non-linux systems
-SCAN_INTERVAL = datetime.timedelta(minutes=60)
 
 
 def human_readable_device_name(
@@ -63,6 +62,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     usb = await async_get_usb(hass)
     usb_discovery = USBDiscovery(hass, FlowDispatcher(hass), usb)
     await usb_discovery.async_setup()
+    hass.data[DOMAIN] = usb_discovery
+    websocket_api.async_register_command(hass, websocket_usb_scan)
+
     return True
 
 
@@ -80,11 +82,11 @@ class USBDiscovery:
         self.flow_dispatcher = flow_dispatcher
         self.usb = usb
         self.seen: set[tuple[str, ...]] = set()
+        self.observer_active = False
 
     async def async_setup(self) -> None:
         """Set up USB Discovery."""
-        if not await self._async_start_monitor():
-            await self._async_start_scanner()
+        await self._async_start_monitor()
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, self.async_start)
 
     async def async_start(self, event: Event) -> None:
@@ -92,19 +94,10 @@ class USBDiscovery:
         self.flow_dispatcher.async_start()
         await self.hass.async_add_executor_job(self.scan_serial)
 
-    async def _async_start_scanner(self) -> None:
-        """Perodic scan with pyserial when the observer is not available."""
-        stop_track = async_track_time_interval(
-            self.hass, lambda now: self.scan_serial(), SCAN_INTERVAL
-        )
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, callback(lambda event: stop_track())
-        )
-
-    async def _async_start_monitor(self) -> bool:
+    async def _async_start_monitor(self) -> None:
         """Start monitoring hardware with pyudev."""
         if not sys.platform.startswith("linux"):
-            return False
+            return
         from pyudev import (  # pylint: disable=import-outside-toplevel
             Context,
             Monitor,
@@ -114,7 +107,7 @@ class USBDiscovery:
         try:
             context = Context()
         except (ImportError, OSError):
-            return False
+            return
 
         monitor = Monitor.from_netlink(context)
         monitor.filter_by(subsystem="tty")
@@ -125,7 +118,7 @@ class USBDiscovery:
         self.hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_STOP, lambda event: observer.stop()
         )
-        return True
+        self.observer_active = True
 
     def _device_discovered(self, device):
         """Call when the observer discovers a new usb tty device."""
@@ -168,3 +161,18 @@ class USBDiscovery:
     def scan_serial(self) -> None:
         """Scan serial ports."""
         self.hass.add_job(self._async_process_ports, comports())
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required("type"): "usb/scan"})
+@websocket_api.async_response
+async def websocket_usb_scan(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict,
+) -> None:
+    """Scan for new usb devices."""
+    usb_discovery: USBDiscovery = hass.data[DOMAIN]
+    if not usb_discovery.observer_active:
+        await hass.async_add_executor_job(usb_discovery.scan_serial)
+    connection.send_result(msg["id"])

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -26,7 +26,7 @@ from .utils import usb_device_from_port
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUEST_SCAN_COOLDOWN = 1
+REQUEST_SCAN_COOLDOWN = 60  # 1 minute cooldown
 
 
 def human_readable_device_name(

--- a/homeassistant/components/usb/manifest.json
+++ b/homeassistant/components/usb/manifest.json
@@ -7,6 +7,7 @@
     "pyserial==3.5"
   ],
   "codeowners": ["@bdraco"],
+  "dependencies": ["websocket_api"],
   "quality_scale": "internal",
   "iot_class": "local_push"
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Switch periodic USB scanning to on-demand websocket when observer is not available per https://github.com/home-assistant/core/pull/54904#discussion_r693135571



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19032

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
