### PR TITLE
Replace *args and **kwargs type hint collections with value types

### DIFF
--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -201,7 +201,7 @@ class ValveControllerSwitch(ValveControllerEntity, SwitchEntity):
         except GuardianError as err:
             LOGGER.error("Error while upgrading firmware: %s", err)
 
-    async def async_turn_off(self, **kwargs: dict[str, Any]) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the valve off (closed)."""
         try:
             async with self._client:
@@ -213,7 +213,7 @@ class ValveControllerSwitch(ValveControllerEntity, SwitchEntity):
         self._attr_is_on = False
         self.async_write_ha_state()
 
-    async def async_turn_on(self, **kwargs: dict[str, Any]) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the valve on (open)."""
         try:
             async with self._client:

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
+from typing import Any, cast
 
 import pyatmo
 import voluptuous as vol
@@ -439,7 +439,7 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
         """Return a list of available preset modes."""
         return SUPPORT_PRESET
 
-    async def async_set_temperature(self, **kwargs: dict) -> None:
+    async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature for 2 hours."""
         temp = kwargs.get(ATTR_TEMPERATURE)
         if temp is None:
@@ -589,7 +589,7 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
 
         return {}
 
-    async def _async_service_set_schedule(self, **kwargs: dict) -> None:
+    async def _async_service_set_schedule(self, **kwargs: Any) -> None:
         schedule_name = kwargs.get(ATTR_SCHEDULE_NAME)
         schedule_id = None
         for sid, name in self.hass.data[DOMAIN][DATA_SCHEDULES][self._home_id].items():

--- a/homeassistant/components/netatmo/light.py
+++ b/homeassistant/components/netatmo/light.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
+from typing import Any, cast
 
 import pyatmo
 
@@ -141,7 +141,7 @@ class NetatmoLight(NetatmoBase, LightEntity):
         """Return true if light is on."""
         return self._is_on
 
-    async def async_turn_on(self, **kwargs: dict) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn camera floodlight on."""
         _LOGGER.debug("Turn camera '%s' on", self.name)
         await self._data.async_set_state(
@@ -150,7 +150,7 @@ class NetatmoLight(NetatmoBase, LightEntity):
             floodlight="on",
         )
 
-    async def async_turn_off(self, **kwargs: dict) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn camera floodlight into auto mode."""
         _LOGGER.debug("Turn camera '%s' to auto mode", self.name)
         await self._data.async_set_state(

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -313,13 +313,13 @@ class RainMachineProgram(RainMachineSwitch):
         """Return a list of active zones associated with this program."""
         return [z for z in self._data["wateringTimes"] if z["active"]]
 
-    async def async_turn_off(self, **kwargs: dict[str, Any]) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the program off."""
         await self._async_run_switch_coroutine(
             self._controller.programs.stop(self._uid)
         )
 
-    async def async_turn_on(self, **kwargs: dict[str, Any]) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the program on."""
         await self._async_run_switch_coroutine(
             self._controller.programs.start(self._uid)
@@ -353,11 +353,11 @@ class RainMachineProgram(RainMachineSwitch):
 class RainMachineZone(RainMachineSwitch):
     """A RainMachine zone."""
 
-    async def async_turn_off(self, **kwargs: dict[str, Any]) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the zone off."""
         await self._async_run_switch_coroutine(self._controller.zones.stop(self._uid))
 
-    async def async_turn_on(self, **kwargs: dict[str, Any]) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the zone on."""
         await self._async_run_switch_coroutine(
             self._controller.zones.start(

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -46,7 +46,7 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
 
         self._lock = lock
 
-    async def async_lock(self, **kwargs: dict[str, Any]) -> None:
+    async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
         try:
             await self._lock.lock()
@@ -57,7 +57,7 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
         self._attr_is_locked = True
         self.async_write_ha_state()
 
-    async def async_unlock(self, **kwargs: dict[str, Any]) -> None:
+    async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
         try:
             await self._lock.unlock()

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -137,13 +137,13 @@ class SwitcherBaseSwitchEntity(CoordinatorEntity, SwitchEntity):
 
         return bool(self.wrapper.data.device_state == DeviceState.ON)
 
-    async def async_turn_on(self, **kwargs: dict) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self._async_call_api("control_device", Command.ON)
         self.control_result = True
         self.async_write_ha_state()
 
-    async def async_turn_off(self, **kwargs: dict) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self._async_call_api("control_device", Command.OFF)
         self.control_result = False

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -103,9 +103,7 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
             ]
         ) == int(self.info.primary_value.value)
 
-    async def _set_lock_state(
-        self, target_state: str, **kwargs: dict[str, Any]
-    ) -> None:
+    async def _set_lock_state(self, target_state: str, **kwargs: Any) -> None:
         """Set the lock state."""
         target_value: ZwaveValue = self.get_zwave_value(
             LOCK_CMD_CLASS_TO_PROPERTY_MAP[self.info.primary_value.command_class]
@@ -116,11 +114,11 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
                 STATE_TO_ZWAVE_MAP[self.info.primary_value.command_class][target_state],
             )
 
-    async def async_lock(self, **kwargs: dict[str, Any]) -> None:
+    async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
         await self._set_lock_state(STATE_LOCKED)
 
-    async def async_unlock(self, **kwargs: dict[str, Any]) -> None:
+    async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
         await self._set_lock_state(STATE_UNLOCKED)
 

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -87,7 +87,7 @@ def deprecated_class(replacement: str) -> Any:
         """Decorate class as deprecated."""
 
         @functools.wraps(cls)
-        def deprecated_cls(*args: tuple, **kwargs: dict[str, Any]) -> Any:
+        def deprecated_cls(*args: Any, **kwargs: Any) -> Any:
             """Wrap for the original class."""
             _print_deprecation_warning(cls, replacement, "class")
             return cls(*args, **kwargs)
@@ -104,7 +104,7 @@ def deprecated_function(replacement: str) -> Callable[..., Callable]:
         """Decorate function as deprecated."""
 
         @functools.wraps(func)
-        def deprecated_func(*args: tuple, **kwargs: dict[str, Any]) -> Any:
+        def deprecated_func(*args: Any, **kwargs: Any) -> Any:
             """Wrap for the original function."""
             _print_deprecation_warning(func, replacement, "function")
             return func(*args, **kwargs)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -151,7 +151,7 @@ def gen_result_wrapper(kls):
     class Wrapper(kls, ResultWrapper):
         """Wrapper of a kls that can store render_result."""
 
-        def __init__(self, *args: tuple, render_result: str | None = None) -> None:
+        def __init__(self, *args: Any, render_result: str | None = None) -> None:
             super().__init__(*args)
             self.render_result = render_result
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Hinting `*args` as tuple means all args must be tuples, and `**kwargs` as dict that all values of the implicit str keyed dict must be dicts. This is not the intent here.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
