### PR TITLE
Remove Configuration CC as choice in zwave_js value device condition

### DIFF
--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -193,6 +193,8 @@ async def async_get_condition_capabilities(
         return {"extra_fields": vol.Schema({vol.Required(ATTR_VALUE): value_schema})}
 
     if config[CONF_TYPE] == VALUE_TYPE:
+        # Only show command classes on this node and exclude Configuration CC since it
+        # is already covered
         return {
             "extra_fields": vol.Schema(
                 {
@@ -200,6 +202,7 @@ async def async_get_condition_capabilities(
                         {
                             CommandClass(cc.id).value: CommandClass(cc.id).name
                             for cc in sorted(node.command_classes, key=lambda cc: cc.name)  # type: ignore[no-any-return]
+                            if cc.id != CommandClass.CONFIGURATION
                         }
                     ),
                     vol.Required(ATTR_PROPERTY): cv.string,

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -433,7 +433,6 @@ async def test_get_condition_capabilities_value(
     cc_options = [
         (133, "ASSOCIATION"),
         (128, "BATTERY"),
-        (112, "CONFIGURATION"),
         (98, "DOOR_LOCK"),
         (122, "FIRMWARE_UPDATE_MD"),
         (114, "MANUFACTURER_SPECIFIC"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
If you have created an automation with the `zwave_js` device condition `Current value of a Z-Wave Value` for the `CONFIGURATION` Command Class, your automation will no longer work. Instead, you should use the `Config parameter` device condition for the value you were trying to use for your condition.


## Proposed change
We offer the Configuration CC as a choice in device conditions on any Z-Wave Value, but we have a better condition for config parameters. While this is a breaking change, I think it will ultimately lead to less confusions and mistakes so I think it is a worthwhile one.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
