### PR TITLE
Move setting extra state attributes to init and use a datasource that is always there for country_code

### DIFF
--- a/homeassistant/components/co2signal/__init__.py
+++ b/homeassistant/components/co2signal/__init__.py
@@ -8,12 +8,17 @@ from typing import TypedDict, cast
 import CO2Signal
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_COUNTRY_CODE, DOMAIN
+from .const import ATTRIBUTION, CONF_COUNTRY_CODE, DOMAIN
 from .util import get_extra_name
 
 PLATFORMS = ["sensor"]
@@ -66,6 +71,15 @@ class CO2SignalCoordinator(DataUpdateCoordinator[CO2SignalResponse]):
             hass, _LOGGER, name=DOMAIN, update_interval=timedelta(minutes=15)
         )
         self._entry = entry
+        self._attr_extra_state_attributes = {ATTR_ATTRIBUTION: ATTRIBUTION}
+
+        if (
+            CONF_COUNTRY_CODE in entry.data
+            and entry.data[CONF_COUNTRY_CODE] is not None
+        ):
+            self._attr_extra_state_attributes.update(
+                {"country_code": entry.data[CONF_COUNTRY_CODE]}
+            )
 
     @property
     def entry_id(self) -> str:

--- a/homeassistant/components/co2signal/sensor.py
+++ b/homeassistant/components/co2signal/sensor.py
@@ -14,7 +14,6 @@ from homeassistant.components.sensor import (
     SensorEntity,
 )
 from homeassistant.const import (
-    ATTR_ATTRIBUTION,
     ATTR_IDENTIFIERS,
     ATTR_MANUFACTURER,
     ATTR_NAME,
@@ -27,7 +26,7 @@ from homeassistant.helpers import config_validation as cv, update_coordinator
 from homeassistant.helpers.typing import StateType
 
 from . import CO2SignalCoordinator, CO2SignalResponse
-from .const import ATTRIBUTION, CONF_COUNTRY_CODE, DOMAIN, MSG_LOCATION
+from .const import CONF_COUNTRY_CODE, DOMAIN, MSG_LOCATION
 
 SCAN_INTERVAL = timedelta(minutes=3)
 
@@ -100,10 +99,6 @@ class CO2Sensor(update_coordinator.CoordinatorEntity[CO2SignalResponse], SensorE
             name = f"{extra_name} - {name}"
 
         self._attr_name = name
-        self._attr_extra_state_attributes = {
-            "country_code": coordinator.data["countryCode"],
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-        }
         self._attr_device_info = {
             ATTR_IDENTIFIERS: {(DOMAIN, coordinator.entry_id)},
             ATTR_NAME: "CO2 signal",


### PR DESCRIPTION
Move setting extra state attributes to init and use a datasource that is always there for country_code

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The setup was/is broken because the response from the API-call to co2signal is missing the key "countryCode", a curl command results in the same response. However, the doc says it should contain this code. Since we already know the country code in 2 out of 3 config options, if we use the config data we can get the country code from there. 

This means that setups with coordinates will not reflect the country code in the _attr_extra_state_attributes. But before adding more complexity, try to make sure it doesn't break anymore.

I took this approach because it will result in the same data from the same source with the smallest change (besides deleting or checking if the response has the key maybe, but why relying on data in a response we already know? Or is it possible that there is a difference?)

I've sent them an mail on the email-address in the response and some other email-address I found on the site of co2signal to check if there is any more information about this unexpected behavior. 

~~Somewhere i think that the dict self._attr_device_info / info also needs to me moved to init/config_flow because it is device-related information, not sensor-specific, but this is maybe not the right PR for that and maybe i'm totally wrong ;-)~~ Meh, maybe not reading https://developers.home-assistant.io/docs/device_registry_index again.

Maybe I would rather fix the root cause instead of fixing it this way, but taken the changes in mind and the fact that the data is already there, I think for this case this is the way to go. Completely open for feedback / arguments against / other proposals ofcourse

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/54888
- This PR is related to issue: https://github.com/home-assistant/core/issues/54888
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
