### PR TITLE
Gracefully handle udev not available via OSError when setting up usb

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -81,7 +81,7 @@ class USBDiscovery:
 
         try:
             context = Context()
-        except ImportError:
+        except (ImportError, OSError):
             return False
 
         monitor = Monitor.from_netlink(context)

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -241,7 +241,8 @@ async def test_discovered_by_scanner_after_started_no_vid_pid(hass):
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_non_matching_discovered_by_scanner_after_started(hass):
+@pytest.mark.parametrize("exception_type", [ImportError, OSError])
+async def test_non_matching_discovered_by_scanner_after_started(hass, exception_type):
     """Test a device is discovered by the scanner after the started event that does not match."""
     new_usb = [{"domain": "test1", "vid": "4444", "pid": "4444"}]
 
@@ -256,7 +257,7 @@ async def test_non_matching_discovered_by_scanner_after_started(hass):
         )
     ]
 
-    with patch("pyudev.Context", side_effect=ImportError), patch(
+    with patch("pyudev.Context", side_effect=exception_type), patch(
         "homeassistant.components.usb.async_get_usb", return_value=new_usb
     ), patch(
         "homeassistant.components.usb.comports", return_value=mock_comports


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Handle OSError when setting up pyudev in usb

Fixes
```
2021-08-20 18:11:51 ERROR (MainThread) [homeassistant.setup] Error during setup of component usb
Traceback (most recent call last):
  File "/home/keith/src/core/homeassistant/setup.py", line 255, in _async_setup_component
    result = await task
  File "/home/keith/src/core/homeassistant/components/usb/__init__.py", line 33, in async_setup
    await usb_discovery.async_setup()
  File "/home/keith/src/core/homeassistant/components/usb/__init__.py", line 54, in async_setup
    if not await self._async_start_monitor():
  File "/home/keith/src/core/homeassistant/components/usb/__init__.py", line 83, in _async_start_monitor
    context = Context()
  File "/home/keith/src/core/venv/lib/python3.9/site-packages/pyudev/core.py", line 61, in __init__
    self._libudev = load_ctypes_library('udev', SIGNATURES, ERROR_CHECKERS)
  File "/home/keith/src/core/venv/lib/python3.9/site-packages/pyudev/_ctypeslib/utils.py", line 56, in load_ctypes_library
    lib = CDLL(library_name, use_errno=True)
  File "/nix/store/81lwy2hfqj4c1943b1x8a0qsivjhdhw9-python3-3.9.6/lib/python3.9/ctypes/__init__.py", line 374, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libudev.so.1: cannot open shared object file: No such file or directory
```

Reported @ https://github.com/home-assistant/core/pull/54904#discussion_r693282161

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
