### PR TITLE
Bump HAP-python to 4.1.0

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -532,11 +532,6 @@ class HomeKit:
         # as pyhap uses a random one until state is restored
         if os.path.exists(persist_file):
             self.driver.load()
-            self.driver.state.config_version += 1
-            if self.driver.state.config_version > 65535:
-                self.driver.state.config_version = 1
-
-        self.driver.persist()
 
     async def async_reset_accessories(self, entity_ids):
         """Reset the accessory to load the latest configuration."""
@@ -688,6 +683,7 @@ class HomeKit:
         self._async_register_bridge()
         _LOGGER.debug("Driver start for %s", self._name)
         await self.driver.async_start()
+        self.driver.async_persist()
         self.status = STATUS_RUNNING
 
         if self.driver.state.paired:

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -528,9 +528,9 @@ class HomeDriver(AccessoryDriver):
         self._bridge_name = bridge_name
         self._entry_title = entry_title
 
-    def pair(self, client_uuid, client_public):
+    def pair(self, client_uuid, client_public, client_permissions):
         """Override super function to dismiss setup message if paired."""
-        success = super().pair(client_uuid, client_public)
+        success = super().pair(client_uuid, client_public, client_permissions)
         if success:
             dismiss_setup_message(self.hass, self._entry_id)
         return success

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
   "requirements": [
-    "HAP-python==4.0.0",
+    "HAP-python==4.1.0",
     "fnvhash==0.1.0",
     "PyQRCode==1.2.1",
     "base36==0.1.1"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -14,7 +14,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.1.1
 
 # homeassistant.components.homekit
-HAP-python==4.0.0
+HAP-python==4.1.0
 
 # homeassistant.components.mastodon
 Mastodon.py==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.homekit
-HAP-python==4.0.0
+HAP-python==4.1.0
 
 # homeassistant.components.flick_electric
 PyFlick==0.0.2

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -696,9 +696,9 @@ def test_home_driver():
     with patch("pyhap.accessory_driver.AccessoryDriver.pair") as mock_pair, patch(
         "homeassistant.components.homekit.accessories.dismiss_setup_message"
     ) as mock_dissmiss_msg:
-        driver.pair("client_uuid", "client_public", 1)
+        driver.pair("client_uuid", "client_public", b"1")
 
-    mock_pair.assert_called_with("client_uuid", "client_public", 1)
+    mock_pair.assert_called_with("client_uuid", "client_public", b"1")
     mock_dissmiss_msg.assert_called_with("hass", "entry_id")
 
     # unpair

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -696,9 +696,9 @@ def test_home_driver():
     with patch("pyhap.accessory_driver.AccessoryDriver.pair") as mock_pair, patch(
         "homeassistant.components.homekit.accessories.dismiss_setup_message"
     ) as mock_dissmiss_msg:
-        driver.pair("client_uuid", "client_public")
+        driver.pair("client_uuid", "client_public", 1)
 
-    mock_pair.assert_called_with("client_uuid", "client_public")
+    mock_pair.assert_called_with("client_uuid", "client_public", 1)
     mock_dissmiss_msg.assert_called_with("hass", "entry_id")
 
     # unpair

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -560,7 +560,7 @@ async def test_homekit_start(hass, hk_driver, mock_zeroconf, device_reg):
     assert (device_registry.CONNECTION_NETWORK_MAC, formatted_mac) in device.connections
 
     assert len(device_reg.devices) == 1
-    assert homekit.driver.state.config_version == 2
+    assert homekit.driver.state.config_version == 1
 
 
 async def test_homekit_start_with_a_broken_accessory(hass, hk_driver, mock_zeroconf):
@@ -695,7 +695,7 @@ async def test_homekit_unpair(hass, device_reg, mock_zeroconf):
         homekit.status = STATUS_RUNNING
 
         state = homekit.driver.state
-        state.add_paired_client("client1", "any", 1)
+        state.add_paired_client("client1", "any", b"1")
         formatted_mac = device_registry.format_mac(state.mac)
         hk_bridge_dev = device_reg.async_get_device(
             {}, {(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)}
@@ -734,7 +734,7 @@ async def test_homekit_unpair_missing_device_id(hass, device_reg, mock_zeroconf)
         homekit.status = STATUS_RUNNING
 
         state = homekit.driver.state
-        state.add_paired_client("client1", "any", 1)
+        state.add_paired_client("client1", "any", b"1")
         with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
                 DOMAIN,
@@ -780,7 +780,7 @@ async def test_homekit_unpair_not_homekit_device(hass, device_reg, mock_zeroconf
         )
 
         state = homekit.driver.state
-        state.add_paired_client("client1", "any", 1)
+        state.add_paired_client("client1", "any", b"1")
         with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
                 DOMAIN,

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -695,7 +695,7 @@ async def test_homekit_unpair(hass, device_reg, mock_zeroconf):
         homekit.status = STATUS_RUNNING
 
         state = homekit.driver.state
-        state.paired_clients = {"client1": "any"}
+        state.add_paired_client("client1", "any", 1)
         formatted_mac = device_registry.format_mac(state.mac)
         hk_bridge_dev = device_reg.async_get_device(
             {}, {(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)}
@@ -734,7 +734,7 @@ async def test_homekit_unpair_missing_device_id(hass, device_reg, mock_zeroconf)
         homekit.status = STATUS_RUNNING
 
         state = homekit.driver.state
-        state.paired_clients = {"client1": "any"}
+        state.add_paired_client("client1", "any", 1)
         with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
                 DOMAIN,
@@ -780,7 +780,7 @@ async def test_homekit_unpair_not_homekit_device(hass, device_reg, mock_zeroconf
         )
 
         state = homekit.driver.state
-        state.paired_clients = {"client1": "any"}
+        state.add_paired_client("client1", "any", 1)
         with pytest.raises(HomeAssistantError):
             await hass.services.async_call(
                 DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removed the manual config version change at startup since the library now handles this automatically as needed.

Changelog: https://github.com/ikalchev/HAP-python/compare/v4.0.0...v4.1.0

Maybe fixes #53420
Maybe fixes #46490

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
