### PR TITLE
Update NL translation for alarm

### DIFF
--- a/homeassistant/components/alarm_control_panel/translations/nl.json
+++ b/homeassistant/components/alarm_control_panel/translations/nl.json
@@ -5,7 +5,7 @@
             "arm_home": "Schakel {entity_name} in voor thuis",
             "arm_night": "Schakel {entity_name} in voor 's nachts",
             "arm_vacation": "Schakel {entity_name} in voor vakantie",
-            "arm_custom_bypass": "Schakel {entity_name} in voor omleiding"
+            "arm_custom_bypass": "Schakel {entity_name} in voor omleiding",
             "disarm": "Schakel {entity_name} uit",
             "trigger": "Laat {entity_name} afgaan"
         },

--- a/homeassistant/components/alarm_control_panel/translations/nl.json
+++ b/homeassistant/components/alarm_control_panel/translations/nl.json
@@ -2,7 +2,6 @@
     "device_automation": {
         "action_type": {
             "arm_away": "Schakel {entity_name} in voor afwezigheid",
-            "arm_custom_bypass": "Schakel {entity_name} in met overbrugging",
             "arm_home": "Schakel {entity_name} in voor thuis",
             "arm_night": "Schakel {entity_name} in voor 's nachts",
             "arm_vacation": "Schakel {entity_name} in voor vakantie",
@@ -11,7 +10,6 @@
         },
         "condition_type": {
             "is_armed_away": "{entity_name} is ingeschakeld voor afwezigheid",
-            "is_armed_custom_bypass": "{entity_name} is ingeschakeld met overbrugging",
             "is_armed_home": "{entity_name} is ingeschakeld voor thuis",
             "is_armed_night": "{entity_name} is ingeschakeld voor 's nachts",
             "is_armed_vacation": "{entity_name} is ingeschakeld voor vakantie",
@@ -20,7 +18,6 @@
         },
         "trigger_type": {
             "armed_away": "{entity_name} ingeschakeld voor afwezigheid",
-            "armed_custom_bypass": "{entity_name} ingeschakeld met overbrugging",
             "armed_home": "{entity_name} ingeschakeld voor thuis",
             "armed_night": "{entity_name} ingeschakeld voor 's nachts",
             "armed_vacation": "{entity_name} ingeschakeld voor vakantie",

--- a/homeassistant/components/alarm_control_panel/translations/nl.json
+++ b/homeassistant/components/alarm_control_panel/translations/nl.json
@@ -1,44 +1,47 @@
 {
     "device_automation": {
         "action_type": {
-            "arm_away": "Inschakelen {entity_name} afwezig",
-            "arm_home": "Inschakelen {entity_name} thuis",
-            "arm_night": "Inschakelen {entity_name} nacht",
-            "arm_vacation": "Schakel {entity_name} in op vakantie",
-            "disarm": "Uitschakelen {entity_name}",
-            "trigger": "Trigger {entity_name}"
+            "arm_away": "Schakel {entity_name} in voor afwezigheid",
+            "arm_home": "Schakel {entity_name} in voor thuis",
+            "arm_night": "Schakel {entity_name} in voor 's nachts",
+            "arm_vacation": "Schakel {entity_name} in voor vakantie",
+            "arm_custom_bypass": "Schakel {entity_name} in voor omleiding"
+            "disarm": "Schakel {entity_name} uit",
+            "trigger": "Laat {entity_name} afgaan"
         },
         "condition_type": {
-            "is_armed_away": "{entity_name}  afwezig ingeschakeld",
-            "is_armed_home": "{entity_name} thuis ingeschakeld",
-            "is_armed_night": "{entity_name}  nachtstand ingeschakeld",
-            "is_armed_vacation": "{entity_name} is in vakantie geschakeld",
+            "is_armed_away": "{entity_name} is ingeschakeld voor afwezigheid",
+            "is_armed_home": "{entity_name} is ingeschakeld voor thuis",
+            "is_armed_night": "{entity_name} is ingeschakeld voor 's nachts",
+            "is_armed_vacation": "{entity_name} is ingeschakeld voor vakantie",
+            "is_armed_custom_bypass": "{entity_name} is ingeschakeld voor omleiding",
             "is_disarmed": "{entity_name} is uitgeschakeld",
-            "is_triggered": "{entity_name} wordt geactiveerd"
+            "is_triggered": "{entity_name} is afgegaan"
         },
         "trigger_type": {
-            "armed_away": "{entity_name}  afwezig ingeschakeld",
-            "armed_home": "{entity_name} thuis ingeschakeld",
-            "armed_night": "{entity_name}  nachtstand ingeschakeld",
-            "armed_vacation": "{entity_name} schakelde vakantie in",
+            "armed_away": "{entity_name} ingeschakeld voor afwezigheid",
+            "armed_home": "{entity_name} ingeschakeld voor thuis",
+            "armed_night": "{entity_name} ingeschakeld voor 's nachts",
+            "armed_vacation": "{entity_name} ingeschakeld voor vakantie",
+            "armed_custom_bypass": "{entity_name} ingeschakeld voor omleiding",
             "disarmed": "{entity_name} uitgeschakeld",
-            "triggered": "{entity_name} geactiveerd"
+            "triggered": "{entity_name} afgegaan"
         }
     },
     "state": {
         "_": {
             "armed": "Ingeschakeld",
-            "armed_away": "Ingeschakeld afwezig",
-            "armed_custom_bypass": "Ingeschakeld met overbrugging(en)",
-            "armed_home": "Ingeschakeld thuis",
-            "armed_night": "Ingeschakeld nacht",
-            "armed_vacation": "Vakantie ingeschakeld",
+            "armed_away": "Ingeschakeld voor afwezigheid",
+            "armed_custom_bypass": "Ingeschakeld voor omleiding",
+            "armed_home": "Ingeschakeld voor thuis",
+            "armed_night": "Ingeschakeld voor 's nachts",
+            "armed_vacation": "Ingeschakeld voor vakantie",
             "arming": "Schakelt in",
             "disarmed": "Uitgeschakeld",
             "disarming": "Schakelt uit",
             "pending": "In wacht",
-            "triggered": "Geactiveerd"
+            "triggered": "Gaat af"
         }
     },
-    "title": "Alarm bedieningspaneel"
+    "title": "Alarmbedieningspaneel"
 }

--- a/homeassistant/components/alarm_control_panel/translations/nl.json
+++ b/homeassistant/components/alarm_control_panel/translations/nl.json
@@ -2,28 +2,28 @@
     "device_automation": {
         "action_type": {
             "arm_away": "Schakel {entity_name} in voor afwezigheid",
+            "arm_custom_bypass": "Schakel {entity_name} in met overbrugging",
             "arm_home": "Schakel {entity_name} in voor thuis",
             "arm_night": "Schakel {entity_name} in voor 's nachts",
             "arm_vacation": "Schakel {entity_name} in voor vakantie",
-            "arm_custom_bypass": "Schakel {entity_name} in voor omleiding",
             "disarm": "Schakel {entity_name} uit",
             "trigger": "Laat {entity_name} afgaan"
         },
         "condition_type": {
             "is_armed_away": "{entity_name} is ingeschakeld voor afwezigheid",
+            "is_armed_custom_bypass": "{entity_name} is ingeschakeld met overbrugging",
             "is_armed_home": "{entity_name} is ingeschakeld voor thuis",
             "is_armed_night": "{entity_name} is ingeschakeld voor 's nachts",
             "is_armed_vacation": "{entity_name} is ingeschakeld voor vakantie",
-            "is_armed_custom_bypass": "{entity_name} is ingeschakeld voor omleiding",
             "is_disarmed": "{entity_name} is uitgeschakeld",
             "is_triggered": "{entity_name} is afgegaan"
         },
         "trigger_type": {
             "armed_away": "{entity_name} ingeschakeld voor afwezigheid",
+            "armed_custom_bypass": "{entity_name} ingeschakeld met overbrugging",
             "armed_home": "{entity_name} ingeschakeld voor thuis",
             "armed_night": "{entity_name} ingeschakeld voor 's nachts",
             "armed_vacation": "{entity_name} ingeschakeld voor vakantie",
-            "armed_custom_bypass": "{entity_name} ingeschakeld voor omleiding",
             "disarmed": "{entity_name} uitgeschakeld",
             "triggered": "{entity_name} afgegaan"
         }
@@ -32,7 +32,7 @@
         "_": {
             "armed": "Ingeschakeld",
             "armed_away": "Ingeschakeld voor afwezigheid",
-            "armed_custom_bypass": "Ingeschakeld voor omleiding",
+            "armed_custom_bypass": "Ingeschakeld met overbrugging",
             "armed_home": "Ingeschakeld voor thuis",
             "armed_night": "Ingeschakeld voor 's nachts",
             "armed_vacation": "Ingeschakeld voor vakantie",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates improves some Dutch translation strings to make them slightly more consistent, complete and pronounceable.

I also quickly looked up the terminology of commercial alarm systems, although I could not map all features of this HA alarm to their products. Further improvements may still be possible.

I also considered literal translations of "arm(ed)/disarm(ed)", namely "bewapen(d)/ontwapen(d)". Those words would be grammatically easier to use than the split verbs "schakel ... in/schakel ... uit", but I haven't seen these words used by commercial alarms.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
