### PR TITLE
Add service to clear completed shoppinglist items

### DIFF
--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -27,6 +27,7 @@ SERVICE_COMPLETE_ITEM = "complete_item"
 SERVICE_INCOMPLETE_ITEM = "incomplete_item"
 SERVICE_COMPLETE_ALL = "complete_all"
 SERVICE_INCOMPLETE_ALL = "incomplete_all"
+SERVICE_CLEAR_COMPLETED_ITEMS = "clear_completed_items"
 SERVICE_ITEM_SCHEMA = vol.Schema({vol.Required(ATTR_NAME): vol.Any(None, cv.string)})
 SERVICE_LIST_SCHEMA = vol.Schema({})
 
@@ -116,6 +117,10 @@ async def async_setup_entry(hass, config_entry):
         """Mark all items in the list as incomplete."""
         await data.async_update_list({"complete": False})
 
+    async def clear_completed_items_service(call):
+        """Clear all completed items from the list."""
+        await data.async_clear_completed()
+
     data = hass.data[DOMAIN] = ShoppingData(hass)
     await data.async_load()
 
@@ -141,6 +146,12 @@ async def async_setup_entry(hass, config_entry):
         DOMAIN,
         SERVICE_INCOMPLETE_ALL,
         incomplete_all_service,
+        schema=SERVICE_LIST_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEAR_COMPLETED_ITEMS,
+        clear_completed_items_service,
         schema=SERVICE_LIST_SCHEMA,
     )
 

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -12,7 +12,15 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.json import load_json, save_json
 
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    SERVICE_ADD_ITEM,
+    SERVICE_CLEAR_COMPLETED_ITEMS,
+    SERVICE_COMPLETE_ALL,
+    SERVICE_COMPLETE_ITEM,
+    SERVICE_INCOMPLETE_ALL,
+    SERVICE_INCOMPLETE_ITEM,
+)
 
 ATTR_COMPLETE = "complete"
 
@@ -22,12 +30,6 @@ EVENT = "shopping_list_updated"
 ITEM_UPDATE_SCHEMA = vol.Schema({ATTR_COMPLETE: bool, ATTR_NAME: str})
 PERSISTENCE = ".shopping_list.json"
 
-SERVICE_ADD_ITEM = "add_item"
-SERVICE_COMPLETE_ITEM = "complete_item"
-SERVICE_INCOMPLETE_ITEM = "incomplete_item"
-SERVICE_COMPLETE_ALL = "complete_all"
-SERVICE_INCOMPLETE_ALL = "incomplete_all"
-SERVICE_CLEAR_COMPLETED_ITEMS = "clear_completed_items"
 SERVICE_ITEM_SCHEMA = vol.Schema({vol.Required(ATTR_NAME): vol.Any(None, cv.string)})
 SERVICE_LIST_SCHEMA = vol.Schema({})
 

--- a/homeassistant/components/shopping_list/const.py
+++ b/homeassistant/components/shopping_list/const.py
@@ -1,2 +1,9 @@
 """All constants related to the shopping list component."""
 DOMAIN = "shopping_list"
+
+SERVICE_ADD_ITEM = "add_item"
+SERVICE_COMPLETE_ITEM = "complete_item"
+SERVICE_INCOMPLETE_ITEM = "incomplete_item"
+SERVICE_COMPLETE_ALL = "complete_all"
+SERVICE_INCOMPLETE_ALL = "incomplete_all"
+SERVICE_CLEAR_COMPLETED_ITEMS = "clear_completed_items"

--- a/homeassistant/components/shopping_list/services.yaml
+++ b/homeassistant/components/shopping_list/services.yaml
@@ -40,3 +40,7 @@ complete_all:
 incomplete_all:
   name: Incomplete all
   description: Marks all items as incomplete in the shopping list.
+
+clear_completed_items:
+  name: Clear completed items
+  description: Clear completed items from the shopping list.

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -59,7 +59,7 @@ async def test_clear_completed_items(hass, sl_setup):
         hass,
         "test",
         "HassShoppingListAddItem",
-        {"item": {"value": "beer", "complete": True}},
+        {"item": {"value": "beer"}},
     )
 
     await intent.async_handle(
@@ -68,13 +68,12 @@ async def test_clear_completed_items(hass, sl_setup):
 
     assert len(hass.data[DOMAIN].items) == 2
 
+    # Update a single attribute, other attributes shouldn't change
+    await hass.data[DOMAIN].async_update_list({"complete": True})
+
     await hass.data[DOMAIN].async_clear_completed()
 
-    assert len(hass.data[DOMAIN].items) == 1
-
-    cheese = hass.data[DOMAIN].items[0]
-    assert cheese["name"] == "cheese"
-    assert cheese["complete"] is False
+    assert len(hass.data[DOMAIN].items) == 0
 
 
 async def test_recent_items_intent(hass, sl_setup):

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -53,6 +53,30 @@ async def test_update_list(hass, sl_setup):
     assert cheese["complete"] is False
 
 
+async def test_clear_completed_items(hass, sl_setup):
+    """Test clear completed list items."""
+    await intent.async_handle(
+        hass,
+        "test",
+        "HassShoppingListAddItem",
+        {"item": {"value": "beer", "complete": True}},
+    )
+
+    await intent.async_handle(
+        hass, "test", "HassShoppingListAddItem", {"item": {"value": "cheese"}}
+    )
+
+    assert len(hass.data[DOMAIN].items) == 2
+
+    await hass.data[DOMAIN].async_clear_completed_items()
+
+    assert len(hass.data[DOMAIN].items) == 1
+
+    cheese = hass.data[DOMAIN].items[0]
+    assert cheese["name"] == "cheese"
+    assert cheese["complete"] is False
+
+
 async def test_recent_items_intent(hass, sl_setup):
     """Test recent items."""
 

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -68,7 +68,7 @@ async def test_clear_completed_items(hass, sl_setup):
 
     assert len(hass.data[DOMAIN].items) == 2
 
-    await hass.data[DOMAIN].async_clear_completed_items()
+    await hass.data[DOMAIN].async_clear_completed()
 
     assert len(hass.data[DOMAIN].items) == 1
 

--- a/tests/components/shopping_list/test_intent.py
+++ b/tests/components/shopping_list/test_intent.py
@@ -20,3 +20,12 @@ async def test_recent_items_intent(hass, sl_setup):
         response.speech["plain"]["speech"]
         == "These are the top 3 items on your shopping list: soda, wine, beer"
     )
+
+
+async def test_recent_items_intent_no_items(hass, sl_setup):
+    """Test recent items."""
+    response = await intent.async_handle(hass, "test", "HassShoppingListLastItems")
+
+    assert (
+        response.speech["plain"]["speech"] == "There are no items on your shopping list"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Allow for pruning completed items from the shopping-list.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19063

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
