### PR TITLE
Remove deprecated YAML configuration from Epson

### DIFF
--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -25,30 +25,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_import(self, import_config):
-        """Import a config entry from configuration.yaml."""
-        for entry in self._async_current_entries(include_ignore=True):
-            if import_config[CONF_HOST] == entry.data[CONF_HOST]:
-                return self.async_abort(reason="already_configured")
-        try:
-            projector = await validate_projector(
-                hass=self.hass,
-                host=import_config[CONF_HOST],
-                check_power=True,
-                check_powered_on=False,
-            )
-        except CannotConnect:
-            _LOGGER.warning("Cannot connect to projector")
-            return self.async_abort(reason="cannot_connect")
-
-        serial_no = await projector.get_serial_number()
-        await self.async_set_unique_id(serial_no)
-        self._abort_if_unique_id_configured()
-        import_config.pop(CONF_PORT, None)
-        return self.async_create_entry(
-            title=import_config.pop(CONF_NAME), data=import_config
-        )
-
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -4,5 +4,4 @@ DOMAIN = "epson"
 SERVICE_SELECT_CMODE = "select_cmode"
 
 ATTR_CMODE = "cmode"
-DEFAULT_NAME = "EPSON Projector"
 HTTP = "http"

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -26,7 +26,7 @@ from epson_projector.const import (
 )
 import voluptuous as vol
 
-from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerEntity
+from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PREVIOUS_TRACK,
@@ -36,13 +36,12 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_STEP,
 )
-from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 
-from .const import ATTR_CMODE, DEFAULT_NAME, DOMAIN, SERVICE_SELECT_CMODE
+from .const import ATTR_CMODE, DOMAIN, SERVICE_SELECT_CMODE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,14 +53,6 @@ SUPPORT_EPSON = (
     | SUPPORT_VOLUME_STEP
     | SUPPORT_NEXT_TRACK
     | SUPPORT_PREVIOUS_TRACK
-)
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_PORT, default=80): cv.port,
-    }
 )
 
 
@@ -82,19 +73,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         SERVICE_SELECT_CMODE,
         {vol.Required(ATTR_CMODE): vol.All(cv.string, vol.Any(*CMODE_LIST_SET))},
         SERVICE_SELECT_CMODE,
-    )
-
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Epson projector."""
-    _LOGGER.warning(
-        "Loading Espon projector via platform setup is deprecated; "
-        "Please remove it from your configuration"
-    )
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
     )
 
 

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -7,8 +7,6 @@ from homeassistant import config_entries, setup
 from homeassistant.components.epson.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME, STATE_UNAVAILABLE
 
-from tests.common import MockConfigEntry
-
 
 async def test_form(hass):
     """Test we get the form."""
@@ -75,70 +73,3 @@ async def test_form_powered_off(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "powered_off"}
-
-
-async def test_import(hass):
-    """Test config.yaml import."""
-    with patch(
-        "homeassistant.components.epson.Projector.get_power",
-        return_value="01",
-    ), patch(
-        "homeassistant.components.epson.Projector.get_property",
-        return_value="04",
-    ), patch(
-        "homeassistant.components.epson.async_setup_entry",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson"},
-        )
-    assert result["type"] == "create_entry"
-    assert result["title"] == "test-epson"
-    assert result["data"] == {CONF_HOST: "1.1.1.1"}
-
-
-async def test_already_imported(hass):
-    """Test config.yaml imported twice."""
-    MockConfigEntry(
-        domain=DOMAIN,
-        source=config_entries.SOURCE_IMPORT,
-        unique_id="bla",
-        title="test-epson",
-        data={CONF_HOST: "1.1.1.1"},
-    ).add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.epson.Projector.get_power",
-        return_value="01",
-    ), patch(
-        "homeassistant.components.epson.Projector.get_property",
-        return_value="04",
-    ), patch(
-        "homeassistant.components.epson.async_setup_entry",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson"},
-        )
-    assert result["type"] == "abort"
-    assert result["reason"] == "already_configured"
-
-
-async def test_import_cannot_connect(hass):
-    """Test we handle cannot connect error."""
-    with patch(
-        "homeassistant.components.epson.Projector.get_power",
-        return_value=STATE_UNAVAILABLE,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson"},
-        )
-
-    assert result["type"] == "abort"
-    assert result["reason"] == "cannot_connect"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previous deprecated YAML configuration of the Epson integration has been removed.
Epson is now configured via the UI, an existing YAML configuration has been imported
in previous releases and can now be safely removed from your YAML configuration files.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean up deprecated YAML import that has been deprecated 2 release cycles

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
YAML configuration was removed from docs before.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
