### PR TITLE
Comfoconnect improvements

### DIFF
--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -9,6 +9,8 @@ from pycomfoconnect import (
     CMD_FAN_MODE_HIGH,
     CMD_FAN_MODE_LOW,
     CMD_FAN_MODE_MEDIUM,
+    CMD_MODE_AUTO,
+    CMD_MODE_MANUAL,
     SENSOR_FAN_SPEED_MODE,
 )
 
@@ -29,6 +31,7 @@ CMD_MAPPING = {
     1: CMD_FAN_MODE_LOW,
     2: CMD_FAN_MODE_MEDIUM,
     3: CMD_FAN_MODE_HIGH,
+    4: CMD_MODE_AUTO
 }
 
 SPEED_RANGE = (1, 3)  # away is not included in speeds and instead mapped to off
@@ -124,13 +127,16 @@ class ComfoConnectFan(FanEntity):
         _LOGGER.debug("Changing fan speed percentage to %s", percentage)
 
         if percentage is None:
-            cmd = CMD_FAN_MODE_LOW
+            cmd = CMD_MODE_AUTO
         elif percentage == 0:
             cmd = CMD_FAN_MODE_AWAY
+            manual_cmd = CMD_MODE_MANUAL
         else:
+            manual_cmd = CMD_MODE_MANUAL
             speed = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
             cmd = CMD_MAPPING[speed]
-
+        if manual_cmd:
+            self._ccb.comfoconnect.cmd_rmi_request(manual_cmd)
         self._ccb.comfoconnect.cmd_rmi_request(cmd)
 
         # Update current mode

--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -125,7 +125,7 @@ class ComfoConnectFan(FanEntity):
     def set_percentage(self, percentage: int):
         """Set fan speed percentage."""
         _LOGGER.debug("Changing fan speed percentage to %s", percentage)
-
+        manual_cmd = None
         if percentage is None:
             cmd = CMD_MODE_AUTO
         elif percentage == 0:
@@ -135,7 +135,7 @@ class ComfoConnectFan(FanEntity):
             manual_cmd = CMD_MODE_MANUAL
             speed = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
             cmd = CMD_MAPPING[speed]
-        if manual_cmd:
+        if manual_cmd is not None:
             self._ccb.comfoconnect.cmd_rmi_request(manual_cmd)
         self._ccb.comfoconnect.cmd_rmi_request(cmd)
 

--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -31,7 +31,7 @@ CMD_MAPPING = {
     1: CMD_FAN_MODE_LOW,
     2: CMD_FAN_MODE_MEDIUM,
     3: CMD_FAN_MODE_HIGH,
-    4: CMD_MODE_AUTO
+    4: CMD_MODE_AUTO,
 }
 
 SPEED_RANGE = (1, 3)  # away is not included in speeds and instead mapped to off


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
comfoconnect module currently set fan speed mode temporary for 2 hrs by default. Afterwards the unit will switch back to auto.
Also it was not possible to to switch back to auto which is the most desired mode.
For example if you turn off the unit it will go to away mode for a specific time only. If you turn it on it will go to fan speed "low" for a specific time (which is not the desired state in most cases).

In this pull request I did two things:
1. When fan speed is adjusted the unit will also go to manual mode (so no temporary change anymore).
2. When turned on or percentage of fan speed is not provided (set to 0) it will go back to "Auto" mode.


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

-Feature request: https://community.home-assistant.io/t/add-auto-manual-mode-switch-for-comfoconnect/143437

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
