### PR TITLE
Break out  mock of pymodbus return from mock_modbus to new fixture

### DIFF
--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -113,7 +113,7 @@ async def mock_modbus(
 
 
 @pytest.fixture
-async def mock_do_cycle(hass):
+async def mock_do_cycle(hass, mock_modbus):
     """Trigger update call with time_changed event."""
     now = dt_util.utcnow() + timedelta(seconds=90)
     with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -68,6 +68,12 @@ def config_addon():
 
 
 @pytest.fixture
+def do_exception():
+    """Remove side_effect to pymodbus calls."""
+    return False
+
+
+@pytest.fixture
 async def mock_modbus(
     hass, caplog, register_words, check_config_loaded, config_addon, do_config
 ):
@@ -101,24 +107,28 @@ async def mock_modbus(
 
 
 @pytest.fixture
-async def mock_pymodbus_return(hass, register_words, mock_modbus):
+async def mock_pymodbus_exception(hass, do_exception, mock_modbus):
     """Trigger update call with time_changed event."""
-    if register_words is None:
+    if do_exception:
         exc = ModbusException("fail read_coils")
         mock_modbus.read_coils.side_effect = exc
         mock_modbus.read_discrete_inputs.side_effect = exc
         mock_modbus.read_input_registers.side_effect = exc
         mock_modbus.read_holding_registers.side_effect = exc
-    else:
-        read_result = ReadResult(register_words)
-        mock_modbus.read_coils.return_value = read_result
-        mock_modbus.read_discrete_inputs.return_value = read_result
-        mock_modbus.read_input_registers.return_value = read_result
-        mock_modbus.read_holding_registers.return_value = read_result
 
 
 @pytest.fixture
-async def mock_do_cycle(hass, mock_pymodbus_return):
+async def mock_pymodbus_return(hass, register_words, mock_modbus):
+    """Trigger update call with time_changed event."""
+    read_result = ReadResult(register_words)
+    mock_modbus.read_coils.return_value = read_result
+    mock_modbus.read_discrete_inputs.return_value = read_result
+    mock_modbus.read_input_registers.return_value = read_result
+    mock_modbus.read_holding_registers.return_value = read_result
+
+
+@pytest.fixture
+async def mock_do_cycle(hass, mock_pymodbus_exception, mock_pymodbus_return):
     """Trigger update call with time_changed event."""
     now = dt_util.utcnow() + timedelta(seconds=90)
     with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -92,18 +92,6 @@ async def mock_modbus(
     with mock.patch(
         "homeassistant.components.modbus.modbus.ModbusTcpClient", return_value=mock_pb
     ):
-        if register_words is None:
-            exc = ModbusException("fail read_coils")
-            mock_pb.read_coils.side_effect = exc
-            mock_pb.read_discrete_inputs.side_effect = exc
-            mock_pb.read_input_registers.side_effect = exc
-            mock_pb.read_holding_registers.side_effect = exc
-        else:
-            read_result = ReadResult(register_words)
-            mock_pb.read_coils.return_value = read_result
-            mock_pb.read_discrete_inputs.return_value = read_result
-            mock_pb.read_input_registers.return_value = read_result
-            mock_pb.read_holding_registers.return_value = read_result
         now = dt_util.utcnow()
         with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
             result = await async_setup_component(hass, DOMAIN, config)
@@ -113,7 +101,24 @@ async def mock_modbus(
 
 
 @pytest.fixture
-async def mock_do_cycle(hass, mock_modbus):
+async def mock_pymodbus_return(hass, register_words, mock_modbus):
+    """Trigger update call with time_changed event."""
+    if register_words is None:
+        exc = ModbusException("fail read_coils")
+        mock_modbus.read_coils.side_effect = exc
+        mock_modbus.read_discrete_inputs.side_effect = exc
+        mock_modbus.read_input_registers.side_effect = exc
+        mock_modbus.read_holding_registers.side_effect = exc
+    else:
+        read_result = ReadResult(register_words)
+        mock_modbus.read_coils.return_value = read_result
+        mock_modbus.read_discrete_inputs.return_value = read_result
+        mock_modbus.read_input_registers.return_value = read_result
+        mock_modbus.read_holding_registers.return_value = read_result
+
+
+@pytest.fixture
+async def mock_do_cycle(hass, mock_pymodbus_return):
     """Trigger update call with time_changed event."""
     now = dt_util.utcnow() + timedelta(seconds=90)
     with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
@@ -129,7 +134,7 @@ async def mock_test_state(hass, request):
 
 
 @pytest.fixture
-async def mock_ha(hass):
+async def mock_ha(hass, mock_pymodbus_return):
     """Load homeassistant to allow service calls."""
     assert await async_setup_component(hass, "homeassistant", {})
     await hass.async_block_till_done()

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -108,7 +108,7 @@ async def test_config_binary_sensor(hass, mock_modbus):
         ),
     ],
 )
-async def test_all_binary_sensor(hass, expected, mock_modbus, mock_do_cycle):
+async def test_all_binary_sensor(hass, expected, mock_do_cycle):
     """Run test for given config."""
     assert hass.states.get(ENTITY_ID).state == expected
 

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -80,30 +80,36 @@ async def test_config_binary_sensor(hass, mock_modbus):
     ],
 )
 @pytest.mark.parametrize(
-    "register_words,expected",
+    "register_words,do_exception,expected",
     [
         (
             [0xFF],
+            False,
             STATE_ON,
         ),
         (
             [0x01],
+            False,
             STATE_ON,
         ),
         (
             [0x00],
+            False,
             STATE_OFF,
         ),
         (
             [0x80],
+            False,
             STATE_OFF,
         ),
         (
             [0xFE],
+            False,
             STATE_OFF,
         ),
         (
-            None,
+            [0x00],
+            True,
             STATE_UNAVAILABLE,
         ),
     ],

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -86,7 +86,7 @@ async def test_config_climate(hass, mock_modbus):
         ),
     ],
 )
-async def test_temperature_climate(hass, expected, mock_modbus, mock_do_cycle):
+async def test_temperature_climate(hass, expected, mock_do_cycle):
     """Run test for given config."""
     assert hass.states.get(ENTITY_ID).state == expected
 

--- a/tests/components/modbus/test_cover.py
+++ b/tests/components/modbus/test_cover.py
@@ -106,7 +106,7 @@ async def test_config_cover(hass, mock_modbus):
         ),
     ],
 )
-async def test_coil_cover(hass, expected, mock_modbus, mock_do_cycle):
+async def test_coil_cover(hass, expected, mock_do_cycle):
     """Run test for given config."""
     assert hass.states.get(ENTITY_ID).state == expected
 
@@ -150,7 +150,7 @@ async def test_coil_cover(hass, expected, mock_modbus, mock_do_cycle):
         ),
     ],
 )
-async def test_register_cover(hass, expected, mock_modbus, mock_do_cycle):
+async def test_register_cover(hass, expected, mock_do_cycle):
     """Run test for given config."""
     assert hass.states.get(ENTITY_ID).state == expected
 

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -186,7 +186,7 @@ async def test_config_fan(hass, mock_modbus):
         ),
     ],
 )
-async def test_all_fan(hass, mock_modbus, mock_do_cycle, expected):
+async def test_all_fan(hass, mock_do_cycle, expected):
     """Run test for given config."""
     assert hass.states.get(ENTITY_ID).state == expected
 

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -157,30 +157,35 @@ async def test_config_fan(hass, mock_modbus):
     ],
 )
 @pytest.mark.parametrize(
-    "register_words,config_addon,expected",
+    "register_words,do_exception,config_addon,expected",
     [
         (
             [0x00],
+            False,
             {CONF_VERIFY: {}},
             STATE_OFF,
         ),
         (
             [0x01],
+            False,
             {CONF_VERIFY: {}},
             STATE_ON,
         ),
         (
             [0xFE],
+            False,
             {CONF_VERIFY: {}},
             STATE_OFF,
         ),
         (
-            None,
+            [0x00],
+            True,
             {CONF_VERIFY: {}},
             STATE_UNAVAILABLE,
         ),
         (
-            None,
+            [0x00],
+            True,
             None,
             STATE_OFF,
         ),

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -186,7 +186,7 @@ async def test_config_light(hass, mock_modbus):
         ),
     ],
 )
-async def test_all_light(hass, mock_modbus, mock_do_cycle, expected):
+async def test_all_light(hass, mock_do_cycle, expected):
     """Run test for given config."""
     assert hass.states.get(ENTITY_ID).state == expected
 

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -157,30 +157,35 @@ async def test_config_light(hass, mock_modbus):
     ],
 )
 @pytest.mark.parametrize(
-    "register_words,config_addon,expected",
+    "register_words,do_exception,config_addon,expected",
     [
         (
             [0x00],
+            False,
             {CONF_VERIFY: {}},
             STATE_OFF,
         ),
         (
             [0x01],
+            False,
             {CONF_VERIFY: {}},
             STATE_ON,
         ),
         (
             [0xFE],
+            False,
             {CONF_VERIFY: {}},
             STATE_OFF,
         ),
         (
-            None,
+            [0x00],
+            True,
             {CONF_VERIFY: {}},
             STATE_UNAVAILABLE,
         ),
         (
-            None,
+            [0x00],
+            True,
             None,
             STATE_OFF,
         ),

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -247,7 +247,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
     ],
 )
 @pytest.mark.parametrize(
-    "config_addon,register_words,expected",
+    "config_addon,register_words,do_exception,expected",
     [
         (
             {
@@ -258,11 +258,13 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [0],
+            False,
             "0",
         ),
         (
             {},
             [0x8000],
+            False,
             "-32768",
         ),
         (
@@ -274,6 +276,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [7],
+            False,
             "20",
         ),
         (
@@ -285,6 +288,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [7],
+            False,
             "34",
         ),
         (
@@ -296,6 +300,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 4,
             },
             [7],
+            False,
             "34.0000",
         ),
         (
@@ -307,6 +312,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [1],
+            False,
             "2",
         ),
         (
@@ -318,6 +324,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: "1",
             },
             [9],
+            False,
             "18.5",
         ),
         (
@@ -329,6 +336,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 2,
             },
             [1],
+            False,
             "2.40",
         ),
         (
@@ -340,6 +348,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 1,
             },
             [2],
+            False,
             "-8.3",
         ),
         (
@@ -351,6 +360,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [0x89AB, 0xCDEF],
+            False,
             "-1985229329",
         ),
         (
@@ -362,6 +372,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [0x89AB, 0xCDEF],
+            False,
             str(0x89ABCDEF),
         ),
         (
@@ -373,6 +384,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [0x89AB, 0xCDEF, 0x0123, 0x4567],
+            False,
             "9920249030613615975",
         ),
         (
@@ -384,6 +396,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [0x0123, 0x4567, 0x89AB, 0xCDEF],
+            False,
             "163971058432973793",
         ),
         (
@@ -395,6 +408,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [0x0123, 0x4567, 0x89AB, 0xCDEF],
+            False,
             "163971058432973792",
         ),
         (
@@ -407,6 +421,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [0x89AB, 0xCDEF],
+            False,
             str(0x89ABCDEF),
         ),
         (
@@ -419,6 +434,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [0x89AB, 0xCDEF],
+            False,
             str(0x89ABCDEF),
         ),
         (
@@ -431,6 +447,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 5,
             },
             [16286, 1617],
+            False,
             "1.23457",
         ),
         (
@@ -443,6 +460,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_PRECISION: 0,
             },
             [0x3037, 0x2D30, 0x352D, 0x3230, 0x3230, 0x2031, 0x343A, 0x3335],
+            False,
             "07-05-2020 14:35",
         ),
         (
@@ -454,7 +472,8 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 0,
             },
-            None,
+            [0x00],
+            True,
             STATE_UNAVAILABLE,
         ),
         (
@@ -466,7 +485,8 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_OFFSET: 0,
                 CONF_PRECISION: 0,
             },
-            None,
+            [0x00],
+            True,
             STATE_UNAVAILABLE,
         ),
         (
@@ -476,6 +496,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_SWAP: CONF_SWAP_NONE,
             },
             [0x0102],
+            False,
             str(int(0x0102)),
         ),
         (
@@ -485,6 +506,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_SWAP: CONF_SWAP_BYTE,
             },
             [0x0201],
+            False,
             str(int(0x0102)),
         ),
         (
@@ -494,6 +516,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_SWAP: CONF_SWAP_BYTE,
             },
             [0x0102, 0x0304],
+            False,
             str(int(0x02010403)),
         ),
         (
@@ -503,6 +526,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_SWAP: CONF_SWAP_WORD,
             },
             [0x0102, 0x0304],
+            False,
             str(int(0x03040102)),
         ),
         (
@@ -512,6 +536,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
                 CONF_SWAP: CONF_SWAP_WORD_BYTE,
             },
             [0x0102, 0x0304],
+            False,
             str(int(0x04030201)),
         ),
     ],

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -516,7 +516,7 @@ async def test_config_wrong_struct_sensor(hass, error_message, mock_modbus, capl
         ),
     ],
 )
-async def test_all_sensor(hass, mock_modbus, mock_do_cycle, expected):
+async def test_all_sensor(hass, mock_do_cycle, expected):
     """Run test for sensor."""
     assert hass.states.get(ENTITY_ID).state == expected
 
@@ -570,7 +570,7 @@ async def test_all_sensor(hass, mock_modbus, mock_do_cycle, expected):
         ),
     ],
 )
-async def test_struct_sensor(hass, mock_modbus, mock_do_cycle, expected):
+async def test_struct_sensor(hass, mock_do_cycle, expected):
     """Run test for sensor struct."""
     assert hass.states.get(ENTITY_ID).state == expected
 

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -200,7 +200,7 @@ async def test_config_switch(hass, mock_modbus):
         ),
     ],
 )
-async def test_all_switch(hass, mock_modbus, mock_do_cycle, expected):
+async def test_all_switch(hass, mock_do_cycle, expected):
     """Run test for given config."""
     assert hass.states.get(ENTITY_ID).state == expected
 

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -171,30 +171,35 @@ async def test_config_switch(hass, mock_modbus):
     ],
 )
 @pytest.mark.parametrize(
-    "register_words,config_addon,expected",
+    "register_words,do_exception,config_addon,expected",
     [
         (
             [0x00],
+            False,
             {CONF_VERIFY: {}},
             STATE_OFF,
         ),
         (
             [0x01],
+            False,
             {CONF_VERIFY: {}},
             STATE_ON,
         ),
         (
             [0xFE],
+            False,
             {CONF_VERIFY: {}},
             STATE_OFF,
         ),
         (
-            None,
+            [0x00],
+            True,
             {CONF_VERIFY: {}},
             STATE_UNAVAILABLE,
         ),
         (
-            None,
+            [0x00],
+            True,
             None,
             STATE_OFF,
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It was proposed in an earlier review that mock_modbus should be kept simple, and break out the mocking of pymodbus return values.

This PR adds a new fixture, that solely handles mocking of pymodbus return values including exceptions.

While at it, removed mock_modbus from test_ functions that did not use the fixture.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
