### PR TITLE
Restore last_triggered state in scripts

### DIFF
--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -32,6 +32,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.script import (
     ATTR_CUR,
     ATTR_MAX,
@@ -42,6 +43,7 @@ from homeassistant.helpers.script import (
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.trace import trace_get, trace_path
 from homeassistant.loader import bind_hass
+from homeassistant.util.dt import parse_datetime
 
 from .config import ScriptConfig, async_validate_config_item
 from .const import (
@@ -296,7 +298,7 @@ async def _async_process_config(hass, config, component) -> bool:
     return blueprints_used
 
 
-class ScriptEntity(ToggleEntity):
+class ScriptEntity(ToggleEntity, RestoreEntity):
     """Representation of a script entity."""
 
     icon = None
@@ -414,6 +416,12 @@ class ScriptEntity(ToggleEntity):
         If multiple runs are in progress, all will be stopped.
         """
         await self.script.async_stop()
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last triggered on startup."""
+        if state := await self.async_get_last_state():
+            if last_triggered := state.attributes.get("last_triggered"):
+                self.script.last_triggered = parse_datetime(last_triggered)
 
     async def async_will_remove_from_hass(self):
         """Stop script and remove service when it will be removed from Home Assistant."""

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -15,16 +15,18 @@ from homeassistant.const import (
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_OFF,
 )
-from homeassistant.core import Context, callback, split_entity_id
+from homeassistant.core import Context, State, callback, split_entity_id
 from homeassistant.exceptions import ServiceNotFound
 from homeassistant.helpers import template
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component, setup_component
+import homeassistant.util.dt as dt_util
 
-from tests.common import async_mock_service, get_test_home_assistant
+from tests.common import async_mock_service, get_test_home_assistant, mock_restore_cache
 from tests.components.logbook.test_init import MockLazyEventPartialState
 
 ENTITY_ID = "script.test"
@@ -796,3 +798,38 @@ async def test_script_this_var_always(hass, caplog):
     # Verify this available to all templates
     assert mock_calls[0].data.get("this_template") == "script.script1"
     assert "Error rendering variables" not in caplog.text
+
+
+async def test_script_restore_last_triggered(hass, caplog):
+    """Test if last triggered is restored on start."""
+    time = dt_util.utcnow()
+    mock_restore_cache(
+        hass,
+        (
+            State("script.no_last_triggered", STATE_OFF),
+            State("script.last_triggered", STATE_OFF, {"last_triggered": time}),
+        ),
+    )
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "no_last_triggered": {
+                    "sequence": [{"delay": {"seconds": 5}}],
+                },
+                "last_triggered": {
+                    "sequence": [{"delay": {"seconds": 5}}],
+                },
+            },
+        },
+    )
+
+    state = hass.states.get("script.no_last_triggered")
+    assert state
+    assert state.attributes["last_triggered"] is None
+
+    state = hass.states.get("script.last_triggered")
+    assert state
+    assert state.attributes["last_triggered"] == time

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -17,7 +17,14 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
 )
-from homeassistant.core import Context, State, callback, split_entity_id
+from homeassistant.core import (
+    Context,
+    CoreState,
+    HomeAssistant,
+    State,
+    callback,
+    split_entity_id,
+)
 from homeassistant.exceptions import ServiceNotFound
 from homeassistant.helpers import template
 from homeassistant.helpers.event import async_track_state_change
@@ -86,6 +93,7 @@ class TestScriptComponent(unittest.TestCase):
 
     def test_passing_variables(self):
         """Test different ways of passing in variables."""
+        mock_restore_cache(self.hass, ())
         calls = []
         context = Context()
 
@@ -800,7 +808,7 @@ async def test_script_this_var_always(hass, caplog):
     assert "Error rendering variables" not in caplog.text
 
 
-async def test_script_restore_last_triggered(hass, caplog):
+async def test_script_restore_last_triggered(hass: HomeAssistant) -> None:
     """Test if last triggered is restored on start."""
     time = dt_util.utcnow()
     mock_restore_cache(
@@ -810,6 +818,7 @@ async def test_script_restore_last_triggered(hass, caplog):
             State("script.last_triggered", STATE_OFF, {"last_triggered": time}),
         ),
     )
+    hass.state = CoreState.starting
 
     assert await async_setup_component(
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR restores the `last_triggered` attribute on startup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #32179
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
