### PR TITLE
Activate mypy for surepetcare 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1002,6 +1002,7 @@ omit =
     homeassistant/components/suez_water/*
     homeassistant/components/supervisord/sensor.py
     homeassistant/components/surepetcare/__init__.py
+    homeassistant/components/surepetcare/binary_sensor.py
     homeassistant/components/surepetcare/sensor.py
     homeassistant/components/swiss_hydrological_data/sensor.py
     homeassistant/components/swiss_public_transport/sensor.py

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -138,7 +138,7 @@ class SurePetcareAPI:
         """Initialize the Sure Petcare object."""
         self.hass = hass
         self.surepy = surepy
-        self.states = {}
+        self.states: dict = {}
 
     async def async_update(self, _: Any = None) -> None:
         """Get the latest data from Sure Petcare."""

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -138,7 +138,7 @@ class SurePetcareAPI:
         """Initialize the Sure Petcare object."""
         self.hass = hass
         self.surepy = surepy
-        self.states: dict = {}
+        self.states: dict[str | int, Any] = {}
 
     async def async_update(self, _: Any = None) -> None:
         """Get the latest data from Sure Petcare."""

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -138,7 +138,7 @@ class SurePetcareAPI:
         """Initialize the Sure Petcare object."""
         self.hass = hass
         self.surepy = surepy
-        self.states: dict[str | int, Any] = {}
+        self.states: dict[int, Any] = {}
 
     async def async_update(self, _: Any = None) -> None:
         """Get the latest data from Sure Petcare."""

--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -28,7 +28,7 @@ async def async_setup_platform(
     if discovery_info is None:
         return
 
-    entities: list[SurepyEntity] = []
+    entities: list[SurepyEntity | Pet | Hub | DeviceConnectivity] = []
 
     spc: SurePetcareAPI = hass.data[DOMAIN][SPC]
 
@@ -112,7 +112,7 @@ class Hub(SurePetcareBinarySensor):
                 ),
             }
         else:
-            self._attr_extra_state_attributes = None
+            self._attr_extra_state_attributes = {}
         _LOGGER.debug("%s -> state: %s", self.name, state)
         self.async_write_ha_state()
 
@@ -139,7 +139,7 @@ class Pet(SurePetcareBinarySensor):
                 "where": state.where,
             }
         else:
-            self._attr_extra_state_attributes = None
+            self._attr_extra_state_attributes = {}
         _LOGGER.debug("%s -> state: %s", self.name, state)
         self.async_write_ha_state()
 
@@ -171,6 +171,6 @@ class DeviceConnectivity(SurePetcareBinarySensor):
                 "hub_rssi": f'{state["signal"]["hub_rssi"]:.2f}',
             }
         else:
-            self._attr_extra_state_attributes = None
+            self._attr_extra_state_attributes = {}
         _LOGGER.debug("%s -> state: %s", self.name, state)
         self.async_write_ha_state()

--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -59,7 +59,10 @@ class SureBattery(SensorEntity):
         surepy_entity: SurepyEntity = self._spc.states[_id]
 
         self._attr_device_class = DEVICE_CLASS_BATTERY
-        self._attr_name = f"{surepy_entity.type.name.capitalize()} {surepy_entity.name.capitalize()} Battery Level"
+        if surepy_entity.name:
+            self._attr_name = f"{surepy_entity.type.name.capitalize()} {surepy_entity.name.capitalize()} Battery Level"
+        else:
+            self._attr_name = f"{surepy_entity.type.name.capitalize()}  Battery Level"
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_unique_id = (
             f"{surepy_entity.household_id}-{surepy_entity.id}-battery"
@@ -88,7 +91,7 @@ class SureBattery(SensorEntity):
                 f"{ATTR_VOLTAGE}_per_battery": f"{voltage_per_battery:.2f}",
             }
         else:
-            self._attr_extra_state_attributes = None
+            self._attr_extra_state_attributes = {}
         self.async_write_ha_state()
         _LOGGER.debug("%s -> state: %s", self.name, state)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1601,9 +1601,6 @@ ignore_errors = true
 [mypy-homeassistant.components.stt.*]
 ignore_errors = true
 
-[mypy-homeassistant.components.surepetcare.*]
-ignore_errors = true
-
 [mypy-homeassistant.components.switchbot.*]
 ignore_errors = true
 

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -126,7 +126,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.sonos.*",
     "homeassistant.components.spotify.*",
     "homeassistant.components.stt.*",
-    "homeassistant.components.surepetcare.*",
     "homeassistant.components.switchbot.*",
     "homeassistant.components.system_health.*",
     "homeassistant.components.system_log.*",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
