### PR TITLE
Fix TypeError in Xiaomi Miio fan platform

### DIFF
--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -244,7 +244,7 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
         self._available_attributes = {}
         self._state = None
         self._mode = None
-        self._fan_level = None
+        self._fan_level = 0
         self._state_attrs = {ATTR_MODEL: self._model}
         self._device_features = 0
         self._supported_features = 0
@@ -316,7 +316,7 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
             }
         )
         self._mode = self._state_attrs.get(ATTR_MODE)
-        self._fan_level = self._state_attrs.get(ATTR_FAN_LEVEL)
+        self._fan_level = self._state_attrs.get(ATTR_FAN_LEVEL, 0)
         self.async_write_ha_state()
 
     #
@@ -423,7 +423,7 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
             {attribute: None for attribute in self._available_attributes}
         )
         self._mode = self._state_attrs.get(ATTR_MODE)
-        self._fan_level = self._state_attrs.get(ATTR_FAN_LEVEL)
+        self._fan_level = self._state_attrs.get(ATTR_FAN_LEVEL, 0)
 
     @property
     def preset_mode(self):

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -244,7 +244,7 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
         self._available_attributes = {}
         self._state = None
         self._mode = None
-        self._fan_level = 0
+        self._fan_level = None
         self._state_attrs = {ATTR_MODEL: self._model}
         self._device_features = 0
         self._supported_features = 0
@@ -316,7 +316,7 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
             }
         )
         self._mode = self._state_attrs.get(ATTR_MODE)
-        self._fan_level = self._state_attrs.get(ATTR_FAN_LEVEL, 0)
+        self._fan_level = self.coordinator.data.fan_level
         self.async_write_ha_state()
 
     #
@@ -423,7 +423,7 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
             {attribute: None for attribute in self._available_attributes}
         )
         self._mode = self._state_attrs.get(ATTR_MODE)
-        self._fan_level = self._state_attrs.get(ATTR_FAN_LEVEL, 0)
+        self._fan_level = self.coordinator.data.fan_level
 
     @property
     def preset_mode(self):
@@ -451,6 +451,10 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
 
         This method is a coroutine.
         """
+        if percentage == 0:
+            await self.async_turn_off()
+            return
+
         speed_mode = math.ceil(
             percentage_to_ranged_value((1, self._speed_count), percentage)
         )
@@ -510,6 +514,8 @@ class XiaomiAirPurifierMiot(XiaomiAirPurifier):
     @property
     def percentage(self):
         """Return the current percentage based speed."""
+        if self._fan_level is None:
+            return None
         if self._state:
             return ranged_value_to_percentage((1, 3), self._fan_level)
 
@@ -529,6 +535,10 @@ class XiaomiAirPurifierMiot(XiaomiAirPurifier):
 
         This method is a coroutine.
         """
+        if percentage == 0:
+            await self.async_turn_off()
+            return
+
         fan_level = math.ceil(percentage_to_ranged_value((1, 3), percentage))
         if not fan_level:
             return


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes at HA startup we get a `TypeError` exception in `ranged_value_to_percentage()` because `self._fan_level` is `None`:
```
2021-08-23 18:45:59 ERROR (MainThread) [homeassistant.helpers.entity] Update for fan.zhimi_airpurifier_mb3 fails
Traceback (most recent call last):
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 446, in async_update_ha_state
    await self.async_device_update()
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 641, in async_device_update
    raise exc
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/update_coordinator.py", line 336, in async_update
    await self.coordinator.async_request_refresh()
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/update_coordinator.py", line 141, in async_request_refresh
    await self._debounced_refresh.async_call()
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/debounce.py", line 78, in async_call
    await task
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/update_coordinator.py", line 165, in async_refresh
    await self._async_refresh(log_failures=True)
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/update_coordinator.py", line 265, in _async_refresh
    update_callback()
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/xiaomi_miio/fan.py", line 320, in _handle_coordinator_update
    self.async_write_ha_state()
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 464, in async_write_ha_state
    self._async_write_ha_state()
  File "/home/maciek/develop/home-assistant-core/homeassistant/helpers/entity.py", line 500, in _async_write_ha_state
    attr.update(self.state_attributes or {})
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/fan/__init__.py", line 621, in state_attributes
    data[ATTR_PERCENTAGE] = self.percentage
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/xiaomi_miio/fan.py", line 514, in percentage
    return ranged_value_to_percentage((1, 3), self._fan_level)
  File "/home/maciek/develop/home-assistant-core/homeassistant/util/percentage.py", line 74, in ranged_value_to_percentage
    return int(((value - offset) * 100) // states_in_range(low_high_range))
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```

This PR fixes this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
