### PR TITLE
Validate requirements format in hassfest

### DIFF
--- a/homeassistant/components/gc100/manifest.json
+++ b/homeassistant/components/gc100/manifest.json
@@ -2,7 +2,7 @@
   "domain": "gc100",
   "name": "Global Cach\u00e9 GC-100",
   "documentation": "https://www.home-assistant.io/integrations/gc100",
-  "requirements": ["python-gc100==1.0.3a"],
+  "requirements": ["python-gc100==1.0.3a0"],
   "codeowners": [],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1853,7 +1853,7 @@ python-forecastio==1.4.0
 # python-gammu==3.1
 
 # homeassistant.components.gc100
-python-gc100==1.0.3a
+python-gc100==1.0.3a0
 
 # homeassistant.components.gitlab_ci
 python-gitlab==1.6.0

--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -120,7 +120,11 @@ def main():
         try:
             start = monotonic()
             print(f"Validating {plugin.__name__.split('.')[-1]}...", end="", flush=True)
-            if plugin is requirements and not config.specific_integrations:
+            if (
+                plugin is requirements
+                and config.requirements
+                and not config.specific_integrations
+            ):
                 print()
             plugin.validate(integrations, config)
             print(f" done in {monotonic() - start:.2f}s")

--- a/script/hassfest/__main__.py
+++ b/script/hassfest/__main__.py
@@ -24,18 +24,19 @@ from . import (
 from .model import Config, Integration
 
 INTEGRATION_PLUGINS = [
-    json,
     codeowners,
     config_flow,
     dependencies,
+    dhcp,
+    json,
     manifest,
     mqtt,
+    requirements,
     services,
     ssdp,
     translations,
-    zeroconf,
-    dhcp,
     usb,
+    zeroconf,
 ]
 HASS_PLUGINS = [
     coverage,
@@ -102,9 +103,6 @@ def main():
         return 1
 
     plugins = [*INTEGRATION_PLUGINS]
-
-    if config.requirements:
-        plugins.append(requirements)
 
     if config.specific_integrations:
         integrations = {}

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -84,7 +84,7 @@ def validate(integrations: dict[str, Integration], config: Config):
 def validate_requirements_format(integration: Integration) -> bool:
     """Validate requirements format.
 
-    Returns if an error was added.
+    Returns if valid.
     """
     start_errors = len(integration.errors)
 
@@ -112,7 +112,7 @@ def validate_requirements_format(integration: Integration) -> bool:
             )
             continue
 
-    return len(integration.errors) > start_errors
+    return len(integration.errors) == start_errors
 
 
 def validate_requirements(integration: Integration):

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -101,12 +101,12 @@ def validate_requirements_format(integration: Integration) -> bool:
         if not sep:
             integration.add_error(
                 "requirements",
-                'Requirements need to be pinned "<pkg name>==<version>".',
+                f'Requirement {req} need to be pinned "<pkg name>==<version>".',
             )
             continue
 
         if AwesomeVersion(version).strategy == AwesomeVersionStrategy.UNKNOWN:
-            integration.add_error("requirements", "Unable to parse package version.")
+            integration.add_error("requirements", f"Unable to parse package version ({version}) for {pkg}.")
             continue
 
     return len(integration.errors) > start_errors

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -98,7 +98,7 @@ def validate_requirements_format(integration: Integration) -> bool:
 
         pkg, sep, version = req.partition("==")
 
-        if not sep:
+        if not sep and integration.core:
             integration.add_error(
                 "requirements",
                 f'Requirement {req} need to be pinned "<pkg name>==<version>".',
@@ -106,7 +106,10 @@ def validate_requirements_format(integration: Integration) -> bool:
             continue
 
         if AwesomeVersion(version).strategy == AwesomeVersionStrategy.UNKNOWN:
-            integration.add_error("requirements", f"Unable to parse package version ({version}) for {pkg}.")
+            integration.add_error(
+                "requirements",
+                f"Unable to parse package version ({version}) for {pkg}.",
+            )
             continue
 
     return len(integration.errors) > start_errors

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -1,0 +1,68 @@
+"""Tests for hassfest requirements."""
+from pathlib import Path
+
+import pytest
+
+from script.hassfest.model import Integration
+from script.hassfest.requirements import validate_requirements_format
+
+
+@pytest.fixture
+def integration():
+    """Fixture for hassfest integration model."""
+    integration = Integration(
+        path=Path("homeassistant/components/test"),
+        manifest={
+            "domain": "test",
+            "documentation": "https://example.com",
+            "name": "test",
+            "codeowners": ["@awesome"],
+            "requirements": [],
+        },
+    )
+    yield integration
+
+
+def test_validate_requirements_format_with_space(integration: Integration):
+    """Test validate requirement with space around separator."""
+    integration.manifest["requirements"] = ["test_package == 1"]
+    assert not validate_requirements_format(integration)
+    assert len(integration.errors) == 1
+    assert 'Requirement "test_package == 1" contains a space' in [
+        x.error for x in integration.errors
+    ]
+
+
+def test_validate_requirements_format_wrongly_pinned(integration: Integration):
+    """Test requirement with loose pin."""
+    integration.manifest["requirements"] = ["test_package>=1"]
+    assert not validate_requirements_format(integration)
+    assert len(integration.errors) == 1
+    assert 'Requirement test_package>=1 need to be pinned "<pkg name>==<version>".' in [
+        x.error for x in integration.errors
+    ]
+
+
+def test_validate_requirements_format_ignore_pin_for_custom(integration: Integration):
+    """Test requirement ignore pinning for custom."""
+    integration.manifest["requirements"] = ["test_package>=1"]
+    integration.path = Path("")
+    assert validate_requirements_format(integration)
+    assert len(integration.errors) == 0
+
+
+def test_validate_requirements_format_invalid_version(integration: Integration):
+    """Test requirement with invalid version."""
+    integration.manifest["requirements"] = ["test_package==invalid"]
+    assert not validate_requirements_format(integration)
+    assert len(integration.errors) == 1
+    assert "Unable to parse package version (invalid) for test_package." in [
+        x.error for x in integration.errors
+    ]
+
+
+def test_validate_requirements_format_successful(integration: Integration):
+    """Test requirement with successful result."""
+    integration.manifest["requirements"] = ["test_package==1.2.3"]
+    assert validate_requirements_format(integration)
+    assert len(integration.errors) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will validate the requirements format in the manifest. Existing logic remains if `--requirements` is added except that we abort out early if we detect an invalid requirements format.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
