### PR TITLE
Guard for unparsable date time

### DIFF
--- a/homeassistant/components/hue/hue_event.py
+++ b/homeassistant/components/hue/hue_event.py
@@ -60,10 +60,17 @@ class HueEvent(GenericHueDevice):
                 self.sensor.last_event is not None
                 and self.sensor.last_event["type"] != EVENT_BUTTON
             )
-            or
-            # Filter out old states. Can happen when events fire while refreshing
-            dt_util.parse_datetime(self.sensor.state["lastupdated"])
-            <= dt_util.parse_datetime(self._last_state["lastupdated"])
+        ):
+            return
+
+        # Filter out old states. Can happen when events fire while refreshing
+        now_updated = dt_util.parse_datetime(self.sensor.state["lastupdated"])
+        last_updated = dt_util.parse_datetime(self._last_state["lastupdated"])
+
+        if (
+            now_updated is not None
+            and last_updated is not None
+            and now_updated <= last_updated
         ):
             return
 

--- a/tests/components/hue/test_device_trigger.py
+++ b/tests/components/hue/test_device_trigger.py
@@ -55,7 +55,7 @@ async def test_get_triggers(hass, mock_bridge, device_reg):
             "type": t_type,
             "subtype": t_subtype,
         }
-        for t_type, t_subtype in device_trigger.HUE_TAP_REMOTE.keys()
+        for t_type, t_subtype in device_trigger.HUE_TAP_REMOTE
     ]
     assert_lists_same(triggers, expected_triggers)
 
@@ -82,7 +82,7 @@ async def test_get_triggers(hass, mock_bridge, device_reg):
                 "type": t_type,
                 "subtype": t_subtype,
             }
-            for t_type, t_subtype in device_trigger.HUE_DIMMER_REMOTE.keys()
+            for t_type, t_subtype in device_trigger.HUE_DIMMER_REMOTE
         ),
     ]
     assert_lists_same(triggers, expected_triggers)
@@ -140,6 +140,7 @@ async def test_if_fires_on_state_change(hass, mock_bridge, device_reg, calls):
 
     # Fake that the remote is being pressed.
     new_sensor_response = dict(REMOTES_RESPONSE)
+    new_sensor_response["7"] = dict(new_sensor_response["7"])
     new_sensor_response["7"]["state"] = {
         "buttonevent": 18,
         "lastupdated": "2019-12-28T22:58:02",
@@ -156,7 +157,7 @@ async def test_if_fires_on_state_change(hass, mock_bridge, device_reg, calls):
     assert calls[0].data["some"] == "B4 - 18"
 
     # Fake another button press.
-    new_sensor_response = dict(REMOTES_RESPONSE)
+    new_sensor_response["7"] = dict(new_sensor_response["7"])
     new_sensor_response["7"]["state"] = {
         "buttonevent": 34,
         "lastupdated": "2019-12-28T22:58:05",

--- a/tests/components/hue/test_sensor_base.py
+++ b/tests/components/hue/test_sensor_base.py
@@ -450,6 +450,7 @@ async def test_hue_events(hass, mock_bridge):
     mock_bridge.api.sensors["8"].last_event = {"type": "button"}
 
     new_sensor_response = dict(SENSOR_RESPONSE)
+    new_sensor_response["7"] = dict(new_sensor_response["7"])
     new_sensor_response["7"]["state"] = {
         "buttonevent": 18,
         "lastupdated": "2019-12-28T22:58:03",
@@ -473,6 +474,7 @@ async def test_hue_events(hass, mock_bridge):
     }
 
     new_sensor_response = dict(new_sensor_response)
+    new_sensor_response["8"] = dict(new_sensor_response["8"])
     new_sensor_response["8"]["state"] = {
         "buttonevent": 3002,
         "lastupdated": "2019-12-28T22:58:03",
@@ -497,6 +499,7 @@ async def test_hue_events(hass, mock_bridge):
 
     # Fire old event, it should be ignored
     new_sensor_response = dict(new_sensor_response)
+    new_sensor_response["8"] = dict(new_sensor_response["8"])
     new_sensor_response["8"]["state"] = {
         "buttonevent": 18,
         "lastupdated": "2019-12-28T22:58:02",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Apparently we sometimes get events that are not valid datetimes. Guard for that.

Fixes #55101

Also realized in testing that some Hue tests were mutating global fixture data so fixed that too.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
