### PR TITLE
Add entity list to zwave_js events

### DIFF
--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -49,6 +49,13 @@ async def test_scenes(hass, hank_binary_switch, integration, client):
     assert events[0].data["label"] == "Event value"
     assert events[0].data["value"] == 255
     assert events[0].data["value_raw"] == 255
+    assert events[0].data["entity_id"] == [
+        "switch.smart_plug_with_two_usb_ports",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_2",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_3",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_4",
+    ]
 
     # Publish fake Scene Activation value notification
     event = Event(
@@ -85,6 +92,13 @@ async def test_scenes(hass, hank_binary_switch, integration, client):
     assert events[1].data["label"] == "Scene ID"
     assert events[1].data["value"] == 16
     assert events[1].data["value_raw"] == 16
+    assert events[1].data["entity_id"] == [
+        "switch.smart_plug_with_two_usb_ports",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_2",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_3",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_4",
+    ]
 
     # Publish fake Central Scene value notification
     event = Event(
@@ -132,6 +146,13 @@ async def test_scenes(hass, hank_binary_switch, integration, client):
     assert events[2].data["label"] == "Scene 001"
     assert events[2].data["value"] == "KeyPressed3x"
     assert events[2].data["value_raw"] == 4
+    assert events[2].data["entity_id"] == [
+        "switch.smart_plug_with_two_usb_ports",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_2",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_3",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_4",
+    ]
 
 
 async def test_notifications(hass, hank_binary_switch, integration, client):
@@ -170,6 +191,13 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
     assert events[0].data["parameters"]["userId"] == 1
     assert events[0].data["command_class"] == CommandClass.NOTIFICATION
     assert events[0].data["command_class_name"] == "Notification"
+    assert events[0].data["entity_id"] == [
+        "switch.smart_plug_with_two_usb_ports",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_2",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_3",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_4",
+    ]
 
     # Publish fake Entry Control CC notification
     event = Event(
@@ -194,6 +222,13 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
     assert events[1].data["event_data"] == "555"
     assert events[1].data["command_class"] == CommandClass.ENTRY_CONTROL
     assert events[1].data["command_class_name"] == "Entry Control"
+    assert events[1].data["entity_id"] == [
+        "switch.smart_plug_with_two_usb_ports",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_2",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_3",
+        "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_4",
+    ]
 
 
 async def test_value_updated(hass, vision_security_zl7432, integration, client):


### PR DESCRIPTION
## Proposed change
A common complaint is that it is hard to tie `notification` and `value notification` events to entities for the purposes of automations. We recently added new device template functions that make this easier, but it seems that most users aren't aware of them. Adding the list of enabled entities for a given device seems like a nice convenience for little cost.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
