### PR TITLE
Improve Tasmota MQTT discovery flow

### DIFF
--- a/homeassistant/components/tasmota/config_flow.py
+++ b/homeassistant/components/tasmota/config_flow.py
@@ -29,16 +29,17 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         await self.async_set_unique_id(DOMAIN)
 
-        # Validate the topic, will throw if it fails
-        prefix = discovery_info["subscribed_topic"]
-        if prefix.endswith("/#"):
-            prefix = prefix[:-2]
-        try:
-            valid_subscribe_topic(f"{prefix}/#")
-        except vol.Invalid:
+        # Validate the message, abort if it fails
+        if not discovery_info["topic"].endswith("/config"):
+            # Not a Tasmota discovery message
+            return self.async_abort(reason="invalid_discovery_info")
+        if not discovery_info["payload"]:
+            # Empty payload, the Tasmota is not configured for native discovery
             return self.async_abort(reason="invalid_discovery_info")
 
-        self._prefix = prefix
+        # "tasmota/discovery/#" is hardcoded in Tasmota's manifest
+        assert discovery_info["subscribed_topic"] == "tasmota/discovery/#"
+        self._prefix = "tasmota/discovery"
 
         return await self.async_step_confirm()
 

--- a/tests/components/tasmota/test_config_flow.py
+++ b/tests/components/tasmota/test_config_flow.py
@@ -19,11 +19,20 @@ async def test_mqtt_abort_if_existing_entry(hass, mqtt_mock):
 async def test_mqtt_abort_invalid_topic(hass, mqtt_mock):
     """Check MQTT flow aborts if discovery topic is invalid."""
     discovery_info = {
-        "topic": "",
-        "payload": "",
+        "topic": "tasmota/discovery/DC4F220848A2/bla",
+        "payload": (
+            '{"ip":"192.168.0.136","dn":"Tasmota","fn":["Tasmota",null,null,null,null,'
+            'null,null,null],"hn":"tasmota_0848A2","mac":"DC4F220848A2","md":"Sonoff Basic",'
+            '"ty":0,"if":0,"ofln":"Offline","onln":"Online","state":["OFF","ON",'
+            '"TOGGLE","HOLD"],"sw":"9.4.0.4","t":"tasmota_0848A2","ft":"%topic%/%prefix%/",'
+            '"tp":["cmnd","stat","tele"],"rl":[1,0,0,0,0,0,0,0],"swc":[-1,-1,-1,-1,-1,-1,-1,-1],'
+            '"swn":[null,null,null,null,null,null,null,null],"btn":[0,0,0,0,0,0,0,0],'
+            '"so":{"4":0,"11":0,"13":0,"17":1,"20":0,"30":0,"68":0,"73":0,"82":0,"114":1,"117":0},'
+            '"lk":1,"lt_st":0,"sho":[0,0,0,0],"ver":1}'
+        ),
         "qos": 0,
         "retain": False,
-        "subscribed_topic": "custom_prefix/##",
+        "subscribed_topic": "tasmota/discovery/#",
         "timestamp": None,
     }
     result = await hass.config_entries.flow.async_init(
@@ -32,15 +41,60 @@ async def test_mqtt_abort_invalid_topic(hass, mqtt_mock):
     assert result["type"] == "abort"
     assert result["reason"] == "invalid_discovery_info"
 
+    discovery_info = {
+        "topic": "tasmota/discovery/DC4F220848A2/config",
+        "payload": "",
+        "qos": 0,
+        "retain": False,
+        "subscribed_topic": "tasmota/discovery/#",
+        "timestamp": None,
+    }
+    result = await hass.config_entries.flow.async_init(
+        "tasmota", context={"source": config_entries.SOURCE_MQTT}, data=discovery_info
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "invalid_discovery_info"
+
+    discovery_info = {
+        "topic": "tasmota/discovery/DC4F220848A2/config",
+        "payload": (
+            '{"ip":"192.168.0.136","dn":"Tasmota","fn":["Tasmota",null,null,null,null,'
+            'null,null,null],"hn":"tasmota_0848A2","mac":"DC4F220848A2","md":"Sonoff Basic",'
+            '"ty":0,"if":0,"ofln":"Offline","onln":"Online","state":["OFF","ON",'
+            '"TOGGLE","HOLD"],"sw":"9.4.0.4","t":"tasmota_0848A2","ft":"%topic%/%prefix%/",'
+            '"tp":["cmnd","stat","tele"],"rl":[1,0,0,0,0,0,0,0],"swc":[-1,-1,-1,-1,-1,-1,-1,-1],'
+            '"swn":[null,null,null,null,null,null,null,null],"btn":[0,0,0,0,0,0,0,0],'
+            '"so":{"4":0,"11":0,"13":0,"17":1,"20":0,"30":0,"68":0,"73":0,"82":0,"114":1,"117":0},'
+            '"lk":1,"lt_st":0,"sho":[0,0,0,0],"ver":1}'
+        ),
+        "qos": 0,
+        "retain": False,
+        "subscribed_topic": "tasmota/discovery/#",
+        "timestamp": None,
+    }
+    result = await hass.config_entries.flow.async_init(
+        "tasmota", context={"source": config_entries.SOURCE_MQTT}, data=discovery_info
+    )
+    assert result["type"] == "form"
+
 
 async def test_mqtt_setup(hass, mqtt_mock) -> None:
     """Test we can finish a config flow through MQTT with custom prefix."""
     discovery_info = {
-        "topic": "",
-        "payload": "",
+        "topic": "tasmota/discovery/DC4F220848A2/config",
+        "payload": (
+            '{"ip":"192.168.0.136","dn":"Tasmota","fn":["Tasmota",null,null,null,null,'
+            'null,null,null],"hn":"tasmota_0848A2","mac":"DC4F220848A2","md":"Sonoff Basic",'
+            '"ty":0,"if":0,"ofln":"Offline","onln":"Online","state":["OFF","ON",'
+            '"TOGGLE","HOLD"],"sw":"9.4.0.4","t":"tasmota_0848A2","ft":"%topic%/%prefix%/",'
+            '"tp":["cmnd","stat","tele"],"rl":[1,0,0,0,0,0,0,0],"swc":[-1,-1,-1,-1,-1,-1,-1,-1],'
+            '"swn":[null,null,null,null,null,null,null,null],"btn":[0,0,0,0,0,0,0,0],'
+            '"so":{"4":0,"11":0,"13":0,"17":1,"20":0,"30":0,"68":0,"73":0,"82":0,"114":1,"117":0},'
+            '"lk":1,"lt_st":0,"sho":[0,0,0,0],"ver":1}'
+        ),
         "qos": 0,
         "retain": False,
-        "subscribed_topic": "custom_prefix/123/#",
+        "subscribed_topic": "tasmota/discovery/#",
         "timestamp": None,
     }
     result = await hass.config_entries.flow.async_init(
@@ -51,9 +105,7 @@ async def test_mqtt_setup(hass, mqtt_mock) -> None:
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
     assert result["type"] == "create_entry"
-    assert result["result"].data == {
-        "discovery_prefix": "custom_prefix/123",
-    }
+    assert result["result"].data == {"discovery_prefix": "tasmota/discovery"}
 
 
 async def test_user_setup(hass, mqtt_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve Tasmota MQTT discovery flow by not triggering on:
 - Empty discovery messages which will be sent by Tasmota devices configured for Home Assistant MQTT discovery (setoption19 1)
 - Messages not ending with `/config`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
