### PR TITLE
Alexa - Remove legacy speed support for fan platform

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1483,16 +1483,6 @@ class AlexaRangeController(AlexaCapability):
         if self.entity.state in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
             return None
 
-        # Fan Speed
-        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_SPEED}":
-            speed_list = self.entity.attributes.get(fan.ATTR_SPEED_LIST)
-            speed = self.entity.attributes.get(fan.ATTR_SPEED)
-            if speed_list is not None and speed is not None:
-                speed_index = next(
-                    (i for i, v in enumerate(speed_list) if v == speed), None
-                )
-                return speed_index
-
         # Cover Position
         if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
             return self.entity.attributes.get(cover.ATTR_CURRENT_POSITION)

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -535,10 +535,6 @@ class FanCapabilities(AlexaEntity):
         if supported & fan.SUPPORT_SET_SPEED:
             yield AlexaPercentageController(self.entity)
             yield AlexaPowerLevelController(self.entity)
-            # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
-            yield AlexaRangeController(
-                self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_SPEED}"
-            )
         if supported & fan.SUPPORT_OSCILLATE:
             yield AlexaToggleController(
                 self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_OSCILLATING}"

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -1091,24 +1091,8 @@ async def async_api_set_range(hass, config, directive, context):
     data = {ATTR_ENTITY_ID: entity.entity_id}
     range_value = directive.payload["rangeValue"]
 
-    # Fan Speed
-    if instance == f"{fan.DOMAIN}.{fan.ATTR_SPEED}":
-        range_value = int(range_value)
-        service = fan.SERVICE_SET_SPEED
-        speed_list = entity.attributes[fan.ATTR_SPEED_LIST]
-        speed = next((v for i, v in enumerate(speed_list) if i == range_value), None)
-
-        if not speed:
-            msg = "Entity does not support value"
-            raise AlexaInvalidValueError(msg)
-
-        if speed == fan.SPEED_OFF:
-            service = fan.SERVICE_TURN_OFF
-
-        data[fan.ATTR_SPEED] = speed
-
     # Cover Position
-    elif instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+    if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
         range_value = int(range_value)
         if range_value == 0:
             service = cover.SERVICE_CLOSE_COVER
@@ -1184,29 +1168,8 @@ async def async_api_adjust_range(hass, config, directive, context):
     range_delta_default = bool(directive.payload["rangeValueDeltaDefault"])
     response_value = 0
 
-    # Fan Speed
-    if instance == f"{fan.DOMAIN}.{fan.ATTR_SPEED}":
-        range_delta = int(range_delta)
-        service = fan.SERVICE_SET_SPEED
-        speed_list = entity.attributes[fan.ATTR_SPEED_LIST]
-        current_speed = entity.attributes[fan.ATTR_SPEED]
-        current_speed_index = next(
-            (i for i, v in enumerate(speed_list) if v == current_speed), 0
-        )
-        new_speed_index = min(
-            len(speed_list) - 1, max(0, current_speed_index + range_delta)
-        )
-        speed = next(
-            (v for i, v in enumerate(speed_list) if i == new_speed_index), None
-        )
-
-        if speed == fan.SPEED_OFF:
-            service = fan.SERVICE_TURN_OFF
-
-        data[fan.ATTR_SPEED] = response_value = speed
-
     # Cover Position
-    elif instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+    if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
         range_delta = int(range_delta * 20) if range_delta_default else int(range_delta)
         service = SERVICE_SET_COVER_POSITION
         current = entity.attributes.get(cover.ATTR_POSITION)

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -346,16 +346,14 @@ async def test_report_colored_temp_light_state(hass):
 
 
 async def test_report_fan_speed_state(hass):
-    """Test PercentageController, PowerLevelController, RangeController reports fan speed correctly."""
+    """Test PercentageController, PowerLevelController reports fan speed correctly."""
     hass.states.async_set(
         "fan.off",
         "off",
         {
             "friendly_name": "Off fan",
-            "speed": "off",
             "supported_features": 1,
             "percentage": 0,
-            "speed_list": ["off", "low", "medium", "high"],
         },
     )
     hass.states.async_set(
@@ -363,10 +361,8 @@ async def test_report_fan_speed_state(hass):
         "on",
         {
             "friendly_name": "Low speed fan",
-            "speed": "low",
             "supported_features": 1,
             "percentage": 33,
-            "speed_list": ["off", "low", "medium", "high"],
         },
     )
     hass.states.async_set(
@@ -374,10 +370,8 @@ async def test_report_fan_speed_state(hass):
         "on",
         {
             "friendly_name": "Medium speed fan",
-            "speed": "medium",
             "supported_features": 1,
             "percentage": 66,
-            "speed_list": ["off", "low", "medium", "high"],
         },
     )
     hass.states.async_set(
@@ -385,32 +379,26 @@ async def test_report_fan_speed_state(hass):
         "on",
         {
             "friendly_name": "High speed fan",
-            "speed": "high",
             "supported_features": 1,
             "percentage": 100,
-            "speed_list": ["off", "low", "medium", "high"],
         },
     )
 
     properties = await reported_properties(hass, "fan.off")
     properties.assert_equal("Alexa.PercentageController", "percentage", 0)
     properties.assert_equal("Alexa.PowerLevelController", "powerLevel", 0)
-    properties.assert_equal("Alexa.RangeController", "rangeValue", 0)
 
     properties = await reported_properties(hass, "fan.low_speed")
     properties.assert_equal("Alexa.PercentageController", "percentage", 33)
     properties.assert_equal("Alexa.PowerLevelController", "powerLevel", 33)
-    properties.assert_equal("Alexa.RangeController", "rangeValue", 1)
 
     properties = await reported_properties(hass, "fan.medium_speed")
     properties.assert_equal("Alexa.PercentageController", "percentage", 66)
     properties.assert_equal("Alexa.PowerLevelController", "powerLevel", 66)
-    properties.assert_equal("Alexa.RangeController", "rangeValue", 2)
 
     properties = await reported_properties(hass, "fan.high_speed")
     properties.assert_equal("Alexa.PercentageController", "percentage", 100)
     properties.assert_equal("Alexa.PowerLevelController", "powerLevel", 100)
-    properties.assert_equal("Alexa.RangeController", "rangeValue", 3)
 
 
 async def test_report_fan_preset_mode(hass):

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -51,8 +51,6 @@ async def test_report_state_instance(hass, aioclient_mock):
         {
             "friendly_name": "Test fan",
             "supported_features": 15,
-            "speed": None,
-            "speed_list": ["off", "low", "high"],
             "oscillating": False,
             "preset_mode": None,
             "preset_modes": ["auto", "smart"],
@@ -68,8 +66,6 @@ async def test_report_state_instance(hass, aioclient_mock):
         {
             "friendly_name": "Test fan",
             "supported_features": 15,
-            "speed": "high",
-            "speed_list": ["off", "low", "high"],
             "oscillating": True,
             "preset_mode": "smart",
             "preset_modes": ["auto", "smart"],
@@ -109,12 +105,7 @@ async def test_report_state_instance(hass, aioclient_mock):
             assert report["value"] == 90
             assert report["namespace"] == "Alexa.PowerLevelController"
             checks += 1
-        if report["name"] == "rangeValue":
-            assert report["value"] == 2
-            assert report["instance"] == "fan.speed"
-            assert report["namespace"] == "Alexa.RangeController"
-            checks += 1
-    assert checks == 5
+    assert checks == 4
 
     assert call_json["event"]["endpoint"]["endpointId"] == "fan#test_fan"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Removes the support for legacy fan speeds. Using `speeds` ('off', 'low', 'medium' or 'high') for the `fan` platform became  deprecated with 2021.07. With 2021.7 preset_mode and percentage support was added (#50466). 
Setting up Alexa will not fail if deprecated attributes still exit in your config. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the use of legacy speeds (implemented with AlexaRangeController)  for the fan entities.
Using the service `fan.set_speed` will no longer work.
Users should set speed using `fan.set_percentage` or set a `fan.set_preset_mode`.

> The use of deprecate speeds was already removed from the documentation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
