### PR TITLE
Use EntityDescription - htu21d

### DIFF
--- a/homeassistant/components/htu21d/sensor.py
+++ b/homeassistant/components/htu21d/sensor.py
@@ -1,4 +1,6 @@
 """Support for HTU21D temperature and humidity sensor."""
+from __future__ import annotations
+
 from datetime import timedelta
 from functools import partial
 import logging
@@ -7,7 +9,11 @@ from i2csense.htu21d import HTU21D  # pylint: disable=import-error
 import smbus
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
+from homeassistant.components.sensor import (
+    PLATFORM_SCHEMA,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.const import (
     CONF_NAME,
     DEVICE_CLASS_HUMIDITY,
@@ -30,17 +36,25 @@ DEFAULT_NAME = "HTU21D Sensor"
 SENSOR_TEMPERATURE = "temperature"
 SENSOR_HUMIDITY = "humidity"
 
+SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key=SENSOR_TEMPERATURE,
+        native_unit_of_measurement=TEMP_CELSIUS,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+    ),
+    SensorEntityDescription(
+        key=SENSOR_HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=DEVICE_CLASS_HUMIDITY,
+    ),
+)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_I2C_BUS, default=DEFAULT_I2C_BUS): vol.Coerce(int),
     }
 )
-
-DEVICE_CLASS_MAP = {
-    SENSOR_TEMPERATURE: DEVICE_CLASS_TEMPERATURE,
-    SENSOR_HUMIDITY: DEVICE_CLASS_HUMIDITY,
-}
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -56,12 +70,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     sensor_handler = await hass.async_add_executor_job(HTU21DHandler, sensor)
 
-    dev = [
-        HTU21DSensor(sensor_handler, name, SENSOR_TEMPERATURE, TEMP_CELSIUS),
-        HTU21DSensor(sensor_handler, name, SENSOR_HUMIDITY, PERCENTAGE),
+    entities = [
+        HTU21DSensor(sensor_handler, name, description) for description in SENSOR_TYPES
     ]
 
-    async_add_entities(dev)
+    async_add_entities(entities)
 
 
 class HTU21DHandler:
@@ -81,38 +94,21 @@ class HTU21DHandler:
 class HTU21DSensor(SensorEntity):
     """Implementation of the HTU21D sensor."""
 
-    def __init__(self, htu21d_client, name, variable, unit):
+    def __init__(self, htu21d_client, name, description: SensorEntityDescription):
         """Initialize the sensor."""
-        self._name = f"{name}_{variable}"
-        self._variable = variable
-        self._unit_of_measurement = unit
+        self.entity_description = description
         self._client = htu21d_client
-        self._state = None
-        self._attr_device_class = DEVICE_CLASS_MAP[variable]
 
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def native_value(self) -> int:
-        """Return the state of the sensor."""
-        return self._state
-
-    @property
-    def native_unit_of_measurement(self) -> str:
-        """Return the unit of measurement of the sensor."""
-        return self._unit_of_measurement
+        self._attr_name = f"{name}_{description.key}"
 
     async def async_update(self):
         """Get the latest data from the HTU21D sensor and update the state."""
         await self.hass.async_add_executor_job(self._client.update)
         if self._client.sensor.sample_ok:
-            if self._variable == SENSOR_TEMPERATURE:
+            if self.entity_description.key == SENSOR_TEMPERATURE:
                 value = round(self._client.sensor.temperature, 1)
             else:
                 value = round(self._client.sensor.humidity, 1)
-            self._state = value
+            self._attr_native_value = value
         else:
             _LOGGER.warning("Bad sample")


### PR DESCRIPTION
## Proposed change
Update `htu21d` to use `EntityDescription` for sensor metadata.
-> #53201

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
