### PR TITLE
Whole-string match reqs in comment_requirement

### DIFF
--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -16,6 +16,7 @@ COMMENT_REQUIREMENTS = (
     "avea",  # depends on bluepy
     "avion",
     "beacontools",
+    "beacontools[scan]",
     "beewi_smartclim",  # depends on bluepy
     "blinkt",
     "bluepy",

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -154,7 +154,7 @@ def gather_recursive_requirements(domain, seen=None):
 
 def comment_requirement(req):
     """Comment out requirement. Some don't install on all systems."""
-    return any(f"{ign.lower()}==" in req.lower() for ign in COMMENT_REQUIREMENTS)
+    return any(req.startswith(f"{ign.lower()}==") for ign in COMMENT_REQUIREMENTS)
 
 
 def gather_modules():

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -154,7 +154,7 @@ def gather_recursive_requirements(domain, seen=None):
 
 def comment_requirement(req):
     """Comment out requirement. Some don't install on all systems."""
-    return any(f"{ign.lower()}==" in req.lower() for ign in COMMENT_REQUIREMENTS)
+    return any(re.match(f"{ign.lower()}(\\[.*\\])*==", req.lower()) for ign in COMMENT_REQUIREMENTS)
 
 
 def gather_modules():

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -15,7 +15,7 @@ COMMENT_REQUIREMENTS = (
     "Adafruit_BBIO",
     "avea",  # depends on bluepy
     "avion",
-    "beacontools[scan]",
+    "beacontools",
     "beewi_smartclim",  # depends on bluepy
     "blinkt",
     "bluepy",
@@ -43,6 +43,10 @@ COMMENT_REQUIREMENTS = (
     "tf-models-official",
     "VL53L1X2",
 )
+
+COMMENT_REQUIREMENTS_NORMALIZED = {
+    commented.lower().replace("_", "-") for commented in COMMENT_REQUIREMENTS
+}
 
 IGNORE_PIN = ("colorlog>2.1,<3", "urllib3")
 
@@ -88,6 +92,8 @@ IGNORE_PRE_COMMIT_HOOK_ID = (
     "prettier",
     "python-typing-update",
 )
+
+PACKAGE_REGEX = re.compile(r"^(?:--.+\s)?([-_\.\w\d]+).*==.+$")
 
 
 def has_tests(module: str):
@@ -152,9 +158,24 @@ def gather_recursive_requirements(domain, seen=None):
     return reqs
 
 
+def normalize_package_name(requirement: str) -> str:
+    """Return a normalized package name from a requirement string."""
+    # This function is also used in hassfest.
+    match = PACKAGE_REGEX.search(requirement)
+    if not match:
+        return ""
+
+    # pipdeptree needs lowercase and dash instead of underscore as separator
+    package = match.group(1).lower().replace("_", "-")
+
+    return package
+
+
 def comment_requirement(req):
     """Comment out requirement. Some don't install on all systems."""
-    return any(req.startswith(f"{ign}==") for ign in COMMENT_REQUIREMENTS)
+    return any(
+        normalize_package_name(req) == ign for ign in COMMENT_REQUIREMENTS_NORMALIZED
+    )
 
 
 def gather_modules():

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -15,7 +15,6 @@ COMMENT_REQUIREMENTS = (
     "Adafruit_BBIO",
     "avea",  # depends on bluepy
     "avion",
-    "beacontools",
     "beacontools[scan]",
     "beewi_smartclim",  # depends on bluepy
     "blinkt",

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -154,7 +154,7 @@ def gather_recursive_requirements(domain, seen=None):
 
 def comment_requirement(req):
     """Comment out requirement. Some don't install on all systems."""
-    return any(re.match(f"{ign.lower()}(\\[.*\\])*==", req.lower()) for ign in COMMENT_REQUIREMENTS)
+    return any(f"{ign.lower()}==" in req.lower() for ign in COMMENT_REQUIREMENTS)
 
 
 def gather_modules():

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -154,7 +154,7 @@ def gather_recursive_requirements(domain, seen=None):
 
 def comment_requirement(req):
     """Comment out requirement. Some don't install on all systems."""
-    return any(req.startswith(f"{ign.lower()}==") for ign in COMMENT_REQUIREMENTS)
+    return any(req.startswith(f"{ign}==") for ign in COMMENT_REQUIREMENTS)
 
 
 def gather_modules():

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -154,10 +154,7 @@ def gather_recursive_requirements(domain, seen=None):
 
 def comment_requirement(req):
     """Comment out requirement. Some don't install on all systems."""
-    idx=req.find("==")
-    if idx >= 0:
-      return any(ign.lower() == req[0:idx].lower() for ign in COMMENT_REQUIREMENTS)
-    return any(ign.lower() == req.lower() for ign in COMMENT_REQUIREMENTS)
+    return any(f"{ign.lower()}==" in req.lower() for ign in COMMENT_REQUIREMENTS)
 
 
 def gather_modules():

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -154,7 +154,10 @@ def gather_recursive_requirements(domain, seen=None):
 
 def comment_requirement(req):
     """Comment out requirement. Some don't install on all systems."""
-    return any(ign.lower() in req.lower() for ign in COMMENT_REQUIREMENTS)
+    idx=req.find("==")
+    if idx >= 0:
+      return any(ign.lower() == req[0:idx].lower() for ign in COMMENT_REQUIREMENTS)
+    return any(ign.lower() == req.lower() for ign in COMMENT_REQUIREMENTS)
 
 
 def gather_modules():

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 
 from homeassistant.const import REQUIRED_PYTHON_VER
 import homeassistant.util.package as pkg_util
-from script.gen_requirements_all import COMMENT_REQUIREMENTS
+from script.gen_requirements_all import COMMENT_REQUIREMENTS, normalize_package_name
 
 from .model import Config, Integration
 
@@ -45,18 +45,6 @@ IGNORE_VIOLATIONS = {
     "slide",
     "suez_water",
 }
-
-
-def normalize_package_name(requirement: str) -> str:
-    """Return a normalized package name from a requirement string."""
-    match = PACKAGE_REGEX.search(requirement)
-    if not match:
-        return ""
-
-    # pipdeptree needs lowercase and dash instead of underscore as separator
-    package = match.group(1).lower().replace("_", "-")
-
-    return package
 
 
 def validate(integrations: dict[str, Integration], config: Config):
@@ -90,7 +78,7 @@ def validate_requirements(integration: Integration):
                 f"Failed to normalize package name from requirement {req}",
             )
             return
-        if package in IGNORE_PACKAGES:
+        if (package == ign for ign in IGNORE_PACKAGES):
             continue
         integration_requirements.add(req)
         integration_packages.add(package)


### PR DESCRIPTION
Change `comment_requirement(req)` to look for whole-string matches to module names listed in COMMENT_REQUIREMENTS.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Proposal to fix #55178 by making `comment_requirements` look for exact, whole-string matches. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #55178
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
