### PR TITLE
Warn if a sensor with state_class_total has a decreasing value

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -298,7 +298,12 @@ class EnergyCostSensor(SensorEntity):
                 )
             return
 
-        if reset_detected(energy, float(self._last_energy_sensor_state)):
+        if reset_detected(
+            self.hass,
+            cast(str, self._config[self._adapter.entity_energy_key]),
+            energy,
+            float(self._last_energy_sensor_state),
+        ):
             # Energy meter was reset, reset cost sensor too
             self._reset(0)
         # Update with newly incurred cost

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -252,14 +252,13 @@ def reset_detected(
     hass: HomeAssistant, entity_id: str, state: float, previous_state: float | None
 ) -> bool:
     """Test if a total_increasing sensor has been reset."""
-    if (
-        previous_state is not None
-        and state < previous_state
-        and state >= 0.9 * previous_state
-    ):
+    if previous_state is None:
+        return False
+
+    if 0.9 * previous_state <= state < previous_state:
         warn_dip(hass, entity_id)
 
-    return previous_state is not None and state < 0.9 * previous_state
+    return state < 0.9 * previous_state
 
 
 def compile_statistics(

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -42,6 +42,7 @@ from homeassistant.const import (
     VOLUME_CUBIC_METERS,
 )
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.entity import entity_sources
 import homeassistant.util.dt as dt_util
 import homeassistant.util.pressure as pressure_util
 import homeassistant.util.temperature as temperature_util
@@ -115,6 +116,8 @@ UNIT_CONVERSIONS: dict[str, dict[str, Callable]] = {
     },
 }
 
+# Keep track of entities for which a warning about decreasing value has been logged
+WARN_DIP = "sensor_warn_total_increasing_dip"
 # Keep track of entities for which a warning about unsupported unit has been logged
 WARN_UNSUPPORTED_UNIT = set()
 
@@ -226,8 +229,36 @@ def _normalize_states(
     return DEVICE_CLASS_UNITS[key], fstates
 
 
-def reset_detected(state: float, previous_state: float | None) -> bool:
+def warn_dip(hass: HomeAssistant, entity_id: str) -> None:
+    """Log a warning once if a sensor with state_class_total has a decreasing value."""
+    if WARN_DIP not in hass.data:
+        hass.data[WARN_DIP] = set()
+    if entity_id not in hass.data[WARN_DIP]:
+        hass.data[WARN_DIP].add(entity_id)
+        domain = entity_sources(hass).get(entity_id, {}).get("domain")
+        if domain in ["energy", "growatt_server", "solaredge"]:
+            return
+        _LOGGER.warning(
+            "Entity %s %shas state class total_increasing, but its state is "
+            "not strictly increasing. Please create a bug report at %s",
+            entity_id,
+            f"from integration {domain} " if domain else "",
+            "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
+            "+label%3A%22integration%3A+recorder%22",
+        )
+
+
+def reset_detected(
+    hass: HomeAssistant, entity_id: str, state: float, previous_state: float | None
+) -> bool:
     """Test if a total_increasing sensor has been reset."""
+    if (
+        previous_state is not None
+        and state < previous_state
+        and state >= 0.9 * previous_state
+    ):
+        warn_dip(hass, entity_id)
+
     return previous_state is not None and state < 0.9 * previous_state
 
 
@@ -313,7 +344,8 @@ def compile_statistics(
                         fstate,
                     )
                 elif state_class == STATE_CLASS_TOTAL_INCREASING and (
-                    old_state is None or reset_detected(fstate, new_state)
+                    old_state is None
+                    or reset_detected(hass, entity_id, fstate, new_state)
                 ):
                     reset = True
                     _LOGGER.info(

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -391,6 +391,12 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
         ]
     }
     assert "Error while processing event StatisticsTask" not in caplog.text
+    assert (
+        "Entity sensor.test1 has state class total_increasing, but its state is not "
+        "strictly increasing. Please create a bug report at https://github.com/"
+        "home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A"
+        "+recorder%22"
+    ) in caplog.text
 
 
 def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Warn if a sensor with `state_class_total` has a decreasing value which decreases less than 10% compared to the previous value, and request the user to open an issue.

The rationale is to get some insight to how common this is.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
