### PR TITLE
Tasmota - Cleanup tests involving legacy fan speed

### DIFF
--- a/tests/components/tasmota/test_fan.py
+++ b/tests/components/tasmota/test_fan.py
@@ -9,6 +9,7 @@ from hatasmota.utils import (
     get_topic_tele_will,
 )
 import pytest
+from voluptuous import MultipleInvalid
 
 from homeassistant.components import fan
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
@@ -51,46 +52,38 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_OFF
-    assert state.attributes["speed"] is None
     assert state.attributes["percentage"] is None
-    assert state.attributes["speed_list"] == ["off", "low", "medium", "high"]
     assert state.attributes["supported_features"] == fan.SUPPORT_SET_SPEED
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"FanSpeed":1}')
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_ON
-    assert state.attributes["speed"] == "low"
     assert state.attributes["percentage"] == 33
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"FanSpeed":2}')
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_ON
-    assert state.attributes["speed"] == "medium"
     assert state.attributes["percentage"] == 66
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"FanSpeed":3}')
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_ON
-    assert state.attributes["speed"] == "high"
     assert state.attributes["percentage"] == 100
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"FanSpeed":0}')
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_OFF
-    assert state.attributes["speed"] == "off"
     assert state.attributes["percentage"] == 0
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/stat/RESULT", '{"FanSpeed":1}')
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_ON
-    assert state.attributes["speed"] == "low"
     assert state.attributes["percentage"] == 33
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/stat/RESULT", '{"FanSpeed":0}')
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_OFF
-    assert state.attributes["speed"] == "off"
     assert state.attributes["percentage"] == 0
 
 
@@ -132,34 +125,6 @@ async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
     )
     mqtt_mock.async_publish.reset_mock()
 
-    # Set speed  and verify MQTT message is sent
-    await common.async_set_speed(hass, "fan.tasmota", fan.SPEED_OFF)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "tasmota_49A3BC/cmnd/FanSpeed", "0", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-
-    # Set speed  and verify MQTT message is sent
-    await common.async_set_speed(hass, "fan.tasmota", fan.SPEED_LOW)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "tasmota_49A3BC/cmnd/FanSpeed", "1", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-
-    # Set speed  and verify MQTT message is sent
-    await common.async_set_speed(hass, "fan.tasmota", fan.SPEED_MEDIUM)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "tasmota_49A3BC/cmnd/FanSpeed", "2", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-
-    # Set speed  and verify MQTT message is sent
-    await common.async_set_speed(hass, "fan.tasmota", fan.SPEED_HIGH)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "tasmota_49A3BC/cmnd/FanSpeed", "3", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-
     # Set speed percentage and verify MQTT message is sent
     await common.async_set_percentage(hass, "fan.tasmota", 0)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -188,7 +153,7 @@ async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
     )
 
 
-async def test_invalid_fan_speed(hass, mqtt_mock, setup_tasmota):
+async def test_invalid_fan_speed_percentage(hass, mqtt_mock, setup_tasmota):
     """Test the sending MQTT commands."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["if"] = 1
@@ -209,9 +174,9 @@ async def test_invalid_fan_speed(hass, mqtt_mock, setup_tasmota):
     mqtt_mock.async_publish.reset_mock()
 
     # Set an unsupported speed and verify MQTT message is not sent
-    with pytest.raises(ValueError) as excinfo:
-        await common.async_set_speed(hass, "fan.tasmota", "no_such_speed")
-    assert "no_such_speed" in str(excinfo.value)
+    with pytest.raises(MultipleInvalid) as excinfo:
+        await common.async_set_percentage(hass, "fan.tasmota", 101)
+    assert "value must be at most 100" in str(excinfo.value)
     mqtt_mock.async_publish.assert_not_called()
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean up tests involving legacy fan speed support for the Tasmota fan platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
