### PR TITLE
Be tolerant of Wemo insight_param keys that might not exist

### DIFF
--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -78,7 +78,9 @@ class InsightCurrentPower(InsightSensor):
     def native_value(self) -> StateType:
         """Return the current power consumption."""
         return (
-            convert(self.wemo.insight_params[self.entity_description.key], float, 0.0)
+            convert(
+                self.wemo.insight_params.get(self.entity_description.key), float, 0.0
+            )
             / 1000.0
         )
 
@@ -98,6 +100,6 @@ class InsightTodayEnergy(InsightSensor):
     def native_value(self) -> StateType:
         """Return the current energy use today."""
         miliwatts = convert(
-            self.wemo.insight_params[self.entity_description.key], float, 0.0
+            self.wemo.insight_params.get(self.entity_description.key), float, 0.0
         )
         return round(miliwatts / (1000.0 * 1000.0 * 60), 2)

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -76,16 +76,17 @@ class WemoSwitch(WemoEntity, SwitchEntity):
 
         if isinstance(self.wemo, Insight):
             attr["on_latest_time"] = WemoSwitch.as_uptime(
-                self.wemo.insight_params["onfor"]
+                self.wemo.insight_params.get("onfor", 0)
             )
             attr["on_today_time"] = WemoSwitch.as_uptime(
-                self.wemo.insight_params["ontoday"]
+                self.wemo.insight_params.get("ontoday", 0)
             )
             attr["on_total_time"] = WemoSwitch.as_uptime(
-                self.wemo.insight_params["ontotal"]
+                self.wemo.insight_params.get("ontotal", 0)
             )
             attr["power_threshold_w"] = (
-                convert(self.wemo.insight_params["powerthreshold"], float, 0.0) / 1000.0
+                convert(self.wemo.insight_params.get("powerthreshold"), float, 0.0)
+                / 1000.0
             )
 
         if isinstance(self.wemo, CoffeeMaker):
@@ -106,14 +107,15 @@ class WemoSwitch(WemoEntity, SwitchEntity):
         """Return the current power usage in W."""
         if isinstance(self.wemo, Insight):
             return (
-                convert(self.wemo.insight_params["currentpower"], float, 0.0) / 1000.0
+                convert(self.wemo.insight_params.get("currentpower"), float, 0.0)
+                / 1000.0
             )
 
     @property
     def today_energy_kwh(self):
         """Return the today total energy usage in kWh."""
         if isinstance(self.wemo, Insight):
-            miliwatts = convert(self.wemo.insight_params["todaymw"], float, 0.0)
+            miliwatts = convert(self.wemo.insight_params.get("todaymw"), float, 0.0)
             return round(miliwatts / (1000.0 * 1000.0 * 60), 2)
 
     @property
@@ -122,7 +124,7 @@ class WemoSwitch(WemoEntity, SwitchEntity):
         if isinstance(self.wemo, CoffeeMaker):
             return self.wemo.mode_string
         if isinstance(self.wemo, Insight):
-            standby_state = int(self.wemo.insight_params["state"])
+            standby_state = int(self.wemo.insight_params.get("state", 0))
             if standby_state == WEMO_ON:
                 return STATE_ON
             if standby_state == WEMO_OFF:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is intended to resolve the issue below, discovered while running the tests.

```
Traceback (most recent call last):
  File "homeassistant/helpers/entity.py", line 446, in async_update_ha_state
    await self.async_device_update()
  File "homeassistant/helpers/entity.py", line 641, in async_device_update
    raise exc
  File "homeassistant/helpers/update_coordinator.py", line 336, in async_update
    await self.coordinator.async_request_refresh()
  File "homeassistant/helpers/update_coordinator.py", line 141, in async_request_refresh
    await self._debounced_refresh.async_call()
  File "homeassistant/helpers/debounce.py", line 78, in async_call
    await task
  File "homeassistant/helpers/update_coordinator.py", line 165, in async_refresh
    await self._async_refresh(log_failures=True)
  File "homeassistant/helpers/update_coordinator.py", line 265, in _async_refresh
    update_callback()
  File "homeassistant/components/wemo/entity.py", line 77, in _handle_coordinator_update
    super()._handle_coordinator_update()
  File "homeassistant/helpers/update_coordinator.py", line 325, in _handle_coordinator_update
    self.async_write_ha_state()
  File "homeassistant/helpers/entity.py", line 464, in async_write_ha_state
    self._async_write_ha_state()
  File "homeassistant/helpers/entity.py", line 500, in _async_write_ha_state
    attr.update(self.state_attributes or {})
  File "homeassistant/components/switch/__init__.py", line 117, in state_attributes
    value = getattr(self, prop)
  File "homeassistant/components/wemo/switch.py", line 116, in today_energy_kwh
    miliwatts = convert(self.wemo.insight_params["todaymw"], float, 0.0)
KeyError: 'todaymw'

 tests/components/wemo/test_sensor.py ⨯                                                                                                                                100% ██████████
============================================================================== short test summary info ===============================================================================
FAILED tests/components/wemo/test_sensor.py::TestInsightCurrentPower::test_state_unavailable[pyloop] - AssertionError: assert '0.001' == 'unavailable'
FAILED tests/components/wemo/test_sensor.py::TestInsightTodayEnergy::test_state_unavailable[pyloop] - AssertionError: assert '3.33' == 'unavailable'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
