### PR TITLE
Limit USB discovery to specific manufacturer/description/serial_number matches

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import dataclasses
+import fnmatch
 import logging
 import os
 import sys
@@ -70,6 +71,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     websocket_api.async_register_command(hass, websocket_usb_scan)
 
     return True
+
+
+def _fnmatch_lower(name: str | None, pattern: str) -> bool:
+    """Match a lowercase version of the name."""
+    if name is None:
+        return False
+    return fnmatch.fnmatch(name.lower(), pattern)
 
 
 class USBDiscovery:
@@ -151,6 +159,18 @@ class USBDiscovery:
             if "vid" in matcher and device.vid != matcher["vid"]:
                 continue
             if "pid" in matcher and device.pid != matcher["pid"]:
+                continue
+            if "serial_number" in matcher and not _fnmatch_lower(
+                device.serial_number, matcher["serial_number"]
+            ):
+                continue
+            if "manufacturer" in matcher and not _fnmatch_lower(
+                device.manufacturer, matcher["manufacturer"]
+            ):
+                continue
+            if "description" in matcher and not _fnmatch_lower(
+                device.description, matcher["description"]
+            ):
                 continue
             flow: USBFlow = {
                 "domain": matcher["domain"],

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -16,10 +16,9 @@
     "zigpy-znp==0.5.3"
   ],
   "usb": [
-   {"vid":"10C4","pid":"EA60","known_devices":["slae.sh cc2652rb stick"]},
-   {"vid":"1CF1","pid":"0030","known_devices":["Conbee II"]},
-   {"vid":"1A86","pid":"7523","known_devices":["Electrolama zig-a-zig-ah"]},
-   {"vid":"10C4","pid":"8A2A","known_devices":["Nortek HUSBZB-1"]}
+   {"vid":"10C4","pid":"EA60","description":"*2652*","known_devices":["slae.sh cc2652rb stick"]},
+   {"vid":"1CF1","pid":"0030","description":"*conbee*","known_devices":["Conbee II"]},
+   {"vid":"10C4","pid":"8A2A","description":"*zigbee*","known_devices":["Nortek HUSBZB-1"]}
   ],
   "codeowners": ["@dmulcahey", "@adminiuga"],
   "zeroconf": [

--- a/homeassistant/generated/usb.py
+++ b/homeassistant/generated/usb.py
@@ -9,22 +9,20 @@ USB = [
     {
         "domain": "zha",
         "vid": "10C4",
-        "pid": "EA60"
+        "pid": "EA60",
+        "description": "*2652*"
     },
     {
         "domain": "zha",
         "vid": "1CF1",
-        "pid": "0030"
-    },
-    {
-        "domain": "zha",
-        "vid": "1A86",
-        "pid": "7523"
+        "pid": "0030",
+        "description": "*conbee*"
     },
     {
         "domain": "zha",
         "vid": "10C4",
-        "pid": "8A2A"
+        "pid": "8A2A",
+        "description": "*zigbee*"
     },
     {
         "domain": "zwave_js",

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -210,6 +210,9 @@ MANIFEST_SCHEMA = vol.Schema(
                 {
                     vol.Optional("vid"): vol.All(str, verify_uppercase),
                     vol.Optional("pid"): vol.All(str, verify_uppercase),
+                    vol.Optional("serial_number"): vol.All(str, verify_lowercase),
+                    vol.Optional("manufacturer"): vol.All(str, verify_lowercase),
+                    vol.Optional("description"): vol.All(str, verify_lowercase),
                     vol.Optional("known_devices"): [str],
                 }
             )

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.components import usb
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.setup import async_setup_component
 
-from . import slae_sh_device
+from . import conbee_device, slae_sh_device
 
 
 @pytest.fixture(name="operating_system")
@@ -169,6 +169,258 @@ async def test_discovered_by_websocket_scan(hass, hass_ws_client):
 
     assert len(mock_config_flow.mock_calls) == 1
     assert mock_config_flow.mock_calls[0][1][0] == "test1"
+
+
+async def test_discovered_by_websocket_scan_limited_by_description_matcher(
+    hass, hass_ws_client
+):
+    """Test a device is discovered from websocket scan is limited by the description matcher."""
+    new_usb = [
+        {"domain": "test1", "vid": "3039", "pid": "3039", "description": "*2652*"}
+    ]
+
+    mock_comports = [
+        MagicMock(
+            device=slae_sh_device.device,
+            vid=12345,
+            pid=12345,
+            serial_number=slae_sh_device.serial_number,
+            manufacturer=slae_sh_device.manufacturer,
+            description=slae_sh_device.description,
+        )
+    ]
+
+    with patch("pyudev.Context", side_effect=ImportError), patch(
+        "homeassistant.components.usb.async_get_usb", return_value=new_usb
+    ), patch(
+        "homeassistant.components.usb.comports", return_value=mock_comports
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow:
+        assert await async_setup_component(hass, "usb", {"usb": {}})
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json({"id": 1, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+        await hass.async_block_till_done()
+
+    assert len(mock_config_flow.mock_calls) == 1
+    assert mock_config_flow.mock_calls[0][1][0] == "test1"
+
+
+async def test_discovered_by_websocket_scan_rejected_by_description_matcher(
+    hass, hass_ws_client
+):
+    """Test a device is discovered from websocket scan rejected by the description matcher."""
+    new_usb = [
+        {"domain": "test1", "vid": "3039", "pid": "3039", "description": "*not_it*"}
+    ]
+
+    mock_comports = [
+        MagicMock(
+            device=slae_sh_device.device,
+            vid=12345,
+            pid=12345,
+            serial_number=slae_sh_device.serial_number,
+            manufacturer=slae_sh_device.manufacturer,
+            description=slae_sh_device.description,
+        )
+    ]
+
+    with patch("pyudev.Context", side_effect=ImportError), patch(
+        "homeassistant.components.usb.async_get_usb", return_value=new_usb
+    ), patch(
+        "homeassistant.components.usb.comports", return_value=mock_comports
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow:
+        assert await async_setup_component(hass, "usb", {"usb": {}})
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json({"id": 1, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+        await hass.async_block_till_done()
+
+    assert len(mock_config_flow.mock_calls) == 0
+
+
+async def test_discovered_by_websocket_scan_limited_by_serial_number_matcher(
+    hass, hass_ws_client
+):
+    """Test a device is discovered from websocket scan is limited by the serial_number matcher."""
+    new_usb = [
+        {
+            "domain": "test1",
+            "vid": "3039",
+            "pid": "3039",
+            "serial_number": "00_12_4b_00*",
+        }
+    ]
+
+    mock_comports = [
+        MagicMock(
+            device=slae_sh_device.device,
+            vid=12345,
+            pid=12345,
+            serial_number=slae_sh_device.serial_number,
+            manufacturer=slae_sh_device.manufacturer,
+            description=slae_sh_device.description,
+        )
+    ]
+
+    with patch("pyudev.Context", side_effect=ImportError), patch(
+        "homeassistant.components.usb.async_get_usb", return_value=new_usb
+    ), patch(
+        "homeassistant.components.usb.comports", return_value=mock_comports
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow:
+        assert await async_setup_component(hass, "usb", {"usb": {}})
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json({"id": 1, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+        await hass.async_block_till_done()
+
+    assert len(mock_config_flow.mock_calls) == 1
+    assert mock_config_flow.mock_calls[0][1][0] == "test1"
+
+
+async def test_discovered_by_websocket_scan_rejected_by_serial_number_matcher(
+    hass, hass_ws_client
+):
+    """Test a device is discovered from websocket scan is rejected by the serial_number matcher."""
+    new_usb = [
+        {"domain": "test1", "vid": "3039", "pid": "3039", "serial_number": "123*"}
+    ]
+
+    mock_comports = [
+        MagicMock(
+            device=slae_sh_device.device,
+            vid=12345,
+            pid=12345,
+            serial_number=slae_sh_device.serial_number,
+            manufacturer=slae_sh_device.manufacturer,
+            description=slae_sh_device.description,
+        )
+    ]
+
+    with patch("pyudev.Context", side_effect=ImportError), patch(
+        "homeassistant.components.usb.async_get_usb", return_value=new_usb
+    ), patch(
+        "homeassistant.components.usb.comports", return_value=mock_comports
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow:
+        assert await async_setup_component(hass, "usb", {"usb": {}})
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json({"id": 1, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+        await hass.async_block_till_done()
+
+    assert len(mock_config_flow.mock_calls) == 0
+
+
+async def test_discovered_by_websocket_scan_limited_by_manufacturer_matcher(
+    hass, hass_ws_client
+):
+    """Test a device is discovered from websocket scan is limited by the manufacturer matcher."""
+    new_usb = [
+        {
+            "domain": "test1",
+            "vid": "3039",
+            "pid": "3039",
+            "manufacturer": "dresden elektronik ingenieurtechnik*",
+        }
+    ]
+
+    mock_comports = [
+        MagicMock(
+            device=conbee_device.device,
+            vid=12345,
+            pid=12345,
+            serial_number=conbee_device.serial_number,
+            manufacturer=conbee_device.manufacturer,
+            description=conbee_device.description,
+        )
+    ]
+
+    with patch("pyudev.Context", side_effect=ImportError), patch(
+        "homeassistant.components.usb.async_get_usb", return_value=new_usb
+    ), patch(
+        "homeassistant.components.usb.comports", return_value=mock_comports
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow:
+        assert await async_setup_component(hass, "usb", {"usb": {}})
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json({"id": 1, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+        await hass.async_block_till_done()
+
+    assert len(mock_config_flow.mock_calls) == 1
+    assert mock_config_flow.mock_calls[0][1][0] == "test1"
+
+
+async def test_discovered_by_websocket_scan_rejected_by_manufacturer_matcher(
+    hass, hass_ws_client
+):
+    """Test a device is discovered from websocket scan is rejected by the manufacturer matcher."""
+    new_usb = [
+        {
+            "domain": "test1",
+            "vid": "3039",
+            "pid": "3039",
+            "manufacturer": "other vendor*",
+        }
+    ]
+
+    mock_comports = [
+        MagicMock(
+            device=conbee_device.device,
+            vid=12345,
+            pid=12345,
+            serial_number=conbee_device.serial_number,
+            manufacturer=conbee_device.manufacturer,
+            description=conbee_device.description,
+        )
+    ]
+
+    with patch("pyudev.Context", side_effect=ImportError), patch(
+        "homeassistant.components.usb.async_get_usb", return_value=new_usb
+    ), patch(
+        "homeassistant.components.usb.comports", return_value=mock_comports
+    ), patch.object(
+        hass.config_entries.flow, "async_init"
+    ) as mock_config_flow:
+        assert await async_setup_component(hass, "usb", {"usb": {}})
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json({"id": 1, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+        await hass.async_block_till_done()
+
+    assert len(mock_config_flow.mock_calls) == 0
 
 
 async def test_discovered_by_websocket_scan_match_vid_only(hass, hass_ws_client):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #55225 (part 1)

Todo:
- [x] Remove Electrolama zig-a-zig-ah from tested devices docs since it doesn't have any identifiers that allow us to keep it with the new design https://github.com/home-assistant/home-assistant.io/pull/19084
- [x] Update dev docs: https://github.com/home-assistant/developers.home-assistant/pull/1039


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/55225
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
