### PR TITLE
Defer zha auto configure probe until after clicking configure

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -36,7 +36,6 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize flow instance."""
         self._device_path = None
         self._radio_type = None
-        self._auto_detected_data = None
         self._title = None
 
     async def async_step_user(self, user_input=None):
@@ -124,15 +123,6 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if flow["handler"] == "deconz":
                 return self.async_abort(reason="not_zha_device")
 
-        # The Nortek sticks are a special case since they
-        # have a Z-Wave and a Zigbee radio. We need to reject
-        # the Z-Wave radio.
-        if vid == "10C4" and pid == "8A2A" and "ZigBee" not in description:
-            return self.async_abort(reason="not_zha_device")
-
-        self._auto_detected_data = await detect_radios(dev_path)
-        if self._auto_detected_data is None:
-            return self.async_abort(reason="not_zha_device")
         self._device_path = dev_path
         self._title = usb.human_readable_device_name(
             dev_path,
@@ -149,9 +139,15 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_confirm(self, user_input=None):
         """Confirm a discovery."""
         if user_input is not None:
+            auto_detected_data = await detect_radios(self._device_path)
+            if auto_detected_data is None:
+                # This probably will not happen how they have
+                # have very specific usb matching, but there could
+                # be a problem with the device
+                return self.async_abort(reason="usb_probe_failed")
             return self.async_create_entry(
                 title=self._title,
-                data=self._auto_detected_data,
+                data=auto_detected_data,
             )
 
         return self.async_show_form(

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -30,7 +30,8 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "not_zha_device": "This device is not a zha device"
+      "not_zha_device": "This device is not a zha device",
+      "usb_probe_failed": "Failed to probe the usb device"
     }
   },
   "config_panel": {

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -164,27 +164,17 @@ async def test_discovery_via_usb_no_radio(detect_mock, hass):
         "zha", context={"source": SOURCE_USB}, data=discovery_info
     )
     await hass.async_block_till_done()
-    assert result["type"] == RESULT_TYPE_ABORT
-    assert result["reason"] == "not_zha_device"
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "confirm"
 
+    with patch("homeassistant.components.zha.async_setup_entry"):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        await hass.async_block_till_done()
 
-@patch("zigpy_znp.zigbee.application.ControllerApplication.probe", return_value=True)
-async def test_discovery_via_usb_rejects_nortek_zwave(detect_mock, hass):
-    """Test usb flow -- reject the nortek zwave radio."""
-    discovery_info = {
-        "device": "/dev/null",
-        "vid": "10C4",
-        "pid": "8A2A",
-        "serial_number": "612020FD",
-        "description": "HubZ Smart Home Controller - HubZ Z-Wave Com Port",
-        "manufacturer": "Silicon Labs",
-    }
-    result = await hass.config_entries.flow.async_init(
-        "zha", context={"source": SOURCE_USB}, data=discovery_info
-    )
-    await hass.async_block_till_done()
-    assert result["type"] == RESULT_TYPE_ABORT
-    assert result["reason"] == "not_zha_device"
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "usb_probe_failed"
 
 
 @patch("zigpy_znp.zigbee.application.ControllerApplication.probe", return_value=True)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Requires #55236 to add specific matching to ensure we have a `zha` device.

We only probe after they hit configure now.

Fixes #55225 (part 2)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/55225
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
