### PR TITLE
Remove un-needed asserts on hass in Amecrest

### DIFF
--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -232,8 +232,6 @@ class AmcrestBinarySensor(BinarySensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to signals."""
-        assert self.hass is not None
-
         self._unsub_dispatcher.append(
             async_dispatcher_connect(
                 self.hass,

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -180,7 +180,6 @@ class AmcrestCam(Camera):
             raise CannotSnapshot
 
     async def _async_get_image(self) -> None:
-        assert self.hass is not None
         try:
             # Send the request to snap a picture and return raw jpg data
             # Snapshot command needs a much longer read timeout than other commands.
@@ -201,7 +200,6 @@ class AmcrestCam(Camera):
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return a still image response from the camera."""
-        assert self.hass is not None
         _LOGGER.debug("Take snapshot from %s", self._name)
         try:
             # Amcrest cameras only support one snapshot command at a time.
@@ -226,7 +224,6 @@ class AmcrestCam(Camera):
         self, request: web.Request
     ) -> web.StreamResponse | None:
         """Return an MJPEG stream."""
-        assert self.hass is not None
         # The snapshot implementation is handled by the parent class
         if self._stream_source == "snapshot":
             return await super().handle_async_mjpeg_stream(request)
@@ -344,7 +341,6 @@ class AmcrestCam(Camera):
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to signals and add camera to list."""
-        assert self.hass is not None
         self._unsub_dispatcher.extend(
             async_dispatcher_connect(
                 self.hass,
@@ -364,7 +360,6 @@ class AmcrestCam(Camera):
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove camera from list and disconnect from signals."""
-        assert self.hass is not None
         self.hass.data[DATA_AMCREST][CAMERAS].remove(self.entity_id)
         for unsub_dispatcher in self._unsub_dispatcher:
             unsub_dispatcher()
@@ -428,57 +423,46 @@ class AmcrestCam(Camera):
 
     async def async_enable_recording(self) -> None:
         """Call the job and enable recording."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self._enable_recording, True)
 
     async def async_disable_recording(self) -> None:
         """Call the job and disable recording."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self._enable_recording, False)
 
     async def async_enable_audio(self) -> None:
         """Call the job and enable audio."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self._enable_audio, True)
 
     async def async_disable_audio(self) -> None:
         """Call the job and disable audio."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self._enable_audio, False)
 
     async def async_enable_motion_recording(self) -> None:
         """Call the job and enable motion recording."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self._enable_motion_recording, True)
 
     async def async_disable_motion_recording(self) -> None:
         """Call the job and disable motion recording."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self._enable_motion_recording, False)
 
     async def async_goto_preset(self, preset: int) -> None:
         """Call the job and move camera to preset position."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self._goto_preset, preset)
 
     async def async_set_color_bw(self, color_bw: str) -> None:
         """Call the job and set camera color mode."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self._set_color_bw, color_bw)
 
     async def async_start_tour(self) -> None:
         """Call the job and start camera tour."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self._start_tour, True)
 
     async def async_stop_tour(self) -> None:
         """Call the job and stop camera tour."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self._start_tour, False)
 
     async def async_ptz_control(self, movement: str, travel_time: float) -> None:
         """Move or zoom camera in specified direction."""
-        assert self.hass is not None
         code = _ACTION[_MOV.index(movement)]
 
         kwargs = {"code": code, "arg1": 0, "arg2": 0, "arg3": 0}

--- a/homeassistant/components/amcrest/sensor.py
+++ b/homeassistant/components/amcrest/sensor.py
@@ -129,7 +129,6 @@ class AmcrestSensor(SensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to update signal."""
-        assert self.hass is not None
         self._unsub_dispatcher = async_dispatcher_connect(
             self.hass,
             service_signal(SERVICE_UPDATE, self._signal_name),


### PR DESCRIPTION
## Proposed change

As noted in #54761, the asserts that the `hass` property of the entities is not None is not needed because of the way this is annotated in the base class

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
