### PR TITLE
Add color mode support to zengge light

### DIFF
--- a/homeassistant/components/zengge/light.py
+++ b/homeassistant/components/zengge/light.py
@@ -9,11 +9,10 @@ from zengge import zengge
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
-    ATTR_WHITE_VALUE,
+    ATTR_WHITE,
+    COLOR_MODE_HS,
+    COLOR_MODE_WHITE,
     PLATFORM_SCHEMA,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_WHITE_VALUE,
     LightEntity,
 )
 from homeassistant.const import CONF_DEVICES, CONF_NAME
@@ -24,8 +23,6 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
-
-SUPPORT_ZENGGE_LED = SUPPORT_BRIGHTNESS | SUPPORT_COLOR | SUPPORT_WHITE_VALUE
 
 DEVICE_SCHEMA = vol.Schema({vol.Optional(CONF_NAME): cv.string})
 
@@ -103,20 +100,27 @@ class ZenggeLight(LightEntity):
         return self._white
 
     @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORT_ZENGGE_LED
+    def color_mode(self):
+        """Return the current color mode."""
+        if self._white != 0:
+            return COLOR_MODE_WHITE
+        return COLOR_MODE_HS
+
+    @property
+    def supported_color_modes(self):
+        """Flag supported color modes."""
+        return {COLOR_MODE_HS, COLOR_MODE_WHITE}
 
     @property
     def assumed_state(self):
         """We can report the actual state."""
         return False
 
-    def set_rgb(self, red, green, blue):
+    def _set_rgb(self, red, green, blue):
         """Set the rgb state."""
         return self._bulb.set_rgb(red, green, blue)
 
-    def set_white(self, white):
+    def _set_white(self, white):
         """Set the white state."""
         return self._bulb.set_white(white)
 
@@ -126,28 +130,29 @@ class ZenggeLight(LightEntity):
         self._bulb.on()
 
         hs_color = kwargs.get(ATTR_HS_COLOR)
-        white = kwargs.get(ATTR_WHITE_VALUE)
+        white = kwargs.get(ATTR_WHITE)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
 
         if white is not None:
-            self._white = white
+            # Change the bulb to white
+            self._brightness = self._white = white
             self._hs_color = (0, 0)
 
         if hs_color is not None:
+            # Change the bulb to hs
             self._white = 0
             self._hs_color = hs_color
 
         if brightness is not None:
-            self._white = 0
             self._brightness = brightness
 
         if self._white != 0:
-            self.set_white(self._white)
+            self._set_white(self._brightness)
         else:
             rgb = color_util.color_hsv_to_RGB(
                 self._hs_color[0], self._hs_color[1], self._brightness / 255 * 100
             )
-            self.set_rgb(*rgb)
+            self._set_rgb(*rgb)
 
     def turn_off(self, **kwargs):
         """Turn the specified light off."""
@@ -161,4 +166,6 @@ class ZenggeLight(LightEntity):
         self._hs_color = hsv[:2]
         self._brightness = (hsv[2] / 100) * 255
         self._white = self._bulb.get_white()
+        if self._white:
+            self._brightness = self._white
         self._state = self._bulb.get_on()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
zengge lights no longer support `white_value`, use `white` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add color_ mode support to zengge light
Flag support for hs and white color modes

Note:
The driver for this PR is that white_value is deprecated, with a plan for complete removal in 2021.10.

I have no way to test the changes myself, so I'm marking this PR as draft for now

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
