### PR TITLE
Fix yeelight brightness when nightlight switch is disabled

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -859,7 +859,12 @@ class YeelightColorLightWithoutNightlightSwitch(
 
     @property
     def _brightness_property(self):
-        return "current_brightness"
+        # If the nightlight is not active, we do not
+        # want to "current_brightness" since it will check
+        # "bg_power" and main light could still be on
+        if self.device.is_nightlight_enabled:
+            return "current_brightness"
+        return super()._brightness_property
 
 
 class YeelightColorLightWithNightlightSwitch(
@@ -883,7 +888,12 @@ class YeelightWhiteTempWithoutNightlightSwitch(
 
     @property
     def _brightness_property(self):
-        return "current_brightness"
+        # If the nightlight is not active, we do not
+        # want to "current_brightness" since it will check
+        # "bg_power" and main light could still be on
+        if self.device.is_nightlight_enabled:
+            return "current_brightness"
+        return super()._brightness_property
 
 
 class YeelightWithNightLight(

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -96,6 +96,7 @@ from homeassistant.util.color import (
 )
 
 from . import (
+    CAPABILITIES,
     ENTITY_LIGHT,
     ENTITY_NIGHTLIGHT,
     IP_ADDRESS,
@@ -1178,3 +1179,38 @@ async def test_state_fails_to_update_triggers_update(hass: HomeAssistant):
     )
     assert len(mocked_bulb.async_turn_on.mock_calls) == 1
     assert len(mocked_bulb.async_get_properties.mock_calls) == 3
+
+
+async def test_ambilight_with_nightlight_disabled(hass: HomeAssistant):
+    """Test that main light on ambilights with the nightlight disabled shows the correct brightness."""
+    mocked_bulb = _mocked_bulb()
+    properties = {**PROPERTIES}
+    capabilities = {**CAPABILITIES}
+    capabilities["model"] = "ceiling10"
+    properties["color_mode"] = "3"  # HSV
+    properties["bg_power"] = "off"
+    properties["current_brightness"] = 0
+    properties["bg_lmode"] = "2"  # CT
+    mocked_bulb.last_properties = properties
+    mocked_bulb.bulb_type = BulbType.WhiteTempMood
+    main_light_entity_id = "light.yeelight_ceiling10_0x15243f"
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**CONFIG_ENTRY_DATA, CONF_NIGHTLIGHT_SWITCH: False},
+        options={**CONFIG_ENTRY_DATA, CONF_NIGHTLIGHT_SWITCH: False},
+    )
+    config_entry.add_to_hass(hass)
+    with _patch_discovery(capabilities=capabilities), patch(
+        f"{MODULE}.AsyncBulb", return_value=mocked_bulb
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        # We use asyncio.create_task now to avoid
+        # blocking starting so we need to block again
+        await hass.async_block_till_done()
+
+    state = hass.states.get(main_light_entity_id)
+    assert state.state == "on"
+    # bg_power off should not set the brightness to 0
+    assert state.attributes[ATTR_BRIGHTNESS] == 128


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- If the nightlight switch was disabled, the current_brightness property
  would be used. If the ambient light was turned off `current_brightness`
  is always set to 0 because `bg_power` is off even though the main light
  was on

https://gitlab.com/stavros/python-yeelight/-/blob/master/yeelight/main.py#L667

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
