### PR TITLE
Ensure yeelight model is set in the config entry

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -196,7 +196,6 @@ async def _async_initialize(
     entry_data = hass.data[DOMAIN][DATA_CONFIG_ENTRIES][entry.entry_id] = {
         DATA_PLATFORMS_LOADED: False
     }
-    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     @callback
     def _async_load_platforms():
@@ -212,6 +211,12 @@ async def _async_initialize(
     await device.async_setup()
     entry_data[DATA_DEVICE] = device
 
+    if device.capabilities and not entry.options.get(CONF_MODEL):
+        hass.config_entries.async_update_entry(
+            entry, options={**entry.options, CONF_MODEL: device.capabilities["model"]}
+        )
+
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     entry.async_on_unload(
         async_dispatcher_connect(
             hass, DEVICE_INITIALIZED.format(host), _async_load_platforms
@@ -540,7 +545,7 @@ class YeelightDevice:
         self._config = config
         self._host = host
         self._bulb_device = bulb
-        self._capabilities = {}
+        self.capabilities = {}
         self._device_type = None
         self._available = False
         self._initialized = False
@@ -574,12 +579,12 @@ class YeelightDevice:
     @property
     def model(self):
         """Return configured/autodetected device model."""
-        return self._bulb_device.model or self._capabilities.get("model")
+        return self._bulb_device.model or self.capabilities.get("model")
 
     @property
     def fw_version(self):
         """Return the firmware version."""
-        return self._capabilities.get("fw_ver")
+        return self.capabilities.get("fw_ver")
 
     @property
     def is_nightlight_supported(self) -> bool:
@@ -674,13 +679,13 @@ class YeelightDevice:
     async def async_setup(self):
         """Fetch capabilities and setup name if available."""
         scanner = YeelightScanner.async_get(self._hass)
-        self._capabilities = await scanner.async_get_capabilities(self._host) or {}
+        self.capabilities = await scanner.async_get_capabilities(self._host) or {}
         if name := self._config.get(CONF_NAME):
             # Override default name when name is set in config
             self._name = name
-        elif self._capabilities:
+        elif self.capabilities:
             # Generate name from model and id when capabilities is available
-            self._name = _async_unique_name(self._capabilities)
+            self._name = _async_unique_name(self.capabilities)
         else:
             self._name = self._host  # Default name is host
 

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -211,7 +211,10 @@ async def _async_initialize(
     await device.async_setup()
     entry_data[DATA_DEVICE] = device
 
-    if device.capabilities and not entry.options.get(CONF_MODEL):
+    if (
+        device.capabilities
+        and entry.options.get(CONF_MODEL) != device.capabilities["model"]
+    ):
         hass.config_entries.async_update_entry(
             entry, options={**entry.options, CONF_MODEL: device.capabilities["model"]}
         )

--- a/homeassistant/components/yeelight/config_flow.py
+++ b/homeassistant/components/yeelight/config_flow.py
@@ -96,7 +96,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return self.async_create_entry(
                 title=async_format_model_id(self._discovered_model, self.unique_id),
-                data={CONF_ID: self.unique_id, CONF_HOST: self._discovered_ip},
+                data={
+                    CONF_ID: self.unique_id,
+                    CONF_HOST: self._discovered_ip,
+                    CONF_MODEL: self._discovered_model,
+                },
             )
 
         self._set_confirm_only()
@@ -129,6 +133,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_HOST: user_input[CONF_HOST],
                         CONF_ID: self.unique_id,
+                        CONF_MODEL: model,
                     },
                 )
 
@@ -151,7 +156,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             host = urlparse(capabilities["location"]).hostname
             return self.async_create_entry(
                 title=_async_unique_name(capabilities),
-                data={CONF_ID: unique_id, CONF_HOST: host},
+                data={
+                    CONF_ID: unique_id,
+                    CONF_HOST: host,
+                    CONF_MODEL: capabilities["model"],
+                },
             )
 
         configured_devices = {

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.components.yeelight import (
     DOMAIN,
     NIGHTLIGHT_SWITCH_TYPE_LIGHT,
 )
-from homeassistant.components.yeelight.config_flow import CannotConnect
+from homeassistant.components.yeelight.config_flow import MODEL_UNKNOWN, CannotConnect
 from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_ID, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
@@ -28,6 +28,7 @@ from . import (
     CAPABILITIES,
     ID,
     IP_ADDRESS,
+    MODEL,
     MODULE,
     MODULE_CONFIG_FLOW,
     NAME,
@@ -87,7 +88,7 @@ async def test_discovery(hass: HomeAssistant):
         )
     assert result3["type"] == "create_entry"
     assert result3["title"] == UNIQUE_FRIENDLY_NAME
-    assert result3["data"] == {CONF_ID: ID, CONF_HOST: IP_ADDRESS}
+    assert result3["data"] == {CONF_ID: ID, CONF_HOST: IP_ADDRESS, CONF_MODEL: MODEL}
     await hass.async_block_till_done()
     mock_setup.assert_called_once()
     mock_setup_entry.assert_called_once()
@@ -160,7 +161,11 @@ async def test_discovery_with_existing_device_present(hass: HomeAssistant):
         )
         assert result3["type"] == "create_entry"
         assert result3["title"] == UNIQUE_FRIENDLY_NAME
-        assert result3["data"] == {CONF_ID: ID, CONF_HOST: IP_ADDRESS}
+        assert result3["data"] == {
+            CONF_ID: ID,
+            CONF_HOST: IP_ADDRESS,
+            CONF_MODEL: MODEL,
+        }
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
@@ -300,7 +305,11 @@ async def test_manual(hass: HomeAssistant):
         await hass.async_block_till_done()
     assert result4["type"] == "create_entry"
     assert result4["title"] == "Color 0x15243f"
-    assert result4["data"] == {CONF_HOST: IP_ADDRESS, CONF_ID: "0x000000000015243f"}
+    assert result4["data"] == {
+        CONF_HOST: IP_ADDRESS,
+        CONF_ID: "0x000000000015243f",
+        CONF_MODEL: MODEL,
+    }
 
     # Duplicate
     result = await hass.config_entries.flow.async_init(
@@ -383,7 +392,11 @@ async def test_manual_no_capabilities(hass: HomeAssistant):
             result["flow_id"], {CONF_HOST: IP_ADDRESS}
         )
     assert result["type"] == "create_entry"
-    assert result["data"] == {CONF_HOST: IP_ADDRESS, CONF_ID: None}
+    assert result["data"] == {
+        CONF_HOST: IP_ADDRESS,
+        CONF_ID: None,
+        CONF_MODEL: MODEL_UNKNOWN,
+    }
 
 
 async def test_discovered_by_homekit_and_dhcp(hass):
@@ -480,7 +493,11 @@ async def test_discovered_by_dhcp_or_homekit(hass, source, data):
         await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
-    assert result2["data"] == {CONF_HOST: IP_ADDRESS, CONF_ID: "0x000000000015243f"}
+    assert result2["data"] == {
+        CONF_HOST: IP_ADDRESS,
+        CONF_ID: "0x000000000015243f",
+        CONF_MODEL: MODEL,
+    }
     assert mock_async_setup.called
     assert mock_async_setup_entry.called
 
@@ -540,7 +557,11 @@ async def test_discovered_ssdp(hass):
         await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
-    assert result2["data"] == {CONF_HOST: IP_ADDRESS, CONF_ID: "0x000000000015243f"}
+    assert result2["data"] == {
+        CONF_HOST: IP_ADDRESS,
+        CONF_ID: "0x000000000015243f",
+        CONF_MODEL: MODEL,
+    }
     assert mock_async_setup.called
     assert mock_async_setup_entry.called
 

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -342,7 +342,7 @@ async def test_options(hass: HomeAssistant):
 
     config = {
         CONF_NAME: NAME,
-        CONF_MODEL: "",
+        CONF_MODEL: MODEL,
         CONF_TRANSITION: DEFAULT_TRANSITION,
         CONF_MODE_MUSIC: DEFAULT_MODE_MUSIC,
         CONF_SAVE_ON_CHANGE: DEFAULT_SAVE_ON_CHANGE,

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 from yeelight import BulbException, BulbType
 
 from homeassistant.components.yeelight import (
+    CONF_MODEL,
     CONF_NIGHTLIGHT_SWITCH,
     CONF_NIGHTLIGHT_SWITCH_TYPE,
     DATA_CONFIG_ENTRIES,
@@ -35,6 +36,7 @@ from . import (
     FAIL_TO_BIND_IP,
     ID,
     IP_ADDRESS,
+    MODEL,
     MODULE,
     SHORT_ID,
     _mocked_bulb,
@@ -360,6 +362,7 @@ async def test_async_listen_error_late_discovery(hass, caplog):
 
     assert "Failed to connect to bulb at" not in caplog.text
     assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.options[CONF_MODEL] == MODEL
 
 
 async def test_async_listen_error_has_host_with_id(hass: HomeAssistant):


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- If the model was not set in the config entry the light could
  be sent commands it could not handle




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
