### PR TITLE
Try to avoid rate limiting in honeywell

### DIFF
--- a/homeassistant/components/honeywell/__init__.py
+++ b/homeassistant/components/honeywell/__init__.py
@@ -1,5 +1,6 @@
 """Support for Honeywell (US) Total Connect Comfort climate systems."""
 from datetime import timedelta
+import time
 
 import somecomfort
 
@@ -106,6 +107,7 @@ class HoneywellData:
         """Refresh each enabled device."""
         for device in self.devices:
             device.refresh()
+            time.sleep(3)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def update(self) -> None:
@@ -124,7 +126,7 @@ class HoneywellData:
                 if retries == 0:
                     raise exp
 
-                result = await self._hass.async_add_executor_job(self._retry())
+                result = await self._retry()
 
                 if not result:
                     raise exp

--- a/homeassistant/components/honeywell/__init__.py
+++ b/homeassistant/components/honeywell/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.util import Throttle
 
 from .const import _LOGGER, CONF_DEV_ID, CONF_LOC_ID, DOMAIN
 
+UPDATE_LOOP_SLEEP_TIME = 5
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
 PLATFORMS = ["climate"]
 
@@ -107,7 +108,7 @@ class HoneywellData:
         """Refresh each enabled device."""
         for device in self.devices:
             await self._hass.async_add_executor_job(device.refresh)
-            await asyncio.sleep(5)
+            await asyncio.sleep(UPDATE_LOOP_SLEEP_TIME)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self) -> None:

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -386,4 +386,4 @@ class HoneywellUSThermostat(ClimateEntity):
 
     async def async_update(self):
         """Get the latest state from the service."""
-        await self._data.update()
+        await self._data.async_update()

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -107,6 +107,8 @@ HW_FAN_MODE_TO_HA = {
     "follow schedule": FAN_AUTO,
 }
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(hass, config, async_add_entities, discovery_info=None):
     """Set up the Honeywell thermostat."""

--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-@patch("homeassistant.components.honeywell.UPDATE_LOOP_SLEEP_TIME", 1)
+@patch("homeassistant.components.honeywell.UPDATE_LOOP_SLEEP_TIME", 0)
 async def test_setup_entry(hass: HomeAssistant, config_entry: MockConfigEntry):
     """Initialize the config entry."""
     config_entry.add_to_hass(hass)
@@ -18,7 +18,7 @@ async def test_setup_entry(hass: HomeAssistant, config_entry: MockConfigEntry):
     assert hass.states.async_entity_ids_count() == 1
 
 
-@patch("homeassistant.components.honeywell.UPDATE_LOOP_SLEEP_TIME", 1)
+@patch("homeassistant.components.honeywell.UPDATE_LOOP_SLEEP_TIME", 0)
 async def test_setup_multiple_thermostats(
     hass: HomeAssistant, config_entry: MockConfigEntry, location, another_device
 ) -> None:

--- a/tests/components/honeywell/test_init.py
+++ b/tests/components/honeywell/test_init.py
@@ -1,11 +1,14 @@
 """Test honeywell setup process."""
 
+from unittest.mock import patch
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
+@patch("homeassistant.components.honeywell.UPDATE_LOOP_SLEEP_TIME", 1)
 async def test_setup_entry(hass: HomeAssistant, config_entry: MockConfigEntry):
     """Initialize the config entry."""
     config_entry.add_to_hass(hass)
@@ -15,6 +18,7 @@ async def test_setup_entry(hass: HomeAssistant, config_entry: MockConfigEntry):
     assert hass.states.async_entity_ids_count() == 1
 
 
+@patch("homeassistant.components.honeywell.UPDATE_LOOP_SLEEP_TIME", 1)
 async def test_setup_multiple_thermostats(
     hass: HomeAssistant, config_entry: MockConfigEntry, location, another_device
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Many users are reporting increased TCC API rate limiting since the honeywell integration upgrade. This PR will limit the SCAN_INTERVAL and PARALLEL_UPDATE to hopefully reduce the number requests going to the TCC API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/55095

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
