### PR TITLE
Ensure yeelights resync state if they are busy on first connect

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -712,7 +712,7 @@ class YeelightDevice:
         was_available = self._available
         self._available = data.get(KEY_CONNECTED, True)
         if self._did_first_update and not was_available and self._available:
-            #
+            # On reconnect the properties may be out of sync
             #
             # We need to make sure the DEVICE_INITIALIZED dispatcher
             # before we can update on reconnect by checking self._did_first_update
@@ -722,7 +722,6 @@ class YeelightDevice:
             # to be called when async_setup_entry reaches the end of the
             # function
             #
-            # On reconnect the properties may be out of sync
             asyncio.create_task(self.async_update(True))
         async_dispatcher_send(self._hass, DATA_UPDATED.format(self._host))
 

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -707,11 +707,11 @@ class YeelightDevice:
     @callback
     def async_update_callback(self, data):
         """Update push from device."""
-        connected = data.get(KEY_CONNECTED, True)
-        if not self._available and connected:
+        was_available = self._available
+        self._available = data.get(KEY_CONNECTED, True)
+        if not was_available and self._available:
             # On reconnect the properties may be out of sync
             asyncio.create_task(self.async_update(True))
-        self._available = connected
         async_dispatcher_send(self._hass, DATA_UPDATED.format(self._host))
 
 

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -714,7 +714,7 @@ class YeelightDevice:
         if self._did_first_update and not was_available and self._available:
             # On reconnect the properties may be out of sync
             #
-            # We need to make sure the DEVICE_INITIALIZED dispatcher
+            # We need to make sure the DEVICE_INITIALIZED dispatcher is setup
             # before we can update on reconnect by checking self._did_first_update
             #
             # If the device drops the connection right away, we do not want to

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -6,7 +6,7 @@ import math
 
 import voluptuous as vol
 import yeelight
-from yeelight import Bulb, BulbException, Flow, RGBTransition, SleepTransition, flows
+from yeelight import Bulb, Flow, RGBTransition, SleepTransition, flows
 from yeelight.enums import BulbType, LightType, PowerMode, SceneClass
 
 from homeassistant.components.light import (
@@ -49,6 +49,7 @@ from . import (
     ATTR_COUNT,
     ATTR_MODE_MUSIC,
     ATTR_TRANSITIONS,
+    BULB_EXCEPTIONS,
     CONF_FLOW_PARAMS,
     CONF_MODE_MUSIC,
     CONF_NIGHTLIGHT_SWITCH,
@@ -241,7 +242,7 @@ def _async_cmd(func):
         try:
             _LOGGER.debug("Calling %s with %s %s", func, args, kwargs)
             return await func(self, *args, **kwargs)
-        except BulbException as ex:
+        except BULB_EXCEPTIONS as ex:
             _LOGGER.error("Error when calling %s: %s", func, ex)
 
     return _async_wrap
@@ -678,7 +679,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
             flow = Flow(count=count, transitions=transitions)
             try:
                 await self._bulb.async_start_flow(flow, light_type=self.light_type)
-            except BulbException as ex:
+            except BULB_EXCEPTIONS as ex:
                 _LOGGER.error("Unable to set flash: %s", ex)
 
     @_async_cmd
@@ -709,7 +710,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         try:
             await self._bulb.async_start_flow(flow, light_type=self.light_type)
             self._effect = effect
-        except BulbException as ex:
+        except BULB_EXCEPTIONS as ex:
             _LOGGER.error("Unable to set effect: %s", ex)
 
     async def async_turn_on(self, **kwargs) -> None:
@@ -737,7 +738,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
                 await self.hass.async_add_executor_job(
                     self.set_music_mode, self.config[CONF_MODE_MUSIC]
                 )
-            except BulbException as ex:
+            except BULB_EXCEPTIONS as ex:
                 _LOGGER.error(
                     "Unable to turn on music mode, consider disabling it: %s", ex
                 )
@@ -750,7 +751,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
             await self.async_set_brightness(brightness, duration)
             await self.async_set_flash(flash)
             await self.async_set_effect(effect)
-        except BulbException as ex:
+        except BULB_EXCEPTIONS as ex:
             _LOGGER.error("Unable to set bulb properties: %s", ex)
             return
 
@@ -758,7 +759,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         if self.config[CONF_SAVE_ON_CHANGE] and (brightness or colortemp or rgb):
             try:
                 await self.async_set_default()
-            except BulbException as ex:
+            except BULB_EXCEPTIONS as ex:
                 _LOGGER.error("Unable to set the defaults: %s", ex)
                 return
 
@@ -784,7 +785,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         """Set a power mode."""
         try:
             await self._bulb.async_set_power_mode(PowerMode[mode.upper()])
-        except BulbException as ex:
+        except BULB_EXCEPTIONS as ex:
             _LOGGER.error("Unable to set the power mode: %s", ex)
 
     async def async_start_flow(self, transitions, count=0, action=ACTION_RECOVER):
@@ -795,7 +796,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
             )
 
             await self._bulb.async_start_flow(flow, light_type=self.light_type)
-        except BulbException as ex:
+        except BULB_EXCEPTIONS as ex:
             _LOGGER.error("Unable to set effect: %s", ex)
 
     async def async_set_scene(self, scene_class, *args):
@@ -806,7 +807,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         """
         try:
             await self._bulb.async_set_scene(scene_class, *args)
-        except BulbException as ex:
+        except BULB_EXCEPTIONS as ex:
             _LOGGER.error("Unable to set scene: %s", ex)
 
 

--- a/tests/components/yeelight/__init__.py
+++ b/tests/components/yeelight/__init__.py
@@ -110,6 +110,10 @@ class MockAsyncBulb:
         """Drop the listener."""
         self._async_callback = None
 
+    def set_capabilities(self, capabilities):
+        """Mock setting capabilities."""
+        self.capabilities = capabilities
+
 
 def _mocked_bulb(cannot_connect=False):
     bulb = MockAsyncBulb(MODEL, BulbType.Color, cannot_connect)
@@ -136,6 +140,7 @@ def _mocked_bulb(cannot_connect=False):
     bulb.async_set_power_mode = AsyncMock()
     bulb.async_set_scene = AsyncMock()
     bulb.async_set_default = AsyncMock()
+    bulb.start_music = MagicMock()
     return bulb
 
 

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 from yeelight import BulbException, BulbType
+from yeelight.aio import KEY_CONNECTED
 
 from homeassistant.components.yeelight import (
     CONF_MODEL,
@@ -414,3 +415,29 @@ async def test_async_setup_with_missing_id(hass: HomeAssistant):
 
     assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.data[CONF_ID] == ID
+
+
+async def test_connection_dropped_resyncs_properties(hass: HomeAssistant):
+    """Test handling a connection drop results in a property resync."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=ID,
+        data={CONF_HOST: "127.0.0.1"},
+        options={CONF_NAME: "Test name"},
+    )
+    config_entry.add_to_hass(hass)
+    mocked_bulb = _mocked_bulb()
+
+    with _patch_discovery(), _patch_discovery_timeout(), _patch_discovery_interval(), patch(
+        f"{MODULE}.AsyncBulb", return_value=mocked_bulb
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert len(mocked_bulb.async_get_properties.mock_calls) == 1
+        mocked_bulb._async_callback({KEY_CONNECTED: False})
+        await hass.async_block_till_done()
+        assert len(mocked_bulb.async_get_properties.mock_calls) == 1
+        mocked_bulb._async_callback({KEY_CONNECTED: True})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+        assert len(mocked_bulb.async_get_properties.mock_calls) == 2


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ensure yeelights resync state if they are busy on first connect

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #55332
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
