### PR TITLE
Make zwave_js node status sensor always available when connected

### DIFF
--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -481,9 +481,6 @@ class ZWaveNodeStatusSensor(SensorEntity):
             self.node.on("interview started", self._update_availability)
         )
         self.async_on_remove(
-            self.node.on("interview failed", self._update_availability)
-        )
-        self.async_on_remove(
             self.node.on("interview completed", self._update_availability)
         )
         # Add value_changed callbacks.

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -468,21 +468,8 @@ class ZWaveNodeStatusSensor(SensorEntity):
         self._attr_native_value = self.node.status.name.lower()
         self.async_write_ha_state()
 
-    @callback
-    def _update_availability(self, event: dict) -> None:
-        """Call when availability needs to be checked and possible updated."""
-        self.async_write_ha_state()
-
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
-        self.async_on_remove(self.node.on("ready", self._update_availability))
-        self.async_on_remove(self.node.on("value updated", self._update_availability))
-        self.async_on_remove(
-            self.node.on("interview started", self._update_availability)
-        )
-        self.async_on_remove(
-            self.node.on("interview completed", self._update_availability)
-        )
         # Add value_changed callbacks.
         for evt in ("wake up", "sleep", "dead", "alive"):
             self.async_on_remove(self.node.on(evt, self._status_changed))
@@ -494,8 +481,3 @@ class ZWaveNodeStatusSensor(SensorEntity):
             )
         )
         self.async_write_ha_state()
-
-    @property
-    def available(self) -> bool:
-        """Return entity availability."""
-        return self.client.connected and bool(self.node.ready)

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -769,6 +769,16 @@ def lock_id_lock_as_id150(client, lock_id_lock_as_id150_state):
     return node
 
 
+@pytest.fixture(name="lock_id_lock_as_id150_not_ready")
+def node_not_ready(client, lock_id_lock_as_id150_state):
+    """Mock an id lock id-150 lock node that's not ready."""
+    state = copy.deepcopy(lock_id_lock_as_id150_state)
+    state["ready"] = False
+    node = Node(client, state)
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
 @pytest.fixture(name="climate_radio_thermostat_ct101_multiple_temp_units")
 def climate_radio_thermostat_ct101_multiple_temp_units_fixture(
     client, climate_radio_thermostat_ct101_multiple_temp_units_state

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
     POWER_WATT,
+    STATE_UNAVAILABLE,
     TEMP_CELSIUS,
 )
 from homeassistant.helpers import entity_registry as er
@@ -136,7 +137,7 @@ async def test_config_parameter_sensor(hass, lock_id_lock_as_id150, integration)
     assert entity_entry.disabled
 
 
-async def test_node_status_sensor(hass, lock_id_lock_as_id150, integration):
+async def test_node_status_sensor(hass, client, lock_id_lock_as_id150, integration):
     """Test node status sensor is created and gets updated on node state changes."""
     NODE_STATUS_ENTITY = "sensor.z_wave_module_for_id_lock_150_and_101_node_status"
     node = lock_id_lock_as_id150
@@ -178,6 +179,10 @@ async def test_node_status_sensor(hass, lock_id_lock_as_id150, integration):
     )
     node.receive_event(event)
     assert hass.states.get(NODE_STATUS_ENTITY).state == "alive"
+
+    # Disconnect the client and make sure the entity is still available
+    await client.disconnect()
+    assert hass.states.get(NODE_STATUS_ENTITY).state != STATE_UNAVAILABLE
 
 
 async def test_reset_meter(

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -185,6 +185,40 @@ async def test_node_status_sensor(hass, client, lock_id_lock_as_id150, integrati
     assert hass.states.get(NODE_STATUS_ENTITY).state != STATE_UNAVAILABLE
 
 
+async def test_node_status_sensor_not_ready(
+    hass,
+    client,
+    lock_id_lock_as_id150_not_ready,
+    lock_id_lock_as_id150_state,
+    integration,
+):
+    """Test node status sensor is created and available if node is not ready."""
+    NODE_STATUS_ENTITY = "sensor.z_wave_module_for_id_lock_150_and_101_node_status"
+    node = lock_id_lock_as_id150_not_ready
+    assert not node.ready
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(NODE_STATUS_ENTITY)
+    assert entity_entry.disabled
+    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
+    updated_entry = ent_reg.async_update_entity(
+        entity_entry.entity_id, **{"disabled_by": None}
+    )
+
+    await hass.config_entries.async_reload(integration.entry_id)
+    await hass.async_block_till_done()
+
+    assert not updated_entry.disabled
+    assert hass.states.get(NODE_STATUS_ENTITY)
+    assert hass.states.get(NODE_STATUS_ENTITY).state == "alive"
+
+    # Mark node as ready
+    event = Event("ready", {"nodeState": lock_id_lock_as_id150_state})
+    node.receive_event(event)
+    assert node.ready
+    assert hass.states.get(NODE_STATUS_ENTITY)
+    assert hass.states.get(NODE_STATUS_ENTITY).state == "alive"
+
+
 async def test_reset_meter(
     hass,
     client,


### PR DESCRIPTION
## Proposed change
~~If a node status sensor moves to unavailable, it won't become available again until the node sends a status change event. Here, we are tracking multiple node events which serve different purposes:~~
~~- `ready`, `interview started`, `interview completed` all impact the node's `ready` status~~
~~- `value updated` is an implicit way to learn that the client is connected since the entity class can't explicitly know when the client goes from disconnected to connected or vice versa. Would it instead be worth making `Client` a subclass of `EventBase` and firing an event on connect and disconnect?~~

EDIT: I've changed this to remove the `available` property from the sensor entirely. See here for context as to why: https://discord.com/channels/330944238910963714/800356888827002880/880884566536110180


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/54721
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
