### PR TITLE
Convert solarlog to coordinator

### DIFF
--- a/homeassistant/components/solarlog/__init__.py
+++ b/homeassistant/components/solarlog/__init__.py
@@ -1,12 +1,28 @@
 """Solar-Log integration."""
+from datetime import timedelta
+import logging
+from urllib.parse import ParseResult, urlparse
+
+from requests.exceptions import HTTPError, Timeout
+from sunwatcher.solarlog.solarlog import SolarLog
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import update_coordinator
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = ["sensor"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry for solarlog."""
+    coordinator = SolarlogData(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     return True
 
@@ -14,3 +30,69 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+class SolarlogData(update_coordinator.DataUpdateCoordinator):
+    """Get and update the latest data."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the data object."""
+        super().__init__(
+            hass, _LOGGER, name="SolarLog", update_interval=timedelta(seconds=60)
+        )
+
+        host_entry = entry.data[CONF_HOST]
+
+        url = urlparse(host_entry, "http")
+        netloc = url.netloc or url.path
+        path = url.path if url.netloc else ""
+        url = ParseResult("http", netloc, path, *url[3:])
+        self.unique_id = entry.entry_id
+        self.name = entry.title
+        self.host = url.geturl()
+
+    async def _async_update_data(self):
+        """Update the data from the SolarLog device."""
+        try:
+            api = await self.hass.async_add_executor_job(SolarLog, self.host)
+        except (OSError, Timeout, HTTPError) as err:
+            return update_coordinator.UpdateFailed(err)
+
+        response = api.time
+        self.logger.debug(
+            "Connection to Solarlog successful. Retrieving latest Solarlog update of %s",
+            response,
+        )
+
+        data = {}
+
+        try:
+            data["TIME"] = api.time
+            data["powerAC"] = api.power_ac
+            data["powerDC"] = api.power_dc
+            data["voltageAC"] = api.voltage_ac
+            data["voltageDC"] = api.voltage_dc
+            data["yieldDAY"] = api.yield_day / 1000
+            data["yieldYESTERDAY"] = api.yield_yesterday / 1000
+            data["yieldMONTH"] = api.yield_month / 1000
+            data["yieldYEAR"] = api.yield_year / 1000
+            data["yieldTOTAL"] = api.yield_total / 1000
+            data["consumptionAC"] = api.consumption_ac
+            data["consumptionDAY"] = api.consumption_day / 1000
+            data["consumptionYESTERDAY"] = api.consumption_yesterday / 1000
+            data["consumptionMONTH"] = api.consumption_month / 1000
+            data["consumptionYEAR"] = api.consumption_year / 1000
+            data["consumptionTOTAL"] = api.consumption_total / 1000
+            data["totalPOWER"] = api.total_power
+            data["alternatorLOSS"] = api.alternator_loss
+            data["CAPACITY"] = round(api.capacity * 100, 0)
+            data["EFFICIENCY"] = round(api.efficiency * 100, 0)
+            data["powerAVAILABLE"] = api.power_available
+            data["USAGE"] = round(api.usage * 100, 0)
+        except AttributeError as err:
+            raise update_coordinator.UpdateFailed(
+                f"Missing details data in Solarlog response: {err}"
+            ) from err
+
+        _LOGGER.debug("Updated Solarlog overview data: %s", data)
+        return data

--- a/homeassistant/components/solarlog/__init__.py
+++ b/homeassistant/components/solarlog/__init__.py
@@ -94,5 +94,10 @@ class SolarlogData(update_coordinator.DataUpdateCoordinator):
                 f"Missing details data in Solarlog response: {err}"
             ) from err
 
+        if self.data["yieldTOTAL"] == 0 and self.data["consumptionTOTAL"] == 0:
+            raise update_coordinator.UpdateFailed(
+                "Measurement with zero totals (can happen after Solarlog restart)."
+            )
+
         _LOGGER.debug("Updated Solarlog overview data: %s", data)
         return data

--- a/homeassistant/components/solarlog/__init__.py
+++ b/homeassistant/components/solarlog/__init__.py
@@ -58,10 +58,14 @@ class SolarlogData(update_coordinator.DataUpdateCoordinator):
         except (OSError, Timeout, HTTPError) as err:
             raise update_coordinator.UpdateFailed(err)
 
-        response = api.time
+        if api.time.year == 1999:
+            raise update_coordinator.UpdateFailed(
+                "Invalid data returned (can happen after Solarlog restart)."
+            )
+
         self.logger.debug(
             "Connection to Solarlog successful. Retrieving latest Solarlog update of %s",
-            response,
+            api.time,
         )
 
         data = {}
@@ -93,11 +97,6 @@ class SolarlogData(update_coordinator.DataUpdateCoordinator):
             raise update_coordinator.UpdateFailed(
                 f"Missing details data in Solarlog response: {err}"
             ) from err
-
-        if self.data["yieldTOTAL"] == 0 and self.data["consumptionTOTAL"] == 0:
-            raise update_coordinator.UpdateFailed(
-                "Measurement with zero totals (can happen after Solarlog restart)."
-            )
 
         _LOGGER.debug("Updated Solarlog overview data: %s", data)
         return data

--- a/homeassistant/components/solarlog/__init__.py
+++ b/homeassistant/components/solarlog/__init__.py
@@ -56,7 +56,7 @@ class SolarlogData(update_coordinator.DataUpdateCoordinator):
         try:
             api = await self.hass.async_add_executor_job(SolarLog, self.host)
         except (OSError, Timeout, HTTPError) as err:
-            return update_coordinator.UpdateFailed(err)
+            raise update_coordinator.UpdateFailed(err)
 
         response = api.time
         self.logger.debug(

--- a/homeassistant/components/solarlog/const.py
+++ b/homeassistant/components/solarlog/const.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import timedelta
 
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
@@ -23,12 +22,9 @@ from homeassistant.const import (
 
 DOMAIN = "solarlog"
 
-"""Default config for solarlog."""
+# Default config for solarlog.
 DEFAULT_HOST = "http://solar-log"
 DEFAULT_NAME = "solarlog"
-
-"""Fixed constants."""
-SCAN_INTERVAL = timedelta(seconds=60)
 
 
 @dataclass

--- a/homeassistant/components/solarlog/sensor.py
+++ b/homeassistant/components/solarlog/sensor.py
@@ -1,133 +1,42 @@
 """Platform for solarlog sensors."""
-import logging
-from urllib.parse import ParseResult, urlparse
-
-from requests.exceptions import HTTPError, Timeout
-from sunwatcher.solarlog.solarlog import SolarLog
-
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import CONF_HOST
-from homeassistant.util import Throttle
+from homeassistant.helpers import update_coordinator
+from homeassistant.helpers.entity import StateType
 
-from .const import DOMAIN, SCAN_INTERVAL, SENSOR_TYPES, SolarLogSensorEntityDescription
-
-_LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the solarlog platform."""
-    _LOGGER.warning(
-        "Configuration of the solarlog platform in configuration.yaml is deprecated "
-        "in Home Assistant 0.119. Please remove entry from your configuration"
-    )
+from . import SolarlogData
+from .const import DOMAIN, SENSOR_TYPES, SolarLogSensorEntityDescription
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Add solarlog entry."""
-    host_entry = entry.data[CONF_HOST]
-    device_name = entry.title
-
-    url = urlparse(host_entry, "http")
-    netloc = url.netloc or url.path
-    path = url.path if url.netloc else ""
-    url = ParseResult("http", netloc, path, *url[3:])
-    host = url.geturl()
-
-    try:
-        api = await hass.async_add_executor_job(SolarLog, host)
-        _LOGGER.debug("Connected to Solar-Log device, setting up entries")
-    except (OSError, HTTPError, Timeout):
-        _LOGGER.error(
-            "Could not connect to Solar-Log device at %s, check host ip address", host
-        )
-        return
-
-    # Create solarlog data service which will retrieve and update the data.
-    data = await hass.async_add_executor_job(SolarlogData, hass, api, host)
-
-    # Create a new sensor for each sensor type.
-    entities = [
-        SolarlogSensor(entry.entry_id, device_name, data, description)
-        for description in SENSOR_TYPES
-    ]
-    async_add_entities(entities, True)
-    return True
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        SolarlogSensor(coordinator, description) for description in SENSOR_TYPES
+    )
 
 
-class SolarlogData:
-    """Get and update the latest data."""
-
-    def __init__(self, hass, api, host):
-        """Initialize the data object."""
-        self.api = api
-        self.hass = hass
-        self.host = host
-        self.update = Throttle(SCAN_INTERVAL)(self._update)
-        self.data = {}
-
-    def _update(self):
-        """Update the data from the SolarLog device."""
-        try:
-            self.api = SolarLog(self.host)
-            response = self.api.time
-            _LOGGER.debug(
-                "Connection to Solarlog successful. Retrieving latest Solarlog update of %s",
-                response,
-            )
-        except (OSError, Timeout, HTTPError):
-            _LOGGER.error("Connection error, Could not retrieve data, skipping update")
-            return
-
-        try:
-            self.data["TIME"] = self.api.time
-            self.data["powerAC"] = self.api.power_ac
-            self.data["powerDC"] = self.api.power_dc
-            self.data["voltageAC"] = self.api.voltage_ac
-            self.data["voltageDC"] = self.api.voltage_dc
-            self.data["yieldDAY"] = self.api.yield_day / 1000
-            self.data["yieldYESTERDAY"] = self.api.yield_yesterday / 1000
-            self.data["yieldMONTH"] = self.api.yield_month / 1000
-            self.data["yieldYEAR"] = self.api.yield_year / 1000
-            self.data["yieldTOTAL"] = self.api.yield_total / 1000
-            self.data["consumptionAC"] = self.api.consumption_ac
-            self.data["consumptionDAY"] = self.api.consumption_day / 1000
-            self.data["consumptionYESTERDAY"] = self.api.consumption_yesterday / 1000
-            self.data["consumptionMONTH"] = self.api.consumption_month / 1000
-            self.data["consumptionYEAR"] = self.api.consumption_year / 1000
-            self.data["consumptionTOTAL"] = self.api.consumption_total / 1000
-            self.data["totalPOWER"] = self.api.total_power
-            self.data["alternatorLOSS"] = self.api.alternator_loss
-            self.data["CAPACITY"] = round(self.api.capacity * 100, 0)
-            self.data["EFFICIENCY"] = round(self.api.efficiency * 100, 0)
-            self.data["powerAVAILABLE"] = self.api.power_available
-            self.data["USAGE"] = round(self.api.usage * 100, 0)
-            _LOGGER.debug("Updated Solarlog overview data: %s", self.data)
-        except AttributeError:
-            _LOGGER.error("Missing details data in Solarlog response")
-
-
-class SolarlogSensor(SensorEntity):
+class SolarlogSensor(update_coordinator.CoordinatorEntity, SensorEntity):
     """Representation of a Sensor."""
+
+    entity_description: SolarLogSensorEntityDescription
 
     def __init__(
         self,
-        entry_id: str,
-        device_name: str,
-        data: SolarlogData,
+        coordinator: SolarlogData,
         description: SolarLogSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
+        super().__init__(coordinator)
         self.entity_description = description
-        self.data = data
-        self._attr_name = f"{device_name} {description.name}"
-        self._attr_unique_id = f"{entry_id}_{description.key}"
+        self._attr_name = f"{coordinator.name} {description.name}"
+        self._attr_unique_id = f"{coordinator.unique_id}_{description.key}"
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, entry_id)},
-            "name": device_name,
+            "identifiers": {(DOMAIN, coordinator.unique_id)},
+            "name": coordinator.name,
             "manufacturer": "Solar-Log",
         }
 
-    def update(self):
-        """Get the latest data from the sensor and update the state."""
-        self.data.update()
-        self._attr_native_value = self.data.data[self.entity_description.json_key]
+    @property
+    def native_value(self) -> StateType:
+        """Return the native sensor value."""
+        return self.coordinator.data[self.entity_description.json_key]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This converts the solarlog integration to use a data update coordinator. I did not test this PR as I don't have a solarlog device.

@Ernst79 can you test this?

Fixes #55254

There is still room for improvement to this integration I think, like storing the SolarLog object directly instead of converting it to a dict and moving the calculations into the `SolarLogSensorEntityDescription` object. But that I leave for someone else :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
