### PR TITLE
Add zeroconf discovery to Hue

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -207,6 +207,24 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.bridge = bridge
         return await self.async_step_link()
 
+    async def async_step_zeroconf(self, discovery_info):
+        """Handle a discovered Hue bridge.
+
+        This flow is triggered by the Zeroconf component. It will check if the
+        host is already configured and delegate to the import step if not.
+        """
+        bridge = self._async_get_bridge(
+            discovery_info["host"], discovery_info["properties"]["bridgeid"]
+        )
+
+        await self.async_set_unique_id(bridge.id)
+        self._abort_if_unique_id_configured(
+            updates={CONF_HOST: bridge.host}, reload_on_update=False
+        )
+
+        self.bridge = bridge
+        return await self.async_step_link()
+
     async def async_step_homekit(self, discovery_info):
         """Handle a discovered Hue bridge on HomeKit.
 

--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -21,6 +21,7 @@
   "homekit": {
     "models": ["BSB002"]
   },
+  "zeroconf": ["_hue._tcp.local."],
   "codeowners": ["@balloob", "@frenck"],
   "quality_scale": "platinum",
   "iot_class": "local_push"

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -131,6 +131,11 @@ ZEROCONF = {
             "name": "shelly*"
         }
     ],
+    "_hue._tcp.local.": [
+        {
+            "domain": "hue"
+        }
+    ],
     "_ipp._tcp.local.": [
         {
             "domain": "ipp"

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -681,3 +681,26 @@ def _get_schema_default(schema, key_name):
         if schema_key == key_name:
             return schema_key.default()
     raise KeyError(f"{key_name} not found in schema")
+
+
+async def test_bridge_zeroconf(hass):
+    """Test a bridge being discovered."""
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data={
+            "host": "192.168.1.217",
+            "port": 443,
+            "hostname": "Philips-hue.local.",
+            "type": "_hue._tcp.local.",
+            "name": "Philips Hue - ABCABC._hue._tcp.local.",
+            "properties": {
+                "_raw": {"bridgeid": b"ecb5fafffeabcabc", "modelid": b"BSB002"},
+                "bridgeid": "ecb5fafffeabcabc",
+                "modelid": "BSB002",
+            },
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "link"

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -704,3 +704,34 @@ async def test_bridge_zeroconf(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "link"
+
+
+async def test_bridge_zeroconf_already_exists(hass):
+    """Test a bridge being discovered by zeroconf already exists."""
+    entry = MockConfigEntry(
+        domain="hue",
+        source=config_entries.SOURCE_SSDP,
+        data={"host": "0.0.0.0"},
+        unique_id="ecb5faabcabc",
+    )
+    entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data={
+            "host": "192.168.1.217",
+            "port": 443,
+            "hostname": "Philips-hue.local.",
+            "type": "_hue._tcp.local.",
+            "name": "Philips Hue - ABCABC._hue._tcp.local.",
+            "properties": {
+                "_raw": {"bridgeid": b"ecb5faabcabc", "modelid": b"BSB002"},
+                "bridgeid": "ecb5faabcabc",
+                "modelid": "BSB002",
+            },
+        },
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    assert entry.data["host"] == "192.168.1.217"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Saw today that Hue has added mDNS discovery. Added zeroconf discovery to Hue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
