### PR TITLE
Add component for binary sensor groups

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -56,7 +56,7 @@ ATTR_ALL = "all"
 SERVICE_SET = "set"
 SERVICE_REMOVE = "remove"
 
-PLATFORMS = ["light", "cover", "notify"]
+PLATFORMS = ["light", "cover", "notify", "binary_sensor"]
 
 REG_KEY = f"{DOMAIN}_registry"
 

--- a/homeassistant/components/group/binary_sensor.py
+++ b/homeassistant/components/group/binary_sensor.py
@@ -1,0 +1,136 @@
+"""This platform allows several binary sensor to be grouped into one binary sensor."""
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import logging
+import voluptuous as vol
+
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASSES_SCHEMA,
+    DOMAIN as BINARY_SENSOR_DOMAIN,
+    PLATFORM_SCHEMA,
+    BinarySensorEntity,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DEVICE_CLASS,
+    CONF_ENTITIES,
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import CoreState, Event, HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.typing import ConfigType
+
+from . import GroupEntity
+
+DEFAULT_NAME = "Binary Sensor Group"
+
+CONF_ALL = "all"
+REG_KEY = f"{BINARY_SENSOR_DOMAIN}_registry"
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITIES): cv.entities_domain(BINARY_SENSOR_DOMAIN),
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_ALL): cv.boolean,
+    }
+)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: dict[str, Any] | None = None,
+) -> None:
+    """Set up the Group Binary Sensor platform."""
+    async_add_entities(
+        [
+            BinarySensorGroup(
+                config.get(CONF_UNIQUE_ID),
+                config[CONF_NAME],
+                config.get(CONF_DEVICE_CLASS),
+                config[CONF_ENTITIES],
+                config.get(CONF_ALL),
+            )
+        ]
+    )
+
+
+class BinarySensorGroup(GroupEntity, BinarySensorEntity):
+    """Representation of a BinarySensorGroup."""
+
+    _attr_assumed_state: bool = True
+
+    def __init__(
+        self,
+        unique_id: str | None,
+        name: str,
+        device_class: str | None,
+        entity_ids: list[str],
+        mode: str | None,
+    ) -> None:
+        """Initialize a BinarySensorGroup entity."""
+        super(BinarySensorGroup, self).__init__()
+        self._entity_ids = entity_ids
+        self._attr_name = name
+        self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
+        self._attr_unique_id = unique_id
+        self._device_class = device_class
+        self._state: Optional[str] = None
+        self.mode = any
+        if mode:
+            self.mode = all
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+
+        async def async_state_changed_listener(event: Event) -> None:
+            """Handle child updates."""
+            self.async_set_context(event.context)
+            await self.async_defer_or_update_ha_state()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, self._entity_ids, async_state_changed_listener
+            )
+        )
+
+        if self.hass.state == CoreState.running:
+            await self.async_update()
+            return
+
+        await super().async_added_to_hass()
+
+    async def async_update(self) -> None:
+        """Query all members and determine the binary sensor group state."""
+        all_states = [self.hass.states.get(x) for x in self._entity_ids]
+        filtered_states: List[str] = [x.state for x in all_states if x is not None]
+        if STATE_UNAVAILABLE in filtered_states:
+            self._state = STATE_UNAVAILABLE
+        else:
+            states = list(map(lambda x: x == STATE_ON, filtered_states))
+            state = self.mode(states)
+            self._state = STATE_ON if state else STATE_OFF
+        self.async_write_ha_state()
+
+    @property
+    def device_class(self) -> str | None:
+        """Return the sensor class of the binary sensor."""
+        return self._device_class
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if sensor is on."""
+        return bool(self._state) if self._state is not None else None

--- a/homeassistant/components/group/binary_sensor.py
+++ b/homeassistant/components/group/binary_sensor.py
@@ -116,6 +116,9 @@ class BinarySensorGroup(GroupEntity, BinarySensorEntity):
         """Query all members and determine the binary sensor group state."""
         all_states = [self.hass.states.get(x) for x in self._entity_ids]
         filtered_states: list[str] = [x.state for x in all_states if x is not None]
+        self._attr_available = any(
+            state != STATE_UNAVAILABLE for state in filtered_states
+        )
         if STATE_UNAVAILABLE in filtered_states:
             self._attr_is_on = None
         else:

--- a/tests/components/group/test_binary_sensor.py
+++ b/tests/components/group/test_binary_sensor.py
@@ -1,0 +1,94 @@
+"""The tests for the Group Binary Sensor platform."""
+from os import path
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.group import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+
+async def test_default_state(hass):
+    """Test binary_sensor group default state."""
+    hass.states.async_set("binary_sensor.kitchen", "on")
+    hass.states.async_set("binary_sensor.bedroom", "on")
+    await async_setup_component(
+        hass,
+        BINARY_SENSOR_DOMAIN,
+        {
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "entities": ["binary_sensor.kitchen", "binary_sensor.bedroom"],
+                "name": "Bedroom Group",
+                "unique_id": "unique_identifier",
+                "device_class": "presence",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.bedroom_group")
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_ENTITY_ID) == [
+        "binary_sensor.kitchen",
+        "binary_sensor.bedroom",
+    ]
+
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get("binary_sensor.bedroom_group")
+    assert entry
+    assert entry.unique_id == "unique_identifier"
+
+
+async def test_state_reporting(hass):
+    """Test the state reporting."""
+    await async_setup_component(
+        hass,
+        BINARY_SENSOR_DOMAIN,
+        {
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "entities": ["binary_sensor.test1", "binary_sensor.test2"],
+                "name": "Binary Sensor Group",
+                "device_class": "presence",
+                "all": "true",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    # binary sensors have state off if unavailable
+    hass.states.async_set("binary_sensor.test1", STATE_ON)
+    hass.states.async_set("binary_sensor.test2", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_OFF
+
+    hass.states.async_set("binary_sensor.test1", STATE_ON)
+    hass.states.async_set("binary_sensor.test2", STATE_OFF)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_OFF
+
+    hass.states.async_set("binary_sensor.test1", STATE_OFF)
+    hass.states.async_set("binary_sensor.test2", STATE_OFF)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_OFF
+
+    hass.states.async_set("binary_sensor.test1", STATE_ON)
+    hass.states.async_set("binary_sensor.test2", STATE_ON)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_ON
+
+    # binary sensors have state off if unavailable
+    hass.states.async_set("binary_sensor.test1", STATE_UNAVAILABLE)
+    hass.states.async_set("binary_sensor.test2", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_OFF
+
+
+def _get_fixtures_base_path():
+    return path.dirname(path.dirname(path.dirname(__file__)))

--- a/tests/components/group/test_binary_sensor.py
+++ b/tests/components/group/test_binary_sensor.py
@@ -43,7 +43,7 @@ async def test_default_state(hass):
     assert entry.unique_id == "unique_identifier"
 
 
-async def test_state_reporting(hass):
+async def test_state_reporting_all(hass):
     """Test the state reporting."""
     await async_setup_component(
         hass,
@@ -72,6 +72,53 @@ async def test_state_reporting(hass):
     hass.states.async_set("binary_sensor.test2", STATE_OFF)
     await hass.async_block_till_done()
     assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_OFF
+
+    hass.states.async_set("binary_sensor.test1", STATE_OFF)
+    hass.states.async_set("binary_sensor.test2", STATE_OFF)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_OFF
+
+    hass.states.async_set("binary_sensor.test1", STATE_ON)
+    hass.states.async_set("binary_sensor.test2", STATE_ON)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_ON
+
+    # binary sensors have state off if unavailable
+    hass.states.async_set("binary_sensor.test1", STATE_UNAVAILABLE)
+    hass.states.async_set("binary_sensor.test2", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_OFF
+
+
+async def test_state_reporting_any(hass):
+    """Test the state reporting."""
+    await async_setup_component(
+        hass,
+        BINARY_SENSOR_DOMAIN,
+        {
+            BINARY_SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "entities": ["binary_sensor.test1", "binary_sensor.test2"],
+                "name": "Binary Sensor Group",
+                "device_class": "presence",
+                "all": "false",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    # binary sensors have state off if unavailable
+    hass.states.async_set("binary_sensor.test1", STATE_ON)
+    hass.states.async_set("binary_sensor.test2", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_OFF
+
+    hass.states.async_set("binary_sensor.test1", STATE_ON)
+    hass.states.async_set("binary_sensor.test2", STATE_OFF)
+    await hass.async_block_till_done()
+    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_ON
 
     hass.states.async_set("binary_sensor.test1", STATE_OFF)
     hass.states.async_set("binary_sensor.test2", STATE_OFF)

--- a/tests/components/group/test_binary_sensor.py
+++ b/tests/components/group/test_binary_sensor.py
@@ -62,7 +62,6 @@ async def test_state_reporting_all(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    # binary sensors have state off if unavailable
     hass.states.async_set("binary_sensor.test1", STATE_ON)
     hass.states.async_set("binary_sensor.test2", STATE_UNAVAILABLE)
     await hass.async_block_till_done()
@@ -83,11 +82,12 @@ async def test_state_reporting_all(hass):
     await hass.async_block_till_done()
     assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_ON
 
-    # binary sensors have state off if unavailable
     hass.states.async_set("binary_sensor.test1", STATE_UNAVAILABLE)
     hass.states.async_set("binary_sensor.test2", STATE_UNAVAILABLE)
     await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_OFF
+    assert (
+        hass.states.get("binary_sensor.binary_sensor_group").state == STATE_UNAVAILABLE
+    )
 
 
 async def test_state_reporting_any(hass):
@@ -102,6 +102,7 @@ async def test_state_reporting_any(hass):
                 "name": "Binary Sensor Group",
                 "device_class": "presence",
                 "all": "false",
+                "unique_id": "unique_identifier",
             }
         },
     )
@@ -134,7 +135,14 @@ async def test_state_reporting_any(hass):
     hass.states.async_set("binary_sensor.test1", STATE_UNAVAILABLE)
     hass.states.async_set("binary_sensor.test2", STATE_UNAVAILABLE)
     await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.binary_sensor_group").state == STATE_OFF
+    assert (
+        hass.states.get("binary_sensor.binary_sensor_group").state == STATE_UNAVAILABLE
+    )
+
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get("binary_sensor.binary_sensor_group")
+    assert entry
+    assert entry.unique_id == "unique_identifier"
 
 
 def _get_fixtures_base_path():

--- a/tests/components/group/test_binary_sensor.py
+++ b/tests/components/group/test_binary_sensor.py
@@ -41,6 +41,8 @@ async def test_default_state(hass):
     entry = entity_registry.async_get("binary_sensor.bedroom_group")
     assert entry
     assert entry.unique_id == "unique_identifier"
+    assert entry.original_name == "Bedroom Group"
+    assert entry.device_class == "presence"
 
 
 async def test_state_reporting_all(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
This change allows you to create a group of binary sensors with a device class, where the group itself is a binary sensor with a configurable device class.

### Background
If you create a group of binary sensors they do not have the device class of the sensors they contain. Workaround are to create a template.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
If my code was more clever, it would do this anytime you have a heterogeneous group of sensors. But it is not, so in the yaml you must define the device class and you should be sure all the sensors are of that class - though not strictly required. 

 * Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19297

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository] https://github.com/home-assistant/home-assistant.io/pull/19297

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
