### PR TITLE
Add a perceived brightness sensor to Ambient PWS

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -260,20 +260,18 @@ class AmbientWeatherEntity(Entity):
         @callback
         def update() -> None:
             """Update the state."""
-            if self.entity_description.key == TYPE_SOLARRADIATION_LX:
-                self._attr_available = (
-                    self._ambient.stations[self._mac_address][ATTR_LAST_DATA][
-                        TYPE_SOLARRADIATION
-                    ]
-                    is not None
-                )
+            if self.entity_description.key in [
+                TYPE_SOLARRADIATION_LX,
+                TYPE_SOLARRADIATION_PERCEIVED,
+            ]:
+                target_key = TYPE_SOLARRADIATION
             else:
-                self._attr_available = (
-                    self._ambient.stations[self._mac_address][ATTR_LAST_DATA][
-                        self.entity_description.key
-                    ]
-                    is not None
-                )
+                target_key = self.entity_description.key
+
+            self._attr_available = (
+                self._ambient.stations[self._mac_address][ATTR_LAST_DATA][target_key]
+                is not None
+            )
 
             self.update_from_latest_data()
             self.async_write_ha_state()

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -44,7 +44,7 @@ DEFAULT_SOCKET_MIN_RETRY = 15
 CONFIG_SCHEMA = cv.deprecated(DOMAIN)
 
 
-def async_lux_to_perceived(value: float) -> int:
+def async_lux_to_perceived(value: int) -> int:
     """Calculate illuminance (in lux)."""
     lux = async_wm2_to_lx(value)
 

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -51,8 +51,8 @@ def async_lux_to_perceived(value: float) -> int:
     try:
         perceived = round(math.log10(lux) / 5) * 100
     except ValueError:
-        # If we've approached negative infinity, we'll get a math domain error; in that
-        # case, return 0.0:
+        # A ValueError can be thrown if the value approaches negative infinity; in that
+        # case, provide a floor:
         return 0
 
     return max(perceived, 0)

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -44,7 +44,7 @@ DEFAULT_SOCKET_MIN_RETRY = 15
 CONFIG_SCHEMA = cv.deprecated(DOMAIN)
 
 
-def async_lux_to_perceived(value: int) -> int:
+def async_lx_to_perceived(value: int) -> int:
     """Calculate illuminance (in lux)."""
     lux = async_wm2_to_lx(value)
 
@@ -69,7 +69,7 @@ def async_hydrate_station_data(data: dict[str, Any]) -> dict[str, Any]:
     """Hydrate station data with addition or normalized data."""
     if (irradiation := data.get(TYPE_SOLARRADIATION)) is not None:
         lux = data[TYPE_SOLARRADIATION_LX] = async_wm2_to_lx(irradiation)
-        data[TYPE_SOLARRADIATION_PERCEIVED] = async_lux_to_perceived(lux)
+        data[TYPE_SOLARRADIATION_PERCEIVED] = async_lx_to_perceived(lux)
 
     return data
 

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -260,10 +260,10 @@ class AmbientWeatherEntity(Entity):
         @callback
         def update() -> None:
             """Update the state."""
-            if self.entity_description.key in [
+            if self.entity_description.key in (
                 TYPE_SOLARRADIATION_LX,
                 TYPE_SOLARRADIATION_PERCEIVED,
-            ]:
+            ):
                 target_key = TYPE_SOLARRADIATION
             else:
                 target_key = self.entity_description.key

--- a/homeassistant/components/ambient_station/const.py
+++ b/homeassistant/components/ambient_station/const.py
@@ -12,3 +12,4 @@ DATA_CLIENT = "data_client"
 
 TYPE_SOLARRADIATION = "solarradiation"
 TYPE_SOLARRADIATION_LX = "solarradiation_lx"
+TYPE_SOLARRADIATION_PERCEIVED = "solarradiation_perceived"

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -27,8 +27,15 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import TYPE_SOLARRADIATION, TYPE_SOLARRADIATION_LX, AmbientWeatherEntity
-from .const import ATTR_LAST_DATA, DATA_CLIENT, DOMAIN
+from . import AmbientWeatherEntity
+from .const import (
+    ATTR_LAST_DATA,
+    DATA_CLIENT,
+    DOMAIN,
+    TYPE_SOLARRADIATION,
+    TYPE_SOLARRADIATION_LX,
+    TYPE_SOLARRADIATION_PERCEIVED,
+)
 
 TYPE_24HOURRAININ = "24hourrainin"
 TYPE_BAROMABSIN = "baromabsin"
@@ -402,6 +409,12 @@ SENSOR_DESCRIPTIONS = (
         key=TYPE_SOLARRADIATION_LX,
         name="Solar Rad (lx)",
         native_unit_of_measurement=LIGHT_LUX,
+        device_class=DEVICE_CLASS_ILLUMINANCE,
+    ),
+    SensorEntityDescription(
+        key=TYPE_SOLARRADIATION_PERCEIVED,
+        name="Solar Rad (perceived)",
+        native_unit_of_measurement=PERCENTAGE,
         device_class=DEVICE_CLASS_ILLUMINANCE,
     ),
     SensorEntityDescription(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ambient PWS implements sensors for brightness/illuminance in both w/m^2 and lux. However, both of these values tend to swing rather wildly:

<img width="379" alt="CleanShot 2021-08-27 at 21 25 54@2x" src="https://user-images.githubusercontent.com/47216/131204805-756a9dde-850a-4324-a56d-a6490a1fd414.png">

<img width="384" alt="CleanShot 2021-08-27 at 21 28 15@2x" src="https://user-images.githubusercontent.com/47216/131204858-a64e3cc3-6bf4-4322-80fb-f7cc0077bac9.png">

This PR implements an additional, "perceived brightness" sensor. Using the Weber-Fechner Law, this value is more consistent with how human vision perceives brightness (which is less prone to big swings, making it a much more reliable value for determining the percentage brightness).

<img width="374" alt="CleanShot 2021-08-27 at 21 27 12@2x" src="https://user-images.githubusercontent.com/47216/131204837-aa71adf0-b04a-48e0-9904-07f78cc1bd28.png">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
