### PR TITLE
Use individually addressed parts for LL-HLS in stream

### DIFF
--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -34,6 +34,7 @@ def async_setup_hls(hass: HomeAssistant) -> str:
     hass.http.register_view(HlsSegmentView())
     hass.http.register_view(HlsInitView())
     hass.http.register_view(HlsMasterPlaylistView())
+    hass.http.register_view(HlsPartView())
     return "/api/hls/{}/master_playlist.m3u8"
 
 
@@ -94,7 +95,7 @@ class HlsMasterPlaylistView(StreamView):
         return "\n".join(lines) + "\n"
 
     async def handle(
-        self, request: web.Request, stream: Stream, sequence: str
+        self, request: web.Request, stream: Stream, sequence: str, part_num: str
     ) -> web.Response:
         """Return m3u8 playlist."""
         track = stream.add_provider(HLS_PROVIDER)
@@ -220,7 +221,7 @@ class HlsPlaylistView(StreamView):
         )
 
     async def handle(
-        self, request: web.Request, stream: Stream, sequence: str
+        self, request: web.Request, stream: Stream, sequence: str, part_num: str
     ) -> web.Response:
         """Return m3u8 playlist."""
         track: HlsStreamOutput = cast(
@@ -263,7 +264,7 @@ class HlsPlaylistView(StreamView):
             (last_segment := track.last_segment)
             and hls_msn == last_segment.sequence
             and hls_part
-            >= len(last_segment.parts_by_byterange)
+            >= len(last_segment.parts)
             - 1
             + track.stream_settings.hls_advance_part_limit
         ):
@@ -273,7 +274,7 @@ class HlsPlaylistView(StreamView):
         while (
             (last_segment := track.last_segment)
             and hls_msn == last_segment.sequence
-            and hls_part >= len(last_segment.parts_by_byterange)
+            and hls_part >= len(last_segment.parts)
         ):
             if not await track.part_recv(
                 timeout=track.stream_settings.hls_part_timeout
@@ -287,8 +288,8 @@ class HlsPlaylistView(StreamView):
         # request as one for Part Index 0 of the following Parent Segment.
         if hls_msn + 1 == last_segment.sequence:
             if not (previous_segment := track.get_segment(hls_msn)) or (
-                hls_part >= len(previous_segment.parts_by_byterange)
-                and not last_segment.parts_by_byterange
+                hls_part >= len(previous_segment.parts)
+                and not last_segment.parts
                 and not await track.part_recv(
                     timeout=track.stream_settings.hls_part_timeout
                 )
@@ -314,7 +315,7 @@ class HlsInitView(StreamView):
     cors_allowed = True
 
     async def handle(
-        self, request: web.Request, stream: Stream, sequence: str
+        self, request: web.Request, stream: Stream, sequence: str, part_num: str
     ) -> web.Response:
         """Return init.mp4."""
         track = stream.add_provider(HLS_PROVIDER)
@@ -326,21 +327,17 @@ class HlsInitView(StreamView):
         )
 
 
-class HlsSegmentView(StreamView):
+class HlsPartView(StreamView):
     """Stream view to serve a HLS fmp4 segment."""
 
-    url = r"/api/hls/{token:[a-f0-9]+}/segment/{sequence:\d+}.m4s"
-    name = "api:stream:hls:segment"
+    url = r"/api/hls/{token:[a-f0-9]+}/segment/{sequence:\d+}.{part_num:\d+}.m4s"
+    name = "api:stream:hls:part"
     cors_allowed = True
 
     async def handle(
-        self, request: web.Request, stream: Stream, sequence: str
-    ) -> web.StreamResponse:
-        """Handle segments, part segments, and hinted segments.
-
-        For part and hinted segments, the start of the requested range must align
-        with a part boundary.
-        """
+        self, request: web.Request, stream: Stream, sequence: str, part_num: str
+    ) -> web.Response:
+        """Handle part."""
         track: HlsStreamOutput = cast(
             HlsStreamOutput, stream.add_provider(HLS_PROVIDER)
         )
@@ -360,77 +357,58 @@ class HlsSegmentView(StreamView):
                 status=404,
                 headers={"Cache-Control": f"max-age={track.target_duration:.0f}"},
             )
-        # If the segment is ready or has been hinted, the http_range start should be at most
-        # equal to the end of the currently available data.
-        # If the segment is complete, the http_range start should be less than the end of the
-        # currently available data.
-        # If these conditions aren't met then we return a 416.
-        # http_range_start can be None, so use a copy that uses 0 instead of None
-        if (http_start := request.http_range.start or 0) > segment.data_size or (
-            segment.complete and http_start >= segment.data_size
-        ):
+        # If the part is ready or has been hinted,
+        if int(part_num) == len(segment.parts):
+            await track.part_recv(timeout=track.stream_settings.hls_part_timeout)
+        if int(part_num) >= len(segment.parts):
             return web.HTTPRequestRangeNotSatisfiable(
                 headers={
                     "Cache-Control": f"max-age={track.target_duration:.0f}",
-                    "Content-Range": f"bytes */{segment.data_size}",
                 }
             )
-        headers = {
-            "Content-Type": "video/iso.segment",
-            "Cache-Control": f"max-age={6*track.target_duration:.0f}",
-        }
-        # For most cases we have a 206 partial content response.
-        status = 206
-        # For the 206 responses we need to set a Content-Range header
-        # See https://datatracker.ietf.org/doc/html/rfc8673#section-2
-        if request.http_range.stop is None:
-            if request.http_range.start is None:
-                status = 200
-                if segment.complete:
-                    # This is a request for a full segment which is already complete
-                    # We should return a standard 200 response.
-                    return web.Response(
-                        body=segment.get_data(), headers=headers, status=status
-                    )
-                # Otherwise we still return a 200 response, but it is aggregating
-                http_stop = float("inf")
-            else:
-                # See https://datatracker.ietf.org/doc/html/rfc7233#section-2.1
-                headers[
-                    "Content-Range"
-                ] = f"bytes {http_start}-{(http_stop:=segment.data_size)-1}/*"
-        else:  # The remaining cases are all 206 responses
-            if segment.complete:
-                # If the segment is complete we have total size
-                headers["Content-Range"] = (
-                    f"bytes {http_start}-"
-                    + str(
-                        (http_stop := min(request.http_range.stop, segment.data_size))
-                        - 1
-                    )
-                    + f"/{segment.data_size}"
-                )
-            else:
-                # If we don't have the total size we use a *
-                headers[
-                    "Content-Range"
-                ] = f"bytes {http_start}-{(http_stop:=request.http_range.stop)-1}/*"
-        # Set up streaming response that we can write to as data becomes available
-        response = web.StreamResponse(headers=headers, status=status)
-        # Waiting until we write to prepare *might* give clients more accurate TTFB
-        # and ABR measurements, but it is probably not very useful for us since we
-        # only have one rendition anyway. Just prepare here for now.
-        await response.prepare(request)
-        try:
-            for bytes_to_write in segment.get_aggregating_bytes(
-                start_loc=http_start, end_loc=http_stop
-            ):
-                if bytes_to_write:
-                    await response.write(bytes_to_write)
-                elif not await track.part_recv(
-                    timeout=track.stream_settings.hls_part_timeout
-                ):
-                    break
-        except ConnectionResetError:
-            _LOGGER.warning("Connection reset while serving HLS partial segment")
-        return response
+        return web.Response(
+            body=segment.parts[int(part_num)].data,
+            headers={
+                "Content-Type": "video/iso.segment",
+                "Cache-Control": f"max-age={6*track.target_duration:.0f}",
+            },
+        )
+
+
+class HlsSegmentView(StreamView):
+    """Stream view to serve a HLS fmp4 segment."""
+
+    url = r"/api/hls/{token:[a-f0-9]+}/segment/{sequence:\d+}.m4s"
+    name = "api:stream:hls:segment"
+    cors_allowed = True
+
+    async def handle(
+        self, request: web.Request, stream: Stream, sequence: str, part_num: str
+    ) -> web.StreamResponse:
+        """Handle segments."""
+        track: HlsStreamOutput = cast(
+            HlsStreamOutput, stream.add_provider(HLS_PROVIDER)
+        )
+        track.idle_timer.awake()
+        # Ensure that we have a segment. If the request is from a hint for part 0
+        # of a segment, there is a small chance it may have arrived before the
+        # segment has been put. If this happens, wait for one part and retry.
+        if not (
+            (segment := track.get_segment(int(sequence)))
+            or (
+                await track.part_recv(timeout=track.stream_settings.hls_part_timeout)
+                and (segment := track.get_segment(int(sequence)))
+            )
+        ):
+            return web.Response(
+                body=None,
+                status=404,
+                headers={"Cache-Control": f"max-age={track.target_duration:.0f}"},
+            )
+        return web.Response(
+            body=segment.get_data(),
+            headers={
+                "Content-Type": "video/iso.segment",
+                "Cache-Control": f"max-age={6*track.target_duration:.0f}",
+            },
+        )

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -345,13 +345,13 @@ async def test_hls_max_segments(hass, hls_stream, stream_worker_sync):
     # Fetch the actual segments with a fake byte payload
     for segment in hls.get_segments():
         segment.init = INIT_BYTES
-        segment.parts_by_byterange = {
-            0: Part(
+        segment.parts = [
+            Part(
                 duration=SEGMENT_DURATION,
                 has_keyframe=True,
                 data=FAKE_PAYLOAD,
             )
-        }
+        ]
 
     # The segment that fell off the buffer is not accessible
     with patch.object(hls.stream_settings, "hls_part_timeout", 0.1):

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -126,14 +126,14 @@ def add_parts_to_segment(segment, source):
     """Add relevant part data to segment for testing recorder."""
     moof_locs = list(find_box(source.getbuffer(), b"moof")) + [len(source.getbuffer())]
     segment.init = source.getbuffer()[: moof_locs[0]].tobytes()
-    segment.parts_by_byterange = {
-        moof_locs[i]: Part(
+    segment.parts = [
+        Part(
             duration=None,
             has_keyframe=None,
             data=source.getbuffer()[moof_locs[i] : moof_locs[i + 1]],
         )
         for i in range(len(moof_locs) - 1)
-    }
+    ]
 
 
 async def test_recorder_save(tmpdir):

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -699,7 +699,7 @@ async def test_durations(hass, record_worker_sync):
     # check that the Part duration metadata matches the durations in the media
     running_metadata_duration = 0
     for segment in complete_segments:
-        for part in segment.parts_by_byterange.values():
+        for part in segment.parts:
             av_part = av.open(io.BytesIO(segment.init + part.data))
             running_metadata_duration += part.duration
             # av_part.duration will just return the largest dts in av_part.
@@ -713,7 +713,7 @@ async def test_durations(hass, record_worker_sync):
     # check that the Part durations are consistent with the Segment durations
     for segment in complete_segments:
         assert math.isclose(
-            sum(part.duration for part in segment.parts_by_byterange.values()),
+            sum(part.duration for part in segment.parts),
             segment.duration,
             abs_tol=1e-6,
         )
@@ -751,7 +751,7 @@ async def test_has_keyframe(hass, record_worker_sync):
 
     # check that the Part has_keyframe metadata matches the keyframes in the media
     for segment in complete_segments:
-        for part in segment.parts_by_byterange.values():
+        for part in segment.parts:
             av_part = av.open(io.BytesIO(segment.init + part.data))
             media_has_keyframe = any(
                 packet.is_keyframe for packet in av_part.demux(av_part.streams.video[0])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#49608 adds LL-HLS to stream using byte-range addressing for the individual parts. Byte-range addressing is a more efficient solution than having individually named parts, but iOS clients seem to have difficulty using byte-range requests for LL-HLS. This PR replaces the byte-range addressing in stream with individually named parts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
