### PR TITLE
Improvements to the solarlog integration

### DIFF
--- a/homeassistant/components/solarlog/__init__.py
+++ b/homeassistant/components/solarlog/__init__.py
@@ -54,49 +54,18 @@ class SolarlogData(update_coordinator.DataUpdateCoordinator):
     async def _async_update_data(self):
         """Update the data from the SolarLog device."""
         try:
-            api = await self.hass.async_add_executor_job(SolarLog, self.host)
+            data = await self.hass.async_add_executor_job(SolarLog, self.host)
         except (OSError, Timeout, HTTPError) as err:
             raise update_coordinator.UpdateFailed(err)
 
-        if api.time.year == 1999:
+        if data.time.year == 1999:
             raise update_coordinator.UpdateFailed(
                 "Invalid data returned (can happen after Solarlog restart)."
             )
 
         self.logger.debug(
             "Connection to Solarlog successful. Retrieving latest Solarlog update of %s",
-            api.time,
+            data.time,
         )
 
-        data = {}
-
-        try:
-            data["TIME"] = api.time
-            data["powerAC"] = api.power_ac
-            data["powerDC"] = api.power_dc
-            data["voltageAC"] = api.voltage_ac
-            data["voltageDC"] = api.voltage_dc
-            data["yieldDAY"] = api.yield_day / 1000
-            data["yieldYESTERDAY"] = api.yield_yesterday / 1000
-            data["yieldMONTH"] = api.yield_month / 1000
-            data["yieldYEAR"] = api.yield_year / 1000
-            data["yieldTOTAL"] = api.yield_total / 1000
-            data["consumptionAC"] = api.consumption_ac
-            data["consumptionDAY"] = api.consumption_day / 1000
-            data["consumptionYESTERDAY"] = api.consumption_yesterday / 1000
-            data["consumptionMONTH"] = api.consumption_month / 1000
-            data["consumptionYEAR"] = api.consumption_year / 1000
-            data["consumptionTOTAL"] = api.consumption_total / 1000
-            data["totalPOWER"] = api.total_power
-            data["alternatorLOSS"] = api.alternator_loss
-            data["CAPACITY"] = round(api.capacity * 100, 0)
-            data["EFFICIENCY"] = round(api.efficiency * 100, 0)
-            data["powerAVAILABLE"] = api.power_available
-            data["USAGE"] = round(api.usage * 100, 0)
-        except AttributeError as err:
-            raise update_coordinator.UpdateFailed(
-                f"Missing details data in Solarlog response: {err}"
-            ) from err
-
-        _LOGGER.debug("Updated Solarlog overview data: %s", data)
         return data

--- a/homeassistant/components/solarlog/const.py
+++ b/homeassistant/components/solarlog/const.py
@@ -28,17 +28,10 @@ DEFAULT_NAME = "solarlog"
 
 
 @dataclass
-class SolarlogRequiredKeysMixin:
-    """Mixin for required keys."""
-
-    factor: float = None
-
-
-@dataclass
-class SolarLogSensorEntityDescription(
-    SolarlogRequiredKeysMixin, SensorEntityDescription
-):
+class SolarLogSensorEntityDescription(SensorEntityDescription):
     """Describes Solarlog sensor entity."""
+
+    factor: float | None = None
 
 
 SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (

--- a/homeassistant/components/solarlog/const.py
+++ b/homeassistant/components/solarlog/const.py
@@ -31,12 +31,12 @@ DEFAULT_NAME = "solarlog"
 class SolarlogRequiredKeysMixin:
     """Mixin for required keys."""
 
-    json_key: str
+    factor: float = None
 
 
 @dataclass
 class SolarLogSensorEntityDescription(
-    SensorEntityDescription, SolarlogRequiredKeysMixin
+    SolarlogRequiredKeysMixin, SensorEntityDescription
 ):
     """Describes Solarlog sensor entity."""
 
@@ -44,13 +44,11 @@ class SolarLogSensorEntityDescription(
 SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (
     SolarLogSensorEntityDescription(
         key="time",
-        json_key="TIME",
         name="last update",
         device_class=DEVICE_CLASS_TIMESTAMP,
     ),
     SolarLogSensorEntityDescription(
         key="power_ac",
-        json_key="powerAC",
         name="power AC",
         icon="mdi:solar-power",
         native_unit_of_measurement=POWER_WATT,
@@ -58,7 +56,6 @@ SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (
     ),
     SolarLogSensorEntityDescription(
         key="power_dc",
-        json_key="powerDC",
         name="power DC",
         icon="mdi:solar-power",
         native_unit_of_measurement=POWER_WATT,
@@ -66,7 +63,6 @@ SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (
     ),
     SolarLogSensorEntityDescription(
         key="voltage_ac",
-        json_key="voltageAC",
         name="voltage AC",
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         device_class=DEVICE_CLASS_VOLTAGE,
@@ -74,7 +70,6 @@ SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (
     ),
     SolarLogSensorEntityDescription(
         key="voltage_dc",
-        json_key="voltageDC",
         name="voltage DC",
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         device_class=DEVICE_CLASS_VOLTAGE,
@@ -82,43 +77,42 @@ SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (
     ),
     SolarLogSensorEntityDescription(
         key="yield_day",
-        json_key="yieldDAY",
         name="yield day",
         icon="mdi:solar-power",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        factor=0.001,
     ),
     SolarLogSensorEntityDescription(
         key="yield_yesterday",
-        json_key="yieldYESTERDAY",
         name="yield yesterday",
         icon="mdi:solar-power",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        factor=0.001,
     ),
     SolarLogSensorEntityDescription(
         key="yield_month",
-        json_key="yieldMONTH",
         name="yield month",
         icon="mdi:solar-power",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        factor=0.001,
     ),
     SolarLogSensorEntityDescription(
         key="yield_year",
-        json_key="yieldYEAR",
         name="yield year",
         icon="mdi:solar-power",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        factor=0.001,
     ),
     SolarLogSensorEntityDescription(
         key="yield_total",
-        json_key="yieldTOTAL",
         name="yield total",
         icon="mdi:solar-power",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=STATE_CLASS_TOTAL_INCREASING,
+        factor=0.001,
     ),
     SolarLogSensorEntityDescription(
         key="consumption_ac",
-        json_key="consumptionAC",
         name="consumption AC",
         native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
@@ -126,43 +120,42 @@ SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (
     ),
     SolarLogSensorEntityDescription(
         key="consumption_day",
-        json_key="consumptionDAY",
         name="consumption day",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
+        factor=0.001,
     ),
     SolarLogSensorEntityDescription(
         key="consumption_yesterday",
-        json_key="consumptionYESTERDAY",
         name="consumption yesterday",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
+        factor=0.001,
     ),
     SolarLogSensorEntityDescription(
         key="consumption_month",
-        json_key="consumptionMONTH",
         name="consumption month",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
+        factor=0.001,
     ),
     SolarLogSensorEntityDescription(
         key="consumption_year",
-        json_key="consumptionYEAR",
         name="consumption year",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
+        factor=0.001,
     ),
     SolarLogSensorEntityDescription(
         key="consumption_total",
-        json_key="consumptionTOTAL",
         name="consumption total",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
+        state_class=STATE_CLASS_MEASUREMENT,
+        factor=0.001,
     ),
     SolarLogSensorEntityDescription(
         key="total_power",
-        json_key="totalPOWER",
         name="installed peak power",
         icon="mdi:solar-power",
         native_unit_of_measurement=POWER_WATT,
@@ -170,7 +163,6 @@ SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (
     ),
     SolarLogSensorEntityDescription(
         key="alternator_loss",
-        json_key="alternatorLOSS",
         name="alternator loss",
         icon="mdi:solar-power",
         native_unit_of_measurement=POWER_WATT,
@@ -179,24 +171,23 @@ SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (
     ),
     SolarLogSensorEntityDescription(
         key="capacity",
-        json_key="CAPACITY",
         name="capacity",
         icon="mdi:solar-power",
         native_unit_of_measurement=PERCENTAGE,
         device_class=DEVICE_CLASS_POWER_FACTOR,
         state_class=STATE_CLASS_MEASUREMENT,
+        factor=100,
     ),
     SolarLogSensorEntityDescription(
         key="efficiency",
-        json_key="EFFICIENCY",
         name="efficiency",
         native_unit_of_measurement=PERCENTAGE,
         device_class=DEVICE_CLASS_POWER_FACTOR,
         state_class=STATE_CLASS_MEASUREMENT,
+        factor=100,
     ),
     SolarLogSensorEntityDescription(
         key="power_available",
-        json_key="powerAVAILABLE",
         name="power available",
         icon="mdi:solar-power",
         native_unit_of_measurement=POWER_WATT,
@@ -205,10 +196,10 @@ SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (
     ),
     SolarLogSensorEntityDescription(
         key="usage",
-        json_key="USAGE",
         name="usage",
         native_unit_of_measurement=PERCENTAGE,
         device_class=DEVICE_CLASS_POWER_FACTOR,
         state_class=STATE_CLASS_MEASUREMENT,
+        factor=100,
     ),
 )

--- a/homeassistant/components/solarlog/const.py
+++ b/homeassistant/components/solarlog/const.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     PERCENTAGE,
     POWER_WATT,
 )
+from homeassistant.util import dt
 
 DOMAIN = "solarlog"
 
@@ -145,6 +146,7 @@ SENSOR_TYPES: tuple[SolarLogSensorEntityDescription, ...] = (
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_MEASUREMENT,
+        last_reset=dt.utc_from_timestamp(0),
         factor=0.001,
     ),
     SolarLogSensorEntityDescription(

--- a/homeassistant/components/solarlog/sensor.py
+++ b/homeassistant/components/solarlog/sensor.py
@@ -39,4 +39,9 @@ class SolarlogSensor(update_coordinator.CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the native sensor value."""
-        return self.coordinator.data[self.entity_description.json_key]
+        return (
+            getattr(self.coordinator.data, self.entity_description.key)
+            * self.entity_description.factor
+            if self.entity_description.factor
+            else getattr(self.coordinator.data, self.entity_description.key)
+        )

--- a/homeassistant/components/solarlog/sensor.py
+++ b/homeassistant/components/solarlog/sensor.py
@@ -39,9 +39,9 @@ class SolarlogSensor(update_coordinator.CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the native sensor value."""
-        return (
-            getattr(self.coordinator.data, self.entity_description.key)
-            * self.entity_description.factor
-            if self.entity_description.factor
-            else getattr(self.coordinator.data, self.entity_description.key)
-        )
+        result = getattr(self.coordinator.data, self.entity_description.key)
+        if self.entity_description.factor:
+            state = round(result * self.entity_description.factor, 3)
+        else:
+            state = result
+        return state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
@balloob made some suggestions for further improvements of the solarlog integration in #55345 
- [x] storing the `SolarLog` object directly instead of converting it to a dict
- [x] moving the calculations into the `SolarLogSensorEntityDescription` object --> added `factor` to take care of that. 

@MartinHjelmare  also made a suggestion 
- [x] to remove the json_key in the SolarLogSensorEntityDescription and use the `key` instead. 

These points have been addressed with this PR.

I also changed the `state_class` of the `total_consumption` sensor from `total_increasing` to `measurement`  as this measurement apparently can also go down. It is calculated by the solarlog device itself and only outputs the total (e.g. `grid in` minus `grid out`). 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #55356
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
