### PR TITLE
Ensure ReCollect Waste shows pickups for midnight on the actual day

### DIFF
--- a/homeassistant/components/recollect_waste/sensor.py
+++ b/homeassistant/components/recollect_waste/sensor.py
@@ -1,6 +1,8 @@
 """Support for ReCollect Waste sensors."""
 from __future__ import annotations
 
+from datetime import date, datetime, time
+
 from aiorecollect.client import PickupType
 
 from homeassistant.components.sensor import SensorEntity
@@ -17,6 +19,7 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from homeassistant.util.dt import as_utc
 
 from .const import CONF_PLACE_ID, CONF_SERVICE_ID, DATA_COORDINATOR, DOMAIN
 
@@ -29,6 +32,12 @@ DEFAULT_ATTRIBUTION = "Pickup data provided by ReCollect Waste"
 DEFAULT_NAME = "Waste Pickup"
 
 PLATFORM_SCHEMA = cv.deprecated(DOMAIN)
+
+
+@callback
+def async_get_utc_midnight(target_date: date) -> datetime:
+    """Get UTC midnight for a given (assumed local) date."""
+    return as_utc(datetime.combine(target_date, time(0)))
 
 
 @callback
@@ -94,7 +103,9 @@ class ReCollectWasteSensor(CoordinatorEntity, SensorEntity):
                 ATTR_NEXT_PICKUP_TYPES: async_get_pickup_type_names(
                     self._entry, next_pickup_event.pickup_types
                 ),
-                ATTR_NEXT_PICKUP_DATE: next_pickup_event.date.isoformat(),
+                ATTR_NEXT_PICKUP_DATE: async_get_utc_midnight(
+                    next_pickup_event.date
+                ).isoformat(),
             }
         )
-        self._attr_native_value = pickup_event.date.isoformat()
+        self._attr_native_value = async_get_utc_midnight(pickup_event.date).isoformat()

--- a/homeassistant/components/recollect_waste/sensor.py
+++ b/homeassistant/components/recollect_waste/sensor.py
@@ -35,12 +35,6 @@ PLATFORM_SCHEMA = cv.deprecated(DOMAIN)
 
 
 @callback
-def async_get_utc_midnight(target_date: date) -> datetime:
-    """Get UTC midnight for a given (assumed local) date."""
-    return as_utc(datetime.combine(target_date, time(0)))
-
-
-@callback
 def async_get_pickup_type_names(
     entry: ConfigEntry, pickup_types: list[PickupType]
 ) -> list[str]:
@@ -51,6 +45,12 @@ def async_get_pickup_type_names(
         else t.name
         for t in pickup_types
     ]
+
+
+@callback
+def async_get_utc_midnight(target_date: date) -> datetime:
+    """Get UTC midnight for a given date."""
+    return as_utc(datetime.combine(target_date, time(0)))
 
 
 async def async_setup_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/pull/55349 bumped `aiorecollect` to a version that correctly returns ReCollect Waste pickup dates as `date` objects (and not `datetime`s). However, my implementation incorrectly handled HASS's usage of UTC, which would result in an incorrect translation back to the local time. This PR fixes things so that pickups are shown at midnight of the actual day in local time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
