### PR TITLE
Revert "Deprecate last_reset options in MQTT sensor"

### DIFF
--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -53,23 +53,18 @@ MQTT_SENSOR_ATTRIBUTES_BLOCKED = frozenset(
 
 DEFAULT_NAME = "MQTT Sensor"
 DEFAULT_FORCE_UPDATE = False
-PLATFORM_SCHEMA = vol.All(
-    # Deprecated, remove in Home Assistant 2021.11
-    cv.deprecated(CONF_LAST_RESET_TOPIC),
-    cv.deprecated(CONF_LAST_RESET_VALUE_TEMPLATE),
-    mqtt.MQTT_RO_PLATFORM_SCHEMA.extend(
-        {
-            vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-            vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
-            vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
-            vol.Optional(CONF_LAST_RESET_TOPIC): mqtt.valid_subscribe_topic,
-            vol.Optional(CONF_LAST_RESET_VALUE_TEMPLATE): cv.template,
-            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-            vol.Optional(CONF_STATE_CLASS): STATE_CLASSES_SCHEMA,
-            vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
-        }
-    ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema),
-)
+PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
+        vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
+        vol.Optional(CONF_LAST_RESET_TOPIC): mqtt.valid_subscribe_topic,
+        vol.Optional(CONF_LAST_RESET_VALUE_TEMPLATE): cv.template,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_STATE_CLASS): STATE_CLASSES_SCHEMA,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+    }
+).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
 
 async def async_setup_platform(

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -306,28 +306,6 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message(hass, mqtt_mock):
     assert state.attributes.get("last_reset") == "2020-01-02T08:11:00"
 
 
-async def test_last_reset_deprecated(hass, mqtt_mock, caplog):
-    """Test the setting of the last_reset property via MQTT."""
-    assert await async_setup_component(
-        hass,
-        sensor.DOMAIN,
-        {
-            sensor.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "state_topic": "test-topic",
-                "unit_of_measurement": "fav unit",
-                "last_reset_topic": "last-reset-topic",
-                "last_reset_value_template": "{{ value_json.last_reset }}",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert "The 'last_reset_topic' option is deprecated" in caplog.text
-    assert "The 'last_reset_value_template' option is deprecated" in caplog.text
-
-
 async def test_force_update_disabled(hass, mqtt_mock):
     """Test force update option."""
     assert await async_setup_component(


### PR DESCRIPTION
Reverts home-assistant/core#54840

Background:
We should hold this change until we've fully decided to sunset the `last_reset` sensor attribute