### PR TITLE
Fix race in MQTT sensor when last_reset_topic is configured

### DIFF
--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -53,18 +53,48 @@ MQTT_SENSOR_ATTRIBUTES_BLOCKED = frozenset(
 
 DEFAULT_NAME = "MQTT Sensor"
 DEFAULT_FORCE_UPDATE = False
-PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-        vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
-        vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
-        vol.Optional(CONF_LAST_RESET_TOPIC): mqtt.valid_subscribe_topic,
-        vol.Optional(CONF_LAST_RESET_VALUE_TEMPLATE): cv.template,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_STATE_CLASS): STATE_CLASSES_SCHEMA,
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
-    }
-).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
+
+
+def validate_options(conf):
+    """Validate options.
+
+    If last reset topic is present it must be same as the state topic.
+    """
+    if (
+        CONF_LAST_RESET_TOPIC in conf
+        and CONF_STATE_TOPIC in conf
+        and conf[CONF_LAST_RESET_TOPIC] != conf[CONF_STATE_TOPIC]
+    ):
+        _LOGGER.warning(
+            "'%s' must be same as '%s'", CONF_LAST_RESET_TOPIC, CONF_STATE_TOPIC
+        )
+
+    if CONF_LAST_RESET_TOPIC in conf and CONF_LAST_RESET_VALUE_TEMPLATE not in conf:
+        _LOGGER.warning(
+            "'%s' must be set if '%s' is set",
+            CONF_LAST_RESET_VALUE_TEMPLATE,
+            CONF_LAST_RESET_TOPIC,
+        )
+
+    return conf
+
+
+PLATFORM_SCHEMA = vol.All(
+    cv.deprecated(CONF_LAST_RESET_TOPIC),
+    mqtt.MQTT_RO_PLATFORM_SCHEMA.extend(
+        {
+            vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+            vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
+            vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
+            vol.Optional(CONF_LAST_RESET_TOPIC): mqtt.valid_subscribe_topic,
+            vol.Optional(CONF_LAST_RESET_VALUE_TEMPLATE): cv.template,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_STATE_CLASS): STATE_CLASSES_SCHEMA,
+            vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        }
+    ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema),
+    validate_options,
+)
 
 
 async def async_setup_platform(
@@ -127,10 +157,7 @@ class MqttSensor(MqttEntity, SensorEntity):
         """(Re)Subscribe to topics."""
         topics = {}
 
-        @callback
-        @log_messages(self.hass, self.entity_id)
-        def message_received(msg):
-            """Handle new MQTT messages."""
+        def _update_state(msg):
             payload = msg.payload
             # auto-expire enabled?
             expire_after = self._config.get(CONF_EXPIRE_AFTER)
@@ -159,18 +186,8 @@ class MqttSensor(MqttEntity, SensorEntity):
                     variables=variables,
                 )
             self._state = payload
-            self.async_write_ha_state()
 
-        topics["state_topic"] = {
-            "topic": self._config[CONF_STATE_TOPIC],
-            "msg_callback": message_received,
-            "qos": self._config[CONF_QOS],
-        }
-
-        @callback
-        @log_messages(self.hass, self.entity_id)
-        def last_reset_message_received(msg):
-            """Handle new last_reset messages."""
+        def _update_last_reset(msg):
             payload = msg.payload
 
             template = self._config.get(CONF_LAST_RESET_VALUE_TEMPLATE)
@@ -193,9 +210,36 @@ class MqttSensor(MqttEntity, SensorEntity):
                 _LOGGER.warning(
                     "Invalid last_reset message '%s' from '%s'", msg.payload, msg.topic
                 )
+
+        @callback
+        @log_messages(self.hass, self.entity_id)
+        def message_received(msg):
+            """Handle new MQTT messages."""
+            _update_state(msg)
+            if CONF_LAST_RESET_VALUE_TEMPLATE in self._config and (
+                CONF_LAST_RESET_TOPIC not in self._config
+                or self._config[CONF_LAST_RESET_TOPIC] == self._config[CONF_STATE_TOPIC]
+            ):
+                _update_last_reset(msg)
             self.async_write_ha_state()
 
-        if CONF_LAST_RESET_TOPIC in self._config:
+        topics["state_topic"] = {
+            "topic": self._config[CONF_STATE_TOPIC],
+            "msg_callback": message_received,
+            "qos": self._config[CONF_QOS],
+        }
+
+        @callback
+        @log_messages(self.hass, self.entity_id)
+        def last_reset_message_received(msg):
+            """Handle new last_reset messages."""
+            _update_last_reset(msg)
+            self.async_write_ha_state()
+
+        if (
+            CONF_LAST_RESET_TOPIC in self._config
+            and self._config[CONF_LAST_RESET_TOPIC] != self._config[CONF_STATE_TOPIC]
+        ):
             topics["last_reset_topic"] = {
                 "topic": self._config[CONF_LAST_RESET_TOPIC],
                 "msg_callback": last_reset_message_received,

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -327,7 +327,7 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message_2(
                     "state_topic": "test-topic",
                     "unit_of_measurement": "kWh",
                     "value_template": "{{ value_json.value | float / 60000 }}",
-                    "last_reset_value_template": "{{ now().fromtimestamp(value_json.time / 1000).replace(tzinfo=now().tzinfo) }}",
+                    "last_reset_value_template": "{{ utcnow().fromtimestamp(value_json.time / 1000, tz=utcnow().tzinfo) }}",
                 },
                 **extra,
             }
@@ -342,7 +342,7 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message_2(
     )
     state = hass.states.get("sensor.test")
     assert float(state.state) == pytest.approx(0.015796176944444445)
-    assert state.attributes.get("last_reset") == "2021-08-19T17:05:00+00:00"
+    assert state.attributes.get("last_reset") == "2021-08-19T15:05:00+00:00"
     assert "'last_reset_topic' must be same as 'state_topic'" not in caplog.text
     assert (
         "'last_reset_value_template' must be set if 'last_reset_topic' is set"

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -208,7 +208,7 @@ async def test_setting_sensor_value_via_mqtt_json_message(hass, mqtt_mock):
     assert state.state == "100"
 
 
-async def test_setting_sensor_last_reset_via_mqtt_message(hass, mqtt_mock):
+async def test_setting_sensor_last_reset_via_mqtt_message(hass, mqtt_mock, caplog):
     """Test the setting of the last_reset property via MQTT."""
     assert await async_setup_component(
         hass,
@@ -228,6 +228,11 @@ async def test_setting_sensor_last_reset_via_mqtt_message(hass, mqtt_mock):
     async_fire_mqtt_message(hass, "last-reset-topic", "2020-01-02 08:11:00")
     state = hass.states.get("sensor.test")
     assert state.attributes.get("last_reset") == "2020-01-02T08:11:00"
+    assert "'last_reset_topic' must be same as 'state_topic'" in caplog.text
+    assert (
+        "'last_reset_value_template' must be set if 'last_reset_topic' is set"
+        in caplog.text
+    )
 
 
 @pytest.mark.parametrize("datestring", ["2020-21-02 08:11:00", "Hello there!"])
@@ -304,6 +309,45 @@ async def test_setting_sensor_last_reset_via_mqtt_json_message(hass, mqtt_mock):
     )
     state = hass.states.get("sensor.test")
     assert state.attributes.get("last_reset") == "2020-01-02T08:11:00"
+
+
+@pytest.mark.parametrize("extra", [{}, {"last_reset_topic": "test-topic"}])
+async def test_setting_sensor_last_reset_via_mqtt_json_message_2(
+    hass, mqtt_mock, caplog, extra
+):
+    """Test the setting of the value via MQTT with JSON payload."""
+    assert await async_setup_component(
+        hass,
+        sensor.DOMAIN,
+        {
+            sensor.DOMAIN: {
+                **{
+                    "platform": "mqtt",
+                    "name": "test",
+                    "state_topic": "test-topic",
+                    "unit_of_measurement": "kWh",
+                    "value_template": "{{ value_json.value | float / 60000 }}",
+                    "last_reset_value_template": "{{ now().fromtimestamp(value_json.time / 1000).replace(tzinfo=now().tzinfo) }}",
+                },
+                **extra,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass,
+        "test-topic",
+        '{"type":"minute","time":1629385500000,"value":947.7706166666667}',
+    )
+    state = hass.states.get("sensor.test")
+    assert float(state.state) == pytest.approx(0.015796176944444445)
+    assert state.attributes.get("last_reset") == "2021-08-19T17:05:00+00:00"
+    assert "'last_reset_topic' must be same as 'state_topic'" not in caplog.text
+    assert (
+        "'last_reset_value_template' must be set if 'last_reset_topic' is set"
+        not in caplog.text
+    )
 
 
 async def test_force_update_disabled(hass, mqtt_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The `last_reset_topic` configuration variable for MQTT sensor is deprecated, `last_reset_value_template` is still supported but will use the `state_topic` if no `last_reset_topic` is configured.
In Home Assistant core 2021.10, it will no longer be possible to configure a `last_reset_topic`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix race in MQTT sensor when last_reset_topic is configured by updating `last_reset` and `state` in the same message callback

Also:
- Log a warning if `last_reset_topic` is not same as `state_topic`, with plan for a hard fail in HA core 2021.10
- Log a warning if `last_reset_topic` is configured but `last_reset_value_template` isn't, with plan for a hard fail in HA core 2021.10
- Deprecate `last_reset_topic`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
