### PR TITLE
Make new cycles for sensor sum statistics start with 0 as zero-point

### DIFF
--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -403,11 +403,8 @@ def compile_statistics(
                     # ..and update the starting point
                     new_state = fstate
                     old_last_reset = last_reset
-                    # Force a new cycle for STATE_CLASS_TOTAL_INCREASING to start at 0
-                    if (
-                        state_class == STATE_CLASS_TOTAL_INCREASING
-                        and old_state is not None
-                    ):
+                    # Force a new cycle for an existing sensor to start at 0
+                    if old_state is not None:
                         old_state = 0.0
                     else:
                         old_state = new_state

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -258,7 +258,7 @@ def test_compile_hourly_sum_statistics_amount(
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(factor * seq[5]),
-                "sum": approx(factor * 10.0),
+                "sum": approx(factor * 40.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -268,7 +268,7 @@ def test_compile_hourly_sum_statistics_amount(
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(factor * seq[8]),
-                "sum": approx(factor * 40.0),
+                "sum": approx(factor * 70.0),
             },
         ]
     }
@@ -512,7 +512,7 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(40.0),
-                "sum": approx(10.0),
+                "sum": approx(40.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -522,7 +522,7 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(70.0),
-                "sum": approx(40.0),
+                "sum": approx(70.0),
             },
         ]
     }
@@ -595,7 +595,7 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(40.0),
-                "sum": approx(10.0),
+                "sum": approx(40.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -605,7 +605,7 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(70.0),
-                "sum": approx(40.0),
+                "sum": approx(70.0),
             },
         ],
         "sensor.test2": [
@@ -627,7 +627,7 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(45.0),
-                "sum": approx(-95.0),
+                "sum": approx(-65.0),
             },
             {
                 "statistic_id": "sensor.test2",
@@ -637,7 +637,7 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(75.0),
-                "sum": approx(-65.0),
+                "sum": approx(-35.0),
             },
         ],
         "sensor.test3": [
@@ -659,7 +659,7 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(50.0 / 1000),
-                "sum": approx(30.0 / 1000),
+                "sum": approx(60.0 / 1000),
             },
             {
                 "statistic_id": "sensor.test3",
@@ -669,7 +669,7 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "min": None,
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(90.0 / 1000),
-                "sum": approx(70.0 / 1000),
+                "sum": approx(100.0 / 1000),
             },
         ],
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make new cycles for sensor sum statistics start with 0 as zero-point.
This is already the case for `state_class = total_increasing`, this PR uses the same logic also for `state_class = measurement`.

The initial zero-point when the very first statistics is compiled for a sensor is still the state when the first statistic is compiled, not 0.

Rationale:
It's a reasonable assumption that a meter cycle starts at 0, and not any other value.
This is the case for `utility_meter`, which is the only core integration actively using `last_reset`.
MQTT sensor also supports setting `last_reset`, but the implementation was not working until very recently for use cases where `last_reset` was actively set to a non-fixed value: https://github.com/home-assistant/core/pull/55463

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/pull/54751

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
