### PR TITLE
Add Eagle 200 name back

### DIFF
--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -38,6 +38,7 @@ _LOGGER = logging.getLogger(__name__)
 SENSORS = (
     SensorEntityDescription(
         key="zigbee:InstantaneousDemand",
+        # We can drop the "Eagle-200" part of the name in HA 2021.12
         name="Eagle-200 Meter Power Demand",
         native_unit_of_measurement=POWER_KILO_WATT,
         device_class=DEVICE_CLASS_POWER,

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -38,21 +38,21 @@ _LOGGER = logging.getLogger(__name__)
 SENSORS = (
     SensorEntityDescription(
         key="zigbee:InstantaneousDemand",
-        name="Meter Power Demand",
+        name="Eagle-200 Meter Power Demand",
         native_unit_of_measurement=POWER_KILO_WATT,
         device_class=DEVICE_CLASS_POWER,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     SensorEntityDescription(
         key="zigbee:CurrentSummationDelivered",
-        name="Total Meter Energy Delivered",
+        name="Eagle-200 Total Meter Energy Delivered",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="zigbee:CurrentSummationReceived",
-        name="Total Meter Energy Received",
+        name="Eagle-200 Total Meter Energy Received",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,

--- a/tests/components/rainforest_eagle/test_sensor.py
+++ b/tests/components/rainforest_eagle/test_sensor.py
@@ -114,17 +114,17 @@ async def test_sensors_200(hass, setup_rainforest_200):
     """Test the sensors."""
     assert len(hass.states.async_all()) == 3
 
-    demand = hass.states.get("sensor.meter_power_demand")
+    demand = hass.states.get("sensor.eagle_200_meter_power_demand")
     assert demand is not None
     assert demand.state == "1.152000"
     assert demand.attributes["unit_of_measurement"] == "kW"
 
-    delivered = hass.states.get("sensor.total_meter_energy_delivered")
+    delivered = hass.states.get("sensor.eagle_200_total_meter_energy_delivered")
     assert delivered is not None
     assert delivered.state == "45251.285000"
     assert delivered.attributes["unit_of_measurement"] == "kWh"
 
-    received = hass.states.get("sensor.total_meter_energy_received")
+    received = hass.states.get("sensor.eagle_200_total_meter_energy_received")
     assert received is not None
     assert received.state == "232.232000"
     assert received.attributes["unit_of_measurement"] == "kWh"
@@ -147,17 +147,17 @@ async def test_sensors_100(hass, setup_rainforest_100):
     """Test the sensors."""
     assert len(hass.states.async_all()) == 3
 
-    demand = hass.states.get("sensor.meter_power_demand")
+    demand = hass.states.get("sensor.eagle_200_meter_power_demand")
     assert demand is not None
     assert demand.state == "1.152000"
     assert demand.attributes["unit_of_measurement"] == "kW"
 
-    delivered = hass.states.get("sensor.total_meter_energy_delivered")
+    delivered = hass.states.get("sensor.eagle_200_total_meter_energy_delivered")
     assert delivered is not None
     assert delivered.state == "45251.285000"
     assert delivered.attributes["unit_of_measurement"] == "kWh"
 
-    received = hass.states.get("sensor.total_meter_energy_received")
+    received = hass.states.get("sensor.eagle_200_total_meter_energy_received")
     assert received is not None
     assert received.state == "232.232000"
     assert received.attributes["unit_of_measurement"] == "kWh"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The old Rainforest Eagle integration had no unique IDs. This adds the “Eagle-200” name back so that the entities have the same entity IDs as the old ones without a unique ID.

In a couple of releases we can change it back to having no “Eagle-200” in the name because the unique ID guarantees entity ID stability.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
