### PR TITLE
Fix ArestSwitchBase missing is on attribute

### DIFF
--- a/homeassistant/components/arest/switch.py
+++ b/homeassistant/components/arest/switch.py
@@ -88,6 +88,7 @@ class ArestSwitchBase(SwitchEntity):
         self._resource = resource
         self._attr_name = f"{location.title()} {name.title()}"
         self._attr_available = True
+        self._attr_is_on = False
 
 
 class ArestSwitchFunction(ArestSwitchBase):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#51231 defines ToggleEntity entity attributes as class variables, and #52678 uses these attributes for `arest`. However, `ArestSwitchBase` needs to define an instance attribute _attr_is_on that matches the `ToggleEntity` attribute _attr_is_on.


>     Logger: homeassistant.components.switch
>     Source: helpers/entity.py:883
>     Integration: Switch (documentation, issues)
>     First occurred: 5:50:10 AM (2 occurrences)
>     Last logged: 5:50:11 AM
> 
>     Error adding entities for domain switch with platform arest
>     Error while setting up arest platform for switch
> 
>     Traceback (most recent call last):
>     File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 382, in async_add_entities
>     await asyncio.gather(*tasks)
>     File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 587, in _async_add_entity
>     await entity.add_to_platform_finish()
>     File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 711, in add_to_platform_finish
>     self.async_write_ha_state()
>     File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 464, in async_write_ha_state
>     self._async_write_ha_state()
>     File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 498, in _async_write_ha_state
>     state = self._stringify_state()
>     File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 470, in _stringify_state
>     state = self.state
>     File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 878, in state
>     return STATE_ON if self.is_on else STATE_OFF
>     File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 883, in is_on
>     return self._attr_is_on
>     AttributeError: 'ArestSwitchPin' object has no attribute '_attr_is_on'
> 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
