### PR TITLE
Add nut Watts datapoint

### DIFF
--- a/homeassistant/components/nut/const.py
+++ b/homeassistant/components/nut/const.py
@@ -457,9 +457,8 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         key="watts",
         name="Watts",
         native_unit_of_measurement=POWER_WATT,
-        device_class=DEVICE_CLASS_POWER
+        device_class=DEVICE_CLASS_POWER,
     ),
-    
 }
 
 STATE_TYPES = {

--- a/homeassistant/components/nut/const.py
+++ b/homeassistant/components/nut/const.py
@@ -457,7 +457,7 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         key="watts",
         name="Watts",
         native_unit_of_measurement=POWER_VOLT_AMPERE,
-        icon="mdi:flash",
+        device_class=DEVICE_CLASS_POWER
     ),
     
 }

--- a/homeassistant/components/nut/const.py
+++ b/homeassistant/components/nut/const.py
@@ -456,7 +456,7 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     "watts": SensorEntityDescription(
         key="watts",
         name="Watts",
-        native_unit_of_measurement=POWER_VOLT_AMPERE,
+        native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER
     ),
     

--- a/homeassistant/components/nut/const.py
+++ b/homeassistant/components/nut/const.py
@@ -453,6 +453,13 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         device_class=DEVICE_CLASS_TEMPERATURE,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
+    "watts": SensorEntityDescription(
+        key="watts",
+        name="Watts",
+        native_unit_of_measurement=POWER_VOLT_AMPERE,
+        icon="mdi:flash",
+    ),
+    
 }
 
 STATE_TYPES = {

--- a/homeassistant/components/nut/const.py
+++ b/homeassistant/components/nut/const.py
@@ -458,6 +458,7 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         name="Watts",
         native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
     ),
 }
 


### PR DESCRIPTION
## Proposed change
Some UPS's don't provide Nominal power but all should provide Watts.
This update will allow the user to select WATTS as an item they wish to track in Home assistant


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
