### PR TITLE
Add remote server to cloud system health

### DIFF
--- a/homeassistant/components/cloud/strings.json
+++ b/homeassistant/components/cloud/strings.json
@@ -7,6 +7,7 @@
       "relayer_connected": "Relayer Connected",
       "remote_connected": "Remote Connected",
       "remote_enabled": "Remote Enabled",
+      "sintun_server": "Sintun Server",
       "alexa_enabled": "Alexa Enabled",
       "google_enabled": "Google Enabled",
       "logged_in": "Logged In",

--- a/homeassistant/components/cloud/strings.json
+++ b/homeassistant/components/cloud/strings.json
@@ -7,7 +7,7 @@
       "relayer_connected": "Relayer Connected",
       "remote_connected": "Remote Connected",
       "remote_enabled": "Remote Enabled",
-      "sintun_server": "Sintun Server",
+      "remote_server": "Remote Server",
       "alexa_enabled": "Alexa Enabled",
       "google_enabled": "Google Enabled",
       "logged_in": "Logged In",

--- a/homeassistant/components/cloud/system_health.py
+++ b/homeassistant/components/cloud/system_health.py
@@ -33,7 +33,7 @@ async def system_health_info(hass):
         data["remote_connected"] = cloud.remote.is_connected
         data["alexa_enabled"] = client.prefs.alexa_enabled
         data["google_enabled"] = client.prefs.google_enabled
-        data["sintun_server"] = cloud.remote.snitun_server
+        data["remote_server"] = cloud.remote.snitun_server
 
     data["can_reach_cert_server"] = system_health.async_check_can_reach_url(
         hass, cloud.acme_directory_server

--- a/homeassistant/components/cloud/system_health.py
+++ b/homeassistant/components/cloud/system_health.py
@@ -33,6 +33,7 @@ async def system_health_info(hass):
         data["remote_connected"] = cloud.remote.is_connected
         data["alexa_enabled"] = client.prefs.alexa_enabled
         data["google_enabled"] = client.prefs.google_enabled
+        data["sintun_server"] = cloud.remote.snitun_server
 
     data["can_reach_cert_server"] = system_health.async_check_can_reach_url(
         hass, cloud.acme_directory_server

--- a/homeassistant/components/cloud/translations/en.json
+++ b/homeassistant/components/cloud/translations/en.json
@@ -7,6 +7,7 @@
             "can_reach_cloud_auth": "Reach Authentication Server",
             "google_enabled": "Google Enabled",
             "logged_in": "Logged In",
+            "sintun_server": "Sintun Server",
             "relayer_connected": "Relayer Connected",
             "remote_connected": "Remote Connected",
             "remote_enabled": "Remote Enabled",

--- a/homeassistant/components/cloud/translations/en.json
+++ b/homeassistant/components/cloud/translations/en.json
@@ -7,7 +7,7 @@
             "can_reach_cloud_auth": "Reach Authentication Server",
             "google_enabled": "Google Enabled",
             "logged_in": "Logged In",
-            "sintun_server": "Sintun Server",
+            "remote_server": "Remote Server",
             "relayer_connected": "Relayer Connected",
             "remote_connected": "Remote Connected",
             "remote_enabled": "Remote Enabled",

--- a/tests/components/cloud/test_system_health.py
+++ b/tests/components/cloud/test_system_health.py
@@ -28,7 +28,7 @@ async def test_cloud_system_health(hass, aioclient_mock):
         relayer="wss://cloud.bla.com/websocket_api",
         acme_directory_server="https://cert-server",
         is_logged_in=True,
-        remote=Mock(is_connected=False),
+        remote=Mock(is_connected=False, snitun_server="us-west-1"),
         expiration_date=now,
         is_connected=True,
         client=Mock(
@@ -52,6 +52,7 @@ async def test_cloud_system_health(hass, aioclient_mock):
         "relayer_connected": True,
         "remote_enabled": True,
         "remote_connected": False,
+        "remote_server": "us-west-1",
         "alexa_enabled": True,
         "google_enabled": False,
         "can_reach_cert_server": "ok",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add remote server to system health
![Screenshot from 2021-08-31 22-26-38](https://user-images.githubusercontent.com/15093472/131571197-adb5fa02-75a3-46b3-9dac-2dacf5be96e1.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
