### PR TITLE
Add iotawatt high-accuracy energy readout sensors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -248,7 +248,7 @@ homeassistant/components/integration/* @dgomes
 homeassistant/components/intent/* @home-assistant/core
 homeassistant/components/intesishome/* @jnimmo
 homeassistant/components/ios/* @robbiet480
-homeassistant/components/iotawatt/* @gtdiehl
+homeassistant/components/iotawatt/* @gtdiehl @jyavenard
 homeassistant/components/iperf3/* @rohankapoorcom
 homeassistant/components/ipma/* @dgomes @abmantis
 homeassistant/components/ipp/* @ctalkington

--- a/homeassistant/components/iotawatt/const.py
+++ b/homeassistant/components/iotawatt/const.py
@@ -9,4 +9,6 @@ DOMAIN = "iotawatt"
 VOLT_AMPERE_REACTIVE = "VAR"
 VOLT_AMPERE_REACTIVE_HOURS = "VARh"
 
+ATTR_LAST_UPDATE = "last_update"
+
 CONNECTION_ERRORS = (KeyError, json.JSONDecodeError, httpx.HTTPError)

--- a/homeassistant/components/iotawatt/coordinator.py
+++ b/homeassistant/components/iotawatt/coordinator.py
@@ -33,7 +33,6 @@ class IotawattUpdater(DataUpdateCoordinator):
         )
 
         self._last_run = None
-        self._refresh_requested = False
 
     def update_last_run(self, last_run: datetime):
         """Notify coordinator of a sensor last update time."""
@@ -45,9 +44,6 @@ class IotawattUpdater(DataUpdateCoordinator):
 
     async def request_refresh(self):
         """Request a refresh of the iotawatt sensors."""
-        if self._refresh_requested:
-            return
-        self._refresh_requested = True
         await self.async_request_refresh()
 
     async def _async_update_data(self):
@@ -72,5 +68,4 @@ class IotawattUpdater(DataUpdateCoordinator):
 
         await self.api.update(lastUpdate=self._last_run)
         self._last_run = None
-        self._refresh_requested = False
         return self.api.getSensors()

--- a/homeassistant/components/iotawatt/coordinator.py
+++ b/homeassistant/components/iotawatt/coordinator.py
@@ -32,19 +32,15 @@ class IotawattUpdater(DataUpdateCoordinator):
             update_interval=timedelta(seconds=30),
         )
 
-        self._last_run = None
+        self._last_run: datetime | None = None
 
-    def update_last_run(self, last_run: datetime):
+    def update_last_run(self, last_run: datetime) -> None:
         """Notify coordinator of a sensor last update time."""
         # We want to fetch the data from the iotawatt since HA was last shutdown.
         # We retrieve from the sensor last updated.
         # This method is called from each sensor upon their state being restored.
         if self._last_run is None or last_run > self._last_run:
-            self._last_run = last_run  # type: ignore
-
-    async def request_refresh(self):
-        """Request a refresh of the iotawatt sensors."""
-        await self.async_request_refresh()
+            self._last_run = last_run
 
     async def _async_update_data(self):
         """Fetch sensors from IoTaWatt device."""

--- a/homeassistant/components/iotawatt/coordinator.py
+++ b/homeassistant/components/iotawatt/coordinator.py
@@ -1,7 +1,7 @@
 """IoTaWatt DataUpdateCoordinator."""
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 from iotawattpy.iotawatt import Iotawatt
@@ -32,6 +32,24 @@ class IotawattUpdater(DataUpdateCoordinator):
             update_interval=timedelta(seconds=30),
         )
 
+        self._last_run = None
+        self._refresh_requested = False
+
+    def update_last_run(self, last_run: datetime):
+        """Notify coordinator of a sensor last update time."""
+        # We want to fetch the data from the iotawatt since HA was last shutdown.
+        # We retrieve from the sensor last updated.
+        # This method is called from each sensor upon their state being restored.
+        if self._last_run is None or last_run > self._last_run:
+            self._last_run = last_run  # type: ignore
+
+    async def request_refresh(self):
+        """Request a refresh of the iotawatt sensors."""
+        if self._refresh_requested:
+            return
+        self._refresh_requested = True
+        await self.async_request_refresh()
+
     async def _async_update_data(self):
         """Fetch sensors from IoTaWatt device."""
         if self.api is None:
@@ -52,5 +70,7 @@ class IotawattUpdater(DataUpdateCoordinator):
 
             self.api = api
 
-        await self.api.update()
+        await self.api.update(lastUpdate=self._last_run)
+        self._last_run = None
+        self._refresh_requested = False
         return self.api.getSensors()

--- a/homeassistant/components/iotawatt/manifest.json
+++ b/homeassistant/components/iotawatt/manifest.json
@@ -7,7 +7,8 @@
     "iotawattpy==0.1.0"
   ],
   "codeowners": [
-    "@gtdiehl"
+    "@gtdiehl",
+    "@jyavenard"
   ],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/iotawatt/manifest.json
+++ b/homeassistant/components/iotawatt/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/iotawatt",
   "requirements": [
-    "iotawattpy==0.0.8"
+    "iotawattpy==0.1.0"
   ],
   "codeowners": [
     "@gtdiehl"

--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -244,13 +244,9 @@ class IotaWattAccumulatingSensor(IotaWattSensor, RestoreEntity):
 
         self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
         if self._attr_unique_id is not None:
-            self._attr_unique_id += self._name_suffix
+            self._attr_unique_id += ".accumulated"
 
         self._accumulated_value: float | None = None
-
-    @property
-    def _name_suffix(self) -> str:
-        return ".accumulated"
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -292,7 +288,7 @@ class IotaWattAccumulatingSensor(IotaWattSensor, RestoreEntity):
     @property
     def name(self) -> str | None:
         """Return name of the entity."""
-        return f"{self._sensor_data.getSourceName()}{self._name_suffix}"
+        return f"{self._sensor_data.getSourceName()} Accumulating"
 
     @property
     def extra_state_attributes(self) -> dict[str, str]:

--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -288,7 +288,7 @@ class IotaWattAccumulatingSensor(IotaWattSensor, RestoreEntity):
     @property
     def name(self) -> str | None:
         """Return name of the entity."""
-        return f"{self._sensor_data.getSourceName()} Accumulating"
+        return f"{self._sensor_data.getSourceName()} Accumulated"
 
     @property
     def extra_state_attributes(self) -> dict[str, str]:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -865,7 +865,7 @@ influxdb-client==1.14.0
 influxdb==5.2.3
 
 # homeassistant.components.iotawatt
-iotawattpy==0.0.8
+iotawattpy==0.1.0
 
 # homeassistant.components.iperf3
 iperf3==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -505,7 +505,7 @@ influxdb-client==1.14.0
 influxdb==5.2.3
 
 # homeassistant.components.iotawatt
-iotawattpy==0.0.8
+iotawattpy==0.1.0
 
 # homeassistant.components.gogogate2
 ismartgate==4.0.0

--- a/tests/components/iotawatt/__init__.py
+++ b/tests/components/iotawatt/__init__.py
@@ -3,7 +3,8 @@ from iotawattpy.sensor import Sensor
 
 INPUT_SENSOR = Sensor(
     channel="1",
-    name="My Sensor",
+    base_name="My Sensor",
+    suffix=None,
     io_type="Input",
     unit="WattHours",
     value="23",
@@ -12,7 +13,8 @@ INPUT_SENSOR = Sensor(
 )
 OUTPUT_SENSOR = Sensor(
     channel="N/A",
-    name="My WattHour Sensor",
+    base_name="My WattHour Sensor",
+    suffix=None,
     io_type="Output",
     unit="WattHours",
     value="243",

--- a/tests/components/iotawatt/__init__.py
+++ b/tests/components/iotawatt/__init__.py
@@ -6,8 +6,8 @@ INPUT_SENSOR = Sensor(
     base_name="My Sensor",
     suffix=None,
     io_type="Input",
-    unit="WattHours",
-    value="23",
+    unit="Watts",
+    value=23,
     begin="",
     mac_addr="mock-mac",
 )
@@ -17,7 +17,32 @@ OUTPUT_SENSOR = Sensor(
     suffix=None,
     io_type="Output",
     unit="WattHours",
-    value="243",
+    value=243,
     begin="",
     mac_addr="mock-mac",
+    fromStart=True,
+)
+
+OUTPUT_ACCUMULATED_SENSOR = Sensor(
+    channel="N/A",
+    base_name="My WattHour Accumulated Sensor",
+    suffix=".wh",
+    io_type="Output",
+    unit="WattHours",
+    value=200,
+    begin="",
+    mac_addr="mock-mac",
+    fromStart=False,
+)
+
+OUTPUT_ACCUMULATED_SENSOR2 = Sensor(
+    channel="N/A",
+    base_name="My WattHour Accumulated Sensor2",
+    suffix=".wh",
+    io_type="Output",
+    unit="WattHours",
+    value=500,
+    begin="",
+    mac_addr="mock-mac",
+    fromStart=False,
 )

--- a/tests/components/iotawatt/__init__.py
+++ b/tests/components/iotawatt/__init__.py
@@ -23,25 +23,25 @@ OUTPUT_SENSOR = Sensor(
     fromStart=True,
 )
 
-OUTPUT_ACCUMULATED_SENSOR = Sensor(
+INPUT_ACCUMULATED_SENSOR = Sensor(
     channel="N/A",
-    base_name="My WattHour Accumulated Sensor",
+    base_name="My WattHour Accumulated Input Sensor",
     suffix=".wh",
-    io_type="Output",
+    io_type="Input",
     unit="WattHours",
-    value=200,
+    value=500,
     begin="",
     mac_addr="mock-mac",
     fromStart=False,
 )
 
-OUTPUT_ACCUMULATED_SENSOR2 = Sensor(
+OUTPUT_ACCUMULATED_SENSOR = Sensor(
     channel="N/A",
-    base_name="My WattHour Accumulated Sensor2",
+    base_name="My WattHour Accumulated Output Sensor",
     suffix=".wh",
     io_type="Output",
     unit="WattHours",
-    value=500,
+    value=200,
     begin="",
     mac_addr="mock-mac",
     fromStart=False,

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -1,19 +1,33 @@
 """Test setting up sensors."""
 from datetime import timedelta
 
-from homeassistant.components.sensor import ATTR_STATE_CLASS, DEVICE_CLASS_ENERGY
+from homeassistant.components.iotawatt.const import ATTR_LAST_UPDATE
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    DEVICE_CLASS_ENERGY,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+)
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
+    DEVICE_CLASS_POWER,
     ENERGY_WATT_HOUR,
+    POWER_WATT,
 )
+from homeassistant.core import State
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from . import INPUT_SENSOR, OUTPUT_SENSOR
+from . import (
+    INPUT_SENSOR,
+    OUTPUT_ACCUMULATED_SENSOR,
+    OUTPUT_ACCUMULATED_SENSOR2,
+    OUTPUT_SENSOR,
+)
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_time_changed, mock_restore_cache
 
 
 async def test_sensor_type_input(hass, mock_iotawatt):
@@ -33,10 +47,10 @@ async def test_sensor_type_input(hass, mock_iotawatt):
     state = hass.states.get("sensor.my_sensor")
     assert state is not None
     assert state.state == "23"
-    assert ATTR_STATE_CLASS not in state.attributes
+    assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_MEASUREMENT
     assert state.attributes[ATTR_FRIENDLY_NAME] == "My Sensor"
-    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
-    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ENERGY
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == POWER_WATT
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_POWER
     assert state.attributes["channel"] == "1"
     assert state.attributes["type"] == "Input"
 
@@ -60,6 +74,7 @@ async def test_sensor_type_output(hass, mock_iotawatt):
     state = hass.states.get("sensor.my_watthour_sensor")
     assert state is not None
     assert state.state == "243"
+    assert ATTR_STATE_CLASS not in state.attributes
     assert state.attributes[ATTR_FRIENDLY_NAME] == "My WattHour Sensor"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ENERGY
@@ -70,3 +85,153 @@ async def test_sensor_type_output(hass, mock_iotawatt):
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.my_watthour_sensor") is None
+
+
+async def test_sensor_type_accumulated_output(hass, mock_iotawatt):
+    """Tests the sensor type of Accumulated Output and that it's properly restored from saved state."""
+    mock_iotawatt.getSensors.return_value["sensors"][
+        "my_watthour_accumulated_sensor_key"
+    ] = OUTPUT_ACCUMULATED_SENSOR
+
+    DUMMY_DATE = "2021-09-01T14:00:00+10:00"
+
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "sensor.my_watthour_accumulated_sensor_wh_accumulated",
+                "100.0",
+                {
+                    "device_class": DEVICE_CLASS_ENERGY,
+                    "unit_of_measurement": ENERGY_WATT_HOUR,
+                    "last_update": DUMMY_DATE,
+                },
+            ),
+        ),
+    )
+
+    assert await async_setup_component(hass, "iotawatt", {})
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_entity_ids()) == 1
+
+    state = hass.states.get("sensor.my_watthour_accumulated_sensor_wh_accumulated")
+    assert state is not None
+
+    assert state.state == "300.0"  # 100 + 200
+    assert (
+        state.attributes[ATTR_FRIENDLY_NAME]
+        == "My WattHour Accumulated Sensor.wh.accumulated"
+    )
+    assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_TOTAL_INCREASING
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ENERGY
+    assert state.attributes["type"] == "Output"
+    assert state.attributes[ATTR_LAST_UPDATE] is not None
+    assert state.attributes[ATTR_LAST_UPDATE] != DUMMY_DATE
+
+
+async def test_sensor_type_accumulated_output_error_restore(hass, mock_iotawatt):
+    """Tests the sensor type of Accumulated Output and that it's properly restored from saved state."""
+    mock_iotawatt.getSensors.return_value["sensors"][
+        "my_watthour_accumulated_sensor_key"
+    ] = OUTPUT_ACCUMULATED_SENSOR
+
+    DUMMY_DATE = "2021-09-01T14:00:00+10:00"
+
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "sensor.my_watthour_accumulated_sensor_wh_accumulated",
+                "INVALID",
+            ),
+        ),
+    )
+
+    assert await async_setup_component(hass, "iotawatt", {})
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_entity_ids()) == 1
+
+    state = hass.states.get("sensor.my_watthour_accumulated_sensor_wh_accumulated")
+    assert state is not None
+
+    assert state.state == "200.0"  # Returns the new read as restore failed.
+    assert (
+        state.attributes[ATTR_FRIENDLY_NAME]
+        == "My WattHour Accumulated Sensor.wh.accumulated"
+    )
+    assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_TOTAL_INCREASING
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ENERGY
+    assert state.attributes["type"] == "Output"
+    assert state.attributes[ATTR_LAST_UPDATE] is not None
+    assert state.attributes[ATTR_LAST_UPDATE] != DUMMY_DATE
+
+
+async def test_sensor_type_multiple_accumulated_output(hass, mock_iotawatt):
+    """Tests the sensor type of Accumulated Output and that it's properly restored from saved state."""
+    mock_iotawatt.getSensors.return_value["sensors"][
+        "my_watthour_accumulated_sensor_key"
+    ] = OUTPUT_ACCUMULATED_SENSOR
+    mock_iotawatt.getSensors.return_value["sensors"][
+        "my_watthour_accumulated_sensor2_key"
+    ] = OUTPUT_ACCUMULATED_SENSOR2
+
+    DUMMY_DATE = "2021-09-01T14:00:00+10:00"
+
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "sensor.my_watthour_accumulated_sensor_wh_accumulated",
+                "100.0",
+                {
+                    "device_class": DEVICE_CLASS_ENERGY,
+                    "unit_of_measurement": ENERGY_WATT_HOUR,
+                    "last_update": DUMMY_DATE,
+                },
+            ),
+            State(
+                "sensor.my_watthour_accumulated_sensor2_wh_accumulated",
+                "50.0",
+                {
+                    "device_class": DEVICE_CLASS_ENERGY,
+                    "unit_of_measurement": ENERGY_WATT_HOUR,
+                    "last_update": DUMMY_DATE,
+                },
+            ),
+        ),
+    )
+
+    assert await async_setup_component(hass, "iotawatt", {})
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_entity_ids()) == 2
+
+    state = hass.states.get("sensor.my_watthour_accumulated_sensor_wh_accumulated")
+    assert state is not None
+
+    assert state.state == "300.0"  # 100 + 200
+    assert (
+        state.attributes[ATTR_FRIENDLY_NAME]
+        == "My WattHour Accumulated Sensor.wh.accumulated"
+    )
+    assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_TOTAL_INCREASING
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ENERGY
+    assert state.attributes["type"] == "Output"
+    assert state.attributes[ATTR_LAST_UPDATE] is not None
+    assert state.attributes[ATTR_LAST_UPDATE] != DUMMY_DATE
+
+    state = hass.states.get("sensor.my_watthour_accumulated_sensor2_wh_accumulated")
+    assert state is not None
+
+    assert state.state == "550.0"  # 50 + 500
+    assert (
+        state.attributes[ATTR_FRIENDLY_NAME]
+        == "My WattHour Accumulated Sensor2.wh.accumulated"
+    )
+    assert state.attributes[ATTR_LAST_UPDATE] is not None
+    assert state.attributes[ATTR_LAST_UPDATE] != DUMMY_DATE

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -144,7 +144,7 @@ async def test_sensor_type_accumulated_output_error_restore(hass, mock_iotawatt)
         (
             State(
                 "sensor.my_watthour_accumulated_sensor_wh_accumulated",
-                "INVALID",
+                "unknown",
             ),
         ),
     )

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -21,9 +21,9 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from . import (
+    INPUT_ACCUMULATED_SENSOR,
     INPUT_SENSOR,
     OUTPUT_ACCUMULATED_SENSOR,
-    OUTPUT_ACCUMULATED_SENSOR2,
     OUTPUT_SENSOR,
 )
 
@@ -90,7 +90,7 @@ async def test_sensor_type_output(hass, mock_iotawatt):
 async def test_sensor_type_accumulated_output(hass, mock_iotawatt):
     """Tests the sensor type of Accumulated Output and that it's properly restored from saved state."""
     mock_iotawatt.getSensors.return_value["sensors"][
-        "my_watthour_accumulated_sensor_key"
+        "my_watthour_accumulated_output_sensor_key"
     ] = OUTPUT_ACCUMULATED_SENSOR
 
     DUMMY_DATE = "2021-09-01T14:00:00+10:00"
@@ -99,7 +99,7 @@ async def test_sensor_type_accumulated_output(hass, mock_iotawatt):
         hass,
         (
             State(
-                "sensor.my_watthour_accumulated_sensor_wh_accumulated",
+                "sensor.my_watthour_accumulated_output_sensor_wh_accumulated",
                 "100.0",
                 {
                     "device_class": DEVICE_CLASS_ENERGY,
@@ -115,13 +115,15 @@ async def test_sensor_type_accumulated_output(hass, mock_iotawatt):
 
     assert len(hass.states.async_entity_ids()) == 1
 
-    state = hass.states.get("sensor.my_watthour_accumulated_sensor_wh_accumulated")
+    state = hass.states.get(
+        "sensor.my_watthour_accumulated_output_sensor_wh_accumulated"
+    )
     assert state is not None
 
     assert state.state == "300.0"  # 100 + 200
     assert (
         state.attributes[ATTR_FRIENDLY_NAME]
-        == "My WattHour Accumulated Sensor.wh.accumulated"
+        == "My WattHour Accumulated Output Sensor.wh Accumulated"
     )
     assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_TOTAL_INCREASING
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
@@ -134,7 +136,7 @@ async def test_sensor_type_accumulated_output(hass, mock_iotawatt):
 async def test_sensor_type_accumulated_output_error_restore(hass, mock_iotawatt):
     """Tests the sensor type of Accumulated Output and that it's properly restored from saved state."""
     mock_iotawatt.getSensors.return_value["sensors"][
-        "my_watthour_accumulated_sensor_key"
+        "my_watthour_accumulated_output_sensor_key"
     ] = OUTPUT_ACCUMULATED_SENSOR
 
     DUMMY_DATE = "2021-09-01T14:00:00+10:00"
@@ -143,7 +145,7 @@ async def test_sensor_type_accumulated_output_error_restore(hass, mock_iotawatt)
         hass,
         (
             State(
-                "sensor.my_watthour_accumulated_sensor_wh_accumulated",
+                "sensor.my_watthour_accumulated_output_sensor_wh_accumulated",
                 "unknown",
             ),
         ),
@@ -154,13 +156,15 @@ async def test_sensor_type_accumulated_output_error_restore(hass, mock_iotawatt)
 
     assert len(hass.states.async_entity_ids()) == 1
 
-    state = hass.states.get("sensor.my_watthour_accumulated_sensor_wh_accumulated")
+    state = hass.states.get(
+        "sensor.my_watthour_accumulated_output_sensor_wh_accumulated"
+    )
     assert state is not None
 
     assert state.state == "200.0"  # Returns the new read as restore failed.
     assert (
         state.attributes[ATTR_FRIENDLY_NAME]
-        == "My WattHour Accumulated Sensor.wh.accumulated"
+        == "My WattHour Accumulated Output Sensor.wh Accumulated"
     )
     assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_TOTAL_INCREASING
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
@@ -173,11 +177,11 @@ async def test_sensor_type_accumulated_output_error_restore(hass, mock_iotawatt)
 async def test_sensor_type_multiple_accumulated_output(hass, mock_iotawatt):
     """Tests the sensor type of Accumulated Output and that it's properly restored from saved state."""
     mock_iotawatt.getSensors.return_value["sensors"][
-        "my_watthour_accumulated_sensor_key"
+        "my_watthour_accumulated_output_sensor_key"
     ] = OUTPUT_ACCUMULATED_SENSOR
     mock_iotawatt.getSensors.return_value["sensors"][
-        "my_watthour_accumulated_sensor2_key"
-    ] = OUTPUT_ACCUMULATED_SENSOR2
+        "my_watthour_accumulated_input_sensor_key"
+    ] = INPUT_ACCUMULATED_SENSOR
 
     DUMMY_DATE = "2021-09-01T14:00:00+10:00"
 
@@ -185,7 +189,7 @@ async def test_sensor_type_multiple_accumulated_output(hass, mock_iotawatt):
         hass,
         (
             State(
-                "sensor.my_watthour_accumulated_sensor_wh_accumulated",
+                "sensor.my_watthour_accumulated_output_sensor_wh_accumulated",
                 "100.0",
                 {
                     "device_class": DEVICE_CLASS_ENERGY,
@@ -194,7 +198,7 @@ async def test_sensor_type_multiple_accumulated_output(hass, mock_iotawatt):
                 },
             ),
             State(
-                "sensor.my_watthour_accumulated_sensor2_wh_accumulated",
+                "sensor.my_watthour_accumulated_input_sensor_wh_accumulated",
                 "50.0",
                 {
                     "device_class": DEVICE_CLASS_ENERGY,
@@ -210,13 +214,15 @@ async def test_sensor_type_multiple_accumulated_output(hass, mock_iotawatt):
 
     assert len(hass.states.async_entity_ids()) == 2
 
-    state = hass.states.get("sensor.my_watthour_accumulated_sensor_wh_accumulated")
+    state = hass.states.get(
+        "sensor.my_watthour_accumulated_output_sensor_wh_accumulated"
+    )
     assert state is not None
 
     assert state.state == "300.0"  # 100 + 200
     assert (
         state.attributes[ATTR_FRIENDLY_NAME]
-        == "My WattHour Accumulated Sensor.wh.accumulated"
+        == "My WattHour Accumulated Output Sensor.wh Accumulated"
     )
     assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_TOTAL_INCREASING
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_WATT_HOUR
@@ -225,13 +231,15 @@ async def test_sensor_type_multiple_accumulated_output(hass, mock_iotawatt):
     assert state.attributes[ATTR_LAST_UPDATE] is not None
     assert state.attributes[ATTR_LAST_UPDATE] != DUMMY_DATE
 
-    state = hass.states.get("sensor.my_watthour_accumulated_sensor2_wh_accumulated")
+    state = hass.states.get(
+        "sensor.my_watthour_accumulated_input_sensor_wh_accumulated"
+    )
     assert state is not None
 
     assert state.state == "550.0"  # 50 + 500
     assert (
         state.attributes[ATTR_FRIENDLY_NAME]
-        == "My WattHour Accumulated Sensor2.wh.accumulated"
+        == "My WattHour Accumulated Input Sensor.wh Accumulated"
     )
     assert state.attributes[ATTR_LAST_UPDATE] is not None
     assert state.attributes[ATTR_LAST_UPDATE] != DUMMY_DATE


### PR DESCRIPTION
There were previously two types of sensors: current and energy. The current reads the value that is the average of the last 30s
And the energy which is the amount in Wh since the January 1st of the current year.

Due to how the iotawatt performs calculation internally, the energy sensors only works with outputs that use a limited set of mathematical operation (e.g. only + and -). More complex ones, such as what you would use to calculate the net energy export and import if you had a net solar system, will read wrong (and read 0 for export).

This change adds an extra energy sensor, with an " Accumulated" suffix that will read the last 30s of energy used or produced and progressively add to a permanent counter. This counter would typically always monotically increase or decrease.

In order to prevent data from being lost when the iotawatt becomes inaccessible or when the HA instance is offline (such as during an update), the sensor will fetch the missing data from the iotawatt since the last known update upon restart.

This requires the iotawattpy 0.1.0 version which was just released.

Fly-by fix: remove unused name ad mac_address IotaWattSensor parameters.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None.
This only adds a new sensors to the existing iotawatt integration. They will be automatically added once HA is restarted.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The iotawatt integration doesn't allow to correctly read energy sensors due to the way the iotawatt process the request.
A summary of the problem is in the comment above.

For more details the issue is as follow:
Assume we have defined an output in the iotawatt UI to calculate import and export power from/to the grid.
The calculation would be:
Export = (Consumption+Production) min 0
Import = (Consumption+Production) max 0
where Production is a negative number as the current flows out.

When the current integration queries the energy force those sensors, it does so by requesting the energy value since January 1st of the year.
the iotawatt device will calculate it this way:
Export = (Average(Consumption, period) + Average(Consumption, period)) * duration_in_hour

rather than running the expression on the individual measurements. The reason for this is the lack of processing power by the iotawatt and the slow access speed to the storage medium.

So imagine you power load is a constant 1000W since the beginning of the year. a total of 1kw * 243 days * 24 = 5832kWh
and today you installed a solar system that produced 2000W for 1h; a total of -2kWh since January 2021.

If you query the iotawatt it will then return:
min(0, 5832kWh + -2kW) = 0

When obviously the correct was 1kWh (the excess power was 1000W over an hour)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: I didn't open a bug.
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
