### PR TITLE
Block tests from opening sockets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -700,6 +700,7 @@ jobs:
             -p no:sugar \
             --disable-socket \
             --allow-unix-socket \
+            --allow-hosts="127.0.0.1" \
             tests
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v2.2.4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -698,6 +698,8 @@ jobs:
             --cov-report= \
             -o console_output_style=count \
             -p no:sugar \
+            --disable-socket \
+            --allow-unix-socket \
             tests
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v2.2.4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -698,9 +698,6 @@ jobs:
             --cov-report= \
             -o console_output_style=count \
             -p no:sugar \
-            --disable-socket \
-            --allow-unix-socket \
-            --allow-hosts="127.0.0.1" \
             tests
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v2.2.4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -18,6 +18,7 @@ pipdeptree==2.1.0
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.12.1
+pytest-socket==0.4.1
 pytest-test-groups==1.0.3
 pytest-sugar==0.9.4
 pytest-timeout==1.4.2

--- a/tests/components/auth/conftest.py
+++ b/tests/components/auth/conftest.py
@@ -1,0 +1,8 @@
+"""Test configuration for auth."""
+import pytest
+
+
+@pytest.fixture
+def aiohttp_client(loop, aiohttp_client, socket_enabled):
+    """Return aiohttp_client and allow opening sockets."""
+    return aiohttp_client

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -29,6 +29,12 @@ class MockTransport:
 
 
 @pytest.fixture
+def aiohttp_client(loop, aiohttp_client, socket_enabled):
+    """Return aiohttp_client and allow opening sockets."""
+    return aiohttp_client
+
+
+@pytest.fixture
 def hue_client(aiohttp_client):
     """Return a hue API client."""
     app = web.Application()

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -80,6 +80,12 @@ async def frontend_themes(hass):
 
 
 @pytest.fixture
+def aiohttp_client(loop, aiohttp_client, socket_enabled):
+    """Return aiohttp_client and allow opening sockets."""
+    return aiohttp_client
+
+
+@pytest.fixture
 async def mock_http_client(hass, aiohttp_client, frontend):
     """Start the Home Assistant HTTP component."""
     return await aiohttp_client(hass.http.app)

--- a/tests/components/http/conftest.py
+++ b/tests/components/http/conftest.py
@@ -1,0 +1,8 @@
+"""Test configuration for http."""
+import pytest
+
+
+@pytest.fixture
+def aiohttp_client(loop, aiohttp_client, socket_enabled):
+    """Return aiohttp_client and allow opening sockets."""
+    return aiohttp_client

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -1,6 +1,8 @@
 """The tests for the image_processing component."""
 from unittest.mock import PropertyMock, patch
 
+import pytest
+
 import homeassistant.components.http as http
 import homeassistant.components.image_processing as ip
 from homeassistant.const import ATTR_ENTITY_PICTURE
@@ -9,6 +11,12 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_capture_events
 from tests.components.image_processing import common
+
+
+@pytest.fixture
+def aiohttp_unused_port(loop, aiohttp_unused_port, socket_enabled):
+    """Return aiohttp_unused_port and allow opening sockets."""
+    return aiohttp_unused_port
 
 
 def get_url(hass):

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -1,6 +1,5 @@
 """Test the motionEye camera."""
 import copy
-import logging
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 
@@ -48,7 +47,11 @@ from . import (
 
 from tests.common import async_fire_time_changed
 
-_LOGGER = logging.getLogger(__name__)
+
+@pytest.fixture
+def aiohttp_server(loop, aiohttp_server, socket_enabled):
+    """Return aiohttp_server and allow opening sockets."""
+    return aiohttp_server
 
 
 async def test_setup_camera(hass: HomeAssistant) -> None:

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -49,6 +49,12 @@ class FakeAuth(AbstractAuth):
 
 
 @pytest.fixture
+def aiohttp_client(loop, aiohttp_client, socket_enabled):
+    """Return aiohttp_client and allow opening sockets."""
+    return aiohttp_client
+
+
+@pytest.fixture
 async def auth(aiohttp_client):
     """Fixture for an AbstractAuth."""
     auth = FakeAuth()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock, patch
 from aiohttp.test_utils import make_mocked_request
 import multidict
 import pytest
-import pytest_socket
 import requests_mock as _requests_mock
 
 from homeassistant import core as ha, loader, runner, util
@@ -320,14 +319,11 @@ def local_auth(hass):
 
 
 @pytest.fixture
-def hass_client(hass, aiohttp_client, hass_access_token):
+def hass_client(hass, aiohttp_client, hass_access_token, socket_enabled):
     """Return an authenticated HTTP client."""
 
     async def auth_client():
         """Return an authenticated client."""
-        # Allow creating sockets, but restricted to 127.0.0.1
-        pytest_socket.enable_socket()
-        pytest_socket.socket_allow_hosts("127.0.0.1")
         return await aiohttp_client(
             hass.http.app, headers={"Authorization": f"Bearer {hass_access_token}"}
         )
@@ -371,16 +367,13 @@ def current_request_with_host(current_request):
 
 
 @pytest.fixture
-def hass_ws_client(aiohttp_client, hass_access_token, hass):
+def hass_ws_client(aiohttp_client, hass_access_token, hass, socket_enabled):
     """Websocket client fixture connected to websocket server."""
 
     async def create_client(hass=hass, access_token=hass_access_token):
         """Create a websocket client."""
         assert await async_setup_component(hass, "websocket_api", {})
 
-        # Allow creating sockets, but restricted to 127.0.0.1
-        pytest_socket.enable_socket()
-        pytest_socket.socket_allow_hosts("127.0.0.1")
         client = await aiohttp_client(hass.http.app)
 
         with patch("homeassistant.components.http.auth.setup_auth"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,7 +332,7 @@ def hass_client(hass, aiohttp_client, hass_access_token, socket_enabled):
 
 
 @pytest.fixture
-def hass_client_no_auth(hass, aiohttp_client):
+def hass_client_no_auth(hass, aiohttp_client, socket_enabled):
     """Return an unauthenticated HTTP client."""
 
     async def client():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from aiohttp.test_utils import make_mocked_request
 import multidict
 import pytest
+import pytest_socket
 import requests_mock as _requests_mock
 
 from homeassistant import core as ha, loader, runner, util
@@ -324,6 +325,9 @@ def hass_client(hass, aiohttp_client, hass_access_token):
 
     async def auth_client():
         """Return an authenticated client."""
+        # Allow creating sockets, but restricted to 127.0.0.1
+        pytest_socket.enable_socket()
+        pytest_socket.socket_allow_hosts("127.0.0.1")
         return await aiohttp_client(
             hass.http.app, headers={"Authorization": f"Bearer {hass_access_token}"}
         )
@@ -374,6 +378,9 @@ def hass_ws_client(aiohttp_client, hass_access_token, hass):
         """Create a websocket client."""
         assert await async_setup_component(hass, "websocket_api", {})
 
+        # Allow creating sockets, but restricted to 127.0.0.1
+        pytest_socket.enable_socket()
+        pytest_socket.socket_allow_hosts("127.0.0.1")
         client = await aiohttp_client(hass.http.app)
 
         with patch("homeassistant.components.http.auth.setup_auth"):

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -1,0 +1,18 @@
+"""Test test fixture configuration."""
+import socket
+
+import pytest
+import pytest_socket
+
+
+def test_sockets_disabled():
+    """Test we can't open sockets."""
+    with pytest.raises(pytest_socket.SocketBlockedError):
+        socket.socket()
+
+
+def test_sockets_enabled(socket_enabled):
+    """Test we can't connect to an address different from 127.0.0.1."""
+    mysocket = socket.socket()
+    with pytest.raises(pytest_socket.SocketConnectBlockedError):
+        mysocket.connect(("127.0.0.2", 1234))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Block tests from opening sockets

The blocking is implemented by using the `pytest_socket` package which is enabled in a `pytest_runtest_setup` in the top-level conftest.py.
Workarounds for two pytest_socket PRs, https://github.com/miketheman/pytest-socket/pull/75, https://github.com/miketheman/pytest-socket/pull/76 are added in the top-level conftest.py.

### Related PRs
  - https://github.com/home-assistant/core/pull/55521
  - https://github.com/home-assistant/core/pull/55526
  - https://github.com/home-assistant/core/pull/55561
  - https://github.com/home-assistant/core/pull/55581
  - https://github.com/home-assistant/core/pull/55583
  - https://github.com/home-assistant/core/pull/55585
  - https://github.com/home-assistant/core/pull/55592
  - https://github.com/home-assistant/core/pull/55593
  - https://github.com/home-assistant/core/pull/55594
  - https://github.com/home-assistant/core/pull/55595
  - https://github.com/home-assistant/core/pull/55596
  - https://github.com/home-assistant/core/pull/55636
  - https://github.com/home-assistant/core/pull/55647
  - https://github.com/home-assistant/core/pull/55668
  - https://github.com/home-assistant/core/pull/56307
  - https://github.com/home-assistant/core/pull/56308
  - https://github.com/home-assistant/core/pull/56310
  - https://github.com/home-assistant/core/pull/56324
  - https://github.com/home-assistant/core/pull/56325
  - https://github.com/home-assistant/core/pull/56326
  - https://github.com/home-assistant/core/pull/56328
  - https://github.com/home-assistant/core/pull/56329
  - https://github.com/home-assistant/core/pull/56330
  - https://github.com/home-assistant/core/pull/56331
  - https://github.com/home-assistant/core/pull/56334
  - https://github.com/home-assistant/core/pull/56337
  - https://github.com/home-assistant/core/pull/56339
  - https://github.com/home-assistant/core/pull/56342
  - https://github.com/home-assistant/core/pull/56345
  - https://github.com/home-assistant/core/pull/57037
  - https://github.com/home-assistant/core/pull/57038
  - https://github.com/home-assistant/core/pull/57039
  - https://github.com/home-assistant/core/pull/57040
  - https://github.com/home-assistant/core/pull/57058
  - https://github.com/home-assistant/core/pull/57059
  - https://github.com/home-assistant/core/pull/57101

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
