### PR TITLE
OpenGarage, change to attributes

### DIFF
--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -86,25 +86,17 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class OpenGarageCover(CoverEntity):
     """Representation of a OpenGarage cover."""
 
+    _attr_device_class = DEVICE_CLASS_GARAGE
+    _attr_supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
+
     def __init__(self, name, open_garage, device_id):
         """Initialize the cover."""
-        self._name = name
+        self._attr_name = name
         self._open_garage = open_garage
         self._state = None
         self._state_before_move = None
         self._extra_state_attributes = {}
-        self._available = True
-        self._device_id = device_id
-
-    @property
-    def name(self):
-        """Return the name of the cover."""
-        return self._name
-
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._available
+        self._attr_unique_id = device_id
 
     @property
     def extra_state_attributes(self):
@@ -153,11 +145,11 @@ class OpenGarageCover(CoverEntity):
         status = await self._open_garage.update_state()
         if status is None:
             _LOGGER.error("Unable to connect to OpenGarage device")
-            self._available = False
+            self._attr_available = False
             return
 
-        if self._name is None and status["name"] is not None:
-            self._name = status["name"]
+        if self.name is None and status["name"] is not None:
+            self._attr_name = status["name"]
         state = STATES_MAP.get(status.get("door"))
         if self._state_before_move is not None:
             if self._state_before_move != state:
@@ -166,7 +158,7 @@ class OpenGarageCover(CoverEntity):
         else:
             self._state = state
 
-        _LOGGER.debug("%s status: %s", self._name, self._state)
+        _LOGGER.debug("%s status: %s", self.name, self._state)
         if status.get("rssi") is not None:
             self._extra_state_attributes[ATTR_SIGNAL_STRENGTH] = status.get("rssi")
         if status.get("dist") is not None:
@@ -174,7 +166,7 @@ class OpenGarageCover(CoverEntity):
         if self._state is not None:
             self._extra_state_attributes[ATTR_DOOR_STATE] = self._state
 
-        self._available = True
+        self._attr_available = True
 
     async def _push_button(self):
         """Send commands to API."""
@@ -185,24 +177,9 @@ class OpenGarageCover(CoverEntity):
             return
 
         if result == 2:
-            _LOGGER.error("Unable to control %s: Device key is incorrect", self._name)
+            _LOGGER.error("Unable to control %s: Device key is incorrect", self.name)
         elif result > 2:
-            _LOGGER.error("Unable to control %s: Error code %s", self._name, result)
+            _LOGGER.error("Unable to control %s: Error code %s", self.name, result)
 
         self._state = self._state_before_move
         self._state_before_move = None
-
-    @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return DEVICE_CLASS_GARAGE
-
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORT_OPEN | SUPPORT_CLOSE
-
-    @property
-    def unique_id(self):
-        """Return a unique ID."""
-        return self._device_id


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
OpenGarage, change to attributes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
