### PR TITLE
Add default currency constant

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.components.sensor import (
 from homeassistant.components.sensor.recorder import reset_detected
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
+    CURRENCY_DEFAULT,
     ENERGY_KILO_WATT_HOUR,
     ENERGY_WATT_HOUR,
     VOLUME_CUBIC_METERS,
@@ -363,4 +364,4 @@ class EnergyCostSensor(SensorEntity):
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the units of measurement."""
-        return self.hass.config.currency
+        return CURRENCY_DEFAULT

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -45,8 +45,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.components.switch import DOMAIN as SWITCH
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
-    CURRENCY_CENT,
-    CURRENCY_DOLLAR,
+    CURRENCY_US_DOLLAR,
     DEGREE,
     ELECTRIC_CURRENT_MILLIAMPERE,
     ELECTRIC_POTENTIAL_MILLIVOLT,
@@ -418,8 +417,8 @@ UOM_FRIENDLY_NAME = {
     UOM_8_BIT_RANGE: "",  # Range 0-255, no unit.
     UOM_DOUBLE_TEMP: UOM_DOUBLE_TEMP,
     "102": "kWs",
-    "103": CURRENCY_DOLLAR,
-    "104": CURRENCY_CENT,
+    "103": CURRENCY_US_DOLLAR,
+    "104": "¢",
     "105": LENGTH_INCHES,
     "106": SPEED_MILLIMETERS_PER_DAY,
     "107": "",  # raw 1-byte unsigned value

--- a/homeassistant/components/nsw_fuel_station/sensor.py
+++ b/homeassistant/components/nsw_fuel_station/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.nsw_fuel_station import (
     StationPriceData,
 )
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.const import ATTR_ATTRIBUTION, CURRENCY_CENT, VOLUME_LITERS
+from homeassistant.const import ATTR_ATTRIBUTION, VOLUME_LITERS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -119,7 +119,7 @@ class StationPriceSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self) -> str:
         """Return the units of measurement."""
-        return f"{CURRENCY_CENT}/{VOLUME_LITERS}"
+        return f"¢/{VOLUME_LITERS}"
 
     def _get_station_name(self):
         default_name = f"station {self._station_id}"

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    CURRENCY_DEFAULT,
     DEVICE_CLASS_AQI,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_CO,
@@ -256,6 +257,9 @@ class SensorEntity(Entity):
 
         if native_unit_of_measurement in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
             return self.hass.config.units.temperature_unit
+
+        if native_unit_of_measurement == CURRENCY_DEFAULT:
+            return self.hass.config.currency
 
         return native_unit_of_measurement
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -429,10 +429,10 @@ ELECTRIC_POTENTIAL_VOLT: Final = "V"
 # Degree units
 DEGREE: Final = "°"
 
-# Currency units
-CURRENCY_EURO: Final = "€"
-CURRENCY_DOLLAR: Final = "$"
-CURRENCY_CENT: Final = "¢"
+# Currency units, any ISO4217 currency code is also allowed
+CURRENCY_EURO: Final = "EUR"
+CURRENCY_US_DOLLAR: Final = "USD"
+CURRENCY_DEFAULT: Final = "currency_default"  # HA core config currency
 
 # Temperature units
 TEMP_CELSIUS: Final = "°C"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add default currency constant `CURRENCY_DEFAULT`
If a sensor's `native_unit_of_measurement` is `CURRENCY_DEFAULT`, its `unit_of_measurement` will be `self.hass.config.currency`
Set energy cost sensor's currency to `CURRENCY_DEFAULT`

### Background
When the system's default currency changes, we want to find sensors using that as unit of measurement to wipe affected statistics

### Suggested next step
The sensor integration should listen to `EVENT_CORE_CONFIG_UPDATE`, and identify sensors with `native_unit_of_measurement == CURRENCY_DEFAULT` and wipe their statistics, if it exists.

### Also
Change `CURRENCY_EURO` from `€` to `EUR`
Rename `CURRENCY_DOLLAR` to `CURRENCY_US_DOLLAR` and change it from `$` to `USD`
Remove `CURRENCY_CENT`, cent is not a currency

Update integrations using `CURRENCY_DOLLAR` or `CURRENCY_CENT`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
