### PR TITLE
2021.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,21 @@ RUN \
     -e ./homeassistant \
     && python3 -m compileall homeassistant/homeassistant
 
+# Fix Bug with Alpine 3.14 and sqlite 3.35
+# https://gitlab.alpinelinux.org/alpine/aports/-/issues/12524
+ARG BUILD_ARCH
+RUN \
+    if [ "${BUILD_ARCH}" = "amd64" ]; then \
+        export APK_ARCH=x86_64; \
+    elif [ "${BUILD_ARCH}" = "i386" ]; then \
+        export APK_ARCH=x86; \
+    else \
+        export APK_ARCH=${BUILD_ARCH}; \
+    fi \
+    && curl -O http://dl-cdn.alpinelinux.org/alpine/v3.13/main/${APK_ARCH}/sqlite-libs-3.34.1-r0.apk \
+    && apk add --no-cache sqlite-libs-3.34.1-r0.apk \
+    && rm -f sqlite-libs-3.34.1-r0.apk
+
 # Home Assistant S6-Overlay
 COPY rootfs /
 

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -10,6 +10,8 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_ADDRESS,
+    CONF_COMMAND_OFF,
+    CONF_COMMAND_ON,
     CONF_COUNT,
     CONF_HOST,
     CONF_NAME,
@@ -201,15 +203,19 @@ def scan_interval_validator(config: dict) -> dict:
 def duplicate_entity_validator(config: dict) -> dict:
     """Control scan_interval."""
     for hub_index, hub in enumerate(config):
-        addresses: set[str] = set()
         for component, conf_key in PLATFORMS:
             if conf_key not in hub:
                 continue
             names: set[str] = set()
             errors: list[int] = []
+            addresses: set[str] = set()
             for index, entry in enumerate(hub[conf_key]):
                 name = entry[CONF_NAME]
                 addr = str(entry[CONF_ADDRESS])
+                if CONF_COMMAND_ON in entry:
+                    addr += "_" + str(entry[CONF_COMMAND_ON])
+                if CONF_COMMAND_OFF in entry:
+                    addr += "_" + str(entry[CONF_COMMAND_OFF])
                 if CONF_SLAVE in entry:
                     addr += "_" + str(entry[CONF_SLAVE])
                 if addr in addresses:

--- a/homeassistant/components/uptimerobot/manifest.json
+++ b/homeassistant/components/uptimerobot/manifest.json
@@ -3,7 +3,7 @@
   "name": "Uptime Robot",
   "documentation": "https://www.home-assistant.io/integrations/uptimerobot",
   "requirements": [
-    "pyuptimerobot==21.8.2"
+    "pyuptimerobot==21.9.0"
   ],
   "codeowners": [
     "@ludeeus"

--- a/homeassistant/components/xiaomi_miio/manifest.json
+++ b/homeassistant/components/xiaomi_miio/manifest.json
@@ -3,7 +3,7 @@
   "name": "Xiaomi Miio",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_miio",
-  "requirements": ["construct==2.10.56", "micloud==0.3", "python-miio==0.5.7"],
+  "requirements": ["construct==2.10.56", "micloud==0.3", "python-miio==0.5.8"],
   "codeowners": ["@rytilahti", "@syssi", "@starkillerOG", "@bieniu"],
   "zeroconf": ["_miio._udp.local."],
   "iot_class": "local_polling"

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -174,7 +174,7 @@ class ZHAGateway:
         """Restore ZHA devices from zigpy application state."""
         for zigpy_device in self.application_controller.devices.values():
             zha_device = self._async_get_or_create_device(zigpy_device, restored=True)
-            if zha_device.nwk == 0x0000:
+            if zha_device.ieee == self.application_controller.ieee:
                 self.coordinator_zha_device = zha_device
             zha_dev_entry = self.zha_storage.devices.get(str(zigpy_device.ieee))
             delta_msg = "not known"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 9
-PATCH_VERSION: Final = "0"
+PATCH_VERSION: Final = "1"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1880,7 +1880,7 @@ python-juicenet==1.0.2
 # python-lirc==1.2.3
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.5.7
+python-miio==0.5.8
 
 # homeassistant.components.mpd
 python-mpd2==3.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1968,7 +1968,7 @@ pytrafikverket==0.1.6.2
 pyudev==0.22.0
 
 # homeassistant.components.uptimerobot
-pyuptimerobot==21.8.2
+pyuptimerobot==21.9.0
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1067,7 +1067,7 @@ python-izone==1.1.6
 python-juicenet==1.0.2
 
 # homeassistant.components.xiaomi_miio
-python-miio==0.5.7
+python-miio==0.5.8
 
 # homeassistant.components.nest
 python-nest==4.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1109,7 +1109,7 @@ pytradfri[async]==7.0.6
 pyudev==0.22.0
 
 # homeassistant.components.uptimerobot
-pyuptimerobot==21.8.2
+pyuptimerobot==21.9.0
 
 # homeassistant.components.vera
 pyvera==0.3.13


### PR DESCRIPTION
- Bump pyuptimerobot to 21.9.0 ([@ludeeus] - [#55546]) ([uptimerobot docs])
- xiaomi_miio: bump python-miio dependency ([@rytilahti] - [#55549]) ([xiaomi_miio docs])
- Pick right coordinator ([@Adminiuga] - [#55555]) ([zha docs])
- Correct duplicate address. ([@janiversen] - [#55578]) ([modbus docs])
- Downgrade sqlite-libs on docker image ([@pvizeli] - [#55591])

[#55546]: https://github.com/home-assistant/core/pull/55546
[#55549]: https://github.com/home-assistant/core/pull/55549
[#55555]: https://github.com/home-assistant/core/pull/55555
[#55578]: https://github.com/home-assistant/core/pull/55578
[#55591]: https://github.com/home-assistant/core/pull/55591
[@Adminiuga]: https://github.com/Adminiuga
[@janiversen]: https://github.com/janiversen
[@ludeeus]: https://github.com/ludeeus
[@pvizeli]: https://github.com/pvizeli
[@rytilahti]: https://github.com/rytilahti
[modbus docs]: https://www.home-assistant.io/integrations/modbus/
[uptimerobot docs]: https://www.home-assistant.io/integrations/uptimerobot/
[xiaomi_miio docs]: https://www.home-assistant.io/integrations/xiaomi_miio/
[zha docs]: https://www.home-assistant.io/integrations/zha/