### PR TITLE
Simplify utility_meter code base with croniter

### DIFF
--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -65,6 +65,16 @@ def period_or_cron(config):
     return config
 
 
+def max_31_days(config):
+    """Check that time period does not include more then 31 days."""
+    if config.days >= 31:
+        raise vol.Invalid(
+            "Unsupported offset of more then 31 days, please use a cron pattern. Continuing without offset"
+        )
+
+    return config
+
+
 METER_CONFIG_SCHEMA = vol.Schema(
     vol.All(
         {
@@ -72,7 +82,7 @@ METER_CONFIG_SCHEMA = vol.Schema(
             vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_METER_TYPE): vol.In(METER_TYPES),
             vol.Optional(CONF_METER_OFFSET, default=DEFAULT_OFFSET): vol.All(
-                cv.time_period, cv.positive_timedelta
+                cv.time_period, cv.positive_timedelta, max_31_days
             ),
             vol.Optional(CONF_METER_NET_CONSUMPTION, default=False): cv.boolean,
             vol.Optional(CONF_TARIFFS, default=[]): vol.All(

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -66,10 +66,10 @@ def period_or_cron(config):
 
 
 def max_31_days(config):
-    """Check that time period does not include more then 31 days."""
-    if config.days >= 31:
+    """Check that time period does not include more then 28 days."""
+    if config.days >= 28:
         raise vol.Invalid(
-            "Unsupported offset of more then 31 days, please use a cron pattern. Continuing without offset"
+            "Unsupported offset of more then 28 days, please use a cron pattern. Continuing without offset"
         )
 
     return config

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -69,7 +69,7 @@ def max_28_days(config):
     """Check that time period does not include more then 28 days."""
     if config.days >= 28:
         raise vol.Invalid(
-            "Unsupported offset of more then 28 days, please use a cron pattern. Continuing without offset"
+            "Unsupported offset of more then 28 days, please use a cron pattern."
         )
 
     return config

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -65,7 +65,7 @@ def period_or_cron(config):
     return config
 
 
-def max_31_days(config):
+def max_28_days(config):
     """Check that time period does not include more then 28 days."""
     if config.days >= 28:
         raise vol.Invalid(
@@ -82,7 +82,7 @@ METER_CONFIG_SCHEMA = vol.Schema(
             vol.Optional(CONF_NAME): cv.string,
             vol.Optional(CONF_METER_TYPE): vol.In(METER_TYPES),
             vol.Optional(CONF_METER_OFFSET, default=DEFAULT_OFFSET): vol.All(
-                cv.time_period, cv.positive_timedelta, max_31_days
+                cv.time_period, cv.positive_timedelta, max_28_days
             ),
             vol.Optional(CONF_METER_NET_CONSUMPTION, default=False): cv.boolean,
             vol.Optional(CONF_TARIFFS, default=[]): vol.All(

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -58,7 +58,6 @@ from .const import (
 )
 
 PERIOD2CRON = {
-    None: None,
     QUARTER_HOURLY: "{minute}/15 * * * *",
     HOURLY: "{minute} * * * *",
     DAILY: "{minute} {hour} * * *",

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -1,5 +1,5 @@
 """Utility meter from sensors providing raw data."""
-from datetime import datetime, timedelta
+from datetime import datetime
 from decimal import Decimal, DecimalException
 import logging
 
@@ -163,11 +163,6 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         self._period = meter_type
         if meter_type is not None:
             # For backwards compatibility reasons we convert the period and offset into a cron pattern
-            if meter_offset.days >= 31:
-                _LOGGER.error(
-                    "Unsupported offset, please use a cron pattern. Continuing without offset"
-                )
-                meter_offset = timedelta()
             self._cron_pattern = PERIOD2CRON[meter_type].format(
                 minute=meter_offset.seconds % 3600 // 60,
                 hour=meter_offset.seconds // 3600,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -1,6 +1,6 @@
 """Utility meter from sensors providing raw data."""
 from datetime import datetime
-from decimal import Decimal, DecimalException
+from decimal import Decimal, DecimalException, InvalidOperation
 import logging
 
 from croniter import croniter
@@ -291,7 +291,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         if state:
             try:
                 self._state = Decimal(state.state)
-            except decimal.InvalidOperation:
+            except InvalidOperation:
                 _LOGGER.error(
                     "Could not restore state <%s>. Resetting utility_meter.%s",
                     state.state,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -172,9 +172,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
             self._cron_pattern = PERIOD2CRON[meter_type].format(
                 minute=meter_offset.seconds % 3600 // 60,
                 hour=meter_offset.seconds // 3600,
-                day=meter_offset.days + 1
-                if meter_type in [WEEKLY, YEARLY]
-                else 0,  # required for different reasons for backwards compatibility
+                day=meter_offset.days + 1,
             )
             _LOGGER.debug("CRON pattern: %s", self._cron_pattern)
         else:

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -162,7 +162,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         self._unit_of_measurement = None
         self._period = meter_type
         if meter_type is not None:
-            """For backwards compatibility reasons we convert the period and offset into a cron pattern"""
+            # For backwards compatibility reasons we convert the period and offset into a cron pattern
             if meter_offset.days >= 31:
                 _LOGGER.error(
                     "Unsupported offset, please use a cron pattern. Continuing without offset"

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -1,6 +1,5 @@
 """Utility meter from sensors providing raw data."""
-from datetime import date, datetime, timedelta
-import decimal
+from datetime import datetime, timedelta
 from decimal import Decimal, DecimalException
 import logging
 
@@ -29,7 +28,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import (
     async_track_point_in_time,
     async_track_state_change_event,
-    async_track_time_change,
 )
 from homeassistant.helpers.restore_state import RestoreEntity
 import homeassistant.util.dt as dt_util
@@ -58,6 +56,18 @@ from .const import (
     WEEKLY,
     YEARLY,
 )
+
+PERIOD2CRON = {
+    None: None,
+    QUARTER_HOURLY: "{minute}/15 * * * *",
+    HOURLY: "{minute} * * * *",
+    DAILY: "{minute} {hour} * * *",
+    WEEKLY: "{minute} {hour} * * {day}",
+    MONTHLY: "{minute} {hour} {day} * *",
+    BIMONTHLY: "{minute} {hour} {day} */2 *",
+    QUARTERLY: "{minute} {hour} {day} */3 *",
+    YEARLY: "{minute} {hour} {day} 1/12 *",
+}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -152,8 +162,23 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
             self._name = f"{source_entity} meter"
         self._unit_of_measurement = None
         self._period = meter_type
-        self._period_offset = meter_offset
-        self._cron_pattern = cron_pattern
+        if meter_type is not None:
+            """For backwards compatibility reasons we convert the period and offset into a cron pattern"""
+            if meter_offset.days >= 31:
+                _LOGGER.error(
+                    "Unsupported offset, please use a cron pattern. Continuing without offset"
+                )
+                meter_offset = timedelta()
+            self._cron_pattern = PERIOD2CRON[meter_type].format(
+                minute=meter_offset.seconds % 3600 // 60,
+                hour=meter_offset.seconds // 3600,
+                day=meter_offset.days + 1
+                if meter_type in [WEEKLY, YEARLY]
+                else 0,  # required for different reasons for backwards compatibility
+            )
+            _LOGGER.debug("CRON pattern: %s", self._cron_pattern)
+        else:
+            self._cron_pattern = cron_pattern
         self._sensor_net_consumption = net_consumption
         self._tariff = tariff
         self._tariff_entity = tariff_entity
@@ -233,39 +258,12 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
 
     async def _async_reset_meter(self, event):
         """Determine cycle - Helper function for larger than daily cycles."""
-        now = dt_util.now().date()
         if self._cron_pattern is not None:
             async_track_point_in_time(
                 self.hass,
                 self._async_reset_meter,
                 croniter(self._cron_pattern, dt_util.now()).get_next(datetime),
             )
-        elif (
-            self._period == WEEKLY
-            and now != now - timedelta(days=now.weekday()) + self._period_offset
-        ):
-            return
-        elif (
-            self._period == MONTHLY
-            and now != date(now.year, now.month, 1) + self._period_offset
-        ):
-            return
-        elif (
-            self._period == BIMONTHLY
-            and now
-            != date(now.year, (((now.month - 1) // 2) * 2 + 1), 1) + self._period_offset
-        ):
-            return
-        elif (
-            self._period == QUARTERLY
-            and now
-            != date(now.year, (((now.month - 1) // 3) * 3 + 1), 1) + self._period_offset
-        ):
-            return
-        elif (
-            self._period == YEARLY and now != date(now.year, 1, 1) + self._period_offset
-        ):
-            return
         await self.async_reset_meter(self._tariff_entity)
 
     async def async_reset_meter(self, entity_id):
@@ -293,30 +291,6 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
                 self.hass,
                 self._async_reset_meter,
                 croniter(self._cron_pattern, dt_util.now()).get_next(datetime),
-            )
-        elif self._period == QUARTER_HOURLY:
-            for quarter in range(4):
-                async_track_time_change(
-                    self.hass,
-                    self._async_reset_meter,
-                    minute=(quarter * 15)
-                    + self._period_offset.seconds % (15 * 60) // 60,
-                    second=self._period_offset.seconds % 60,
-                )
-        elif self._period == HOURLY:
-            async_track_time_change(
-                self.hass,
-                self._async_reset_meter,
-                minute=self._period_offset.seconds // 60,
-                second=self._period_offset.seconds % 60,
-            )
-        elif self._period in [DAILY, WEEKLY, MONTHLY, BIMONTHLY, QUARTERLY, YEARLY]:
-            async_track_time_change(
-                self.hass,
-                self._async_reset_meter,
-                hour=self._period_offset.seconds // 3600,
-                minute=self._period_offset.seconds % 3600 // 60,
-                second=self._period_offset.seconds % 3600 % 60,
             )
 
         async_dispatcher_connect(self.hass, SIGNAL_RESET_METER, self.async_reset_meter)

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -627,7 +627,7 @@ async def test_no_reset_yearly_offset(hass, legacy_patchable_time):
     """Test yearly reset of meter."""
     await _test_self_reset(
         hass,
-        gen_config("yearly", timedelta(31)),
-        "2018-01-30T23:59:00.000000+00:00",
+        gen_config("yearly", timedelta(30)),
+        "2018-04-29T23:59:00.000000+00:00",
         expect_reset=False,
     )

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -627,7 +627,14 @@ async def test_no_reset_yearly_offset(hass, legacy_patchable_time):
     """Test yearly reset of meter."""
     await _test_self_reset(
         hass,
-        gen_config("yearly", timedelta(30)),
+        gen_config("yearly", timedelta(27)),
         "2018-04-29T23:59:00.000000+00:00",
         expect_reset=False,
+    )
+
+
+async def test_bad_offset(hass, legacy_patchable_time):
+    """Test bad offset of meter."""
+    assert not await async_setup_component(
+        hass, DOMAIN, gen_config("monthly", timedelta(days=31))
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `offset` parameter for `utility_meter` sensors is now limited to at most 27 days. If you used more then 27 days you must now migrate to `cron` 

-----
Tests pass, and extra testing was done, but users should be on the lookout

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Code improvement

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20009

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
