### PR TITLE
Use NamedTuple for color temperature range

### DIFF
--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -66,16 +66,24 @@ LIGHT_SYSINFO_IS_COLOR = "is_color"
 MAX_ATTEMPTS = 300
 SLEEP_TIME = 2
 
-TPLINK_KELVIN = {
-    "LB130": (2500, 9000),
-    "LB120": (2700, 6500),
-    "LB230": (2500, 9000),
-    "KB130": (2500, 9000),
-    "KL130": (2500, 9000),
-    "KL125": (2500, 6500),
-    r"KL120\(EU\)": (2700, 6500),
-    r"KL120\(US\)": (2700, 5000),
-    r"KL430\(US\)": (2500, 9000),
+
+class ColorTempRange(NamedTuple):
+    """Color temperature range (in Kelvin)."""
+
+    min: int
+    max: int
+
+
+TPLINK_KELVIN: dict[str, ColorTempRange] = {
+    "LB130": ColorTempRange(2500, 9000),
+    "LB120": ColorTempRange(2700, 6500),
+    "LB230": ColorTempRange(2500, 9000),
+    "KB130": ColorTempRange(2500, 9000),
+    "KL130": ColorTempRange(2500, 9000),
+    "KL125": ColorTempRange(2500, 6500),
+    r"KL120\(EU\)": ColorTempRange(2700, 6500),
+    r"KL120\(US\)": ColorTempRange(2700, 5000),
+    r"KL430\(US\)": ColorTempRange(2500, 9000),
 }
 
 FALLBACK_MIN_COLOR = 2700
@@ -294,7 +302,7 @@ class TPLinkSmartBulb(LightEntity):
         """Flag supported features."""
         return self._light_features.supported_features
 
-    def _get_valid_temperature_range(self) -> tuple[int, int]:
+    def _get_valid_temperature_range(self) -> ColorTempRange:
         """Return the device-specific white temperature range (in Kelvin).
 
         :return: White temperature range in Kelvin (minimum, maximum)
@@ -305,7 +313,7 @@ class TPLinkSmartBulb(LightEntity):
                 return temp_range
         # pyHS100 is abandoned, but some bulb definitions aren't present
         # use "safe" values for something that advertises color temperature
-        return FALLBACK_MIN_COLOR, FALLBACK_MAX_COLOR
+        return ColorTempRange(FALLBACK_MIN_COLOR, FALLBACK_MAX_COLOR)
 
     def _get_light_features(self) -> LightFeatures:
         """Determine all supported features in one go."""
@@ -323,9 +331,9 @@ class TPLinkSmartBulb(LightEntity):
             supported_features += SUPPORT_BRIGHTNESS
         if sysinfo.get(LIGHT_SYSINFO_IS_VARIABLE_COLOR_TEMP):
             supported_features += SUPPORT_COLOR_TEMP
-            max_range, min_range = self._get_valid_temperature_range()
-            min_mireds = kelvin_to_mired(min_range)
-            max_mireds = kelvin_to_mired(max_range)
+            color_temp_range = self._get_valid_temperature_range()
+            min_mireds = kelvin_to_mired(color_temp_range.max)
+            max_mireds = kelvin_to_mired(color_temp_range.min)
         if sysinfo.get(LIGHT_SYSINFO_IS_COLOR):
             supported_features += SUPPORT_COLOR
 


### PR DESCRIPTION
## Proposed change
Use `NamedTuple` for a small code quality improvement.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
