### PR TITLE
Make scapy imports in DHCP local

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -14,13 +14,8 @@ from aiodiscover.discovery import (
     IP_ADDRESS as DISCOVERY_IP_ADDRESS,
     MAC_ADDRESS as DISCOVERY_MAC_ADDRESS,
 )
-from scapy.arch.common import compile_filter
 from scapy.config import conf
 from scapy.error import Scapy_Exception
-from scapy.layers.dhcp import DHCP
-from scapy.layers.inet import IP
-from scapy.layers.l2 import Ether
-from scapy.sendrecv import AsyncSniffer
 
 from homeassistant.components.device_tracker.const import (
     ATTR_HOST_NAME,
@@ -282,6 +277,12 @@ class DHCPWatcher(WatcherBase):
 
     async def async_start(self):
         """Start watching for dhcp packets."""
+        # Local import because importing from scapy has side effects such as opening
+        # sockets
+        from scapy.sendrecv import (  # pylint: disable=import-outside-toplevel
+            AsyncSniffer,
+        )
+
         # disable scapy promiscuous mode as we do not need it
         conf.sniff_promisc = 0
 
@@ -318,6 +319,12 @@ class DHCPWatcher(WatcherBase):
 
     def handle_dhcp_packet(self, packet):
         """Process a dhcp packet."""
+        # Local import because importing from scapy has side effects such as opening
+        # sockets
+        from scapy.layers.dhcp import DHCP  # pylint: disable=import-outside-toplevel
+        from scapy.layers.inet import IP  # pylint: disable=import-outside-toplevel
+        from scapy.layers.l2 import Ether  # pylint: disable=import-outside-toplevel
+
         if DHCP not in packet:
             return
 
@@ -382,4 +389,10 @@ def _verify_working_pcap(cap_filter):
     If we cannot create a filter we will be listening for
     all traffic which is too intensive.
     """
+    # Local import because importing from scapy has side effects such as opening
+    # sockets
+    from scapy.arch.common import (  # pylint: disable=import-outside-toplevel
+        compile_filter,
+    )
+
     compile_filter(cap_filter)

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -390,9 +390,9 @@ async def test_setup_and_stop(hass):
     )
     await hass.async_block_till_done()
 
-    with patch("homeassistant.components.dhcp.AsyncSniffer.start") as start_call, patch(
+    with patch("scapy.sendrecv.AsyncSniffer.start") as start_call, patch(
         "homeassistant.components.dhcp._verify_l2socket_setup",
-    ), patch("homeassistant.components.dhcp.compile_filter",), patch(
+    ), patch("scapy.arch.common.compile_filter"), patch(
         "homeassistant.components.dhcp.DiscoverHosts.async_discover"
     ):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -461,12 +461,10 @@ async def test_setup_fails_with_broken_libpcap(hass, caplog):
     )
     await hass.async_block_till_done()
 
-    with patch("homeassistant.components.dhcp._verify_l2socket_setup",), patch(
-        "homeassistant.components.dhcp.compile_filter",
+    with patch("homeassistant.components.dhcp._verify_l2socket_setup"), patch(
+        "scapy.arch.common.compile_filter",
         side_effect=ImportError,
-    ) as compile_filter, patch(
-        "homeassistant.components.dhcp.AsyncSniffer",
-    ) as async_sniffer, patch(
+    ) as compile_filter, patch("scapy.sendrecv.AsyncSniffer") as async_sniffer, patch(
         "homeassistant.components.dhcp.DiscoverHosts.async_discover"
     ):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make `scapy` imports in DHCP local

Importing from `scapy` has surprising side effects, such as the opening of sockets.
As an example: https://github.com/secdev/scapy/blob/05036527bf0ccb5f4da18fe5791fbfca22695183/scapy/arch/__init__.py#L141

Make imports local to allow blocking of unneeded sockets in tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
