### PR TITLE
Avoid creating sockets in homekit port available tests

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -103,9 +103,9 @@ from .const import (
 from .type_triggers import DeviceTriggerAccessory
 from .util import (
     accessory_friendly_name,
+    async_port_is_available,
     dismiss_setup_message,
     get_persist_fullpath_for_entry_id,
-    port_is_available,
     remove_state_files_for_entry_id,
     show_setup_message,
     state_needs_accessory_mode,
@@ -330,7 +330,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     logged_shutdown_wait = False
     for _ in range(0, SHUTDOWN_TIMEOUT):
-        if await hass.async_add_executor_job(port_is_available, entry.data[CONF_PORT]):
+        if async_port_is_available(entry.data[CONF_PORT]):
             break
 
         if not logged_shutdown_wait:

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -172,9 +172,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_pairing(self, user_input=None):
         """Pairing instructions."""
         if user_input is not None:
-            port = await async_find_next_available_port(
-                self.hass, DEFAULT_CONFIG_FLOW_PORT
-            )
+            port = async_find_next_available_port(self.hass, DEFAULT_CONFIG_FLOW_PORT)
             await self._async_add_entries_for_accessory_mode_entities(port)
             self.hk_data[CONF_PORT] = port
             include_domains_filter = self.hk_data[CONF_FILTER][CONF_INCLUDE_DOMAINS]
@@ -205,7 +203,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         for entity_id in accessory_mode_entity_ids:
             if entity_id in exiting_entity_ids_accessory_mode:
                 continue
-            port = await async_find_next_available_port(self.hass, next_port_to_check)
+            port = async_find_next_available_port(self.hass, next_port_to_check)
             next_port_to_check = port + 1
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     CONF_TYPE,
     TEMP_CELSIUS,
 )
-from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.core import HomeAssistant, callback, split_entity_id
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
 import homeassistant.util.temperature as temp_util
@@ -433,34 +433,32 @@ def _get_test_socket():
     return test_socket
 
 
-def port_is_available(port: int) -> bool:
+@callback
+def async_port_is_available(port: int) -> bool:
     """Check to see if a port is available."""
-    test_socket = _get_test_socket()
     try:
-        test_socket.bind(("", port))
+        _get_test_socket().bind(("", port))
     except OSError:
         return False
-
     return True
 
 
-async def async_find_next_available_port(hass: HomeAssistant, start_port: int) -> int:
+@callback
+def async_find_next_available_port(hass: HomeAssistant, start_port: int) -> int:
     """Find the next available port not assigned to a config entry."""
     exclude_ports = {
         entry.data[CONF_PORT]
         for entry in hass.config_entries.async_entries(DOMAIN)
         if CONF_PORT in entry.data
     }
-
-    return await hass.async_add_executor_job(
-        _find_next_available_port, start_port, exclude_ports
-    )
+    return _async_find_next_available_port(start_port, exclude_ports)
 
 
-def _find_next_available_port(start_port: int, exclude_ports: set) -> int:
+@callback
+def _async_find_next_available_port(start_port: int, exclude_ports: set) -> int:
     """Find the next available port starting with the given port."""
     test_socket = _get_test_socket()
-    for port in range(start_port, MAX_PORT):
+    for port in range(start_port, MAX_PORT + 1):
         if port in exclude_ports:
             continue
         try:

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -951,10 +951,15 @@ async def test_converting_bridge_to_accessory_mode(hass, hk_driver, mock_get_sou
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result2["step_id"] == "cameras"
 
-    result3 = await hass.config_entries.options.async_configure(
-        result2["flow_id"],
-        user_input={"camera_copy": ["camera.tv"]},
-    )
+    with patch(
+        "homeassistant.components.homekit.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result3 = await hass.config_entries.options.async_configure(
+            result2["flow_id"],
+            user_input={"camera_copy": ["camera.tv"]},
+        )
+        await hass.async_block_till_done()
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {
@@ -968,6 +973,7 @@ async def test_converting_bridge_to_accessory_mode(hass, hk_driver, mock_get_sou
             "include_entities": ["camera.tv"],
         },
     }
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 def _get_schema_default(schema, key_name):

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1308,7 +1308,7 @@ async def test_homekit_uses_system_zeroconf(hass, hk_driver, mock_zeroconf):
 
     with patch("pyhap.accessory_driver.AccessoryDriver.async_start"), patch(
         f"{PATH_HOMEKIT}.HomeKit.async_stop"
-    ), patch(f"{PATH_HOMEKIT}.port_is_available"):
+    ), patch(f"{PATH_HOMEKIT}.async_port_is_available"):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -1701,7 +1701,7 @@ async def test_wait_for_port_to_free(hass, hk_driver, mock_zeroconf, caplog):
 
     with patch("pyhap.accessory_driver.AccessoryDriver.async_start"), patch(
         f"{PATH_HOMEKIT}.HomeKit.async_stop"
-    ), patch(f"{PATH_HOMEKIT}.port_is_available", return_value=True) as port_mock:
+    ), patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True) as port_mock:
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
         assert await hass.config_entries.async_unload(entry.entry_id)
@@ -1712,7 +1712,7 @@ async def test_wait_for_port_to_free(hass, hk_driver, mock_zeroconf, caplog):
     with patch("pyhap.accessory_driver.AccessoryDriver.async_start"), patch(
         f"{PATH_HOMEKIT}.HomeKit.async_stop"
     ), patch.object(homekit_base, "PORT_CLEANUP_CHECK_INTERVAL_SECS", 0), patch(
-        f"{PATH_HOMEKIT}.port_is_available", return_value=False
+        f"{PATH_HOMEKIT}.async_port_is_available", return_value=False
     ) as port_mock:
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Avoid creating sockets in homekit port available tests

Also fixed that these didn't actually do any blocking operations so no need to run in the executor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
