### PR TITLE
Add caplog setup phase fixture for template

### DIFF
--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -25,3 +25,9 @@ async def start_ha(hass, count, domain, config, caplog):
     await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
+
+
+@pytest.fixture
+async def caplog_setup_text(caplog):
+    """Return setup log of integration."""
+    yield caplog.text

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -431,13 +431,12 @@ async def test_availability_template(hass, start_ha):
         },
     ],
 )
-async def test_invalid_attribute_template(hass, caplog, start_ha):
+async def test_invalid_attribute_template(hass, start_ha, caplog_setup_text):
     """Test that errors are logged if rendering template fails."""
     hass.states.async_set("binary_sensor.test_sensor", "true")
     assert len(hass.states.async_all()) == 2
-    text = str([x.getMessage() for x in caplog.get_records("setup")])
-    assert ("test_attribute") in text
-    assert ("TemplateError") in text
+    assert ("test_attribute") in caplog_setup_text
+    assert ("TemplateError") in caplog_setup_text
 
 
 @pytest.mark.parametrize("count,domain", [(1, binary_sensor.DOMAIN)])
@@ -458,13 +457,12 @@ async def test_invalid_attribute_template(hass, caplog, start_ha):
     ],
 )
 async def test_invalid_availability_template_keeps_component_available(
-    hass, caplog, start_ha
+    hass, start_ha, caplog_setup_text
 ):
     """Test that an invalid availability keeps the device available."""
 
     assert hass.states.get("binary_sensor.my_sensor").state != STATE_UNAVAILABLE
-    text = str([x.getMessage() for x in caplog.get_records("setup")])
-    assert ("UndefinedError: \\'x\\' is undefined") in text
+    assert "UndefinedError: 'x' is undefined" in caplog_setup_text
 
 
 async def test_no_update_template_match_all(hass, caplog):

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -381,7 +381,7 @@ async def test_available_template_with_entities(hass, start_ha):
         },
     ],
 )
-async def test_invalid_attribute_template(hass, caplog, start_ha):
+async def test_invalid_attribute_template(hass, caplog, start_ha, caplog_setup_text):
     """Test that errors are logged if rendering template fails."""
     hass.states.async_set("sensor.test_sensor", "startup")
     await hass.async_block_till_done()
@@ -390,9 +390,7 @@ async def test_invalid_attribute_template(hass, caplog, start_ha):
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
     await hass.helpers.entity_component.async_update_entity("sensor.invalid_template")
-
-    messages = str([x.message for x in caplog.get_records("setup")])
-    assert "TemplateError" in messages
+    assert "TemplateError" in caplog_setup_text
     assert "test_attribute" in caplog.text
 
 
@@ -414,12 +412,11 @@ async def test_invalid_attribute_template(hass, caplog, start_ha):
     ],
 )
 async def test_invalid_availability_template_keeps_component_available(
-    hass, caplog, start_ha
+    hass, start_ha, caplog_setup_text
 ):
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("sensor.my_sensor").state != STATE_UNAVAILABLE
-    messages = str([x.message for x in caplog.get_records("setup")])
-    assert "UndefinedError: \\'x\\' is undefined" in messages
+    assert "UndefinedError: 'x' is undefined" in caplog_setup_text
 
 
 async def test_no_template_match_all(hass, caplog):
@@ -624,14 +621,12 @@ async def test_sun_renders_once_per_sensor(hass, start_ha):
         },
     ],
 )
-async def test_self_referencing_sensor_loop(hass, caplog, start_ha):
+async def test_self_referencing_sensor_loop(hass, start_ha, caplog_setup_text):
     """Test a self referencing sensor does not loop forever."""
     assert len(hass.states.async_all()) == 1
     await hass.async_block_till_done()
     await hass.async_block_till_done()
-    messages = str([x.message for x in caplog.get_records("setup")])
-    assert "Template loop detected" in messages
-
+    assert "Template loop detected" in caplog_setup_text
     assert int(hass.states.get("sensor.test").state) == 2
     await hass.async_block_till_done()
     assert int(hass.states.get("sensor.test").state) == 2
@@ -654,13 +649,14 @@ async def test_self_referencing_sensor_loop(hass, caplog, start_ha):
         },
     ],
 )
-async def test_self_referencing_sensor_with_icon_loop(hass, caplog, start_ha):
+async def test_self_referencing_sensor_with_icon_loop(
+    hass, start_ha, caplog_setup_text
+):
     """Test a self referencing sensor loops forever with a valid self referencing icon."""
     assert len(hass.states.async_all()) == 1
     await hass.async_block_till_done()
     await hass.async_block_till_done()
-    messages = str([x.message for x in caplog.get_records("setup")])
-    assert "Template loop detected" in messages
+    assert "Template loop detected" in caplog_setup_text
 
     state = hass.states.get("sensor.test")
     assert int(state.state) == 3
@@ -689,14 +685,13 @@ async def test_self_referencing_sensor_with_icon_loop(hass, caplog, start_ha):
     ],
 )
 async def test_self_referencing_sensor_with_icon_and_picture_entity_loop(
-    hass, caplog, start_ha
+    hass, start_ha, caplog_setup_text
 ):
     """Test a self referencing sensor loop forevers with a valid self referencing icon."""
     assert len(hass.states.async_all()) == 1
     await hass.async_block_till_done()
     await hass.async_block_till_done()
-    messages = str([x.message for x in caplog.get_records("setup")])
-    assert "Template loop detected" in messages
+    assert "Template loop detected" in caplog_setup_text
 
     state = hass.states.get("sensor.test")
     assert int(state.state) == 4
@@ -724,7 +719,7 @@ async def test_self_referencing_sensor_with_icon_and_picture_entity_loop(
         },
     ],
 )
-async def test_self_referencing_entity_picture_loop(hass, caplog, start_ha):
+async def test_self_referencing_entity_picture_loop(hass, start_ha, caplog_setup_text):
     """Test a self referencing sensor does not loop forever with a looping self referencing entity picture."""
     assert len(hass.states.async_all()) == 1
     next_time = dt_util.utcnow() + timedelta(seconds=1.2)
@@ -735,8 +730,7 @@ async def test_self_referencing_entity_picture_loop(hass, caplog, start_ha):
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-    messages = str([x.message for x in caplog.get_records("setup")])
-    assert "Template loop detected" in messages
+    assert "Template loop detected" in caplog_setup_text
 
     state = hass.states.get("sensor.test")
     assert int(state.state) == 1
@@ -1006,14 +1000,13 @@ async def test_trigger_entity_render_error(hass, start_ha):
         },
     ],
 )
-async def test_trigger_not_allowed_platform_config(hass, caplog, start_ha):
+async def test_trigger_not_allowed_platform_config(hass, start_ha, caplog_setup_text):
     """Test we throw a helpful warning if a trigger is configured in platform config."""
     state = hass.states.get(TEST_NAME)
     assert state is None
-    messages = str([x.message for x in caplog.get_records("setup")])
     assert (
         "You can only add triggers to template entities if they are defined under `template:`."
-        in messages
+        in caplog_setup_text
     )
 
 

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -207,12 +207,11 @@ async def test_available_template_with_entities(hass, start_ha):
     ],
 )
 async def test_invalid_availability_template_keeps_component_available(
-    hass, caplog, start_ha
+    hass, start_ha, caplog_setup_text
 ):
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("vacuum.test_template_vacuum") != STATE_UNAVAILABLE
-    text = str([x.getMessage() for x in caplog.get_records("setup")])
-    assert ("UndefinedError: \\'x\\' is undefined") in text
+    assert "UndefinedError: 'x' is undefined" in caplog_setup_text
 
 
 @pytest.mark.parametrize(
@@ -275,13 +274,11 @@ async def test_attribute_templates(hass, start_ha):
         )
     ],
 )
-async def test_invalid_attribute_template(hass, caplog, start_ha):
+async def test_invalid_attribute_template(hass, start_ha, caplog_setup_text):
     """Test that errors are logged if rendering template fails."""
     assert len(hass.states.async_all()) == 1
-
-    text = str([x.getMessage() for x in caplog.get_records("setup")])
-    assert "test_attribute" in text
-    assert "TemplateError" in text
+    assert "test_attribute" in caplog_setup_text
+    assert "TemplateError" in caplog_setup_text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Caplog.text is only valid for the current phase ("setup", "run" or "teardown"). There is a function to refer to messages in other phases. The fixture "caplet_setup_text" makes caplog.text from setup available to the text function, and thus simplifies the test code.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Idea comes from review comments in an earlier PR.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
