### PR TITLE
Add multiple adguard support to services

### DIFF
--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -44,6 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {DATA_ADGUARD_CLIENT: adguard}
 
     try:
+        _LOGGER.error(adguard.version)
         await adguard.version()
     except AdGuardHomeConnectionError as exception:
         raise ConfigEntryNotReady from exception

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -4,48 +4,26 @@ from __future__ import annotations
 import logging
 
 from adguardhome import AdGuardHome, AdGuardHomeConnectionError, AdGuardHomeError
-import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
-    CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_SSL,
-    CONF_URL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
     Platform,
 )
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
-from .const import (
-    CONF_FORCE,
-    DATA_ADGUARD_CLIENT,
-    DATA_ADGUARD_VERSION,
-    DOMAIN,
-    SERVICE_ADD_URL,
-    SERVICE_DISABLE_URL,
-    SERVICE_ENABLE_URL,
-    SERVICE_REFRESH,
-    SERVICE_REMOVE_URL,
-)
+from .const import DATA_ADGUARD_CLIENT, DATA_ADGUARD_VERSION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-SERVICE_URL_SCHEMA = vol.Schema({vol.Required(CONF_URL): cv.url})
-SERVICE_ADD_URL_SCHEMA = vol.Schema(
-    {vol.Required(CONF_NAME): cv.string, vol.Required(CONF_URL): cv.url}
-)
-SERVICE_REFRESH_SCHEMA = vol.Schema(
-    {vol.Optional(CONF_FORCE, default=False): cv.boolean}
-)
 
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
 
@@ -72,57 +50,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
-    async def add_url(call: ServiceCall) -> None:
-        """Service call to add a new filter subscription to AdGuard Home."""
-        await adguard.filtering.add_url(
-            allowlist=False, name=call.data[CONF_NAME], url=call.data[CONF_URL]
-        )
-
-    async def remove_url(call: ServiceCall) -> None:
-        """Service call to remove a filter subscription from AdGuard Home."""
-        await adguard.filtering.remove_url(allowlist=False, url=call.data[CONF_URL])
-
-    async def enable_url(call: ServiceCall) -> None:
-        """Service call to enable a filter subscription in AdGuard Home."""
-        await adguard.filtering.enable_url(allowlist=False, url=call.data[CONF_URL])
-
-    async def disable_url(call: ServiceCall) -> None:
-        """Service call to disable a filter subscription in AdGuard Home."""
-        await adguard.filtering.disable_url(allowlist=False, url=call.data[CONF_URL])
-
-    async def refresh(call: ServiceCall) -> None:
-        """Service call to refresh the filter subscriptions in AdGuard Home."""
-        await adguard.filtering.refresh(allowlist=False, force=call.data[CONF_FORCE])
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_ADD_URL, add_url, schema=SERVICE_ADD_URL_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_REMOVE_URL, remove_url, schema=SERVICE_URL_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_ENABLE_URL, enable_url, schema=SERVICE_URL_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_DISABLE_URL, disable_url, schema=SERVICE_URL_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_REFRESH, refresh, schema=SERVICE_REFRESH_SCHEMA
-    )
-
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload AdGuard Home config entry."""
-    hass.services.async_remove(DOMAIN, SERVICE_ADD_URL)
-    hass.services.async_remove(DOMAIN, SERVICE_REMOVE_URL)
-    hass.services.async_remove(DOMAIN, SERVICE_ENABLE_URL)
-    hass.services.async_remove(DOMAIN, SERVICE_DISABLE_URL)
-    hass.services.async_remove(DOMAIN, SERVICE_REFRESH)
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    if not hass.data[DOMAIN]:
         del hass.data[DOMAIN]
 
     return unload_ok

--- a/homeassistant/components/adguard/services.yaml
+++ b/homeassistant/components/adguard/services.yaml
@@ -1,6 +1,12 @@
 add_url:
   name: Add url
   description: Add a new filter subscription to AdGuard Home.
+  target:
+    entity:
+      integration: adguard
+      domain: switch
+    device:
+      integration: adguard
   fields:
     name:
       name: Name
@@ -20,6 +26,12 @@ add_url:
 remove_url:
   name: Remove url
   description: Removes a filter subscription from AdGuard Home.
+  target:
+    entity:
+      integration: adguard
+      domain: switch
+    device:
+      integration: adguard
   fields:
     url:
       name: Url
@@ -32,6 +44,12 @@ remove_url:
 enable_url:
   name: Enable url
   description: Enables a filter subscription in AdGuard Home.
+  target:
+    entity:
+      integration: adguard
+      domain: switch
+    device:
+      integration: adguard
   fields:
     url:
       name: Url
@@ -44,6 +62,12 @@ enable_url:
 disable_url:
   name: Disable url
   description: Disables a filter subscription in AdGuard Home.
+  target:
+    entity:
+      integration: adguard
+      domain: switch
+    device:
+      integration: adguard
   fields:
     url:
       name: Url
@@ -56,6 +80,12 @@ disable_url:
 refresh:
   name: Refresh
   description: Refresh all filter subscriptions in AdGuard Home.
+  target:
+    entity:
+      integration: adguard
+      domain: switch
+    device:
+      integration: adguard
   fields:
     force:
       name: Force

--- a/homeassistant/components/adguard/switch.py
+++ b/homeassistant/components/adguard/switch.py
@@ -6,15 +6,36 @@ import logging
 from typing import Any
 
 from adguardhome import AdGuardHome, AdGuardHomeConnectionError, AdGuardHomeError
+import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_NAME, CONF_URL
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AdGuardHomeDeviceEntity
-from .const import DATA_ADGUARD_CLIENT, DATA_ADGUARD_VERSION, DOMAIN
+from .const import (
+    CONF_FORCE,
+    DATA_ADGUARD_CLIENT,
+    DATA_ADGUARD_VERSION,
+    DOMAIN,
+    SERVICE_ADD_URL,
+    SERVICE_DISABLE_URL,
+    SERVICE_ENABLE_URL,
+    SERVICE_REFRESH,
+    SERVICE_REMOVE_URL,
+)
+
+SERVICE_URL_SCHEMA = cv.make_entity_service_schema({vol.Required(CONF_URL): cv.url})
+SERVICE_ADD_URL_SCHEMA = cv.make_entity_service_schema(
+    {vol.Required(CONF_NAME): cv.string, vol.Required(CONF_URL): cv.url}
+)
+SERVICE_REFRESH_SCHEMA = cv.make_entity_service_schema(
+    {vol.Optional(CONF_FORCE, default=False): cv.boolean}
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,6 +49,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AdGuard Home switch based on a config entry."""
+    platform = entity_platform.async_get_current_platform()
+
     adguard = hass.data[DOMAIN][entry.entry_id][DATA_ADGUARD_CLIENT]
 
     try:
@@ -46,6 +69,75 @@ async def async_setup_entry(
         AdGuardHomeQueryLogSwitch(adguard, entry),
     ]
     async_add_entities(switches, True)
+
+    async def async_service_handle(service_call: ServiceCall) -> None:
+        """Handle dispatched services."""
+        assert platform is not None
+        entities = await platform.async_extract_from_service(service_call)
+
+        adguard_instances = []
+        for entity in entities:
+            assert isinstance(entity, AdGuardHomeDeviceEntity)
+            adguard_instances.append(entity.adguard)
+        for adguard_instance in set(adguard_instances):
+            if service_call.service == SERVICE_ADD_URL:
+                await add_url(adguard_instance, service_call)
+            if service_call.service == SERVICE_REMOVE_URL:
+                await remove_url(adguard_instance, service_call)
+            if service_call.service == SERVICE_ENABLE_URL:
+                await enable_url(adguard_instance, service_call)
+            if service_call.service == SERVICE_DISABLE_URL:
+                await disable_url(adguard_instance, service_call)
+            if service_call.service == SERVICE_REFRESH:
+                await refresh(adguard_instance, service_call)
+
+    async def add_url(adguard: AdGuardHome, service_call: ServiceCall) -> None:
+        """Service call to add a new filter subscription to AdGuard Home."""
+        await adguard.filtering.add_url(
+            allowlist=False,
+            name=str(service_call.data.get(CONF_NAME)),
+            url=str(service_call.data.get(CONF_URL)),
+        )
+
+    async def remove_url(adguard: AdGuardHome, service_call: ServiceCall) -> None:
+        """Service call to remove a filter subscription from AdGuard Home."""
+        await adguard.filtering.remove_url(
+            allowlist=False, url=str(service_call.data.get(CONF_URL))
+        )
+
+    async def enable_url(adguard: AdGuardHome, service_call: ServiceCall) -> None:
+        """Service call to enable a filter subscription in AdGuard Home."""
+        await adguard.filtering.enable_url(
+            allowlist=False, url=str(service_call.data.get(CONF_URL))
+        )
+
+    async def disable_url(adguard: AdGuardHome, service_call: ServiceCall) -> None:
+        """Service call to disable a filter subscription in AdGuard Home."""
+        await adguard.filtering.disable_url(
+            allowlist=False, url=str(service_call.data.get(CONF_URL))
+        )
+
+    async def refresh(adguard: AdGuardHome, service_call: ServiceCall) -> None:
+        """Service call to refresh the filter subscriptions in AdGuard Home."""
+        await adguard.filtering.refresh(
+            allowlist=False, force=service_call.data.get(CONF_FORCE, False)
+        )
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_ADD_URL, async_service_handle, SERVICE_ADD_URL_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_REMOVE_URL, async_service_handle, SERVICE_URL_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_ENABLE_URL, async_service_handle, SERVICE_URL_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_DISABLE_URL, async_service_handle, SERVICE_URL_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_REFRESH, async_service_handle, SERVICE_REFRESH_SCHEMA
+    )
 
 
 class AdGuardHomeSwitch(AdGuardHomeDeviceEntity, SwitchEntity):

--- a/tests/components/adguard/conftest.py
+++ b/tests/components/adguard/conftest.py
@@ -1,0 +1,49 @@
+"""Fixtures for adguard tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL, CONTENT_TYPE_JSON
+
+from .const import FIXTURE_USER_INPUT
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+@pytest.fixture(name="bypass_version")
+def bypass_version_fixture(aioclient_mock: AiohttpClientMocker):
+    """Prevent version call."""
+    aioclient_mock.get(
+        f"{'https' if FIXTURE_USER_INPUT[CONF_SSL] else 'http'}"
+        f"://{FIXTURE_USER_INPUT[CONF_HOST]}"
+        f":{FIXTURE_USER_INPUT[CONF_PORT]}/control/status",
+        json={"version": "v0.99.0"},
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+    )
+
+
+@pytest.fixture(name="bypass_switch_state_update")
+def bypass_switch_state_update_fixture():
+    """Prevent switch state API calls."""
+    with patch(
+        "homeassistant.components.adguard.switch.AdGuardHomeProtectionSwitch._adguard_update"
+    ), patch(
+        "homeassistant.components.adguard.switch.AdGuardHomeParentalSwitch._adguard_update"
+    ), patch(
+        "homeassistant.components.adguard.switch.AdGuardHomeSafeSearchSwitch._adguard_update"
+    ), patch(
+        "homeassistant.components.adguard.switch.AdGuardHomeSafeBrowsingSwitch._adguard_update"
+    ), patch(
+        "homeassistant.components.adguard.switch.AdGuardHomeFilteringSwitch._adguard_update"
+    ), patch(
+        "homeassistant.components.adguard.switch.AdGuardHomeQueryLogSwitch._adguard_update"
+    ):
+        yield
+
+
+@pytest.fixture(name="disable_sensors")
+def disable_sensors_fixture():
+    """Prevent sensor setup."""
+    with patch("homeassistant.components.adguard.sensor.async_setup_entry"):
+        yield

--- a/tests/components/adguard/const.py
+++ b/tests/components/adguard/const.py
@@ -1,0 +1,18 @@
+"""Constants for adguard tests."""
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+
+FIXTURE_USER_INPUT = {
+    CONF_HOST: "127.0.0.1",
+    CONF_PORT: 3000,
+    CONF_USERNAME: "user",
+    CONF_PASSWORD: "pass",
+    CONF_SSL: True,
+    CONF_VERIFY_SSL: True,
+}

--- a/tests/components/adguard/test_config_flow.py
+++ b/tests/components/adguard/test_config_flow.py
@@ -16,17 +16,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
+from .const import FIXTURE_USER_INPUT
+
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
-
-FIXTURE_USER_INPUT = {
-    CONF_HOST: "127.0.0.1",
-    CONF_PORT: 3000,
-    CONF_USERNAME: "user",
-    CONF_PASSWORD: "pass",
-    CONF_SSL: True,
-    CONF_VERIFY_SSL: True,
-}
 
 
 async def test_show_authenticate_form(hass: HomeAssistant) -> None:

--- a/tests/components/adguard/test_switch.py
+++ b/tests/components/adguard/test_switch.py
@@ -1,0 +1,98 @@
+"""Tests for the AdGuard Home switch platform."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.adguard.const import (
+    DOMAIN,
+    SERVICE_ADD_URL,
+    SERVICE_DISABLE_URL,
+    SERVICE_ENABLE_URL,
+    SERVICE_REFRESH,
+    SERVICE_REMOVE_URL,
+)
+from homeassistant.const import ATTR_ENTITY_ID, CONF_NAME, CONF_URL
+from homeassistant.core import HomeAssistant
+
+from .const import FIXTURE_USER_INPUT
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures(
+    "bypass_version", "bypass_switch_state_update", "disable_sensors"
+)
+async def test_services(hass: HomeAssistant):
+    """Test service calls."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=FIXTURE_USER_INPUT, entry_id="test"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch("adguardhome.filtering.AdGuardHomeFiltering.add_url") as mock:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_URL,
+            {
+                ATTR_ENTITY_ID: "switch.adguard_safe_browsing",
+                CONF_NAME: "test",
+                CONF_URL: "http://test.com",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock.assert_awaited_once()
+
+    with patch("adguardhome.filtering.AdGuardHomeFiltering.remove_url") as mock:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_REMOVE_URL,
+            {
+                ATTR_ENTITY_ID: "switch.adguard_safe_browsing",
+                CONF_URL: "http://test.com",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock.assert_awaited_once()
+
+    with patch("adguardhome.filtering.AdGuardHomeFiltering.enable_url") as mock:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ENABLE_URL,
+            {
+                ATTR_ENTITY_ID: "switch.adguard_safe_browsing",
+                CONF_URL: "http://test.com",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock.assert_awaited_once()
+
+    with patch("adguardhome.filtering.AdGuardHomeFiltering.disable_url") as mock:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DISABLE_URL,
+            {
+                ATTR_ENTITY_ID: "switch.adguard_safe_browsing",
+                CONF_URL: "http://test.com",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock.assert_awaited_once()
+
+    with patch("adguardhome.filtering.AdGuardHomeFiltering.refresh") as mock:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_REFRESH,
+            {
+                ATTR_ENTITY_ID: "switch.adguard_safe_browsing",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock.assert_awaited_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
If more than one adguard instance was configured all services would target one instance at random. To target a specific instance all service calls now require a target device or entity of this instance.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The PR https://github.com/home-assistant/core/pull/49116 introduced support for multiple adguard instances but failed to add that support to the service calls as well.

I analyzed several implementations like deconz, yeelight and finally deemed the official guidance for [entity-services](https://developers.home-assistant.io/docs/dev_101_services#entity-services) the most user friendly.

The services are not really related to the switch platform but it seemed more appropiate than the sensor platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53469
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
