### PR TITLE
Rework Tractive integration init

### DIFF
--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import logging
 
 import aiotractive
@@ -20,11 +21,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import (
     ATTR_DAILY_GOAL,
-    ATTR_HW_INFO,
     ATTR_MINUTES_ACTIVE,
-    ATTR_POS_REPORT,
-    ATTR_TRACKABLE,
-    ATTR_TRACKER_DETAILS,
     CLIENT,
     DOMAIN,
     RECONNECT_INTERVAL,
@@ -39,6 +36,16 @@ PLATFORMS = ["device_tracker", "sensor"]
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Trackables:
+    """A class that describes trackables."""
+
+    trackable: dict | None = None
+    tracker_details: dict | None = None
+    hw_info: dict | None = None
+    pos_report: dict | None = None
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -95,12 +102,7 @@ async def _generate_trackables(client, trackable):
         tracker.details(), tracker.hw_info(), tracker.pos_report()
     )
 
-    return {
-        ATTR_TRACKABLE: trackable,
-        ATTR_TRACKER_DETAILS: tracker_details,
-        ATTR_HW_INFO: hw_info,
-        ATTR_POS_REPORT: pos_report,
-    }
+    return Trackables(trackable, tracker_details, hw_info, pos_report)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -45,8 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up tractive from a config entry."""
     data = entry.data
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN].setdefault(entry.entry_id, {})
+    hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
 
     client = aiotractive.Tractive(
         data[CONF_EMAIL], data[CONF_PASSWORD], session=async_get_clientsession(hass)

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -69,8 +69,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     tractive = TractiveClient(hass, client, creds["user_id"])
     tractive.subscribe()
 
-    trackable_objects = await client.trackable_objects()
     try:
+        trackable_objects = await client.trackable_objects()
         trackables = await asyncio.gather(
             *(_generate_trackables(client, item) for item in trackable_objects)
         )

--- a/homeassistant/components/tractive/const.py
+++ b/homeassistant/components/tractive/const.py
@@ -7,11 +7,7 @@ DOMAIN = "tractive"
 RECONNECT_INTERVAL = timedelta(seconds=10)
 
 ATTR_DAILY_GOAL = "daily_goal"
-ATTR_HW_INFO = "hw_info"
 ATTR_MINUTES_ACTIVE = "minutes_active"
-ATTR_POS_REPORT = "pos_report"
-ATTR_TRACKABLE = "trackable"
-ATTR_TRACKER_DETAILS = "tracker_details"
 
 CLIENT = "client"
 TRACKABLES = "trackables"

--- a/homeassistant/components/tractive/const.py
+++ b/homeassistant/components/tractive/const.py
@@ -7,7 +7,14 @@ DOMAIN = "tractive"
 RECONNECT_INTERVAL = timedelta(seconds=10)
 
 ATTR_DAILY_GOAL = "daily_goal"
+ATTR_HW_INFO = "hw_info"
 ATTR_MINUTES_ACTIVE = "minutes_active"
+ATTR_POS_REPORT = "pos_report"
+ATTR_TRACKABLE = "trackable"
+ATTR_TRACKER_DETAILS = "tracker_details"
+
+CLIENT = "client"
+TRACKABLES = "trackables"
 
 TRACKER_HARDWARE_STATUS_UPDATED = f"{DOMAIN}_tracker_hardware_status_updated"
 TRACKER_POSITION_UPDATED = f"{DOMAIN}_tracker_position_updated"

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -8,10 +8,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import (
-    ATTR_HW_INFO,
-    ATTR_POS_REPORT,
-    ATTR_TRACKABLE,
-    ATTR_TRACKER_DETAILS,
     CLIENT,
     DOMAIN,
     SERVER_UNAVAILABLE,
@@ -35,10 +31,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
         entities.append(
             TractiveDeviceTracker(
                 client.user_id,
-                item[ATTR_TRACKABLE],
-                item[ATTR_TRACKER_DETAILS],
-                item[ATTR_HW_INFO],
-                item[ATTR_POS_REPORT],
+                item.trackable,
+                item.tracker_details,
+                item.hw_info,
+                item.pos_report,
             )
         )
 

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -1,6 +1,5 @@
 """Support for Tractive device trackers."""
 
-import asyncio
 import logging
 
 from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
@@ -9,8 +8,14 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import (
+    ATTR_HW_INFO,
+    ATTR_POS_REPORT,
+    ATTR_TRACKABLE,
+    ATTR_TRACKER_DETAILS,
+    CLIENT,
     DOMAIN,
     SERVER_UNAVAILABLE,
+    TRACKABLES,
     TRACKER_HARDWARE_STATUS_UPDATED,
     TRACKER_POSITION_UPDATED,
 )
@@ -21,29 +26,23 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Tractive device trackers."""
-    client = hass.data[DOMAIN][entry.entry_id]
+    client = hass.data[DOMAIN][entry.entry_id][CLIENT]
+    trackables = hass.data[DOMAIN][entry.entry_id][TRACKABLES]
 
-    trackables = await client.trackable_objects()
+    entities = []
 
-    entities = await asyncio.gather(
-        *(create_trackable_entity(client, trackable) for trackable in trackables)
-    )
+    for item in trackables:
+        entities.append(
+            TractiveDeviceTracker(
+                client.user_id,
+                item[ATTR_TRACKABLE],
+                item[ATTR_TRACKER_DETAILS],
+                item[ATTR_HW_INFO],
+                item[ATTR_POS_REPORT],
+            )
+        )
 
     async_add_entities(entities)
-
-
-async def create_trackable_entity(client, trackable):
-    """Create an entity instance."""
-    trackable = await trackable.details()
-    tracker = client.tracker(trackable["device_id"])
-
-    tracker_details, hw_info, pos_report = await asyncio.gather(
-        tracker.details(), tracker.hw_info(), tracker.pos_report()
-    )
-
-    return TractiveDeviceTracker(
-        client.user_id, trackable, tracker_details, hw_info, pos_report
-    )
 
 
 class TractiveDeviceTracker(TractiveEntity, TrackerEntity):

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -16,8 +16,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from .const import (
     ATTR_DAILY_GOAL,
     ATTR_MINUTES_ACTIVE,
-    ATTR_TRACKABLE,
-    ATTR_TRACKER_DETAILS,
     CLIENT,
     DOMAIN,
     SERVER_UNAVAILABLE,
@@ -150,9 +148,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
             entities.append(
                 description.entity_class(
                     client.user_id,
-                    item[ATTR_TRACKABLE],
-                    item[ATTR_TRACKER_DETAILS],
-                    f"{item[ATTR_TRACKABLE]['_id']}_{description.key}",
+                    item.trackable,
+                    item.tracker_details,
+                    f"{item.trackable['_id']}_{description.key}",
                     description,
                 )
             )

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -1,7 +1,6 @@
 """Support for Tractive sensors."""
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
@@ -17,8 +16,12 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from .const import (
     ATTR_DAILY_GOAL,
     ATTR_MINUTES_ACTIVE,
+    ATTR_TRACKABLE,
+    ATTR_TRACKER_DETAILS,
+    CLIENT,
     DOMAIN,
     SERVER_UNAVAILABLE,
+    TRACKABLES,
     TRACKER_ACTIVITY_STATUS_UPDATED,
     TRACKER_HARDWARE_STATUS_UPDATED,
 )
@@ -137,29 +140,21 @@ SENSOR_TYPES = (
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Tractive device trackers."""
-    client = hass.data[DOMAIN][entry.entry_id]
-
-    trackables = await client.trackable_objects()
+    client = hass.data[DOMAIN][entry.entry_id][CLIENT]
+    trackables = hass.data[DOMAIN][entry.entry_id][TRACKABLES]
 
     entities = []
 
-    async def _prepare_sensor_entity(item):
-        """Prepare sensor entities."""
-        trackable = await item.details()
-        tracker = client.tracker(trackable["device_id"])
-        tracker_details = await tracker.details()
+    for item in trackables:
         for description in SENSOR_TYPES:
-            unique_id = f"{trackable['_id']}_{description.key}"
             entities.append(
                 description.entity_class(
                     client.user_id,
-                    trackable,
-                    tracker_details,
-                    unique_id,
+                    item[ATTR_TRACKABLE],
+                    item[ATTR_TRACKER_DETAILS],
+                    f"{item[ATTR_TRACKABLE]['_id']}_{description.key}",
                     description,
                 )
             )
-
-    await asyncio.gather(*(_prepare_sensor_entity(item) for item in trackables))
 
     async_add_entities(entities)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, we get trackers data on `device_tracker` platform init and `sensor` platform init. It is very ineffective.
This PR moves trackers data fetch to config entry setup. The data is passed to the platforms via `hass.data`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #55732
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
