### PR TITLE
2021.9.3

### DIFF
--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -9,6 +9,7 @@ from fritzconnection.core.exceptions import (
     FritzActionError,
     FritzActionFailedError,
     FritzConnectionException,
+    FritzInternalError,
     FritzServiceError,
 )
 from fritzconnection.lib.fritzstatus import FritzStatus
@@ -273,7 +274,12 @@ async def async_setup_entry(
             "GetInfo",
         )
         dsl = dslinterface["NewEnable"]
-    except (FritzActionError, FritzActionFailedError, FritzServiceError):
+    except (
+        FritzInternalError,
+        FritzActionError,
+        FritzActionFailedError,
+        FritzServiceError,
+    ):
         pass
 
     for sensor_type, sensor_data in SENSOR_DATA.items():

--- a/homeassistant/components/lifx/manifest.json
+++ b/homeassistant/components/lifx/manifest.json
@@ -3,7 +3,7 @@
   "name": "LIFX",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/lifx",
-  "requirements": ["aiolifx==0.6.10", "aiolifx_effects==0.2.2"],
+  "requirements": ["aiolifx==0.7.0", "aiolifx_effects==0.2.2"],
   "homekit": {
     "models": ["LIFX"]
   },

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -54,7 +54,7 @@ async def async_get_type(hass, cloud_id, install_code, host):
             meters = await hub.get_device_list()
     except aioeagle.BadAuth as err:
         raise InvalidAuth from err
-    except aiohttp.ClientError:
+    except (KeyError, aiohttp.ClientError):
         # This can happen if it's an eagle-100
         meters = None
 

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -240,7 +240,8 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
 
     def _send_key(self, key):
         """Send the key using legacy protocol."""
-        self._get_remote().control(key)
+        if remote := self._get_remote():
+            remote.control(key)
 
     def stop(self):
         """Stop Bridge."""
@@ -315,7 +316,8 @@ class SamsungTVWSBridge(SamsungTVBridge):
         """Send the key using websocket protocol."""
         if key == "KEY_POWEROFF":
             key = "KEY_POWER"
-        self._get_remote().send_key(key)
+        if remote := self._get_remote():
+            remote.send_key(key)
 
     def _get_remote(self, avoid_open: bool = False):
         """Create or return a remote control instance."""

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 9
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -201,7 +201,7 @@ aiokafka==0.6.0
 aiokef==0.2.16
 
 # homeassistant.components.lifx
-aiolifx==0.6.10
+aiolifx==0.7.0
 
 # homeassistant.components.lifx
 aiolifx_effects==0.2.2

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -50,18 +50,18 @@ GAS_SENSOR_ATTRIBUTES = {
 @pytest.mark.parametrize(
     "device_class,unit,native_unit,mean,min,max",
     [
-        (None, "%", "%", 16.440677, 10, 30),
-        ("battery", "%", "%", 16.440677, 10, 30),
-        ("battery", None, None, 16.440677, 10, 30),
-        ("humidity", "%", "%", 16.440677, 10, 30),
-        ("humidity", None, None, 16.440677, 10, 30),
-        ("pressure", "Pa", "Pa", 16.440677, 10, 30),
-        ("pressure", "hPa", "Pa", 1644.0677, 1000, 3000),
-        ("pressure", "mbar", "Pa", 1644.0677, 1000, 3000),
-        ("pressure", "inHg", "Pa", 55674.53, 33863.89, 101591.67),
-        ("pressure", "psi", "Pa", 113354.48, 68947.57, 206842.71),
-        ("temperature", "°C", "°C", 16.440677, 10, 30),
-        ("temperature", "°F", "°C", -8.644068, -12.22222, -1.111111),
+        (None, "%", "%", 13.050847, -10, 30),
+        ("battery", "%", "%", 13.050847, -10, 30),
+        ("battery", None, None, 13.050847, -10, 30),
+        ("humidity", "%", "%", 13.050847, -10, 30),
+        ("humidity", None, None, 13.050847, -10, 30),
+        ("pressure", "Pa", "Pa", 13.050847, -10, 30),
+        ("pressure", "hPa", "Pa", 1305.0847, -1000, 3000),
+        ("pressure", "mbar", "Pa", 1305.0847, -1000, 3000),
+        ("pressure", "inHg", "Pa", 44195.25, -33863.89, 101591.67),
+        ("pressure", "psi", "Pa", 89982.42, -68947.57, 206842.71),
+        ("temperature", "°C", "°C", 13.050847, -10, 30),
+        ("temperature", "°F", "°C", -10.52731, -23.33333, -1.111111),
     ],
 )
 def test_compile_hourly_statistics(
@@ -155,8 +155,8 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
             {
                 "statistic_id": "sensor.test1",
                 "start": process_timestamp_to_utc_isoformat(zero),
-                "mean": approx(16.440677966101696),
-                "min": approx(10.0),
+                "mean": approx(13.050847),
+                "min": approx(-10.0),
                 "max": approx(30.0),
                 "last_reset": None,
                 "state": None,
@@ -167,8 +167,8 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
             {
                 "statistic_id": "sensor.test6",
                 "start": process_timestamp_to_utc_isoformat(zero),
-                "mean": approx(16.440677966101696),
-                "min": approx(10.0),
+                "mean": approx(13.050847),
+                "min": approx(-10.0),
                 "max": approx(30.0),
                 "last_reset": None,
                 "state": None,
@@ -179,8 +179,8 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
             {
                 "statistic_id": "sensor.test7",
                 "start": process_timestamp_to_utc_isoformat(zero),
-                "mean": approx(16.440677966101696),
-                "min": approx(10.0),
+                "mean": approx(13.050847),
+                "min": approx(-10.0),
                 "max": approx(30.0),
                 "last_reset": None,
                 "state": None,
@@ -988,10 +988,10 @@ def test_list_statistic_ids_unsupported(hass_recorder, caplog, _attributes):
 @pytest.mark.parametrize(
     "device_class,unit,native_unit,mean,min,max",
     [
-        (None, None, None, 16.440677, 10, 30),
-        (None, "%", "%", 16.440677, 10, 30),
-        ("battery", "%", "%", 16.440677, 10, 30),
-        ("battery", None, None, 16.440677, 10, 30),
+        (None, None, None, 13.050847, -10, 30),
+        (None, "%", "%", 13.050847, -10, 30),
+        ("battery", "%", "%", 13.050847, -10, 30),
+        ("battery", None, None, 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics_changing_units_1(
@@ -1074,10 +1074,10 @@ def test_compile_hourly_statistics_changing_units_1(
 @pytest.mark.parametrize(
     "device_class,unit,native_unit,mean,min,max",
     [
-        (None, None, None, 16.440677, 10, 30),
-        (None, "%", "%", 16.440677, 10, 30),
-        ("battery", "%", "%", 16.440677, 10, 30),
-        ("battery", None, None, 16.440677, 10, 30),
+        (None, None, None, 13.050847, -10, 30),
+        (None, "%", "%", 13.050847, -10, 30),
+        ("battery", "%", "%", 13.050847, -10, 30),
+        ("battery", None, None, 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics_changing_units_2(
@@ -1119,10 +1119,10 @@ def test_compile_hourly_statistics_changing_units_2(
 @pytest.mark.parametrize(
     "device_class,unit,native_unit,mean,min,max",
     [
-        (None, None, None, 16.440677, 10, 30),
-        (None, "%", "%", 16.440677, 10, 30),
-        ("battery", "%", "%", 16.440677, 10, 30),
-        ("battery", None, None, 16.440677, 10, 30),
+        (None, None, None, 13.050847, -10, 30),
+        (None, "%", "%", 13.050847, -10, 30),
+        ("battery", "%", "%", 13.050847, -10, 30),
+        ("battery", None, None, 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics_changing_units_3(
@@ -1203,7 +1203,7 @@ def test_compile_hourly_statistics_changing_units_3(
 @pytest.mark.parametrize(
     "device_class,unit,native_unit,mean,min,max",
     [
-        (None, None, None, 16.440677, 10, 30),
+        (None, None, None, 13.050847, -10, 30),
     ],
 )
 def test_compile_hourly_statistics_changing_statistics(
@@ -1309,7 +1309,7 @@ def record_states(hass, zero, entity_id, attributes):
 
     states = {entity_id: []}
     with patch("homeassistant.components.recorder.dt_util.utcnow", return_value=one):
-        states[entity_id].append(set_state(entity_id, "10", attributes=attributes))
+        states[entity_id].append(set_state(entity_id, "-10", attributes=attributes))
 
     with patch("homeassistant.components.recorder.dt_util.utcnow", return_value=two):
         states[entity_id].append(set_state(entity_id, "15", attributes=attributes))


### PR DESCRIPTION
- better detect legacy eagly devices ([@balloob] - [#55706]) ([rainforest_eagle docs])
- Handle negative numbers in sensor long term statistics ([@emontnemery] - [#55708]) ([sensor docs])
- Handle Fritz InternalError ([@chemelli74] - [#55711]) ([fritz docs])
- Fix LIFX firmware version information ([@amelchio] - [#55713]) ([lifx docs])
- Fix SamsungTV sendkey when not connected ([@chemelli74] - [#55723]) ([samsungtv docs])

[#55706]: https://github.com/home-assistant/core/pull/55706
[#55708]: https://github.com/home-assistant/core/pull/55708
[#55711]: https://github.com/home-assistant/core/pull/55711
[#55713]: https://github.com/home-assistant/core/pull/55713
[#55723]: https://github.com/home-assistant/core/pull/55723
[@amelchio]: https://github.com/amelchio
[@balloob]: https://github.com/balloob
[@chemelli74]: https://github.com/chemelli74
[@emontnemery]: https://github.com/emontnemery
[fritz docs]: https://www.home-assistant.io/integrations/fritz/
[lifx docs]: https://www.home-assistant.io/integrations/lifx/
[rainforest_eagle docs]: https://www.home-assistant.io/integrations/rainforest_eagle/
[samsungtv docs]: https://www.home-assistant.io/integrations/samsungtv/
[sensor docs]: https://www.home-assistant.io/integrations/sensor/