### PR TITLE
Startup in safe mode after 3 crashes in 15 minutes (container/os/supervised only)

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -86,6 +86,12 @@ STAGE_1_INTEGRATIONS = {
 }
 
 
+def _slurp_file(dir: str, file_name: str) -> str:
+    """Read a file."""
+    file_path = Path(dir) / file_name
+    return file_path.read_text()
+
+
 def _check_and_log_crash_reports(config_dir: str) -> bool:
     """Check and log crash reports."""
     timestamp = time.time()
@@ -98,7 +104,9 @@ def _check_and_log_crash_reports(config_dir: str) -> bool:
         if crash_timestamp_int + MAX_RECENT_CRASHES_AGE < timestamp:
             os.unlink(file_path)
             continue
-        crash_reports.append((crash_timestamp_int, file_path, file_path.read_text()))
+        crash_reports.append(
+            (crash_timestamp_int, file_path, _slurp_file(config_dir, file_name))
+        )
 
     activate_safe_mode = len(crash_reports) >= MAX_RECENT_CRASHES_SAFE_MODE
     for timestamp, file_path, crash_report in crash_reports:

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -86,9 +86,9 @@ STAGE_1_INTEGRATIONS = {
 }
 
 
-def _slurp_file(dir: str, file_name: str) -> str:
+def _slurp_file(dir_name: str, file_name: str) -> str:
     """Read a file."""
-    file_path = Path(dir) / file_name
+    file_path = Path(dir_name) / file_name
     return file_path.read_text()
 
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -159,7 +159,7 @@ async def async_setup_hass(
                 _check_and_log_crash_reports, runtime_config.config_dir
             ):
                 safe_mode = True
-        except (ValueError, OSError):
+        except (ValueError, OSError, FileNotFoundError):
             _LOGGER.exception("Unable to check for recent crash reports")
 
     if not safe_mode:

--- a/rootfs/etc/services.d/home-assistant/run
+++ b/rootfs/etc/services.d/home-assistant/run
@@ -9,4 +9,38 @@ cd /config || bashio::exit.nok "Can't find config folder!"
 if [[ -z "${DISABLE_JEMALLOC+x}" ]]; then
   export LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
 fi
-exec python3 -m homeassistant --config /config
+
+function write_crash_report() {
+  # This function should write the first part of the
+  # crash report with built-ins only as there may not
+  # be enough memory to execute an external command
+  local exit_signal=${1}
+  local epoch="$(printf "%(%s)T")"
+
+  echo "Home Assistant exited with signal $exit_signal" > /config/hass_crash_report.$epoch
+  echo "Writing crash report to /config/hass_crash_report.$epoch"
+  # only built-in commands will likely work at this point if we are out of memory
+  return
+}
+
+function check_for_crash() {
+  # This function must only use built-ins as there may not be
+  # enough memory to execute an external command
+  local exit_status=${1:-}
+
+  if [ $exit_status -lt 128 ]; then
+    return
+  fi
+
+  local exit_signal=$(($exit_status - 128))
+  # Report as a crash for
+  # 4) SIGILL, 6) SIGABRT, 7) SIGBUS, 8) SIGFPE, 11) SIGSEGV
+  case "$exit_signal" in
+    4|6|7|8|11)
+      write_crash_report $exit_signal
+      ;;
+  esac
+}
+
+python3 -m homeassistant --config /config && exit_code=$? || exit_code=$?
+check_for_crash $exit_code

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -510,9 +510,7 @@ async def test_setup_hass_continues_if_cannot_determine_if_crashed(
     with patch(
         "homeassistant.config.async_hass_config_yaml",
         return_value={"browser": {}, "frontend": {}},
-    ), patch("homeassistant.bootstrap._slurp_file", side_effect=ValueError), patch(
-        "homeassistant.bootstrap.time.time", return_value=1632335297
-    ), patch(
+    ), patch("homeassistant.bootstrap.time.time", return_value=1632335297), patch(
         "homeassistant.bootstrap.os.unlink"
     ) as mock_unlink, patch(
         "homeassistant.bootstrap.os.listdir", return_value=DIR_LIST_WITH_CRASHES


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Startup in safe mode after 3 crashes in 15 minutes (container/os/supervised only). Segfaults due to upstream libraries, deps, or cpython bugs are inevitable (although hopefully rare). The goal is to make it easy to recover in case something like #55350 or #55541 happens.  

The working concept is to write `/config/crash_report.EPOCH` every time python exits with any of `4) SIGILL, 6) SIGABRT, 7) SIGBUS, 8) SIGFPE, 11) SIGSEGV`.  When startup happens, we look for these files and if there are 3 within 15 minutes, we startup in safe mode.

On successful start (safe mode or otherwise), we wipe the crash logs so it only ends up in safe mode once.

<img width="497" alt="Screen Shot 2021-09-12 at 5 49 59 PM" src="https://user-images.githubusercontent.com/663432/133021270-75741118-d1bd-4150-bcbc-d51350755124.png">





## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
