### PR TITLE
Edit unit of measurement for gas/electricity supplier prices

### DIFF
--- a/homeassistant/components/dsmr_reader/definitions.py
+++ b/homeassistant/components/dsmr_reader/definitions.py
@@ -21,6 +21,8 @@ from homeassistant.const import (
     ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
     POWER_KILO_WATT,
+    PRICE_EUR_KWH,
+    PRICE_EUR_M3,
     VOLUME_CUBIC_METERS,
 )
 
@@ -301,31 +303,31 @@ SENSORS: tuple[DSMRReaderSensorEntityDescription, ...] = (
         key="dsmr/day-consumption/energy_supplier_price_electricity_delivered_1",
         name="Low tariff delivered price",
         icon="mdi:currency-eur",
-        native_unit_of_measurement=CURRENCY_EURO,
+        native_unit_of_measurement=PRICE_EUR_KWH,
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/energy_supplier_price_electricity_delivered_2",
         name="High tariff delivered price",
         icon="mdi:currency-eur",
-        native_unit_of_measurement=CURRENCY_EURO,
+        native_unit_of_measurement=PRICE_EUR_KWH,
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/energy_supplier_price_electricity_returned_1",
         name="Low tariff returned price",
         icon="mdi:currency-eur",
-        native_unit_of_measurement=CURRENCY_EURO,
+        native_unit_of_measurement=PRICE_EUR_KWH,
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/energy_supplier_price_electricity_returned_2",
         name="High tariff returned price",
         icon="mdi:currency-eur",
-        native_unit_of_measurement=CURRENCY_EURO,
+        native_unit_of_measurement=PRICE_EUR_KWH,
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/energy_supplier_price_gas",
         name="Gas price",
         icon="mdi:currency-eur",
-        native_unit_of_measurement=CURRENCY_EURO,
+        native_unit_of_measurement=PRICE_EUR_M3,
     ),
     DSMRReaderSensorEntityDescription(
         key="dsmr/day-consumption/fixed_cost",

--- a/homeassistant/components/dsmr_reader/definitions.py
+++ b/homeassistant/components/dsmr_reader/definitions.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Final
 
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
@@ -21,10 +21,11 @@ from homeassistant.const import (
     ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
     POWER_KILO_WATT,
-    PRICE_EUR_KWH,
-    PRICE_EUR_M3,
     VOLUME_CUBIC_METERS,
 )
+
+PRICE_EUR_KWH: Final = f"EUR/{ENERGY_KILO_WATT_HOUR}"
+PRICE_EUR_M3: Final = f"EUR/{VOLUME_CUBIC_METERS}"
 
 
 def dsmr_transform(value):

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -474,6 +474,11 @@ PRESSURE_MBAR: Final = "mbar"
 PRESSURE_INHG: Final = "inHg"
 PRESSURE_PSI: Final = "psi"
 
+# Price units
+PRICE_EUR_KWH: Final = "EUR/kWh"
+PRICE_EUR_WH: Final = "EUR/Wh"
+PRICE_EUR_M3: Final = "EUR/m³"
+
 # Sound pressure units
 SOUND_PRESSURE_DB: Final = "dB"
 SOUND_PRESSURE_WEIGHTED_DBA: Final = "dBa"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -474,11 +474,6 @@ PRESSURE_MBAR: Final = "mbar"
 PRESSURE_INHG: Final = "inHg"
 PRESSURE_PSI: Final = "psi"
 
-# Price units
-PRICE_EUR_KWH: Final = "EUR/kWh"
-PRICE_EUR_WH: Final = "EUR/Wh"
-PRICE_EUR_M3: Final = "EUR/m³"
-
 # Sound pressure units
 SOUND_PRESSURE_DB: Final = "dB"
 SOUND_PRESSURE_WEIGHTED_DBA: Final = "dBa"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #55319
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
