### PR TITLE
Add motion_blinds VerticalBlind and cleanup

### DIFF
--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -3,8 +3,7 @@ from datetime import timedelta
 import logging
 from socket import timeout
 
-from motionblinds import MotionMulticast
-from motionblinds.motion_blinds import ParseException
+from motionblinds import MotionMulticast, ParseException
 
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_API_KEY, CONF_HOST, EVENT_HOMEASSISTANT_STOP
@@ -40,7 +39,7 @@ class DataUpdateCoordinatorMotionBlinds(DataUpdateCoordinator):
         name,
         update_interval=None,
         update_method=None,
-    ):
+    ) -> None:
         """Initialize global data updater."""
         super().__init__(
             hass,
@@ -137,6 +136,11 @@ async def async_setup_entry(
         KEY_COORDINATOR: coordinator,
     }
 
+    if motion_gateway.firmware is not None:
+        version = f"{motion_gateway.firmware}, proto: {motion_gateway.protocol}"
+    else:
+        version = motion_gateway.protocol
+
     device_registry = await dr.async_get_registry(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
@@ -145,7 +149,7 @@ async def async_setup_entry(
         manufacturer=MANUFACTURER,
         name=entry.title,
         model="Wi-Fi bridge",
-        sw_version=motion_gateway.protocol,
+        sw_version=version,
     )
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -137,9 +137,9 @@ async def async_setup_entry(
     }
 
     if motion_gateway.firmware is not None:
-        version = f"{motion_gateway.firmware}, proto: {motion_gateway.protocol}"
+        version = f"{motion_gateway.firmware}, protocol: {motion_gateway.protocol}"
     else:
-        version = motion_gateway.protocol
+        version = f"Protocol: {motion_gateway.protocol}"
 
     device_registry = await dr.async_get_registry(hass)
     device_registry.async_get_or_create(

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -52,6 +52,7 @@ TILT_DEVICE_MAP = {
     BlindType.VenetianBlind: DEVICE_CLASS_BLIND,
     BlindType.ShangriLaBlind: DEVICE_CLASS_BLIND,
     BlindType.DoubleRoller: DEVICE_CLASS_SHADE,
+    BlindType.VerticalBlind: DEVICE_CLASS_BLIND,
 }
 
 TDBU_DEVICE_MAP = {

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -40,11 +40,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 
 class MotionBatterySensor(CoordinatorEntity, SensorEntity):
-    """
-    Representation of a Motion Battery Sensor.
-
-    Updates are done by the cover platform.
-    """
+    """Representation of a Motion Battery Sensor."""
 
     _attr_device_class = DEVICE_CLASS_BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
@@ -91,11 +87,7 @@ class MotionBatterySensor(CoordinatorEntity, SensorEntity):
 
 
 class MotionTDBUBatterySensor(MotionBatterySensor):
-    """
-    Representation of a Motion Battery Sensor for a Top Down Bottom Up blind.
-
-    Updates are done by the cover platform.
-    """
+    """Representation of a Motion Battery Sensor for a Top Down Bottom Up blind."""
 
     def __init__(self, coordinator, blind, motor):
         """Initialize the Motion Battery Sensor."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add VerticalBlind support
- Make use of new firmware version in API
- cleanup code

This is a split up version of the big PR: #50067
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
