### PR TITLE
Use EntityDescription - aqualogic

### DIFF
--- a/homeassistant/components/aqualogic/sensor.py
+++ b/homeassistant/components/aqualogic/sensor.py
@@ -39,7 +39,6 @@ SENSOR_TYPES: tuple[AquaLogicSensorEntityDescription, ...] = (
         name="Air Temperature",
         unit_metric=TEMP_CELSIUS,
         unit_imperial=TEMP_FAHRENHEIT,
-        icon=None,
         device_class=DEVICE_CLASS_TEMPERATURE,
     ),
     AquaLogicSensorEntityDescription(
@@ -64,7 +63,6 @@ SENSOR_TYPES: tuple[AquaLogicSensorEntityDescription, ...] = (
         unit_metric=PERCENTAGE,
         unit_imperial=PERCENTAGE,
         icon="mdi:gauge",
-        device_class=None,
     ),
     AquaLogicSensorEntityDescription(
         key="spa_chlorinator",
@@ -72,7 +70,6 @@ SENSOR_TYPES: tuple[AquaLogicSensorEntityDescription, ...] = (
         unit_metric=PERCENTAGE,
         unit_imperial=PERCENTAGE,
         icon="mdi:gauge",
-        device_class=None,
     ),
     AquaLogicSensorEntityDescription(
         key="salt_level",
@@ -80,7 +77,6 @@ SENSOR_TYPES: tuple[AquaLogicSensorEntityDescription, ...] = (
         unit_metric="g/L",
         unit_imperial="PPM",
         icon="mdi:gauge",
-        device_class=None,
     ),
     AquaLogicSensorEntityDescription(
         key="pump_speed",
@@ -88,7 +84,6 @@ SENSOR_TYPES: tuple[AquaLogicSensorEntityDescription, ...] = (
         unit_metric=PERCENTAGE,
         unit_imperial=PERCENTAGE,
         icon="mdi:speedometer",
-        device_class=None,
     ),
     AquaLogicSensorEntityDescription(
         key="pump_power",
@@ -96,13 +91,11 @@ SENSOR_TYPES: tuple[AquaLogicSensorEntityDescription, ...] = (
         unit_metric=POWER_WATT,
         unit_imperial=POWER_WATT,
         icon="mdi:gauge",
-        device_class=None,
     ),
     AquaLogicSensorEntityDescription(
         key="status",
         name="Status",
         icon="mdi:alert",
-        device_class=None,
     ),
 )
 

--- a/homeassistant/components/aqualogic/sensor.py
+++ b/homeassistant/components/aqualogic/sensor.py
@@ -149,11 +149,14 @@ class AquaLogicSensor(SensorEntity):
         """Update callback."""
         panel = self._processor.panel
         if panel is not None:
-            self._attr_native_unit_of_measurement = (
-                self.entity_description.unit_metric
-                if panel.is_metric
-                else self.entity_description.unit_imperial
-            )
+            if panel.is_metric:
+                self._attr_native_unit_of_measurement = (
+                    self.entity_description.unit_metric
+                )
+            else:
+                self._attr_native_unit_of_measurement = (
+                    self.entity_description.unit_imperial
+                )
 
             self._attr_native_value = getattr(panel, self.entity_description.key)
             self.async_write_ha_state()

--- a/homeassistant/components/aqualogic/sensor.py
+++ b/homeassistant/components/aqualogic/sensor.py
@@ -1,8 +1,15 @@
 """Support for AquaLogic sensors."""
+from __future__ import annotations
+
+from dataclasses import dataclass
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
+from homeassistant.components.sensor import (
+    PLATFORM_SCHEMA,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS,
     DEVICE_CLASS_TEMPERATURE,
@@ -16,40 +23,95 @@ import homeassistant.helpers.config_validation as cv
 
 from . import DOMAIN, UPDATE_TOPIC
 
-TEMP_UNITS = [TEMP_CELSIUS, TEMP_FAHRENHEIT]
-PERCENT_UNITS = [PERCENTAGE, PERCENTAGE]
-SALT_UNITS = ["g/L", "PPM"]
-WATT_UNITS = [POWER_WATT, POWER_WATT]
-NO_UNITS = [None, None]
 
-# sensor_type [ description, unit, icon, device_class ]
-# sensor_type corresponds to property names in aqualogic.core.AquaLogic
-SENSOR_TYPES = {
-    "air_temp": ["Air Temperature", TEMP_UNITS, None, DEVICE_CLASS_TEMPERATURE],
-    "pool_temp": [
-        "Pool Temperature",
-        TEMP_UNITS,
-        "mdi:oil-temperature",
-        DEVICE_CLASS_TEMPERATURE,
-    ],
-    "spa_temp": [
-        "Spa Temperature",
-        TEMP_UNITS,
-        "mdi:oil-temperature",
-        DEVICE_CLASS_TEMPERATURE,
-    ],
-    "pool_chlorinator": ["Pool Chlorinator", PERCENT_UNITS, "mdi:gauge", None],
-    "spa_chlorinator": ["Spa Chlorinator", PERCENT_UNITS, "mdi:gauge", None],
-    "salt_level": ["Salt Level", SALT_UNITS, "mdi:gauge", None],
-    "pump_speed": ["Pump Speed", PERCENT_UNITS, "mdi:speedometer", None],
-    "pump_power": ["Pump Power", WATT_UNITS, "mdi:gauge", None],
-    "status": ["Status", NO_UNITS, "mdi:alert", None],
-}
+@dataclass
+class AquaLogicSensorEntityDescription(SensorEntityDescription):
+    """Describes AquaLogic sensor entity."""
+
+    unit_metric: str | None = None
+    unit_imperial: str | None = None
+
+
+# keys correspond to property names in aqualogic.core.AquaLogic
+SENSOR_TYPES: tuple[AquaLogicSensorEntityDescription, ...] = (
+    AquaLogicSensorEntityDescription(
+        key="air_temp",
+        name="Air Temperature",
+        unit_metric=TEMP_CELSIUS,
+        unit_imperial=TEMP_FAHRENHEIT,
+        icon=None,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+    ),
+    AquaLogicSensorEntityDescription(
+        key="pool_temp",
+        name="Pool Temperature",
+        unit_metric=TEMP_CELSIUS,
+        unit_imperial=TEMP_FAHRENHEIT,
+        icon="mdi:oil-temperature",
+        device_class=DEVICE_CLASS_TEMPERATURE,
+    ),
+    AquaLogicSensorEntityDescription(
+        key="spa_temp",
+        name="Spa Temperature",
+        unit_metric=TEMP_CELSIUS,
+        unit_imperial=TEMP_FAHRENHEIT,
+        icon="mdi:oil-temperature",
+        device_class=DEVICE_CLASS_TEMPERATURE,
+    ),
+    AquaLogicSensorEntityDescription(
+        key="pool_chlorinator",
+        name="Pool Chlorinator",
+        unit_metric=PERCENTAGE,
+        unit_imperial=PERCENTAGE,
+        icon="mdi:gauge",
+        device_class=None,
+    ),
+    AquaLogicSensorEntityDescription(
+        key="spa_chlorinator",
+        name="Spa Chlorinator",
+        unit_metric=PERCENTAGE,
+        unit_imperial=PERCENTAGE,
+        icon="mdi:gauge",
+        device_class=None,
+    ),
+    AquaLogicSensorEntityDescription(
+        key="salt_level",
+        name="Salt Level",
+        unit_metric="g/L",
+        unit_imperial="PPM",
+        icon="mdi:gauge",
+        device_class=None,
+    ),
+    AquaLogicSensorEntityDescription(
+        key="pump_speed",
+        name="Pump Speed",
+        unit_metric=PERCENTAGE,
+        unit_imperial=PERCENTAGE,
+        icon="mdi:speedometer",
+        device_class=None,
+    ),
+    AquaLogicSensorEntityDescription(
+        key="pump_power",
+        name="Pump Power",
+        unit_metric=POWER_WATT,
+        unit_imperial=POWER_WATT,
+        icon="mdi:gauge",
+        device_class=None,
+    ),
+    AquaLogicSensorEntityDescription(
+        key="status",
+        name="Status",
+        icon="mdi:alert",
+        device_class=None,
+    ),
+)
+
+SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_TYPES)]
+        vol.Required(CONF_MONITORED_CONDITIONS, default=SENSOR_KEYS): vol.All(
+            cv.ensure_list, [vol.In(SENSOR_KEYS)]
         )
     }
 )
@@ -57,26 +119,29 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the sensor platform."""
-    sensors = []
-
     processor = hass.data[DOMAIN]
-    for sensor_type in config[CONF_MONITORED_CONDITIONS]:
-        sensors.append(AquaLogicSensor(processor, sensor_type))
+    monitored_conditions = config[CONF_MONITORED_CONDITIONS]
 
-    async_add_entities(sensors)
+    entities = [
+        AquaLogicSensor(processor, description)
+        for description in SENSOR_TYPES
+        if description.key in monitored_conditions
+    ]
+
+    async_add_entities(entities)
 
 
 class AquaLogicSensor(SensorEntity):
     """Sensor implementation for the AquaLogic component."""
 
+    entity_description: AquaLogicSensorEntityDescription
     _attr_should_poll = False
 
-    def __init__(self, processor, sensor_type):
+    def __init__(self, processor, description: AquaLogicSensorEntityDescription):
         """Initialize sensor."""
+        self.entity_description = description
         self._processor = processor
-        self._type = sensor_type
-        self._attr_name = f"AquaLogic {SENSOR_TYPES[sensor_type][0]}"
-        self._attr_icon = SENSOR_TYPES[sensor_type][2]
+        self._attr_name = f"AquaLogic {description.name}"
 
     async def async_added_to_hass(self):
         """Register callbacks."""
@@ -91,12 +156,13 @@ class AquaLogicSensor(SensorEntity):
         """Update callback."""
         panel = self._processor.panel
         if panel is not None:
-            if panel.is_metric:
-                self._attr_native_unit_of_measurement = SENSOR_TYPES[self._type][1][0]
-            else:
-                self._attr_native_unit_of_measurement = SENSOR_TYPES[self._type][1][1]
+            self._attr_native_unit_of_measurement = (
+                self.entity_description.unit_metric
+                if panel.is_metric
+                else self.entity_description.unit_imperial
+            )
 
-            self._attr_native_value = getattr(panel, self._type)
+            self._attr_native_value = getattr(panel, self.entity_description.key)
             self.async_write_ha_state()
         else:
             self._attr_native_unit_of_measurement = None


### PR DESCRIPTION
## Proposed change
Update `aqualogic` to use `EntityDescription` for sensor metadata.
-> #53201

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
