### PR TITLE
Fix a lazy preset mode update for Xiaomi Miio fans

### DIFF
--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -456,7 +456,7 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
     def preset_mode(self):
         """Get the active preset mode."""
         if self._state:
-            preset_mode = AirpurifierOperationMode(self._state_attrs[ATTR_MODE]).name
+            preset_mode = self._mode.capitalize()
             return preset_mode if preset_mode in self._preset_modes else None
 
         return None
@@ -500,11 +500,13 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
         if preset_mode not in self.preset_modes:
             _LOGGER.warning("'%s'is not a valid preset mode", preset_mode)
             return
-        await self._try_command(
+        if await self._try_command(
             "Setting operation mode of the miio device failed.",
             self._device.set_mode,
             self.PRESET_MODE_MAPPING[preset_mode],
-        )
+        ):
+            self._mode = preset_mode.lower()
+            self.async_write_ha_state()
 
     async def async_set_extra_features(self, features: int = 1):
         """Set the extra features."""

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -505,7 +505,7 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
             self._device.set_mode,
             self.PRESET_MODE_MAPPING[preset_mode],
         ):
-            self._mode = preset_mode.lower()
+            self._mode = AirpurifierOperationMode[preset_mode].value
             self.async_write_ha_state()
 
     async def async_set_extra_features(self, features: int = 1):
@@ -538,13 +538,6 @@ class XiaomiAirPurifierMiot(XiaomiAirPurifier):
         "Silent": AirpurifierMiotOperationMode.Silent,
         "Favorite": AirpurifierMiotOperationMode.Favorite,
         "Fan": AirpurifierMiotOperationMode.Fan,
-    }
-
-    SPEED_MODE_MAPPING = {
-        0: AirpurifierMiotOperationMode.Auto,
-        1: AirpurifierMiotOperationMode.Silent,
-        2: AirpurifierMiotOperationMode.Favorite,
-        3: AirpurifierMiotOperationMode.Fan,
     }
 
     @property
@@ -599,9 +592,8 @@ class XiaomiAirPurifierMiot(XiaomiAirPurifier):
             self._device.set_mode,
             self.PRESET_MODE_MAPPING[preset_mode],
         ):
-            self._mode = self.SPEED_MODE_MAPPING[
-                self.PRESET_MODE_MAPPING[preset_mode].value
-            ]
+            self._mode = AirpurifierMiotOperationMode[preset_mode].value
+            _LOGGER.warning(self._mode)
             self.async_write_ha_state()
 
 

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -538,6 +538,13 @@ class XiaomiAirPurifierMiot(XiaomiAirPurifier):
         "Fan": AirpurifierMiotOperationMode.Fan,
     }
 
+    SPEED_MODE_MAPPING = {
+        0: AirpurifierMiotOperationMode.Auto,
+        1: AirpurifierMiotOperationMode.Silent,
+        2: AirpurifierMiotOperationMode.Favorite,
+        3: AirpurifierMiotOperationMode.Fan,
+    }
+
     @property
     def percentage(self):
         """Return the current percentage based speed."""
@@ -575,6 +582,24 @@ class XiaomiAirPurifierMiot(XiaomiAirPurifier):
             fan_level,
         ):
             self._fan_level = fan_level
+            self.async_write_ha_state()
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode of the fan.
+
+        This method is a coroutine.
+        """
+        if preset_mode not in self.preset_modes:
+            _LOGGER.warning("'%s'is not a valid preset mode", preset_mode)
+            return
+        if await self._try_command(
+            "Setting operation mode of the miio device failed.",
+            self._device.set_mode,
+            self.PRESET_MODE_MAPPING[preset_mode],
+        ):
+            self._mode = self.SPEED_MODE_MAPPING[
+                self.PRESET_MODE_MAPPING[preset_mode].value
+            ]
             self.async_write_ha_state()
 
 

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -456,7 +456,7 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
     def preset_mode(self):
         """Get the active preset mode."""
         if self._state:
-            preset_mode = self._mode.capitalize()
+            preset_mode = AirpurifierOperationMode(self._mode).name
             return preset_mode if preset_mode in self._preset_modes else None
 
         return None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes lazy preset mode update for Xiaomi Miio fans.
The change was tested with: `zhimi.airpurifier.mb3`, `zhimi.airpurifier.v6` and `zhimi.airpurifier.mc2`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #55720
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
