### PR TITLE
Add sum_decrease and sum_increase statistics

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -505,7 +505,7 @@ def _apply_update(engine, session, new_version, old_version):  # noqa: C901
         _add_columns(
             connection,
             "statistics",
-            ["sum_decrease DOUBLE PRECISION", "sum_increase DOUBLE PRECISION"],
+            ["sum_increase DOUBLE PRECISION"],
         )
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -501,6 +501,12 @@ def _apply_update(engine, session, new_version, old_version):  # noqa: C901
                     "sum DOUBLE PRECISION",
                 ],
             )
+    elif new_version == 21:
+        _add_columns(
+            connection,
+            "statistics",
+            ["sum_decrease DOUBLE PRECISION", "sum_increase DOUBLE PRECISION"],
+        )
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -229,6 +229,8 @@ class StatisticData(TypedDict, total=False):
     last_reset: datetime | None
     state: float
     sum: float
+    sum_decrease: float
+    sum_increase: float
 
 
 class Statistics(Base):  # type: ignore
@@ -253,6 +255,8 @@ class Statistics(Base):  # type: ignore
     last_reset = Column(DATETIME_TYPE)
     state = Column(DOUBLE_TYPE)
     sum = Column(DOUBLE_TYPE)
+    sum_decrease = Column(DOUBLE_TYPE)
+    sum_increase = Column(DOUBLE_TYPE)
 
     @staticmethod
     def from_stats(metadata_id: str, start: datetime, stats: StatisticData):

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -229,7 +229,6 @@ class StatisticData(TypedDict, total=False):
     last_reset: datetime | None
     state: float
     sum: float
-    sum_decrease: float
     sum_increase: float
 
 
@@ -255,7 +254,6 @@ class Statistics(Base):  # type: ignore
     last_reset = Column(DATETIME_TYPE)
     state = Column(DOUBLE_TYPE)
     sum = Column(DOUBLE_TYPE)
-    sum_decrease = Column(DOUBLE_TYPE)
     sum_increase = Column(DOUBLE_TYPE)
 
     @staticmethod

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -39,7 +39,7 @@ import homeassistant.util.dt as dt_util
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 20
+SCHEMA_VERSION = 21
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -48,7 +48,6 @@ QUERY_STATISTICS = [
     Statistics.last_reset,
     Statistics.state,
     Statistics.sum,
-    Statistics.sum_decrease,
     Statistics.sum_increase,
 ]
 
@@ -460,9 +459,9 @@ def _sorted_statistics_to_dict(
                 "max": convert(db_state.max, units),
                 "last_reset": _process_timestamp_to_utc_isoformat(db_state.last_reset),
                 "state": convert(db_state.state, units),
-                "sum": convert(db_state.sum, units),
-                "sum_decrease": convert(db_state.sum_decrease, units),
-                "sum_increase": convert(db_state.sum_increase, units),
+                "sum": (_sum := convert(db_state.sum, units)),
+                "sum_increase": (inc := convert(db_state.sum_increase, units)),
+                "sum_decrease": None if _sum is None or inc is None else inc - _sum,
             }
             for db_state in group
         )

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -48,6 +48,8 @@ QUERY_STATISTICS = [
     Statistics.last_reset,
     Statistics.state,
     Statistics.sum,
+    Statistics.sum_decrease,
+    Statistics.sum_increase,
 ]
 
 QUERY_STATISTIC_META = [
@@ -459,6 +461,8 @@ def _sorted_statistics_to_dict(
                 "last_reset": _process_timestamp_to_utc_isoformat(db_state.last_reset),
                 "state": convert(db_state.state, units),
                 "sum": convert(db_state.sum, units),
+                "sum_decrease": convert(db_state.sum_decrease, units),
+                "sum_increase": convert(db_state.sum_increase, units),
             }
             for db_state in group
         )

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -138,7 +138,7 @@ def _time_weighted_average(
 ) -> float:
     """Calculate a time weighted average.
 
-    The average is calculated by, weighting the states by duration in seconds between
+    The average is calculated by weighting the states by duration in seconds between
     state changes.
     Note: there's no interpolation of values between state changes.
     """
@@ -462,7 +462,7 @@ def compile_statistics(  # noqa: C901
                         sum_increase += sum_increase_tmp
                         sum_increase_tmp = 0.0
                         if fstate > 0:
-                            sum_increase_tmp += fstate - 0
+                            sum_increase_tmp += fstate
                     # ..and update the starting point
                     new_state = fstate
                     old_last_reset = last_reset

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -342,7 +342,11 @@ def compile_statistics(  # noqa: C901
         )
         history_list = {**history_list, **_history_list}
 
-    for entity_id, state_class, device_class in entities:
+    for (  # pylint: disable=too-many-nested-blocks
+        entity_id,
+        state_class,
+        device_class,
+    ) in entities:
         if entity_id not in history_list:
             continue
 

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -914,6 +914,8 @@ async def test_statistics_during_period(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ]
     }

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -170,6 +170,8 @@ def test_compile_hourly_statistics_exception(
         "last_reset": None,
         "state": None,
         "sum": None,
+        "sum_decrease": None,
+        "sum_increase": None,
     }
     expected_2 = {
         "statistic_id": "sensor.test1",
@@ -239,6 +241,8 @@ def test_rename_entity(hass_recorder):
         "last_reset": None,
         "state": None,
         "sum": None,
+        "sum_decrease": None,
+        "sum_increase": None,
     }
     expected_stats1 = [
         {**expected_1, "statistic_id": "sensor.test1"},

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -51,6 +51,8 @@ def test_compile_hourly_statistics(hass_recorder):
         "last_reset": None,
         "state": None,
         "sum": None,
+        "sum_decrease": None,
+        "sum_increase": None,
     }
     expected_2 = {
         "statistic_id": "sensor.test1",
@@ -61,6 +63,8 @@ def test_compile_hourly_statistics(hass_recorder):
         "last_reset": None,
         "state": None,
         "sum": None,
+        "sum_decrease": None,
+        "sum_increase": None,
     }
     expected_stats1 = [
         {**expected_1, "statistic_id": "sensor.test1"},
@@ -176,6 +180,8 @@ def test_compile_hourly_statistics_exception(
         "last_reset": None,
         "state": None,
         "sum": None,
+        "sum_decrease": None,
+        "sum_increase": None,
     }
     expected_stats1 = [
         {**expected_1, "statistic_id": "sensor.test1"},

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -1511,8 +1511,8 @@ def test_compile_hourly_statistics_changing_statistics(
                 "last_reset": None,
                 "state": approx(30.0),
                 "sum": approx(30.0),
-                "sum_decrease": approx(0.0),
-                "sum_increase": approx(30.0),
+                "sum_decrease": approx(10.0),
+                "sum_increase": approx(40.0),
             },
         ]
     }

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -432,6 +432,10 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
                 "last_reset": process_timestamp_to_utc_isoformat(one),
                 "state": approx(factor * seq[7]),
                 "sum": approx(factor * (seq[2] + seq[3] + seq[4] + seq[6] + seq[7])),
+                "sum_decrease": approx(factor * 0.0),
+                "sum_increase": approx(
+                    factor * (seq[2] + seq[3] + seq[4] + seq[6] + seq[7])
+                ),
             },
         ]
     }

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -101,6 +101,8 @@ def test_compile_hourly_statistics(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ]
     }
@@ -163,6 +165,8 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ],
         "sensor.test6": [
@@ -175,6 +179,8 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ],
         "sensor.test7": [
@@ -187,6 +193,8 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ],
     }
@@ -258,6 +266,8 @@ def test_compile_hourly_sum_statistics_amount(
                 "last_reset": process_timestamp_to_utc_isoformat(zero),
                 "state": approx(factor * seq[2]),
                 "sum": approx(factor * 10.0),
+                "sum_decrease": approx(factor * 0.0),
+                "sum_increase": approx(factor * 10.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -268,6 +278,8 @@ def test_compile_hourly_sum_statistics_amount(
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(factor * seq[5]),
                 "sum": approx(factor * 40.0),
+                "sum_decrease": approx(factor * 10.0),
+                "sum_increase": approx(factor * 50.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -278,6 +290,8 @@ def test_compile_hourly_sum_statistics_amount(
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(factor * seq[8]),
                 "sum": approx(factor * 70.0),
+                "sum_decrease": approx(factor * 10.0),
+                "sum_increase": approx(factor * 80.0),
             },
         ]
     }
@@ -352,6 +366,8 @@ def test_compile_hourly_sum_statistics_amount_reset_every_state_change(
                 "last_reset": process_timestamp_to_utc_isoformat(one),
                 "state": approx(factor * seq[7]),
                 "sum": approx(factor * (sum(seq) - seq[0])),
+                "sum_decrease": approx(factor * 0.0),
+                "sum_increase": approx(factor * (sum(seq) - seq[0])),
             },
         ]
     }
@@ -478,6 +494,8 @@ def test_compile_hourly_sum_statistics_total_no_reset(
                 "last_reset": None,
                 "state": approx(factor * seq[2]),
                 "sum": approx(factor * 10.0),
+                "sum_decrease": approx(factor * 0.0),
+                "sum_increase": approx(factor * 10.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -488,6 +506,8 @@ def test_compile_hourly_sum_statistics_total_no_reset(
                 "last_reset": None,
                 "state": approx(factor * seq[5]),
                 "sum": approx(factor * 30.0),
+                "sum_decrease": approx(factor * 10.0),
+                "sum_increase": approx(factor * 40.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -498,6 +518,8 @@ def test_compile_hourly_sum_statistics_total_no_reset(
                 "last_reset": None,
                 "state": approx(factor * seq[8]),
                 "sum": approx(factor * 60.0),
+                "sum_decrease": approx(factor * 10.0),
+                "sum_increase": approx(factor * 70.0),
             },
         ]
     }
@@ -558,6 +580,8 @@ def test_compile_hourly_sum_statistics_total_increasing(
                 "last_reset": None,
                 "state": approx(factor * seq[2]),
                 "sum": approx(factor * 10.0),
+                "sum_decrease": approx(factor * 0.0),
+                "sum_increase": approx(factor * 10.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -568,6 +592,8 @@ def test_compile_hourly_sum_statistics_total_increasing(
                 "last_reset": None,
                 "state": approx(factor * seq[5]),
                 "sum": approx(factor * 50.0),
+                "sum_decrease": approx(factor * 0.0),
+                "sum_increase": approx(factor * 50.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -578,6 +604,8 @@ def test_compile_hourly_sum_statistics_total_increasing(
                 "last_reset": None,
                 "state": approx(factor * seq[8]),
                 "sum": approx(factor * 80.0),
+                "sum_decrease": approx(factor * 0.0),
+                "sum_increase": approx(factor * 80.0),
             },
         ]
     }
@@ -648,6 +676,8 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
                 "min": None,
                 "state": approx(factor * seq[2]),
                 "sum": approx(factor * 10.0),
+                "sum_decrease": approx(factor * 0.0),
+                "sum_increase": approx(factor * 10.0),
             },
             {
                 "last_reset": None,
@@ -658,6 +688,8 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
                 "min": None,
                 "state": approx(factor * seq[5]),
                 "sum": approx(factor * 30.0),
+                "sum_decrease": approx(factor * 1.0),
+                "sum_increase": approx(factor * 31.0),
             },
             {
                 "last_reset": None,
@@ -668,6 +700,8 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
                 "min": None,
                 "state": approx(factor * seq[8]),
                 "sum": approx(factor * 60.0),
+                "sum_decrease": approx(factor * 2.0),
+                "sum_increase": approx(factor * 62.0),
             },
         ]
     }
@@ -735,6 +769,8 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(zero),
                 "state": approx(20.0),
                 "sum": approx(10.0),
+                "sum_decrease": approx(0.0),
+                "sum_increase": approx(10.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -745,6 +781,8 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(40.0),
                 "sum": approx(40.0),
+                "sum_decrease": approx(10.0),
+                "sum_increase": approx(50.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -755,6 +793,8 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(70.0),
                 "sum": approx(70.0),
+                "sum_decrease": approx(10.0),
+                "sum_increase": approx(80.0),
             },
         ]
     }
@@ -818,6 +858,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(zero),
                 "state": approx(20.0),
                 "sum": approx(10.0),
+                "sum_decrease": approx(0.0),
+                "sum_increase": approx(10.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -828,6 +870,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(40.0),
                 "sum": approx(40.0),
+                "sum_decrease": approx(10.0),
+                "sum_increase": approx(50.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -838,6 +882,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(70.0),
                 "sum": approx(70.0),
+                "sum_decrease": approx(10.0),
+                "sum_increase": approx(80.0),
             },
         ],
         "sensor.test2": [
@@ -850,6 +896,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(zero),
                 "state": approx(130.0),
                 "sum": approx(20.0),
+                "sum_decrease": approx(0.0),
+                "sum_increase": approx(20.0),
             },
             {
                 "statistic_id": "sensor.test2",
@@ -860,6 +908,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(45.0),
                 "sum": approx(-65.0),
+                "sum_decrease": approx(130.0),
+                "sum_increase": approx(65.0),
             },
             {
                 "statistic_id": "sensor.test2",
@@ -870,6 +920,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(75.0),
                 "sum": approx(-35.0),
+                "sum_decrease": approx(130.0),
+                "sum_increase": approx(95.0),
             },
         ],
         "sensor.test3": [
@@ -882,6 +934,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(zero),
                 "state": approx(5.0 / 1000),
                 "sum": approx(5.0 / 1000),
+                "sum_decrease": approx(0.0 / 1000),
+                "sum_increase": approx(5.0 / 1000),
             },
             {
                 "statistic_id": "sensor.test3",
@@ -892,6 +946,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(50.0 / 1000),
                 "sum": approx(60.0 / 1000),
+                "sum_decrease": approx(0.0 / 1000),
+                "sum_increase": approx(60.0 / 1000),
             },
             {
                 "statistic_id": "sensor.test3",
@@ -902,6 +958,8 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(90.0 / 1000),
                 "sum": approx(100.0 / 1000),
+                "sum_decrease": approx(0.0 / 1000),
+                "sum_increase": approx(100.0 / 1000),
             },
         ],
     }
@@ -955,6 +1013,8 @@ def test_compile_hourly_statistics_unchanged(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ]
     }
@@ -987,6 +1047,8 @@ def test_compile_hourly_statistics_partially_unavailable(hass_recorder, caplog):
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ]
     }
@@ -1044,6 +1106,8 @@ def test_compile_hourly_statistics_unavailable(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ]
     }
@@ -1194,6 +1258,8 @@ def test_compile_hourly_statistics_changing_units_1(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ]
     }
@@ -1220,6 +1286,8 @@ def test_compile_hourly_statistics_changing_units_1(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ]
     }
@@ -1325,6 +1393,8 @@ def test_compile_hourly_statistics_changing_units_3(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ]
     }
@@ -1349,6 +1419,8 @@ def test_compile_hourly_statistics_changing_units_3(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             }
         ]
     }
@@ -1427,6 +1499,8 @@ def test_compile_hourly_statistics_changing_statistics(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
+                "sum_decrease": None,
+                "sum_increase": None,
             },
             {
                 "statistic_id": "sensor.test1",
@@ -1437,6 +1511,8 @@ def test_compile_hourly_statistics_changing_statistics(
                 "last_reset": None,
                 "state": approx(30.0),
                 "sum": approx(30.0),
+                "sum_decrease": approx(0.0),
+                "sum_increase": approx(30.0),
             },
         ]
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `sum_decrease` and `sum_increase` statistics
This allows us to split a net energy meter in import and export.

Note:
It's a bit redundant to add both `sum_decrease` and `sum_increase` because at any given time `sum` = `sum_increase` - `sum_decrease`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
