### PR TITLE
Use the same server name for all HomeKit bridges

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -519,7 +519,7 @@ class HomeKit:
         self.bridge = None
         self.driver = None
 
-    def setup(self, async_zeroconf_instance):
+    def setup(self, async_zeroconf_instance, uuid):
         """Set up bridge and accessory driver."""
         persist_file = get_persist_fullpath_for_entry_id(self.hass, self._entry_id)
 
@@ -534,6 +534,7 @@ class HomeKit:
             persist_file=persist_file,
             advertised_address=self._advertise_ip,
             async_zeroconf_instance=async_zeroconf_instance,
+            zeroconf_server=f"{uuid}-hap.local.",
         )
 
         # If we do not load the mac address will be wrong
@@ -713,7 +714,8 @@ class HomeKit:
             return
         self.status = STATUS_WAIT
         async_zc_instance = await zeroconf.async_get_async_instance(self.hass)
-        await self.hass.async_add_executor_job(self.setup, async_zc_instance)
+        uuid = await self.hass.helpers.instance_id.async_get()
+        await self.hass.async_add_executor_job(self.setup, async_zc_instance, uuid)
         self.aid_storage = AccessoryAidStorage(self.hass, self._entry_id)
         await self.aid_storage.async_initialize()
         if not await self._async_create_accessories():

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
   "requirements": [
-    "HAP-python==4.1.0",
+    "HAP-python==4.2.1",
     "fnvhash==0.1.0",
     "PyQRCode==1.2.1",
     "base36==0.1.1"

--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -219,7 +219,7 @@ class Fan(HomeAccessory):
             # the rotation speed is mapped to 1 otherwise the update is ignored
             # in order to avoid this incorrect behavior.
             if percentage == 0 and state == STATE_ON:
-                percentage = 1
+                percentage = max(1, self.char_speed.properties[PROP_MIN_STEP])
             if percentage is not None:
                 self.char_speed.set_value(percentage)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -14,7 +14,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.1.1
 
 # homeassistant.components.homekit
-HAP-python==4.1.0
+HAP-python==4.2.1
 
 # homeassistant.components.mastodon
 Mastodon.py==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.homekit
-HAP-python==4.1.0
+HAP-python==4.2.1
 
 # homeassistant.components.flick_electric
 PyFlick==0.0.2

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -265,8 +265,9 @@ async def test_homekit_setup(hass, hk_driver, mock_zeroconf):
     hass.states.async_set("light.demo", "on")
     hass.states.async_set("light.demo2", "on")
     zeroconf_mock = MagicMock()
+    uuid = await hass.helpers.instance_id.async_get()
     with patch(f"{PATH_HOMEKIT}.HomeDriver", return_value=hk_driver) as mock_driver:
-        await hass.async_add_executor_job(homekit.setup, zeroconf_mock)
+        await hass.async_add_executor_job(homekit.setup, zeroconf_mock, uuid)
 
     path = get_persist_fullpath_for_entry_id(hass, entry.entry_id)
     mock_driver.assert_called_with(
@@ -280,6 +281,7 @@ async def test_homekit_setup(hass, hk_driver, mock_zeroconf):
         persist_file=path,
         advertised_address=None,
         async_zeroconf_instance=zeroconf_mock,
+        zeroconf_server=f"{uuid}-hap.local.",
     )
     assert homekit.driver.safe_mode is False
 
@@ -307,8 +309,9 @@ async def test_homekit_setup_ip_address(hass, hk_driver, mock_zeroconf):
 
     mock_zeroconf = MagicMock()
     path = get_persist_fullpath_for_entry_id(hass, entry.entry_id)
+    uuid = await hass.helpers.instance_id.async_get()
     with patch(f"{PATH_HOMEKIT}.HomeDriver", return_value=hk_driver) as mock_driver:
-        await hass.async_add_executor_job(homekit.setup, mock_zeroconf)
+        await hass.async_add_executor_job(homekit.setup, mock_zeroconf, uuid)
     mock_driver.assert_called_with(
         hass,
         entry.entry_id,
@@ -320,6 +323,7 @@ async def test_homekit_setup_ip_address(hass, hk_driver, mock_zeroconf):
         persist_file=path,
         advertised_address=None,
         async_zeroconf_instance=mock_zeroconf,
+        zeroconf_server=f"{uuid}-hap.local.",
     )
 
 
@@ -346,8 +350,9 @@ async def test_homekit_setup_advertise_ip(hass, hk_driver, mock_zeroconf):
 
     async_zeroconf_instance = MagicMock()
     path = get_persist_fullpath_for_entry_id(hass, entry.entry_id)
+    uuid = await hass.helpers.instance_id.async_get()
     with patch(f"{PATH_HOMEKIT}.HomeDriver", return_value=hk_driver) as mock_driver:
-        await hass.async_add_executor_job(homekit.setup, async_zeroconf_instance)
+        await hass.async_add_executor_job(homekit.setup, async_zeroconf_instance, uuid)
     mock_driver.assert_called_with(
         hass,
         entry.entry_id,
@@ -359,6 +364,7 @@ async def test_homekit_setup_advertise_ip(hass, hk_driver, mock_zeroconf):
         persist_file=path,
         advertised_address="192.168.1.100",
         async_zeroconf_instance=async_zeroconf_instance,
+        zeroconf_server=f"{uuid}-hap.local.",
     )
 
 


### PR DESCRIPTION
Requires #55804


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

- When an iOS device wakes up it has to refresh all the A records
  for each paired accessory. When there are many paired accessories
  this can result in HomeKit timing out before it can refresh
  all the records and declaring some accessories unavailable.

  We now use the same server name for all HomeKit bridges and accessories
  on a single Home Assistant instance. This allows the system to avoid
  doing multiple lookups since it only needs to find one A record when
  waking from sleep.

  iOS devices and Home Hubs (Apple TVs / HomePods / iPads) may cache
  the server name even if it expires and may require
  a reboot to see the new name. If this is the case, accessories may
  show unavailable when outside the home until ALL home hubs are rebooted.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
