### PR TITLE
Correctly handle offline and unsupported printers during setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -580,7 +580,7 @@ jobs:
 
           python -m venv venv
           . venv/bin/activate
-          pip install -U "pip<20.3" "setuptools<58" wheel
+          pip install -U "pip<20.3" setuptools wheel
           pip install -r requirements_all.txt
           pip install -r requirements_test.txt
           pip install -e .

--- a/homeassistant/components/syncthru/__init__.py
+++ b/homeassistant/components/syncthru/__init__.py
@@ -5,14 +5,13 @@ from datetime import timedelta
 import logging
 
 import async_timeout
-from pysyncthru import SyncThru
+from pysyncthru import ConnectionMode, SyncThru, SyncThruAPINotSupported
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -28,22 +27,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     session = aiohttp_client.async_get_clientsession(hass)
     hass.data.setdefault(DOMAIN, {})
-    printer = SyncThru(entry.data[CONF_URL], session)
+    printer = SyncThru(
+        entry.data[CONF_URL], session, connection_mode=ConnectionMode.API
+    )
 
     async def async_update_data() -> SyncThru:
         """Fetch data from the printer."""
         try:
             async with async_timeout.timeout(10):
                 await printer.update()
-        except ValueError as value_error:
+        except SyncThruAPINotSupported as api_error:
             # if an exception is thrown, printer does not support syncthru
-            raise UpdateFailed(
-                f"Configured printer at {printer.url} does not respond. "
-                "Please make sure it supports SyncThru and check your configuration."
-            ) from value_error
+            _LOGGER.info(
+                "Configured SyncThru printer does not provide JSON API.",
+                exc_info=api_error,
+            )
+            raise api_error
         else:
-            if printer.is_unknown_state():
-                raise ConfigEntryNotReady
+            # if the printer is offline, we raise an UpdateFailed
+            if not printer.is_online():
+                raise UpdateFailed(
+                    f"Configured printer at {printer.url} does not respond."
+                )
             return printer
 
     coordinator: DataUpdateCoordinator = DataUpdateCoordinator(
@@ -55,6 +60,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     hass.data[DOMAIN][entry.entry_id] = coordinator
     await coordinator.async_config_entry_first_refresh()
+    if isinstance(coordinator.last_exception, SyncThruAPINotSupported):
+        # this means that the printer does not support the syncthru JSON API
+        # and the config should simply be discarded
+        return False
 
     device_registry = await dr.async_get_registry(hass)
     device_registry.async_get_or_create(

--- a/homeassistant/components/syncthru/__init__.py
+++ b/homeassistant/components/syncthru/__init__.py
@@ -39,13 +39,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except SyncThruAPINotSupported as api_error:
             # if an exception is thrown, printer does not support syncthru
             _LOGGER.info(
-                "Configured SyncThru printer does not provide JSON API.",
+                f"Configured printer at {printer.url} does not provide SyncThru JSON API",
                 exc_info=api_error,
             )
             raise api_error
         else:
             # if the printer is offline, we raise an UpdateFailed
-            if not printer.is_online():
+            if printer.is_unknown_state():
                 raise UpdateFailed(
                     f"Configured printer at {printer.url} does not respond."
                 )

--- a/homeassistant/components/syncthru/__init__.py
+++ b/homeassistant/components/syncthru/__init__.py
@@ -39,7 +39,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except SyncThruAPINotSupported as api_error:
             # if an exception is thrown, printer does not support syncthru
             _LOGGER.info(
-                f"Configured printer at {printer.url} does not provide SyncThru JSON API",
+                "Configured printer at %s does not provide SyncThru JSON API",
+                printer.url,
                 exc_info=api_error,
             )
             raise api_error

--- a/homeassistant/components/syncthru/config_flow.py
+++ b/homeassistant/components/syncthru/config_flow.py
@@ -120,7 +120,7 @@ class SyncThruConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     printer.model() or DEFAULT_MODEL
                 )
         except SyncThruAPINotSupported:
-            errors[CONF_URL] = "syncthru_api_not_supported"
+            errors[CONF_URL] = "syncthru_not_supported"
         else:
             if printer.is_unknown_state():
                 errors[CONF_URL] = "unknown_state"

--- a/homeassistant/components/syncthru/config_flow.py
+++ b/homeassistant/components/syncthru/config_flow.py
@@ -3,7 +3,7 @@
 import re
 from urllib.parse import urlparse
 
-from pysyncthru import SyncThru
+from pysyncthru import ConnectionMode, SyncThru, SyncThruAPINotSupported
 from url_normalize import url_normalize
 import voluptuous as vol
 
@@ -109,7 +109,9 @@ class SyncThruConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 break
 
         session = aiohttp_client.async_get_clientsession(self.hass)
-        printer = SyncThru(user_input[CONF_URL], session)
+        printer = SyncThru(
+            user_input[CONF_URL], session, connection_mode=ConnectionMode.API
+        )
         errors = {}
         try:
             await printer.update()
@@ -117,8 +119,8 @@ class SyncThruConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_NAME] = DEFAULT_NAME_TEMPLATE.format(
                     printer.model() or DEFAULT_MODEL
                 )
-        except ValueError:
-            errors[CONF_URL] = "syncthru_not_supported"
+        except SyncThruAPINotSupported:
+            errors[CONF_URL] = "syncthru_api_not_supported"
         else:
             if printer.is_unknown_state():
                 errors[CONF_URL] = "unknown_state"

--- a/homeassistant/components/syncthru/manifest.json
+++ b/homeassistant/components/syncthru/manifest.json
@@ -3,7 +3,7 @@
   "name": "Samsung SyncThru Printer",
   "documentation": "https://www.home-assistant.io/integrations/syncthru",
   "config_flow": true,
-  "requirements": ["pysyncthru==0.7.9", "url-normalize==1.4.1"],
+  "requirements": ["pysyncthru==0.7.10", "url-normalize==1.4.1"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:Printer:1",

--- a/homeassistant/components/syncthru/manifest.json
+++ b/homeassistant/components/syncthru/manifest.json
@@ -3,7 +3,7 @@
   "name": "Samsung SyncThru Printer",
   "documentation": "https://www.home-assistant.io/integrations/syncthru",
   "config_flow": true,
-  "requirements": ["pysyncthru==0.7.3", "url-normalize==1.4.1"],
+  "requirements": ["pysyncthru==0.7.9", "url-normalize==1.4.1"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:Printer:1",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1817,7 +1817,7 @@ pystiebeleltron==0.0.1.dev2
 pysuez==0.1.19
 
 # homeassistant.components.syncthru
-pysyncthru==0.7.9
+pysyncthru==0.7.10
 
 # homeassistant.components.tankerkoenig
 pytankerkoenig==0.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1817,7 +1817,7 @@ pystiebeleltron==0.0.1.dev2
 pysuez==0.1.19
 
 # homeassistant.components.syncthru
-pysyncthru==0.7.3
+pysyncthru==0.7.9
 
 # homeassistant.components.tankerkoenig
 pytankerkoenig==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1052,7 +1052,7 @@ pyspcwebgw==0.4.0
 pysqueezebox==0.5.5
 
 # homeassistant.components.syncthru
-pysyncthru==0.7.3
+pysyncthru==0.7.9
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1052,7 +1052,7 @@ pyspcwebgw==0.4.0
 pysqueezebox==0.5.5
 
 # homeassistant.components.syncthru
-pysyncthru==0.7.9
+pysyncthru==0.7.10
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.11

--- a/tests/components/syncthru/test_config_flow.py
+++ b/tests/components/syncthru/test_config_flow.py
@@ -3,6 +3,8 @@
 import re
 from unittest.mock import patch
 
+from pysyncthru import SyncThruAPINotSupported
+
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components import ssdp
 from homeassistant.components.syncthru.config_flow import SyncThru
@@ -71,7 +73,7 @@ async def test_already_configured_by_url(hass, aioclient_mock):
 
 async def test_syncthru_not_supported(hass):
     """Test we show user form on unsupported device."""
-    with patch.object(SyncThru, "update", side_effect=ValueError):
+    with patch.object(SyncThru, "update", side_effect=SyncThruAPINotSupported):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes the behaviour of user induced configuration of the Syncthru printer, especially in cases where the JSON API is not supported or the printer is temporarily offline.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

The dependency is upgraded in order to use a more specific error in case the JSON API is not supported.
While the package now supports web scraping, this capability is not used at all.
Moreover the backend parser is now https://github.com/nielstron/demjson3, in order not to have 2to3 in the toolchain anymore.

The package changelog is visible here: https://github.com/nielstron/pysyncthru/compare/release-0.7.3...release-0.7.10

- This PR fixes or closes issue: fixes #55725
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
