### PR TITLE
Bump PyJWT to 2.1.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
   pull_request: ~
 
 env:
-  CACHE_VERSION: 2
+  CACHE_VERSION: 3
   DEFAULT_PYTHON: 3.8
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
   SQLALCHEMY_WARN_20: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -580,7 +580,7 @@ jobs:
 
           python -m venv venv
           . venv/bin/activate
-          pip install -U "pip<20.3" setuptools wheel
+          pip install -U "pip<20.3" "setuptools<58" wheel
           pip install -r requirements_all.txt
           pip install -r requirements_test.txt
           pip install -e .

--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -466,7 +466,7 @@ class AuthManager:
             },
             refresh_token.jwt_key,
             algorithm="HS256",
-        ).decode()
+        )
 
     @callback
     def _async_resolve_provider(
@@ -507,7 +507,9 @@ class AuthManager:
     ) -> models.RefreshToken | None:
         """Return refresh token if an access token is valid."""
         try:
-            unverif_claims = jwt.decode(token, verify=False)
+            unverif_claims = jwt.decode(
+                token, algorithms=["HS256"], options={"verify_signature": False}
+            )
         except jwt.InvalidTokenError:
             return None
 

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -51,7 +51,7 @@ def _get_homegraph_jwt(time, iss, key):
         "iat": now,
         "exp": now + 3600,
     }
-    return jwt.encode(jwt_raw, key, algorithm="RS256").decode("utf-8")
+    return jwt.encode(jwt_raw, key, algorithm="RS256")
 
 
 async def _get_homegraph_token(hass, jwt_signed):

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -320,7 +320,9 @@ class HTML5PushCallbackView(HomeAssistantView):
         # 2a. If decode is successful, return the payload.
         # 2b. If decode is unsuccessful, return a 401.
 
-        target_check = jwt.decode(token, verify=False)
+        target_check = jwt.decode(
+            token, algorithms=["ES256", "HS256"], options={"verify_signature": False}
+        )
         if target_check.get(ATTR_TARGET) in self.registrations:
             possible_target = self.registrations[target_check[ATTR_TARGET]]
             key = possible_target[ATTR_SUBSCRIPTION][ATTR_KEYS][ATTR_AUTH]
@@ -557,7 +559,7 @@ def add_jwt(timestamp, target, tag, jwt_secret):
         ATTR_TARGET: target,
         ATTR_TAG: tag,
     }
-    return jwt.encode(jwt_claims, jwt_secret).decode("utf-8")
+    return jwt.encode(jwt_claims, jwt_secret)
 
 
 def create_vapid_headers(vapid_email, subscription_info, vapid_private_key):

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -45,7 +45,7 @@ def async_sign_path(
         secret,
         algorithm="HS256",
     )
-    return f"{path}?{SIGN_QUERY_PARAM}={encoded.decode()}"
+    return f"{path}?{SIGN_QUERY_PARAM}={encoded}"
 
 
 @callback

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -505,7 +505,7 @@ def _encode_jwt(hass: HomeAssistant, data: dict) -> str:
     if secret is None:
         secret = hass.data[DATA_JWT_SECRET] = secrets.token_hex()
 
-    return jwt.encode(data, secret, algorithm="HS256").decode()
+    return jwt.encode(data, secret, algorithm="HS256")
 
 
 @callback

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,4 +1,4 @@
-PyJWT==1.7.1
+PyJWT==2.1.0
 PyNaCl==1.4.0
 aiodiscover==1.4.2
 aiohttp==3.7.4.post0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ certifi>=2020.12.5
 ciso8601==2.1.3
 httpx==0.19.0
 jinja2==3.0.1
-PyJWT==1.7.1
+PyJWT==2.1.0
 cryptography==3.3.2
 pip>=8.0.3,<20.3
 python-slugify==4.0.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -37,7 +37,6 @@ types-decorator==0.1.7
 types-emoji==1.2.4
 types-enum34==0.1.8
 types-ipaddress==0.1.5
-types-jwt==0.1.3
 types-pkg-resources==0.1.3
 types-python-slugify==0.1.2
 types-pytz==2021.1.2

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ REQUIRES = [
     "ciso8601==2.1.3",
     "httpx==0.19.0",
     "jinja2==3.0.1",
-    "PyJWT==1.7.1",
+    "PyJWT==2.1.0",
     # PyJWT has loose dependency. We want the latest one.
     "cryptography==3.3.2",
     "pip>=8.0.3,<20.3",

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -539,7 +539,7 @@ async def test_create_access_token(mock_hass):
     access_token = manager.async_create_access_token(refresh_token)
     assert access_token is not None
     assert refresh_token.jwt_key == jwt_key
-    jwt_payload = jwt.decode(access_token, jwt_key, algorithm=["HS256"])
+    jwt_payload = jwt.decode(access_token, jwt_key, algorithms=["HS256"])
     assert jwt_payload["iss"] == refresh_token.id
     assert (
         jwt_payload["exp"] - jwt_payload["iat"] == timedelta(minutes=30).total_seconds()
@@ -558,7 +558,7 @@ async def test_create_long_lived_access_token(mock_hass):
     )
     assert refresh_token.token_type == auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
     access_token = manager.async_create_access_token(refresh_token)
-    jwt_payload = jwt.decode(access_token, refresh_token.jwt_key, algorithm=["HS256"])
+    jwt_payload = jwt.decode(access_token, refresh_token.jwt_key, algorithms=["HS256"])
     assert jwt_payload["iss"] == refresh_token.id
     assert (
         jwt_payload["exp"] - jwt_payload["iat"] == timedelta(days=300).total_seconds()
@@ -610,7 +610,7 @@ async def test_one_long_lived_access_token_per_refresh_token(mock_hass):
     assert jwt_key != jwt_key_2
 
     rt = await manager.async_validate_access_token(access_token_2)
-    jwt_payload = jwt.decode(access_token_2, rt.jwt_key, algorithm=["HS256"])
+    jwt_payload = jwt.decode(access_token_2, rt.jwt_key, algorithms=["HS256"])
     assert jwt_payload["iss"] == refresh_token_2.id
     assert (
         jwt_payload["exp"] - jwt_payload["iat"] == timedelta(days=3000).total_seconds()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Current version is almost 3 years old and v2 has many improvements: https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-0-0

Although there are some breaking changes:
- `jwt.encode` returns `str` instead of `bytes`
- `jwt.decode` must always have `algorithms`
- `verify` in `jwt.decode` is replaced with `verify_signature` in `options`.

Release notes: https://github.com/jpadilla/pyjwt/releases/tag/2.1.0

https://github.com/jpadilla/pyjwt/compare/1.7.1...2.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
