### PR TITLE
Use EntityDescription - incomfort

### DIFF
--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -1,9 +1,14 @@
 """Support for an Intergas heater via an InComfort/InTouch Lan2RF gateway."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorEntity
+from homeassistant.components.sensor import (
+    DOMAIN as SENSOR_DOMAIN,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.const import (
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
@@ -18,11 +23,36 @@ INCOMFORT_HEATER_TEMP = "CV Temp"
 INCOMFORT_PRESSURE = "CV Pressure"
 INCOMFORT_TAP_TEMP = "Tap Temp"
 
-INCOMFORT_MAP_ATTRS = {
-    INCOMFORT_HEATER_TEMP: ["heater_temp", "is_pumping"],
-    INCOMFORT_PRESSURE: ["pressure", None],
-    INCOMFORT_TAP_TEMP: ["tap_temp", "is_tapping"],
-}
+
+@dataclass
+class IncomfortSensorEntityDescription(SensorEntityDescription):
+    """Describes Incomfort sensor entity."""
+
+    extra_key: str | None = None
+
+
+SENSOR_TYPES: tuple[IncomfortSensorEntityDescription, ...] = (
+    IncomfortSensorEntityDescription(
+        key="pressure",
+        name=INCOMFORT_PRESSURE,
+        device_class=DEVICE_CLASS_PRESSURE,
+        native_unit_of_measurement=PRESSURE_BAR,
+    ),
+    IncomfortSensorEntityDescription(
+        key="heater_temp",
+        name=INCOMFORT_HEATER_TEMP,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        native_unit_of_measurement=TEMP_CELSIUS,
+        extra_key="is_pumping",
+    ),
+    IncomfortSensorEntityDescription(
+        key="tap_temp",
+        name=INCOMFORT_TAP_TEMP,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        native_unit_of_measurement=TEMP_CELSIUS,
+        extra_key="is_tapping",
+    ),
+)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -33,70 +63,41 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     client = hass.data[DOMAIN]["client"]
     heaters = hass.data[DOMAIN]["heaters"]
 
-    async_add_entities(
-        [IncomfortPressure(client, h, INCOMFORT_PRESSURE) for h in heaters]
-        + [IncomfortTemperature(client, h, INCOMFORT_HEATER_TEMP) for h in heaters]
-        + [IncomfortTemperature(client, h, INCOMFORT_TAP_TEMP) for h in heaters]
-    )
+    entities = [
+        IncomfortSensor(client, heater, description)
+        for heater in heaters
+        for description in SENSOR_TYPES
+    ]
+
+    async_add_entities(entities)
 
 
 class IncomfortSensor(IncomfortChild, SensorEntity):
     """Representation of an InComfort/InTouch sensor device."""
 
-    def __init__(self, client, heater, name) -> None:
+    entity_description: IncomfortSensorEntityDescription
+
+    def __init__(
+        self, client, heater, description: IncomfortSensorEntityDescription
+    ) -> None:
         """Initialize the sensor."""
         super().__init__()
+        self.entity_description = description
 
         self._client = client
         self._heater = heater
 
-        self._unique_id = f"{heater.serial_no}_{slugify(name)}"
-        self.entity_id = f"{SENSOR_DOMAIN}.{DOMAIN}_{slugify(name)}"
-        self._name = f"Boiler {name}"
-
-        self._device_class = None
-        self._state_attr = INCOMFORT_MAP_ATTRS[name][0]
-        self._unit_of_measurement = None
+        self._unique_id = f"{heater.serial_no}_{slugify(description.name)}"
+        self.entity_id = f"{SENSOR_DOMAIN}.{DOMAIN}_{slugify(description.name)}"
+        self._name = f"Boiler {description.name}"
 
     @property
     def native_value(self) -> str | None:
         """Return the state of the sensor."""
-        return self._heater.status[self._state_attr]
+        return self._heater.status[self.entity_description.key]
 
-    @property
-    def device_class(self) -> str | None:
-        """Return the device class of the sensor."""
-        return self._device_class
-
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit of measurement of the sensor."""
-        return self._unit_of_measurement
-
-
-class IncomfortPressure(IncomfortSensor):
-    """Representation of an InTouch CV Pressure sensor."""
-
-    def __init__(self, client, heater, name) -> None:
-        """Initialize the sensor."""
-        super().__init__(client, heater, name)
-
-        self._device_class = DEVICE_CLASS_PRESSURE
-        self._unit_of_measurement = PRESSURE_BAR
-
-
-class IncomfortTemperature(IncomfortSensor):
-    """Representation of an InTouch Temperature sensor."""
-
-    def __init__(self, client, heater, name) -> None:
-        """Initialize the signal strength sensor."""
-        super().__init__(client, heater, name)
-
-        self._attr = INCOMFORT_MAP_ATTRS[name][1]
-        self._device_class = DEVICE_CLASS_TEMPERATURE
-        self._unit_of_measurement = TEMP_CELSIUS
-
-    @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the device state attributes."""
-        return {self._attr: self._heater.status[self._attr]}
+        if (extra_key := self.entity_description.extra_key) is None:
+            return None
+        return {extra_key: self._heater.status[extra_key]}

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -96,6 +96,7 @@ class IncomfortSensor(IncomfortChild, SensorEntity):
         """Return the state of the sensor."""
         return self._heater.status[self.entity_description.key]
 
+    @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the device state attributes."""
         if (extra_key := self.entity_description.extra_key) is None:


### PR DESCRIPTION
## Proposed change
Update `incomfort` to use `EntityDescription` for sensor metadata.
-> #53201

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
