### PR TITLE
Add support for state class measurement to energy cost sensor

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -1,13 +1,16 @@
 """Helper sensor for calculating utility costs."""
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 import logging
 from typing import Any, Final, Literal, TypeVar, cast
 
 from homeassistant.components.sensor import (
+    ATTR_LAST_RESET,
     ATTR_STATE_CLASS,
     DEVICE_CLASS_MONETARY,
+    STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
 )
@@ -18,14 +21,19 @@ from homeassistant.const import (
     ENERGY_WATT_HOUR,
     VOLUME_CUBIC_METERS,
 )
-from homeassistant.core import HomeAssistant, callback, split_entity_id
+from homeassistant.core import HomeAssistant, State, callback, split_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
 from .data import EnergyManager, async_get_manager
 
+SUPPORTED_STATE_CLASSES = [
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+]
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -206,15 +214,16 @@ class EnergyCostSensor(SensorEntity):
             f"{config[adapter.entity_energy_key]}_{adapter.entity_id_suffix}"
         )
         self._attr_device_class = DEVICE_CLASS_MONETARY
-        self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
+        self._attr_state_class = STATE_CLASS_MEASUREMENT
         self._config = config
-        self._last_energy_sensor_state: StateType | None = None
+        self._last_energy_sensor_state: State | None = None
         self._cur_value = 0.0
 
-    def _reset(self, energy_state: StateType) -> None:
+    def _reset(self, energy_state: State) -> None:
         """Reset the cost sensor."""
         self._attr_native_value = 0.0
         self._cur_value = 0.0
+        self._attr_last_reset = dt_util.utcnow()
         self._last_energy_sensor_state = energy_state
         self.async_write_ha_state()
 
@@ -228,9 +237,8 @@ class EnergyCostSensor(SensorEntity):
         if energy_state is None:
             return
 
-        if (
-            state_class := energy_state.attributes.get(ATTR_STATE_CLASS)
-        ) != STATE_CLASS_TOTAL_INCREASING:
+        state_class = energy_state.attributes.get(ATTR_STATE_CLASS)
+        if state_class not in SUPPORTED_STATE_CLASSES:
             if not self._wrong_state_class_reported:
                 self._wrong_state_class_reported = True
                 _LOGGER.warning(
@@ -238,6 +246,13 @@ class EnergyCostSensor(SensorEntity):
                     state_class,
                     energy_state.entity_id,
                 )
+            return
+
+        # last_reset must be set if the sensor is STATE_CLASS_MEASUREMENT
+        if (
+            state_class == STATE_CLASS_MEASUREMENT
+            and ATTR_LAST_RESET not in energy_state.attributes
+        ):
             return
 
         try:
@@ -273,7 +288,7 @@ class EnergyCostSensor(SensorEntity):
 
         if self._last_energy_sensor_state is None:
             # Initialize as it's the first time all required entities are in place.
-            self._reset(energy_state.state)
+            self._reset(energy_state)
             return
 
         energy_unit = energy_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
@@ -298,20 +313,29 @@ class EnergyCostSensor(SensorEntity):
                 )
             return
 
-        if reset_detected(
+        if state_class != STATE_CLASS_TOTAL_INCREASING and energy_state.attributes.get(
+            ATTR_LAST_RESET
+        ) != self._last_energy_sensor_state.attributes.get(ATTR_LAST_RESET):
+            # Energy meter was reset, reset cost sensor too
+            energy_state_copy = copy.copy(energy_state)
+            energy_state_copy.state = "0.0"
+            self._reset(energy_state_copy)
+        elif state_class == STATE_CLASS_TOTAL_INCREASING and reset_detected(
             self.hass,
             cast(str, self._config[self._adapter.entity_energy_key]),
             energy,
-            float(self._last_energy_sensor_state),
+            float(self._last_energy_sensor_state.state),
         ):
             # Energy meter was reset, reset cost sensor too
-            self._reset(0)
+            energy_state_copy = copy.copy(energy_state)
+            energy_state_copy.state = "0.0"
+            self._reset(energy_state_copy)
         # Update with newly incurred cost
-        old_energy_value = float(self._last_energy_sensor_state)
+        old_energy_value = float(self._last_energy_sensor_state.state)
         self._cur_value += (energy - old_energy_value) * energy_price
         self._attr_native_value = round(self._cur_value, 2)
 
-        self._last_energy_sensor_state = energy_state.state
+        self._last_energy_sensor_state = energy_state
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -98,7 +98,11 @@ def _async_validate_energy_stat(
 
     state_class = state.attributes.get("state_class")
 
-    if state_class != sensor.STATE_CLASS_TOTAL_INCREASING:
+    supported_state_classes = [
+        sensor.STATE_CLASS_MEASUREMENT,
+        sensor.STATE_CLASS_TOTAL_INCREASING,
+    ]
+    if state_class not in supported_state_classes:
         result.append(
             ValidationIssue(
                 "entity_unexpected_state_class_total_increasing",
@@ -125,15 +129,12 @@ def _async_validate_price_entity(
         return
 
     try:
-        value: float | None = float(state.state)
+        float(state.state)
     except ValueError:
         result.append(
             ValidationIssue("entity_state_non_numeric", entity_id, state.state)
         )
         return
-
-    if value is not None and value < 0:
-        result.append(ValidationIssue("entity_negative_state", entity_id, value))
 
     unit = state.attributes.get("unit_of_measurement")
 
@@ -185,15 +186,6 @@ def _async_validate_cost_entity(
             )
         )
         return
-
-    state_class = state.attributes.get("state_class")
-
-    if state_class != sensor.STATE_CLASS_TOTAL_INCREASING:
-        result.append(
-            ValidationIssue(
-                "entity_unexpected_state_class_total_increasing", entity_id, state_class
-            )
-        )
 
 
 async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -187,6 +187,19 @@ def _async_validate_cost_entity(
         )
         return
 
+    state_class = state.attributes.get("state_class")
+
+    supported_state_classes = [
+        sensor.STATE_CLASS_MEASUREMENT,
+        sensor.STATE_CLASS_TOTAL_INCREASING,
+    ]
+    if state_class not in supported_state_classes:
+        result.append(
+            ValidationIssue(
+                "entity_unexpected_state_class_total_increasing", entity_id, state_class
+            )
+        )
+
 
 async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
     """Validate the energy configuration."""

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -78,7 +78,7 @@ async def test_cost_sensor_no_states(hass, hass_storage) -> None:
         ),
     ],
 )
-async def test_cost_sensor_price_entity(
+async def test_cost_sensor_price_entity_total_increasing(
     hass,
     hass_storage,
     hass_ws_client,
@@ -90,7 +90,7 @@ async def test_cost_sensor_price_entity(
     cost_sensor_entity_id,
     flow_type,
 ) -> None:
-    """Test energy cost price from sensor entity."""
+    """Test energy cost price from total_increasing type sensor entity."""
 
     def _compile_statistics(_):
         return compile_statistics(hass, now, now + timedelta(seconds=1))
@@ -137,6 +137,7 @@ async def test_cost_sensor_price_entity(
     }
 
     now = dt_util.utcnow()
+    last_reset_cost_sensor = now.isoformat()
 
     # Optionally initialize dependent entities
     if initial_energy is not None:
@@ -153,7 +154,9 @@ async def test_cost_sensor_price_entity(
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == initial_cost
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_MONETARY
-    assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_TOTAL_INCREASING
+    if initial_cost != "unknown":
+        assert state.attributes["last_reset"] == last_reset_cost_sensor
+    assert state.attributes[ATTR_STATE_CLASS] == "measurement"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
 
     # Optional late setup of dependent entities
@@ -169,7 +172,8 @@ async def test_cost_sensor_price_entity(
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "0.0"
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_MONETARY
-    assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_TOTAL_INCREASING
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
+    assert state.attributes[ATTR_STATE_CLASS] == "measurement"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
 
     # # Unique ID temp disabled
@@ -186,6 +190,7 @@ async def test_cost_sensor_price_entity(
     await hass.async_block_till_done()
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "10.0"  # 0 EUR + (10-0) kWh * 1 EUR/kWh = 10 EUR
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
 
     # Nothing happens when price changes
     if price_entity is not None:
@@ -200,6 +205,7 @@ async def test_cost_sensor_price_entity(
         assert msg["success"]
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "10.0"  # 10 EUR + (10-10) kWh * 2 EUR/kWh = 10 EUR
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
 
     # Additional consumption is using the new price
     hass.states.async_set(
@@ -210,6 +216,7 @@ async def test_cost_sensor_price_entity(
     await hass.async_block_till_done()
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "19.0"  # 10 EUR + (14.5-10) kWh * 2 EUR/kWh = 19 EUR
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
 
     # Check generated statistics
     await async_wait_recording_done_without_instance(hass)
@@ -226,6 +233,7 @@ async def test_cost_sensor_price_entity(
     await hass.async_block_till_done()
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "18.0"  # 19 EUR + (14-14.5) kWh * 2 EUR/kWh = 18 EUR
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
 
     # Energy sensor is reset, with initial state at 4kWh, 0 kWh is used as zero-point
     hass.states.async_set(
@@ -236,6 +244,8 @@ async def test_cost_sensor_price_entity(
     await hass.async_block_till_done()
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "8.0"  # 0 EUR + (4-0) kWh * 2 EUR/kWh = 8 EUR
+    assert state.attributes["last_reset"] != last_reset_cost_sensor
+    last_reset_cost_sensor = state.attributes["last_reset"]
 
     # Energy use bumped to 10 kWh
     hass.states.async_set(
@@ -246,6 +256,213 @@ async def test_cost_sensor_price_entity(
     await hass.async_block_till_done()
     state = hass.states.get(cost_sensor_entity_id)
     assert state.state == "20.0"  # 8 EUR + (10-4) kWh * 2 EUR/kWh = 20 EUR
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
+
+    # Check generated statistics
+    await async_wait_recording_done_without_instance(hass)
+    statistics = await hass.loop.run_in_executor(None, _compile_statistics, hass)
+    assert cost_sensor_entity_id in statistics
+    assert statistics[cost_sensor_entity_id]["stat"]["sum"] == 38.0
+
+
+@pytest.mark.parametrize("initial_energy,initial_cost", [(0, "0.0"), (None, "unknown")])
+@pytest.mark.parametrize(
+    "price_entity,fixed_price", [("sensor.energy_price", None), (None, 1)]
+)
+@pytest.mark.parametrize(
+    "usage_sensor_entity_id,cost_sensor_entity_id,flow_type",
+    [
+        ("sensor.energy_consumption", "sensor.energy_consumption_cost", "flow_from"),
+        (
+            "sensor.energy_production",
+            "sensor.energy_production_compensation",
+            "flow_to",
+        ),
+    ],
+)
+@pytest.mark.parametrize("energy_state_class", ["measurement"])
+async def test_cost_sensor_price_entity_total(
+    hass,
+    hass_storage,
+    hass_ws_client,
+    initial_energy,
+    initial_cost,
+    price_entity,
+    fixed_price,
+    usage_sensor_entity_id,
+    cost_sensor_entity_id,
+    flow_type,
+    energy_state_class,
+) -> None:
+    """Test energy cost price from total type sensor entity."""
+
+    def _compile_statistics(_):
+        return compile_statistics(hass, now, now + timedelta(seconds=1))
+
+    energy_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_STATE_CLASS: energy_state_class,
+    }
+
+    await async_init_recorder_component(hass)
+    energy_data = data.EnergyManager.default_preferences()
+    energy_data["energy_sources"].append(
+        {
+            "type": "grid",
+            "flow_from": [
+                {
+                    "stat_energy_from": "sensor.energy_consumption",
+                    "entity_energy_from": "sensor.energy_consumption",
+                    "stat_cost": None,
+                    "entity_energy_price": price_entity,
+                    "number_energy_price": fixed_price,
+                }
+            ]
+            if flow_type == "flow_from"
+            else [],
+            "flow_to": [
+                {
+                    "stat_energy_to": "sensor.energy_production",
+                    "entity_energy_to": "sensor.energy_production",
+                    "stat_compensation": None,
+                    "entity_energy_price": price_entity,
+                    "number_energy_price": fixed_price,
+                }
+            ]
+            if flow_type == "flow_to"
+            else [],
+            "cost_adjustment_day": 0,
+        }
+    )
+
+    hass_storage[data.STORAGE_KEY] = {
+        "version": 1,
+        "data": energy_data,
+    }
+
+    now = dt_util.utcnow()
+    last_reset = dt_util.utc_from_timestamp(0).isoformat()
+    last_reset_cost_sensor = now.isoformat()
+
+    # Optionally initialize dependent entities
+    if initial_energy is not None:
+        hass.states.async_set(
+            usage_sensor_entity_id,
+            initial_energy,
+            {**energy_attributes, **{"last_reset": last_reset}},
+        )
+    hass.states.async_set("sensor.energy_price", "1")
+
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        await setup_integration(hass)
+
+    state = hass.states.get(cost_sensor_entity_id)
+    assert state.state == initial_cost
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_MONETARY
+    if initial_cost != "unknown":
+        assert state.attributes["last_reset"] == last_reset_cost_sensor
+    assert state.attributes[ATTR_STATE_CLASS] == "measurement"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
+
+    # Optional late setup of dependent entities
+    if initial_energy is None:
+        with patch("homeassistant.util.dt.utcnow", return_value=now):
+            hass.states.async_set(
+                usage_sensor_entity_id,
+                "0",
+                {**energy_attributes, **{"last_reset": last_reset}},
+            )
+            await hass.async_block_till_done()
+
+    state = hass.states.get(cost_sensor_entity_id)
+    assert state.state == "0.0"
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_MONETARY
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
+    assert state.attributes[ATTR_STATE_CLASS] == "measurement"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == "EUR"
+
+    # # Unique ID temp disabled
+    # # entity_registry = er.async_get(hass)
+    # # entry = entity_registry.async_get(cost_sensor_entity_id)
+    # # assert entry.unique_id == "energy_energy_consumption cost"
+
+    # Energy use bumped to 10 kWh
+    hass.states.async_set(
+        usage_sensor_entity_id,
+        "10",
+        {**energy_attributes, **{"last_reset": last_reset}},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(cost_sensor_entity_id)
+    assert state.state == "10.0"  # 0 EUR + (10-0) kWh * 1 EUR/kWh = 10 EUR
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
+
+    # Nothing happens when price changes
+    if price_entity is not None:
+        hass.states.async_set(price_entity, "2")
+        await hass.async_block_till_done()
+    else:
+        energy_data = copy.deepcopy(energy_data)
+        energy_data["energy_sources"][0][flow_type][0]["number_energy_price"] = 2
+        client = await hass_ws_client(hass)
+        await client.send_json({"id": 5, "type": "energy/save_prefs", **energy_data})
+        msg = await client.receive_json()
+        assert msg["success"]
+    state = hass.states.get(cost_sensor_entity_id)
+    assert state.state == "10.0"  # 10 EUR + (10-10) kWh * 2 EUR/kWh = 10 EUR
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
+
+    # Additional consumption is using the new price
+    hass.states.async_set(
+        usage_sensor_entity_id,
+        "14.5",
+        {**energy_attributes, **{"last_reset": last_reset}},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(cost_sensor_entity_id)
+    assert state.state == "19.0"  # 10 EUR + (14.5-10) kWh * 2 EUR/kWh = 19 EUR
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
+
+    # Check generated statistics
+    await async_wait_recording_done_without_instance(hass)
+    statistics = await hass.loop.run_in_executor(None, _compile_statistics, hass)
+    assert cost_sensor_entity_id in statistics
+    assert statistics[cost_sensor_entity_id]["stat"]["sum"] == 19.0
+
+    # Energy sensor has a small dip
+    hass.states.async_set(
+        usage_sensor_entity_id,
+        "14",
+        {**energy_attributes, **{"last_reset": last_reset}},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(cost_sensor_entity_id)
+    assert state.state == "18.0"  # 19 EUR + (14-14.5) kWh * 2 EUR/kWh = 18 EUR
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
+
+    # Energy sensor is reset, with initial state at 4kWh, 0 kWh is used as zero-point
+    last_reset = (now + timedelta(seconds=1)).isoformat()
+    hass.states.async_set(
+        usage_sensor_entity_id,
+        "4",
+        {**energy_attributes, **{"last_reset": last_reset}},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(cost_sensor_entity_id)
+    assert state.state == "8.0"  # 0 EUR + (4-0) kWh * 2 EUR/kWh = 8 EUR
+    assert state.attributes["last_reset"] != last_reset_cost_sensor
+    last_reset_cost_sensor = state.attributes["last_reset"]
+
+    # Energy use bumped to 10 kWh
+    hass.states.async_set(
+        usage_sensor_entity_id,
+        "10",
+        {**energy_attributes, **{"last_reset": last_reset}},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(cost_sensor_entity_id)
+    assert state.state == "20.0"  # 8 EUR + (10-4) kWh * 2 EUR/kWh = 20 EUR
+    assert state.attributes["last_reset"] == last_reset_cost_sensor
 
     # Check generated statistics
     await async_wait_recording_done_without_instance(hass)
@@ -285,6 +502,7 @@ async def test_cost_sensor_handle_wh(hass, hass_storage) -> None:
 
     now = dt_util.utcnow()
 
+    # Initial state: 10kWh
     hass.states.async_set(
         "sensor.energy_consumption",
         10000,
@@ -297,7 +515,7 @@ async def test_cost_sensor_handle_wh(hass, hass_storage) -> None:
     state = hass.states.get("sensor.energy_consumption_cost")
     assert state.state == "0.0"
 
-    # Energy use bumped to 10 kWh
+    # Energy use bumped by 10 kWh
     hass.states.async_set(
         "sensor.energy_consumption",
         20000,
@@ -362,7 +580,7 @@ async def test_cost_sensor_handle_gas(hass, hass_storage) -> None:
 async def test_cost_sensor_wrong_state_class(
     hass, hass_storage, caplog, state_class
 ) -> None:
-    """Test energy sensor rejects wrong state_class."""
+    """Test energy sensor rejects state_class with wrong state_class."""
     energy_attributes = {
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
         ATTR_STATE_CLASS: state_class,
@@ -407,6 +625,64 @@ async def test_cost_sensor_wrong_state_class(
         f"Found unexpected state_class {state_class} for sensor.energy_consumption"
         in caplog.text
     )
+
+    # Energy use bumped to 10 kWh
+    hass.states.async_set(
+        "sensor.energy_consumption",
+        20000,
+        energy_attributes,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.energy_consumption_cost")
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize("state_class", ["measurement"])
+async def test_cost_sensor_state_class_measurement_no_reset(
+    hass, hass_storage, caplog, state_class
+) -> None:
+    """Test energy sensor rejects state_class with no last_reset."""
+    energy_attributes = {
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        ATTR_STATE_CLASS: state_class,
+    }
+    energy_data = data.EnergyManager.default_preferences()
+    energy_data["energy_sources"].append(
+        {
+            "type": "grid",
+            "flow_from": [
+                {
+                    "stat_energy_from": "sensor.energy_consumption",
+                    "entity_energy_from": "sensor.energy_consumption",
+                    "stat_cost": None,
+                    "entity_energy_price": None,
+                    "number_energy_price": 0.5,
+                }
+            ],
+            "flow_to": [],
+            "cost_adjustment_day": 0,
+        }
+    )
+
+    hass_storage[data.STORAGE_KEY] = {
+        "version": 1,
+        "data": energy_data,
+    }
+
+    now = dt_util.utcnow()
+
+    hass.states.async_set(
+        "sensor.energy_consumption",
+        10000,
+        energy_attributes,
+    )
+
+    with patch("homeassistant.util.dt.utcnow", return_value=now):
+        await setup_integration(hass)
+
+    state = hass.states.get("sensor.energy_consumption_cost")
+    assert state.state == STATE_UNKNOWN
 
     # Energy use bumped to 10 kWh
     hass.states.async_set(

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -383,15 +383,6 @@ async def test_validation_grid_price_not_exist(hass, mock_energy_manager):
             },
         ),
         (
-            "-100",
-            "$/kWh",
-            {
-                "type": "entity_negative_state",
-                "identifier": "sensor.grid_price_1",
-                "value": -100.0,
-            },
-        ),
-        (
             "123",
             "$/Ws",
             {
@@ -414,7 +405,7 @@ async def test_validation_grid_price_errors(
     hass.states.async_set(
         "sensor.grid_price_1",
         state,
-        {"unit_of_measurement": unit, "state_class": "total_increasing"},
+        {"unit_of_measurement": unit, "state_class": "measurement"},
     )
     await mock_energy_manager.async_update(
         {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for state class measurement to energy cost sensor

Also:
 - This change also means negative energy prices are now supported, so the corresponding validation check is removed
 - Remove an incorrect validation requiring energy price entity to be state_class total_increasing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/55937
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
