### PR TITLE
Fix zwave_js/node_state WS API command

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -307,7 +307,7 @@ async def websocket_node_state(
     """Get the state data of a Z-Wave JS node."""
     connection.send_result(
         msg[ID],
-        node.data,
+        {**node.data, "values": [value.data for value in node.values.values()]},
     )
 
 

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -33,3 +33,5 @@ ID_LOCK_CONFIG_PARAMETER_SENSOR = (
 ZEN_31_ENTITY = "light.kitchen_under_cabinet_lights"
 METER_ENERGY_SENSOR = "sensor.smart_switch_6_electric_consumed_kwh"
 METER_VOLTAGE_SENSOR = "sensor.smart_switch_6_electric_consumed_v"
+
+PROPERTY_ULTRAVIOLET = "Ultraviolet"

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -40,6 +40,8 @@ from homeassistant.components.zwave_js.const import (
 )
 from homeassistant.helpers import device_registry as dr
 
+from .common import PROPERTY_ULTRAVIOLET
+
 
 async def test_network_status(hass, integration, hass_ws_client):
     """Test the network status websocket command."""
@@ -130,7 +132,7 @@ async def test_node_state(hass, multisensor_6, integration, hass_ws_client):
     node = multisensor_6
 
     # Update a value and ensure it is reflected in the node state
-    value_id = get_value_id(node, CommandClass.SENSOR_MULTILEVEL, "Ultraviolet")
+    value_id = get_value_id(node, CommandClass.SENSOR_MULTILEVEL, PROPERTY_ULTRAVIOLET)
     event = Event(
         type="value updated",
         data={
@@ -141,10 +143,10 @@ async def test_node_state(hass, multisensor_6, integration, hass_ws_client):
                 "commandClassName": "Multilevel Sensor",
                 "commandClass": 49,
                 "endpoint": 0,
-                "property": "Ultraviolet",
+                "property": PROPERTY_ULTRAVIOLET,
                 "newValue": 1,
                 "prevValue": 0,
-                "propertyName": "Ultraviolet",
+                "propertyName": PROPERTY_ULTRAVIOLET,
             },
         },
     )

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -3,7 +3,7 @@ import json
 from unittest.mock import patch
 
 import pytest
-from zwave_js_server.const import InclusionStrategy, LogLevel
+from zwave_js_server.const import CommandClass, InclusionStrategy, LogLevel
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import (
     FailedCommand,
@@ -12,6 +12,7 @@ from zwave_js_server.exceptions import (
     NotFoundError,
     SetValueFailed,
 )
+from zwave_js_server.model.value import _get_value_id_from_dict, get_value_id
 
 from homeassistant.components.websocket_api.const import ERR_NOT_FOUND
 from homeassistant.components.zwave_js.api import (
@@ -127,6 +128,28 @@ async def test_node_state(hass, multisensor_6, integration, hass_ws_client):
     ws_client = await hass_ws_client(hass)
 
     node = multisensor_6
+
+    # Update a value and ensure it is reflected in the node state
+    value_id = get_value_id(node, CommandClass.SENSOR_MULTILEVEL, "Ultraviolet")
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Multilevel Sensor",
+                "commandClass": 49,
+                "endpoint": 0,
+                "property": "Ultraviolet",
+                "newValue": 1,
+                "prevValue": 0,
+                "propertyName": "Ultraviolet",
+            },
+        },
+    )
+    node.receive_event(event)
+
     await ws_client.send_json(
         {
             ID: 3,
@@ -136,7 +159,14 @@ async def test_node_state(hass, multisensor_6, integration, hass_ws_client):
         }
     )
     msg = await ws_client.receive_json()
-    assert msg["result"] == node.data
+
+    # Replace data for the value we updated and assert the new node data is the same
+    # as what's returned
+    updated_node_data = node.data.copy()
+    for n, value in enumerate(updated_node_data["values"]):
+        if _get_value_id_from_dict(node, value) == value_id:
+            updated_node_data["values"][n] = node.values[value_id].data.copy()
+    assert msg["result"] == updated_node_data
 
     # Test getting non-existent node fails
     await ws_client.send_json(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -160,7 +160,7 @@ async def test_node_state(hass, multisensor_6, integration, hass_ws_client):
     )
     msg = await ws_client.receive_json()
 
-    # Assert that the data returned doesn't match the stale note state data
+    # Assert that the data returned doesn't match the stale node state data
     assert msg["result"] != node.data
 
     # Replace data for the value we updated and assert the new node data is the same

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -160,6 +160,9 @@ async def test_node_state(hass, multisensor_6, integration, hass_ws_client):
     )
     msg = await ws_client.receive_json()
 
+    # Assert that the data returned doesn't match the stale note state data
+    assert msg["result"] != node.data
+
     # Replace data for the value we updated and assert the new node data is the same
     # as what's returned
     updated_node_data = node.data.copy()


### PR DESCRIPTION
## Proposed change
As I was looking into an issue around values getting after the fact, I realized that when we get value updates, we update the `Value` instance data and not the `Node` instance data that includes a list of values when we initially loaded the node. This means that the raw node state is not accurate, and we need to combine the raw node state with the value state to get the real state of a node. This is only a problem when we get node state and not a full state dump because with the former, we are using the lib as the source, whereas with the latter we use the driver/server.

This is a bugfix but this API command is not in use yet so it can wait for the next release.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
