### PR TITLE
Handle entity creation on new added zwave_js value

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -170,7 +170,7 @@ async def async_setup_entry(  # noqa: C901
         if not disc_info.assumed_state:
             return
         value_updates_disc_info[disc_info.primary_value.value_id] = disc_info
-        # If this isn't the first time we found a value we want to watch for updates,
+        # If this is the first time we found a value we want to watch for updates,
         # return early
         if len(value_updates_disc_info) != 1:
             return

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -68,7 +68,11 @@ from .const import (
     ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
     ZWAVE_JS_VALUE_UPDATED_EVENT,
 )
-from .discovery import ZwaveDiscoveryInfo, async_discover_values
+from .discovery import (
+    ZwaveDiscoveryInfo,
+    async_discover_node_values,
+    async_discover_single_value,
+)
 from .helpers import async_enable_statistics, get_device_id, get_unique_id
 from .migrate import async_migrate_discovered_value
 from .services import ZWaveServices
@@ -129,13 +133,63 @@ async def async_setup_entry(  # noqa: C901
     entry_hass_data[DATA_PLATFORM_SETUP] = {}
 
     registered_unique_ids: dict[str, dict[str, set[str]]] = defaultdict(dict)
+    processed_value_ids: dict[str, set[str]] = defaultdict(set)
+
+    async def async_handle_discovery_info(
+        device: device_registry.DeviceEntry,
+        disc_info: ZwaveDiscoveryInfo,
+        value_updates_disc_info: dict[str, ZwaveDiscoveryInfo],
+    ) -> None:
+        """Handle discovery info and all dependent tasks."""
+        # This migration logic was added in 2021.3 to handle a breaking change to
+        # the value_id format. Some time in the future, this call (as well as the
+        # helper functions) can be removed.
+        async_migrate_discovered_value(
+            hass,
+            ent_reg,
+            registered_unique_ids[device.id][disc_info.platform],
+            device,
+            client,
+            disc_info,
+        )
+        platform_setup_tasks = entry_hass_data[DATA_PLATFORM_SETUP]
+        platform = disc_info.platform
+        if platform not in platform_setup_tasks:
+            platform_setup_tasks[platform] = hass.async_create_task(
+                hass.config_entries.async_forward_entry_setup(entry, platform)
+            )
+
+        await platform_setup_tasks[platform]
+
+        LOGGER.debug("Discovered entity: %s", disc_info)
+        async_dispatcher_send(
+            hass, f"{DOMAIN}_{entry.entry_id}_add_{platform}", disc_info
+        )
+
+        # If we don't need to watch for updates return early
+        if not disc_info.assumed_state:
+            return
+
+        value_updates_disc_info[disc_info.primary_value.value_id] = disc_info
+
+        # If this isn't the first time we found a value we want to watch for updates,
+        # return early
+        if len(value_updates_disc_info) != 1:
+            return
+
+        # add listener for value updated events
+        entry.async_on_unload(
+            disc_info.node.on(
+                "value updated",
+                lambda event: async_on_value_updated_fire_event(
+                    value_updates_disc_info, event["value"]
+                ),
+            )
+        )
 
     async def async_on_node_ready(node: ZwaveNode) -> None:
         """Handle node ready event."""
         LOGGER.debug("Processing node %s", node)
-
-        platform_setup_tasks = entry_hass_data[DATA_PLATFORM_SETUP]
-
         # register (or update) node in device registry
         device = register_node_in_dev_reg(hass, entry, dev_reg, client, node)
         # We only want to create the defaultdict once, even on reinterviews
@@ -145,44 +199,18 @@ async def async_setup_entry(  # noqa: C901
         value_updates_disc_info: dict[str, ZwaveDiscoveryInfo] = {}
 
         # run discovery on all node values and create/update entities
-        for disc_info in async_discover_values(node, device):
-            platform = disc_info.platform
-
-            # This migration logic was added in 2021.3 to handle a breaking change to
-            # the value_id format. Some time in the future, this call (as well as the
-            # helper functions) can be removed.
-            async_migrate_discovered_value(
-                hass,
-                ent_reg,
-                registered_unique_ids[device.id][platform],
-                device,
-                client,
-                disc_info,
+        for disc_info in async_discover_node_values(node, device, processed_value_ids):
+            await async_handle_discovery_info(
+                device, disc_info, value_updates_disc_info
             )
 
-            if platform not in platform_setup_tasks:
-                platform_setup_tasks[platform] = hass.async_create_task(
-                    hass.config_entries.async_forward_entry_setup(entry, platform)
-                )
-
-            await platform_setup_tasks[platform]
-
-            LOGGER.debug("Discovered entity: %s", disc_info)
-            async_dispatcher_send(
-                hass, f"{DOMAIN}_{entry.entry_id}_add_{platform}", disc_info
-            )
-
-            # Capture discovery info for values we want to watch for updates
-            if disc_info.assumed_state:
-                value_updates_disc_info[disc_info.primary_value.value_id] = disc_info
-
-        # add listener for value updated events if necessary
-        if value_updates_disc_info:
+        # add listeners to handle new values that get added later
+        for event in ("value added", "value updated", "metadata updated"):
             entry.async_on_unload(
                 node.on(
-                    "value updated",
-                    lambda event: async_on_value_updated(
-                        value_updates_disc_info, event["value"]
+                    event,
+                    lambda event: hass.async_create_task(
+                        async_on_value_added(value_updates_disc_info, event["value"])
                     ),
                 )
             )
@@ -238,6 +266,29 @@ async def async_setup_entry(  # noqa: C901
         # some visual feedback that something is (in the process of) being added
         register_node_in_dev_reg(hass, entry, dev_reg, client, node)
 
+    async def async_on_value_added(
+        value_updates_disc_info: dict[str, ZwaveDiscoveryInfo], value: Value
+    ) -> None:
+        """Fire value updated event."""
+        # If node isn't ready or a device for this node doesn't already exist, we can
+        # let the node ready event handler perform discovery. If a value has already
+        # been processed, we don't need to do it again
+        device_id = get_device_id(client, value.node)
+        if (
+            not value.node.ready
+            or not (device := dev_reg.async_get_device({device_id}))
+            or value.value_id in processed_value_ids[device.id]
+        ):
+            return
+
+        LOGGER.debug("Processing node %s added value %s", value.node, value)
+
+        processed_value_ids[device.id].add(value.value_id)
+        for disc_info in async_discover_single_value(value, device):
+            await async_handle_discovery_info(
+                device, disc_info, value_updates_disc_info
+            )
+
     @callback
     def async_on_node_removed(node: ZwaveNode) -> None:
         """Handle node removed event."""
@@ -247,6 +298,7 @@ async def async_setup_entry(  # noqa: C901
         # note: removal of entity registry entry is handled by core
         dev_reg.async_remove_device(device.id)  # type: ignore
         registered_unique_ids.pop(device.id, None)  # type: ignore
+        processed_value_ids.pop(device.id, None)  # type: ignore
 
     @callback
     def async_on_value_notification(notification: ValueNotification) -> None:
@@ -313,7 +365,7 @@ async def async_setup_entry(  # noqa: C901
         hass.bus.async_fire(ZWAVE_JS_NOTIFICATION_EVENT, event_data)
 
     @callback
-    def async_on_value_updated(
+    def async_on_value_updated_fire_event(
         value_updates_disc_info: dict[str, ZwaveDiscoveryInfo], value: Value
     ) -> None:
         """Fire value updated event."""

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -283,12 +283,12 @@ async def async_setup_entry(  # noqa: C901
             return
 
         LOGGER.debug("Processing node %s added value %s", value.node, value)
-
-        discovered_value_ids[device.id].add(value.value_id)
         await asyncio.gather(
             *(
                 async_handle_discovery_info(device, disc_info, value_updates_disc_info)
-                for disc_info in async_discover_single_value(value, device)
+                for disc_info in async_discover_single_value(
+                    value, device, discovered_value_ids
+                )
             )
         )
 

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -152,13 +152,13 @@ async def async_setup_entry(  # noqa: C901
             client,
             disc_info,
         )
+
         platform_setup_tasks = entry_hass_data[DATA_PLATFORM_SETUP]
         platform = disc_info.platform
         if platform not in platform_setup_tasks:
             platform_setup_tasks[platform] = hass.async_create_task(
                 hass.config_entries.async_forward_entry_setup(entry, platform)
             )
-
         await platform_setup_tasks[platform]
 
         LOGGER.debug("Discovered entity: %s", disc_info)
@@ -169,14 +169,11 @@ async def async_setup_entry(  # noqa: C901
         # If we don't need to watch for updates return early
         if not disc_info.assumed_state:
             return
-
         value_updates_disc_info[disc_info.primary_value.value_id] = disc_info
-
         # If this isn't the first time we found a value we want to watch for updates,
         # return early
         if len(value_updates_disc_info) != 1:
             return
-
         # add listener for value updated events
         entry.async_on_unload(
             disc_info.node.on(

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -671,126 +671,138 @@ DISCOVERY_SCHEMAS = [
 
 
 @callback
-def async_discover_values(
-    node: ZwaveNode, device: DeviceEntry
+def async_discover_node_values(
+    node: ZwaveNode, device: DeviceEntry, processed_value_ids: dict[str, set[str]]
 ) -> Generator[ZwaveDiscoveryInfo, None, None]:
     """Run discovery on ZWave node and return matching (primary) values."""
     for value in node.values.values():
-        for schema in DISCOVERY_SCHEMAS:
-            # check manufacturer_id
-            if (
-                schema.manufacturer_id is not None
-                and value.node.manufacturer_id not in schema.manufacturer_id
-            ):
-                continue
+        # We don't need to rediscover an already processed value_id
+        if value.value_id in processed_value_ids[device.id]:
+            continue
+        processed_value_ids[device.id].add(value.value_id)
+        yield from async_discover_single_value(value, device)
 
-            # check product_id
-            if (
-                schema.product_id is not None
-                and value.node.product_id not in schema.product_id
-            ):
-                continue
 
-            # check product_type
-            if (
-                schema.product_type is not None
-                and value.node.product_type not in schema.product_type
-            ):
-                continue
+@callback
+def async_discover_single_value(
+    value: ZwaveValue, device: DeviceEntry
+) -> Generator[ZwaveDiscoveryInfo, None, None]:
+    """Run discovery on a single ZWave value and return matching schema info."""
+    for schema in DISCOVERY_SCHEMAS:
+        # check manufacturer_id
+        if (
+            schema.manufacturer_id is not None
+            and value.node.manufacturer_id not in schema.manufacturer_id
+        ):
+            continue
 
-            # check firmware_version_range
-            if schema.firmware_version_range is not None and (
-                (
-                    schema.firmware_version_range.min is not None
-                    and schema.firmware_version_range.min_ver
-                    > AwesomeVersion(value.node.firmware_version)
+        # check product_id
+        if (
+            schema.product_id is not None
+            and value.node.product_id not in schema.product_id
+        ):
+            continue
+
+        # check product_type
+        if (
+            schema.product_type is not None
+            and value.node.product_type not in schema.product_type
+        ):
+            continue
+
+        # check firmware_version_range
+        if schema.firmware_version_range is not None and (
+            (
+                schema.firmware_version_range.min is not None
+                and schema.firmware_version_range.min_ver
+                > AwesomeVersion(value.node.firmware_version)
+            )
+            or (
+                schema.firmware_version_range.max is not None
+                and schema.firmware_version_range.max_ver
+                < AwesomeVersion(value.node.firmware_version)
+            )
+        ):
+            continue
+
+        # check firmware_version
+        if (
+            schema.firmware_version is not None
+            and value.node.firmware_version not in schema.firmware_version
+        ):
+            continue
+
+        # check device_class_basic
+        if not check_device_class(
+            value.node.device_class.basic, schema.device_class_basic
+        ):
+            continue
+
+        # check device_class_generic
+        if not check_device_class(
+            value.node.device_class.generic, schema.device_class_generic
+        ):
+            continue
+
+        # check device_class_specific
+        if not check_device_class(
+            value.node.device_class.specific, schema.device_class_specific
+        ):
+            continue
+
+        # check primary value
+        if not check_value(value, schema.primary_value):
+            continue
+
+        # check additional required values
+        if schema.required_values is not None and not all(
+            any(check_value(val, val_scheme) for val in value.node.values.values())
+            for val_scheme in schema.required_values
+        ):
+            continue
+
+        # check for values that may not be present
+        if schema.absent_values is not None and any(
+            any(check_value(val, val_scheme) for val in value.node.values.values())
+            for val_scheme in schema.absent_values
+        ):
+            continue
+
+        # resolve helper data from template
+        resolved_data = None
+        additional_value_ids_to_watch = set()
+        if schema.data_template:
+            try:
+                resolved_data = schema.data_template.resolve_data(value)
+            except UnknownValueData as err:
+                LOGGER.error(
+                    "Discovery for value %s on device '%s' (%s) will be skipped: %s",
+                    value,
+                    device.name_by_user or device.name,
+                    value.node,
+                    err,
                 )
-                or (
-                    schema.firmware_version_range.max is not None
-                    and schema.firmware_version_range.max_ver
-                    < AwesomeVersion(value.node.firmware_version)
-                )
-            ):
                 continue
-
-            # check firmware_version
-            if (
-                schema.firmware_version is not None
-                and value.node.firmware_version not in schema.firmware_version
-            ):
-                continue
-
-            # check device_class_basic
-            if not check_device_class(
-                value.node.device_class.basic, schema.device_class_basic
-            ):
-                continue
-
-            # check device_class_generic
-            if not check_device_class(
-                value.node.device_class.generic, schema.device_class_generic
-            ):
-                continue
-
-            # check device_class_specific
-            if not check_device_class(
-                value.node.device_class.specific, schema.device_class_specific
-            ):
-                continue
-
-            # check primary value
-            if not check_value(value, schema.primary_value):
-                continue
-
-            # check additional required values
-            if schema.required_values is not None and not all(
-                any(check_value(val, val_scheme) for val in node.values.values())
-                for val_scheme in schema.required_values
-            ):
-                continue
-
-            # check for values that may not be present
-            if schema.absent_values is not None and any(
-                any(check_value(val, val_scheme) for val in node.values.values())
-                for val_scheme in schema.absent_values
-            ):
-                continue
-
-            # resolve helper data from template
-            resolved_data = None
-            additional_value_ids_to_watch = set()
-            if schema.data_template:
-                try:
-                    resolved_data = schema.data_template.resolve_data(value)
-                except UnknownValueData as err:
-                    LOGGER.error(
-                        "Discovery for value %s on device '%s' (%s) will be skipped: %s",
-                        value,
-                        device.name_by_user or device.name,
-                        node,
-                        err,
-                    )
-                    continue
-                additional_value_ids_to_watch = schema.data_template.value_ids_to_watch(
-                    resolved_data
-                )
-
-            # all checks passed, this value belongs to an entity
-            yield ZwaveDiscoveryInfo(
-                node=value.node,
-                primary_value=value,
-                assumed_state=schema.assumed_state,
-                platform=schema.platform,
-                platform_hint=schema.hint,
-                platform_data_template=schema.data_template,
-                platform_data=resolved_data,
-                additional_value_ids_to_watch=additional_value_ids_to_watch,
-                entity_registry_enabled_default=schema.entity_registry_enabled_default,
+            additional_value_ids_to_watch = schema.data_template.value_ids_to_watch(
+                resolved_data
             )
 
-            if not schema.allow_multi:
-                # break out of loop, this value may not be discovered by other schemas/platforms
-                break
+        # all checks passed, this value belongs to an entity
+        yield ZwaveDiscoveryInfo(
+            node=value.node,
+            primary_value=value,
+            assumed_state=schema.assumed_state,
+            platform=schema.platform,
+            platform_hint=schema.hint,
+            platform_data_template=schema.data_template,
+            platform_data=resolved_data,
+            additional_value_ids_to_watch=additional_value_ids_to_watch,
+            entity_registry_enabled_default=schema.entity_registry_enabled_default,
+        )
+
+        if not schema.allow_multi:
+            # return early since this value may not be discovered by other schemas/platforms
+            return
 
 
 @callback

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -672,14 +672,14 @@ DISCOVERY_SCHEMAS = [
 
 @callback
 def async_discover_node_values(
-    node: ZwaveNode, device: DeviceEntry, processed_value_ids: dict[str, set[str]]
+    node: ZwaveNode, device: DeviceEntry, discovered_value_ids: dict[str, set[str]]
 ) -> Generator[ZwaveDiscoveryInfo, None, None]:
     """Run discovery on ZWave node and return matching (primary) values."""
     for value in node.values.values():
         # We don't need to rediscover an already processed value_id
-        if value.value_id in processed_value_ids[device.id]:
+        if value.value_id in discovered_value_ids[device.id]:
             continue
-        processed_value_ids[device.id].add(value.value_id)
+        discovered_value_ids[device.id].add(value.value_id)
         yield from async_discover_single_value(value, device)
 
 

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -679,15 +679,15 @@ def async_discover_node_values(
         # We don't need to rediscover an already processed value_id
         if value.value_id in discovered_value_ids[device.id]:
             continue
-        discovered_value_ids[device.id].add(value.value_id)
-        yield from async_discover_single_value(value, device)
+        yield from async_discover_single_value(value, device, discovered_value_ids)
 
 
 @callback
 def async_discover_single_value(
-    value: ZwaveValue, device: DeviceEntry
+    value: ZwaveValue, device: DeviceEntry, discovered_value_ids: dict[str, set[str]]
 ) -> Generator[ZwaveDiscoveryInfo, None, None]:
     """Run discovery on a single ZWave value and return matching schema info."""
+    discovered_value_ids[device.id].add(value.value_id)
     for schema in DISCOVERY_SCHEMAS:
         # check manufacturer_id
         if (


### PR DESCRIPTION
## Proposed change
Right now when a value is added after a node is ready, it is a no-op from an HA perspective - we only run discovery on node `ready` events which means that we lose out on the creation of entities for these values that were added later. There are valid scenarios where a value will be added to a node after it is ready and we should be running discovery on those values. In the long run, the main problem this solves is the current requirement to restart HA to pick up the new cached value. In the short term, this indirectly fixes a bug which I think is upstream that is causing us to not get values in the initial state dump that we then see later in a `value added` or `value updated` event.

I am not sure whether this should be considered a bug fix or a feature - in the short term it's a bug fix but I think the bug is upstream, although that hasn't been confirmed. We should get confirmation from upstream to confirm that but I will mark it as a feature for now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
