### PR TITLE
Report integrations that block startup wrap up

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -564,6 +564,14 @@ async def _async_set_up_integrations(
         except asyncio.TimeoutError:
             _LOGGER.warning("Setup timed out for stage 2 - moving forward")
 
+    # Wrap up startup
+    _LOGGER.debug("Waiting for startup to wrap up")
+    try:
+        async with hass.timeout.async_timeout(WRAP_UP_TIMEOUT, cool_down=COOLDOWN_TIME):
+            await hass.async_block_till_done()
+    except asyncio.TimeoutError:
+        _LOGGER.warning("Setup timed out for bootstrap - moving forward")
+
     watch_task.cancel()
     async_dispatcher_send(hass, SIGNAL_BOOTSTRAP_INTEGRATONS, {})
 
@@ -576,11 +584,3 @@ async def _async_set_up_integrations(
             )
         },
     )
-
-    # Wrap up startup
-    _LOGGER.debug("Waiting for startup to wrap up")
-    try:
-        async with hass.timeout.async_timeout(WRAP_UP_TIMEOUT, cool_down=COOLDOWN_TIME):
-            await hass.async_block_till_done()
-    except asyncio.TimeoutError:
-        _LOGGER.warning("Setup timed out for bootstrap - moving forward")

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -710,21 +710,12 @@ async def test_warning_logged_on_wrap_up_timeout(hass, caplog):
         MockModule(
             domain="normal_integration",
             async_setup=gen_domain_setup("normal_integration"),
-            partial_manifest={"after_dependencies": ["an_after_dep"]},
-        ),
-    )
-    mock_integration(
-        hass,
-        MockModule(
-            domain="an_after_dep",
-            async_setup=gen_domain_setup("an_after_dep"),
+            partial_manifest={},
         ),
     )
 
     with patch.object(bootstrap, "WRAP_UP_TIMEOUT", 0):
-        await bootstrap._async_set_up_integrations(
-            hass, {"normal_integration": {}, "an_after_dep": {}}
-        )
+        await bootstrap._async_set_up_integrations(hass, {"normal_integration": {}})
         await hass.async_block_till_done()
 
     assert "Setup timed out for bootstrap - moving forward" in caplog.text

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -689,7 +689,6 @@ async def test_empty_integrations_list_is_only_sent_at_the_end_of_bootstrap(hass
     assert order == ["an_after_dep", "normal_integration"]
 
 
-@pytest.mark.parametrize("load_registries", [False])
 async def test_warning_logged_on_wrap_up_timeout(hass, caplog):
     """Test we log a warning on bootstrap timeout."""
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -678,6 +678,7 @@ async def test_empty_integrations_list_is_only_sent_at_the_end_of_bootstrap(hass
         await bootstrap._async_set_up_integrations(
             hass, {"normal_integration": {}, "an_after_dep": {}}
         )
+        await hass.async_block_till_done()
 
     assert integrations[0] != {}
     assert "an_after_dep" in integrations[0]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -689,6 +689,7 @@ async def test_empty_integrations_list_is_only_sent_at_the_end_of_bootstrap(hass
     assert order == ["an_after_dep", "normal_integration"]
 
 
+@pytest.mark.parametrize("load_registries", [False])
 async def test_warning_logged_on_wrap_up_timeout(hass, caplog):
     """Test we log a warning on bootstrap timeout."""
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Integrations that blocked startup wrap up were not reported
because we canceled the watcher once we hit the startup wrap-up.

Since config entries call async_wait_init_flow_finish
and entry.async_setup with asyncio.gather, there is a window
where there are no tracked tasks which allows bootstrap to
move up even though there are about to be tracked tasks spawned
from async_wait_init_flow_finish or async_setup

This made it hard to track down which integration was the
cause of
```
2021-09-09 07:59:31 DEBUG (MainThread) [homeassistant.core] Waited 234 seconds for task: <Task pending name='Task-2525' coro=<_async_setup_component() running at /usr/src/homeassistant/homeassistant/setup.py:286> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7f3b53f1e550>()]> cb=[<TaskWakeupMethWrapper object at 0x7f3b549e8400>(), <1 more>, <TaskWakeupMethWrapper object at 0x7f3b549e8610>()]>: [<frame at 0x7f3b6200fc90, file '/usr/src/homeassistant/homeassistant/setup.py', line 286, code _async_setup_component>]
```

When testing https://github.com/home-assistant/core/pull/55540





## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
