### PR TITLE
Fix circular import of scapy in dhcp

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -279,6 +279,9 @@ class DHCPWatcher(WatcherBase):
         """Start watching for dhcp packets."""
         # Local import because importing from scapy has side effects such as opening
         # sockets
+        from scapy.arch import (  # pylint: disable=import-outside-toplevel  # noqa: F401
+            read_routes,
+        )
         from scapy.sendrecv import (  # pylint: disable=import-outside-toplevel
             AsyncSniffer,
         )

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -279,7 +279,9 @@ class DHCPWatcher(WatcherBase):
         """Start watching for dhcp packets."""
         # Local import because importing from scapy has side effects such as opening
         # sockets
-        from scapy import arch  # pylint: disable=import-outside-toplevel  # noqa: F401
+        from scapy import (  # pylint: disable=import-outside-toplevel,unused-import  # noqa: F401
+            arch,
+        )
 
         #
         # Importing scapy.sendrecv will cause a scapy resync which will

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -285,7 +285,7 @@ class DHCPWatcher(WatcherBase):
         # Importing scapy.sendrecv will cause a scapy resync which will
         # import scapy.arch.read_routes which will import scapy.sendrecv
         #
-        # We avoid this circular import by importing it above to ensure
+        # We avoid this circular import by importing arch above to ensure
         # the module is loaded and avoid the problem
         #
         from scapy.sendrecv import (  # pylint: disable=import-outside-toplevel

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -279,9 +279,15 @@ class DHCPWatcher(WatcherBase):
         """Start watching for dhcp packets."""
         # Local import because importing from scapy has side effects such as opening
         # sockets
-        from scapy.arch import (  # pylint: disable=import-outside-toplevel  # noqa: F401
-            read_routes,
-        )
+        from scapy import arch  # pylint: disable=import-outside-toplevel  # noqa: F401
+
+        #
+        # Importing scapy.sendrecv will cause a scapy resync which will
+        # import scapy.arch.read_routes which will import scapy.sendrecv
+        #
+        # We avoid this circular import by importing it above to ensure
+        # the module is loaded and avoid the problem
+        #
         from scapy.sendrecv import (  # pylint: disable=import-outside-toplevel
             AsyncSniffer,
         )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Note that this does not need a backport since it only occurs after #55647

Fixes

```
2021-09-10 08:47:49 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/components/dhcp/__init__.py", line 67, in _initialize
    await watcher.async_start()
  File "/Users/bdraco/home-assistant/homeassistant/components/dhcp/__init__.py", line 282, in async_start
    from scapy.sendrecv import (  # pylint: disable=import-outside-toplevel
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/sendrecv.py", line 61, in <module>
    import scapy.route  # noqa: F401
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/route.py", line 218, in <module>
    conf.route = Route()
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/route.py", line 37, in __init__
    self.resync()
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/route.py", line 45, in resync
    from scapy.arch import read_routes
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/arch/__init__.py", line 124, in <module>
    from scapy.arch.bpf.supersocket import *  # noqa F403
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/arch/bpf/supersocket.py", line 27, in <module>
    from scapy.layers.l2 import Loopback
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/layers/l2.py", line 17, in <module>
    from scapy.ansmachine import AnsweringMachine
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/ansmachine.py", line 20, in <module>
    from scapy.sendrecv import send, sniff
ImportError: cannot import name 'send' from partially initialized module 'scapy.sendrecv' (most likely due to a circular import) (/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/sendrecv.py)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
