### PR TITLE
Revert "Suppress last_reset deprecation warning for energy cost sensor"

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -216,9 +216,6 @@ class SensorEntity(Entity):
                 and not self._last_reset_reported
             ):
                 self._last_reset_reported = True
-                if self.platform and self.platform.platform_name == "energy":
-                    return {ATTR_LAST_RESET: last_reset.isoformat()}
-
                 report_issue = self._suggest_report_issue()
                 _LOGGER.warning(
                     "Entity %s (%s) with state_class %s has set last_reset. Setting "


### PR DESCRIPTION
Reverts home-assistant/core#56037

Background: 
home-assistant/core#56037 is needed for 2021.9.x but we don't need it on dev