### PR TITLE
Add timeout_scale option to Epson integration

### DIFF
--- a/homeassistant/components/epson/__init__.py
+++ b/homeassistant/components/epson/__init__.py
@@ -12,8 +12,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DOMAIN, HTTP
+from .const import DOMAIN, HTTP, SIGNAL_CONFIG_OPTIONS_UPDATE, TIMEOUT_SCALE
 from .exceptions import CannotConnect, PoweredOff
 
 PLATFORMS = [MEDIA_PLAYER_PLATFORM]
@@ -22,13 +23,18 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def validate_projector(
-    hass: HomeAssistant, host, check_power=True, check_powered_on=True
+    hass: HomeAssistant,
+    host,
+    timeout_scale=1.0,
+    check_power=True,
+    check_powered_on=True,
 ):
     """Validate the given projector host allows us to connect."""
     epson_proj = Projector(
         host=host,
         websession=async_get_clientsession(hass, verify_ssl=False),
         type=HTTP,
+        timeout_scale=timeout_scale,
     )
     if check_power:
         _power = await epson_proj.get_power()
@@ -46,13 +52,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     projector = await validate_projector(
         hass=hass,
         host=entry.data[CONF_HOST],
+        timeout_scale=entry.options.get(TIMEOUT_SCALE, 1.0),
         check_power=False,
         check_powered_on=False,
     )
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = projector
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-
+    entry.async_on_unload(entry.add_update_listener(update_listener))
     return True
 
 
@@ -62,3 +69,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
+
+
+async def update_listener(hass, entry):
+    """Handle options update."""
+    async_dispatcher_send(
+        hass, SIGNAL_CONFIG_OPTIONS_UPDATE.format(entry.entry_id), entry.options
+    )

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -26,6 +26,12 @@ class EpsonConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return EpsonOptionsFlowHandler(config_entry)
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
@@ -55,12 +61,6 @@ class EpsonConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Get the options flow for this handler."""
-        return EpsonOptionsFlowHandler(config_entry)
 
 
 class EpsonOptionsFlowHandler(OptionsFlow):

--- a/homeassistant/components/epson/config_flow.py
+++ b/homeassistant/components/epson/config_flow.py
@@ -3,11 +3,12 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.core import callback
 
 from . import validate_projector
-from .const import DOMAIN
+from .const import DOMAIN, TIMEOUT_SCALE
 from .exceptions import CannotConnect, PoweredOff
 
 DATA_SCHEMA = vol.Schema(
@@ -20,7 +21,7 @@ DATA_SCHEMA = vol.Schema(
 _LOGGER = logging.getLogger(__name__)
 
 
-class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class EpsonConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for epson."""
 
     VERSION = 1
@@ -53,4 +54,35 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return EpsonOptionsFlowHandler(config_entry)
+
+
+class EpsonOptionsFlowHandler(OptionsFlow):
+    """Config flow options for Epson."""
+
+    def __init__(self, config_entry):
+        """Initialize Epson options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        TIMEOUT_SCALE,
+                        default=self.config_entry.options.get(TIMEOUT_SCALE, 1.0),
+                    ): vol.All(vol.Coerce(float), vol.Range(min=1.0, max=10.0))
+                }
+            ),
         )

--- a/homeassistant/components/epson/const.py
+++ b/homeassistant/components/epson/const.py
@@ -5,3 +5,7 @@ SERVICE_SELECT_CMODE = "select_cmode"
 
 ATTR_CMODE = "cmode"
 HTTP = "http"
+
+TIMEOUT_SCALE = "timeout_scale"
+
+SIGNAL_CONFIG_OPTIONS_UPDATE = "epson_config_options_update {}"

--- a/homeassistant/components/epson/strings.json
+++ b/homeassistant/components/epson/strings.json
@@ -12,5 +12,16 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "powered_off": "Is projector turned on? You need to turn on projector for initial configuration."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Epson Options",
+        "description": "Epson projectors sometimes have delay responding. Default timeouts are turn_on - 40s, off - 10s, source-5s, rest-3s. You can multiply this time by setting timeout scale eg. 1.5.",
+        "data": {
+          "timeout_scale": "Timeout scale"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/epson/translations/en.json
+++ b/homeassistant/components/epson/translations/en.json
@@ -12,5 +12,16 @@
                 }
             }
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "timeout_scale": "Timeout scale"
+                },
+                "description": "Epson projectors sometimes have delay responding. Default timeouts are turn_on - 40s, off - 10s, source-5s, rest-3s. You can multiply this time by setting timeout scale eg. 1.5.",
+                "title": "Epson Options"
+            }
+        }
     }
 }

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -4,8 +4,10 @@ from unittest.mock import patch
 from epson_projector.const import PWR_OFF_STATE
 
 from homeassistant import config_entries, setup
-from homeassistant.components.epson.const import DOMAIN
+from homeassistant.components.epson.const import DOMAIN, TIMEOUT_SCALE
 from homeassistant.const import CONF_HOST, CONF_NAME, STATE_UNAVAILABLE
+
+from tests.common import MockConfigEntry
 
 
 async def test_form(hass):
@@ -76,3 +78,26 @@ async def test_form_powered_off(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "powered_off"}
+
+
+async def test_options_flow(hass):
+    """Test config flow options."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="12345",
+        data={CONF_HOST: "1.1.1.1", CONF_NAME: "test-epson"},
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={TIMEOUT_SCALE: 1.1},
+    )
+
+    assert entry.options[TIMEOUT_SCALE] == 1.1
+    assert TIMEOUT_SCALE not in entry.data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add option timeout scale to Epson integration, so it will multiply standard timeouts for response.
Some projectors are slower sometimes in response for unknown reason.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/52994
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
