### PR TITLE
Deprecate passing template to notify

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -10,9 +10,9 @@ import voluptuous as vol
 
 import homeassistant.components.persistent_notification as pn
 from homeassistant.const import CONF_DESCRIPTION, CONF_NAME, CONF_PLATFORM
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_per_platform, discovery
+from homeassistant.helpers import config_per_platform, discovery, template
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.loader import async_get_integration, bind_hass
@@ -66,6 +66,19 @@ PERSISTENT_NOTIFICATION_SERVICE_SCHEMA = vol.Schema(
         vol.Optional(ATTR_TITLE): cv.template,
     }
 )
+
+
+@callback
+def _check_templates_warn(hass: HomeAssistant, tpl: template.Template) -> None:
+    """Warn user that passing templates to notify service is deprecated."""
+    if tpl.is_static or hass.data.get("notify_template_warned"):
+        return
+
+    hass.data["notify_template_warned"] = True
+    _LOGGER.warning(
+        "Passing templates to notify service is deprecated and will be removed in 2021.12. "
+        "Automations and scripts handle templates automatically"
+    )
 
 
 @bind_hass
@@ -144,6 +157,7 @@ class BaseNotificationService:
         title = service.data.get(ATTR_TITLE)
 
         if title:
+            _check_templates_warn(self.hass, title)
             title.hass = self.hass
             kwargs[ATTR_TITLE] = title.async_render(parse_result=False)
 
@@ -152,6 +166,7 @@ class BaseNotificationService:
         elif service.data.get(ATTR_TARGET) is not None:
             kwargs[ATTR_TARGET] = service.data.get(ATTR_TARGET)
 
+        _check_templates_warn(self.hass, message)
         message.hass = self.hass
         kwargs[ATTR_MESSAGE] = message.async_render(parse_result=False)
         kwargs[ATTR_DATA] = service.data.get(ATTR_DATA)
@@ -261,10 +276,12 @@ async def async_setup(hass, config):
         payload = {}
         message = service.data[ATTR_MESSAGE]
         message.hass = hass
+        _check_templates_warn(hass, message)
         payload[ATTR_MESSAGE] = message.async_render(parse_result=False)
 
         title = service.data.get(ATTR_TITLE)
         if title:
+            _check_templates_warn(hass, title)
             title.hass = hass
             payload[ATTR_TITLE] = title.async_render(parse_result=False)
 

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -1,6 +1,7 @@
 """The tests for notify services that change targets."""
 from homeassistant.components import notify
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 
 async def test_same_targets(hass: HomeAssistant):
@@ -81,3 +82,19 @@ class NotificationService(notify.BaseNotificationService):
     def targets(self):
         """Return a dictionary of devices."""
         return self.target_list
+
+
+async def test_warn_template(hass, caplog):
+    """Test warning when template used."""
+    assert await async_setup_component(hass, "notify", {})
+    assert await async_setup_component(hass, "persistent_notification", {})
+
+    await hass.services.async_call(
+        "notify",
+        "persistent_notification",
+        {"message": "{{ 1 + 1 }}", "title": "Test notif {{ 1 + 1 }}"},
+        blocking=True,
+    )
+    # We should only log it once
+    assert caplog.text.count("Passing templates to notify service is deprecated") == 1
+    assert hass.states.get("persistent_notification.notification") is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The notify services now warn when service parameters `title` and `message` are dynamic templates. Input is already processed as a template by scripts/automations before sending it to the notify integration so this shouldn't happen. This feature will be removed in 2021.12.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate passing templates to notify. It is already handled by automation/scripts.

For #55905

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
