### PR TITLE
Clean up Surepetcare binary sensor

### DIFF
--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -59,7 +59,6 @@ class SurePetcareBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self,
         _id: int,
         coordinator: DataUpdateCoordinator,
-        device_class: str,
     ) -> None:
         """Initialize a Sure Petcare binary sensor."""
         super().__init__(coordinator)
@@ -74,29 +73,26 @@ class SurePetcareBinarySensor(CoordinatorEntity, BinarySensorEntity):
         else:
             name = f"Unnamed {surepy_entity.type.name.capitalize()}"
 
-        self._attr_device_class = device_class
         self._attr_name = f"{surepy_entity.type.name.capitalize()} {name.capitalize()}"
         self._attr_unique_id = f"{surepy_entity.household_id}-{self._id}"
-        self._update_attr()
+        self._update_attr(coordinator.data[_id])
 
     @abstractmethod
     @callback
-    def _update_attr(self) -> None:
+    def _update_attr(self, surepy_entity) -> None:
         """Update the state and attributes."""
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Get the latest data and update the state."""
-        self._update_attr()
+        self._update_attr(self.coordinator.data[self._id])
         self.async_write_ha_state()
 
 
 class Hub(SurePetcareBinarySensor):
     """Sure Petcare Hub."""
 
-    def __init__(self, _id: int, coordinator: DataUpdateCoordinator) -> None:
-        """Initialize a Sure Petcare Hub."""
-        super().__init__(_id, coordinator, DEVICE_CLASS_CONNECTIVITY)
+    _attr_device_class = DEVICE_CLASS_CONNECTIVITY
 
     @property
     def available(self) -> bool:
@@ -104,9 +100,8 @@ class Hub(SurePetcareBinarySensor):
         return super().available and bool(self._attr_is_on)
 
     @callback
-    def _update_attr(self) -> None:
+    def _update_attr(self, surepy_entity) -> None:
         """Get the latest data and update the state."""
-        surepy_entity = self.coordinator.data[self._id]
         state = surepy_entity.raw_data()["status"]
         self._attr_is_on = self._attr_available = bool(state["online"])
         if surepy_entity.raw_data():
@@ -124,14 +119,11 @@ class Hub(SurePetcareBinarySensor):
 class Pet(SurePetcareBinarySensor):
     """Sure Petcare Pet."""
 
-    def __init__(self, _id: int, coordinator: DataUpdateCoordinator) -> None:
-        """Initialize a Sure Petcare Pet."""
-        super().__init__(_id, coordinator, DEVICE_CLASS_PRESENCE)
+    _attr_device_class = DEVICE_CLASS_PRESENCE
 
     @callback
-    def _update_attr(self) -> None:
+    def _update_attr(self, surepy_entity) -> None:
         """Get the latest data and update the state."""
-        surepy_entity = self.coordinator.data[self._id]
         state = surepy_entity.location
         try:
             self._attr_is_on = bool(Location(state.where) == Location.INSIDE)
@@ -150,21 +142,22 @@ class Pet(SurePetcareBinarySensor):
 class DeviceConnectivity(SurePetcareBinarySensor):
     """Sure Petcare Device."""
 
+    _attr_device_class = DEVICE_CLASS_CONNECTIVITY
+
     def __init__(
         self,
         _id: int,
         coordinator: DataUpdateCoordinator,
     ) -> None:
         """Initialize a Sure Petcare Device."""
-        super().__init__(_id, coordinator, DEVICE_CLASS_CONNECTIVITY)
+        super().__init__(_id, coordinator)
         self._attr_name = f"{self.name}_connectivity"
         self._attr_unique_id = (
             f"{self.coordinator.data[self._id].household_id}-{self._id}-connectivity"
         )
 
     @callback
-    def _update_attr(self):
-        surepy_entity = self.coordinator.data[self._id]
+    def _update_attr(self, surepy_entity):
         state = surepy_entity.raw_data()["status"]
         self._attr_is_on = bool(state)
         if state:

--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -65,7 +65,7 @@ class SurePetcareBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
         self._id = _id
 
-        surepy_entity: SurepyEntity = coordinator.data[self._id]
+        surepy_entity: SurepyEntity = coordinator.data[_id]
 
         # cover special case where a device has no name set
         if surepy_entity.name:
@@ -74,7 +74,7 @@ class SurePetcareBinarySensor(CoordinatorEntity, BinarySensorEntity):
             name = f"Unnamed {surepy_entity.type.name.capitalize()}"
 
         self._attr_name = f"{surepy_entity.type.name.capitalize()} {name.capitalize()}"
-        self._attr_unique_id = f"{surepy_entity.household_id}-{self._id}"
+        self._attr_unique_id = f"{surepy_entity.household_id}-{_id}"
         self._update_attr(coordinator.data[_id])
 
     @abstractmethod


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Surepetcare, cleanup binary sensor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
