### PR TITLE
Remove unnecessary extra attribute from NUT sensors

### DIFF
--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -5,7 +5,7 @@ import logging
 
 from homeassistant.components.nut import PyNUTData
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
-from homeassistant.const import ATTR_STATE, CONF_RESOURCES, STATE_UNKNOWN
+from homeassistant.const import CONF_RESOURCES, STATE_UNKNOWN
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -132,11 +132,6 @@ class NUTSensor(CoordinatorEntity, SensorEntity):
         if self.entity_description.key == KEY_STATUS_DISPLAY:
             return _format_display_state(self._data.status)
         return self._data.status.get(self.entity_description.key)
-
-    @property
-    def extra_state_attributes(self):
-        """Return the sensor attributes."""
-        return {ATTR_STATE: _format_display_state(self._data.status)}
 
 
 def _format_display_state(status):

--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -21,7 +21,6 @@ async def test_pr3000rt2u(hass):
     expected_attributes = {
         "device_class": "battery",
         "friendly_name": "Ups1 Battery Charge",
-        "state": "Online",
         "unit_of_measurement": PERCENTAGE,
     }
     # Only test for a subset of attributes in case
@@ -47,7 +46,6 @@ async def test_cp1350c(hass):
     expected_attributes = {
         "device_class": "battery",
         "friendly_name": "Ups1 Battery Charge",
-        "state": "Online",
         "unit_of_measurement": PERCENTAGE,
     }
     # Only test for a subset of attributes in case
@@ -72,7 +70,6 @@ async def test_5e850i(hass):
     expected_attributes = {
         "device_class": "battery",
         "friendly_name": "Ups1 Battery Charge",
-        "state": "Online",
         "unit_of_measurement": PERCENTAGE,
     }
     # Only test for a subset of attributes in case
@@ -97,7 +94,6 @@ async def test_5e650i(hass):
     expected_attributes = {
         "device_class": "battery",
         "friendly_name": "Ups1 Battery Charge",
-        "state": "Online Battery Charging",
         "unit_of_measurement": PERCENTAGE,
     }
     # Only test for a subset of attributes in case
@@ -125,7 +121,6 @@ async def test_backupsses600m1(hass):
     expected_attributes = {
         "device_class": "battery",
         "friendly_name": "Ups1 Battery Charge",
-        "state": "Online",
         "unit_of_measurement": PERCENTAGE,
     }
     # Only test for a subset of attributes in case
@@ -152,7 +147,6 @@ async def test_cp1500pfclcd(hass):
     expected_attributes = {
         "device_class": "battery",
         "friendly_name": "Ups1 Battery Charge",
-        "state": "Online",
         "unit_of_measurement": PERCENTAGE,
     }
     # Only test for a subset of attributes in case
@@ -177,7 +171,6 @@ async def test_dl650elcd(hass):
     expected_attributes = {
         "device_class": "battery",
         "friendly_name": "Ups1 Battery Charge",
-        "state": "Online",
         "unit_of_measurement": PERCENTAGE,
     }
     # Only test for a subset of attributes in case
@@ -202,7 +195,6 @@ async def test_blazer_usb(hass):
     expected_attributes = {
         "device_class": "battery",
         "friendly_name": "Ups1 Battery Charge",
-        "state": "Online",
         "unit_of_measurement": PERCENTAGE,
     }
     # Only test for a subset of attributes in case


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The extra attribute `state` is removed from all sensors, since it is already exposed as an own sensor.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will remove the unnecessary extra attribute `state` from all sensors, since it is already exposed as a sensor itself.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
