### PR TITLE
Updated changes for aioshelly 1.0.0

### DIFF
--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -48,7 +48,7 @@ SENSORS: Final = {
     ("sensor", "dwIsOpened"): BlockAttributeDescription(
         name="Door",
         device_class=DEVICE_CLASS_OPENING,
-        available=lambda block: cast(bool, block.dwIsOpened != -1),
+        available=lambda block: cast(int, block.dwIsOpened) != -1,
     ),
     ("sensor", "flood"): BlockAttributeDescription(
         name="Flood", device_class=DEVICE_CLASS_MOISTURE

--- a/homeassistant/components/shelly/cover.py
+++ b/homeassistant/components/shelly/cover.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from aioshelly import Block
+from aioshelly.block_device import Block
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -57,7 +57,7 @@ class ShellyCover(ShellyBlockEntity, CoverEntity):
         if self.control_result:
             return cast(bool, self.control_result["current_pos"] == 0)
 
-        return cast(bool, self.block.rollerPos == 0)
+        return cast(int, self.block.rollerPos) == 0
 
     @property
     def current_cover_position(self) -> int:
@@ -73,7 +73,7 @@ class ShellyCover(ShellyBlockEntity, CoverEntity):
         if self.control_result:
             return cast(bool, self.control_result["state"] == "close")
 
-        return cast(bool, self.block.roller == "close")
+        return self.block.roller == "close"
 
     @property
     def is_opening(self) -> bool:
@@ -81,7 +81,7 @@ class ShellyCover(ShellyBlockEntity, CoverEntity):
         if self.control_result:
             return cast(bool, self.control_result["state"] == "open")
 
-        return cast(bool, self.block.roller == "open")
+        return self.block.roller == "open"
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/shelly/device_trigger.py
+++ b/homeassistant/components/shelly/device_trigger.py
@@ -60,6 +60,8 @@ async def async_validate_trigger_config(
 
     trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
 
+    assert wrapper.device.blocks
+
     for block in wrapper.device.blocks:
         input_triggers = get_input_triggers(wrapper.device, block)
         if trigger in input_triggers:
@@ -92,6 +94,8 @@ async def async_get_triggers(
                 }
             )
         return triggers
+
+    assert wrapper.device.blocks
 
     for block in wrapper.device.blocks:
         input_triggers = get_input_triggers(wrapper.device, block)

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 from typing import Any, Final, cast
 
-from aioshelly import Block
+from aioshelly.block_device import Block
 import async_timeout
 
 from homeassistant.components.light import (
@@ -117,7 +117,7 @@ class ShellyLight(ShellyBlockEntity, LightEntity):
             self._supported_features |= SUPPORT_EFFECT
 
         if wrapper.model in MODELS_SUPPORTING_LIGHT_TRANSITION:
-            match = FIRMWARE_PATTERN.search(wrapper.device.settings.get("fw"))
+            match = FIRMWARE_PATTERN.search(wrapper.device.settings.get("fw", ""))
             if (
                 match is not None
                 and int(match[0]) >= LIGHT_TRANSITION_MIN_FIRMWARE_DATE

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/shelly",
-  "requirements": ["aioshelly==0.6.4"],
+  "requirements": ["aioshelly==1.0.0"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -40,7 +40,7 @@ SENSORS: Final = {
         device_class=sensor.DEVICE_CLASS_BATTERY,
         state_class=sensor.STATE_CLASS_MEASUREMENT,
         removal_condition=lambda settings, _: settings.get("external_power") == 1,
-        available=lambda block: cast(bool, block.battery != -1),
+        available=lambda block: cast(int, block.battery) != -1,
     ),
     ("device", "deviceTemp"): BlockAttributeDescription(
         name="Device Temperature",
@@ -162,7 +162,7 @@ SENSORS: Final = {
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_TEMPERATURE,
         state_class=sensor.STATE_CLASS_MEASUREMENT,
-        available=lambda block: cast(bool, block.extTemp != 999),
+        available=lambda block: cast(int, block.extTemp) != 999,
     ),
     ("sensor", "humidity"): BlockAttributeDescription(
         name="Humidity",
@@ -170,14 +170,14 @@ SENSORS: Final = {
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_HUMIDITY,
         state_class=sensor.STATE_CLASS_MEASUREMENT,
-        available=lambda block: cast(bool, block.extTemp != 999),
+        available=lambda block: cast(int, block.extTemp) != 999,
     ),
     ("sensor", "luminosity"): BlockAttributeDescription(
         name="Luminosity",
         unit=LIGHT_LUX,
         device_class=sensor.DEVICE_CLASS_ILLUMINANCE,
         state_class=sensor.STATE_CLASS_MEASUREMENT,
-        available=lambda block: cast(bool, block.luminosity != -1),
+        available=lambda block: cast(int, block.luminosity) != -1,
     ),
     ("sensor", "tilt"): BlockAttributeDescription(
         name="Tilt",
@@ -191,7 +191,7 @@ SENSORS: Final = {
         icon="mdi:progress-wrench",
         value=lambda value: round(100 - (value / 3600 / SHAIR_MAX_WORK_HOURS), 1),
         extra_state_attributes=lambda block: {
-            "Operational hours": round(block.totalWorkTime / 3600, 1)
+            "Operational hours": round(cast(int, block.totalWorkTime) / 3600, 1)
         },
     ),
     ("adc", "adc"): BlockAttributeDescription(

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from aioshelly import Block
+from aioshelly.block_device import Block
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import logging
 from typing import Any, Final, cast
 
-import aioshelly
+from aioshelly.block_device import BLOCK_VALUE_UNIT, COAP, Block, BlockDevice
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant, callback
@@ -40,18 +40,20 @@ async def async_remove_shelly_entity(
 
 def temperature_unit(block_info: dict[str, Any]) -> str:
     """Detect temperature unit."""
-    if block_info[aioshelly.BLOCK_VALUE_UNIT] == "F":
+    if block_info[BLOCK_VALUE_UNIT] == "F":
         return TEMP_FAHRENHEIT
     return TEMP_CELSIUS
 
 
-def get_device_name(device: aioshelly.Device) -> str:
+def get_device_name(device: BlockDevice) -> str:
     """Naming for device."""
     return cast(str, device.settings["name"] or device.settings["device"]["hostname"])
 
 
-def get_number_of_channels(device: aioshelly.Device, block: aioshelly.Block) -> int:
+def get_number_of_channels(device: BlockDevice, block: Block) -> int:
     """Get number of channels for block type."""
+    assert isinstance(device.shelly, dict)
+
     channels = None
 
     if block.type == "input":
@@ -71,8 +73,8 @@ def get_number_of_channels(device: aioshelly.Device, block: aioshelly.Block) -> 
 
 
 def get_entity_name(
-    device: aioshelly.Device,
-    block: aioshelly.Block,
+    device: BlockDevice,
+    block: Block | None,
     description: str | None = None,
 ) -> str:
     """Naming for switch and sensors."""
@@ -84,10 +86,7 @@ def get_entity_name(
     return channel_name
 
 
-def get_device_channel_name(
-    device: aioshelly.Device,
-    block: aioshelly.Block,
-) -> str:
+def get_device_channel_name(device: BlockDevice, block: Block | None) -> str:
     """Get name based on device and channel name."""
     entity_name = get_device_name(device)
 
@@ -98,8 +97,10 @@ def get_device_channel_name(
     ):
         return entity_name
 
+    assert block.channel
+
     channel_name: str | None = None
-    mode = block.type + "s"
+    mode = cast(str, block.type) + "s"
     if mode in device.settings:
         channel_name = device.settings[mode][int(block.channel)].get("name")
 
@@ -114,7 +115,7 @@ def get_device_channel_name(
     return f"{entity_name} channel {chr(int(block.channel)+base)}"
 
 
-def is_momentary_input(settings: dict[str, Any], block: aioshelly.Block) -> bool:
+def is_momentary_input(settings: dict[str, Any], block: Block) -> bool:
     """Return true if input button settings is set to a momentary type."""
     # Shelly Button type is fixed to momentary and no btn_type
     if settings["device"]["type"] in SHBTN_MODELS:
@@ -150,9 +151,7 @@ def get_device_uptime(status: dict[str, Any], last_uptime: str | None) -> str:
     return last_uptime
 
 
-def get_input_triggers(
-    device: aioshelly.Device, block: aioshelly.Block
-) -> list[tuple[str, str]]:
+def get_input_triggers(device: BlockDevice, block: Block) -> list[tuple[str, str]]:
     """Return list of input triggers for block."""
     if "inputEvent" not in block.sensor_ids or "inputEventCnt" not in block.sensor_ids:
         return []
@@ -165,6 +164,7 @@ def get_input_triggers(
     if block.type == "device" or get_number_of_channels(device, block) == 1:
         subtype = "button"
     else:
+        assert block.channel
         subtype = f"button{int(block.channel)+1}"
 
     if device.settings["device"]["type"] in SHBTN_MODELS:
@@ -181,9 +181,9 @@ def get_input_triggers(
 
 
 @singleton.singleton("shelly_coap")
-async def get_coap_context(hass: HomeAssistant) -> aioshelly.COAP:
+async def get_coap_context(hass: HomeAssistant) -> COAP:
     """Get CoAP context to be used in all Shelly devices."""
-    context = aioshelly.COAP()
+    context = COAP()
     if DOMAIN in hass.data:
         port = hass.data[DOMAIN].get(CONF_COAP_PORT, DEFAULT_COAP_PORT)
     else:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -240,7 +240,7 @@ aiopylgtv==0.4.0
 aiorecollect==1.0.8
 
 # homeassistant.components.shelly
-aioshelly==0.6.4
+aioshelly==1.0.0
 
 # homeassistant.components.switcher_kis
 aioswitcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -161,7 +161,7 @@ aiopylgtv==0.4.0
 aiorecollect==1.0.8
 
 # homeassistant.components.shelly
-aioshelly==0.6.4
+aioshelly==1.0.0
 
 # homeassistant.components.switcher_kis
 aioswitcher==2.0.5


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Bump aioshelly to 1.0.0**
- Bump version to 1.0.0 (#https://github.com/home-assistant-libs/aioshelly/pull/135) @thecode
- Add typing to example.py (https://github.com/home-assistant-libs/aioshelly/pull/#138) @thecode
- Add py.typed file (https://github.com/home-assistant-libs/aioshelly/pull/#137) @bieniu
- Enable strict typing (https://github.com/home-assistant-libs/aioshelly/pull/#127) @chemelli74
- Strict typing part V: block_device.py (https://github.com/home-assistant-libs/aioshelly/pull/#136) @chemelli74
- Strict typing part IV: rpc_device.py (https://github.com/home-assistant-libs/aioshelly/pull/#133) @chemelli74
- Strict typing part III: wsrpc.py (https://github.com/home-assistant-libs/aioshelly/pull/#132) @chemelli74
- Update README.md file for Gen2 support (https://github.com/home-assistant-libs/aioshelly/pull/#134) @thecode
- Strict typing part I: coap.py (https://github.com/home-assistant-libs/aioshelly/pull/#130) @chemelli74
- Strict typing part II: common.py (https://github.com/home-assistant-libs/aioshelly/pull/#131) @chemelli74
- Revert BlockDevice shutdown to sync (https://github.com/home-assistant-libs/aioshelly/pull/#129) @thecode
- Add Shelly Gen2 Support (https://github.com/home-assistant-libs/aioshelly/pull/#128) @thecode

Full changelog: https://github.com/home-assistant-libs/aioshelly/compare/0.6.4...1.0.0

In order to prepare for supporting Shelly Gen2 devices, `aioshelly` was updated to support both Gen1 & Gen2 devices, for supporting both Gen1 & Gen2 devices library was refactored and has some API changes. This PR update these changes. 
`mypy` strict typing was enabled in `aioshelly` and requires some changes in Shelly integration to pass `mypy`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
