### PR TITLE
Blank out discovery info

### DIFF
--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -1,6 +1,5 @@
 """Rest API for Home Assistant."""
 import asyncio
-from contextlib import suppress
 import json
 import logging
 
@@ -30,15 +29,12 @@ from homeassistant.const import (
     URL_API_STATES,
     URL_API_STREAM,
     URL_API_TEMPLATE,
-    __version__,
 )
 import homeassistant.core as ha
 from homeassistant.exceptions import ServiceNotFound, TemplateError, Unauthorized
 from homeassistant.helpers import template
 from homeassistant.helpers.json import JSONEncoder
-from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.service import async_get_all_descriptions
-from homeassistant.helpers.system_info import async_get_system_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -173,7 +169,11 @@ class APIConfigView(HomeAssistantView):
 
 
 class APIDiscoveryView(HomeAssistantView):
-    """View to provide Discovery information."""
+    """
+    View to provide Discovery information.
+
+    DEPRECATED: To be removed in 2022.1
+    """
 
     requires_auth = False
     url = URL_API_DISCOVERY_INFO
@@ -181,32 +181,18 @@ class APIDiscoveryView(HomeAssistantView):
 
     async def get(self, request):
         """Get discovery information."""
-        hass = request.app["hass"]
-        uuid = await hass.helpers.instance_id.async_get()
-        system_info = await async_get_system_info(hass)
-
-        data = {
-            ATTR_UUID: uuid,
-            ATTR_BASE_URL: None,
-            ATTR_EXTERNAL_URL: None,
-            ATTR_INTERNAL_URL: None,
-            ATTR_LOCATION_NAME: hass.config.location_name,
-            ATTR_INSTALLATION_TYPE: system_info[ATTR_INSTALLATION_TYPE],
-            # always needs authentication
-            ATTR_REQUIRES_API_PASSWORD: True,
-            ATTR_VERSION: __version__,
-        }
-
-        with suppress(NoURLAvailableError):
-            data["external_url"] = get_url(hass, allow_internal=False)
-
-        with suppress(NoURLAvailableError):
-            data["internal_url"] = get_url(hass, allow_external=False)
-
-        # Set old base URL based on external or internal
-        data["base_url"] = data["external_url"] or data["internal_url"]
-
-        return self.json(data)
+        return self.json(
+            {
+                ATTR_UUID: "",
+                ATTR_BASE_URL: "",
+                ATTR_EXTERNAL_URL: "",
+                ATTR_INTERNAL_URL: "",
+                ATTR_LOCATION_NAME: "",
+                ATTR_INSTALLATION_TYPE: "",
+                ATTR_REQUIRES_API_PASSWORD: True,
+                ATTR_VERSION: "",
+            }
+        )
 
 
 class APIStatesView(HomeAssistantView):

--- a/tests/components/api/test_init.py
+++ b/tests/components/api/test_init.py
@@ -559,3 +559,20 @@ async def test_api_call_service_bad_data(hass, mock_api_client):
         "/api/services/test_domain/test_service", json={"hello": 5}
     )
     assert resp.status == 400
+
+
+async def test_api_get_discovery_info(hass, mock_api_client):
+    """Test the return of discovery info."""
+    resp = await mock_api_client.get(const.URL_API_DISCOVERY_INFO)
+    result = await resp.json()
+
+    assert result == {
+        "base_url": "",
+        "external_url": "",
+        "installation_type": "",
+        "internal_url": "",
+        "location_name": "",
+        "requires_api_password": True,
+        "uuid": "",
+        "version": "",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The API endpoint `/api/discovery_info` now only return blank values.
This endpoint is scheduled to be removed in version 2022.1


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Blank out values in `/api/discovery_info`

Needs https://github.com/home-assistant/frontend/pull/10015

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
