### PR TITLE
WIP: Add separate flow mode climates for ATW devices

### DIFF
--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -1,6 +1,7 @@
 """Platform for climate integration."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import Any
 
@@ -16,6 +17,7 @@ import voluptuous as vol
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
+    ATTR_HVAC_MODE,
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_TEMP,
     HVAC_MODE_COOL,
@@ -29,7 +31,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 
@@ -60,8 +62,8 @@ ATA_HVAC_MODE_REVERSE_LOOKUP = {v: k for k, v in ATA_HVAC_MODE_LOOKUP.items()}
 
 
 ATW_ZONE_HVAC_MODE_LOOKUP = {
-    atw.ZONE_OPERATION_MODE_HEAT: HVAC_MODE_HEAT,
-    atw.ZONE_OPERATION_MODE_COOL: HVAC_MODE_COOL,
+    atw.ZONE_OPERATION_MODE_HEAT_THERMOSTAT: HVAC_MODE_HEAT,
+    atw.ZONE_OPERATION_MODE_COOL_THERMOSTAT: HVAC_MODE_COOL,
 }
 ATW_ZONE_HVAC_MODE_REVERSE_LOOKUP = {v: k for k, v in ATW_ZONE_HVAC_MODE_LOOKUP.items()}
 
@@ -77,9 +79,25 @@ async def async_setup_entry(
             for mel_device in mel_devices[DEVICE_TYPE_ATA]
         ]
         + [
-            AtwDeviceZoneClimate(mel_device, mel_device.device, zone)
+            AtwDeviceZoneThermostatClimate(mel_device, mel_device.device, zone)
             for mel_device in mel_devices[DEVICE_TYPE_ATW]
             for zone in mel_device.device.zones
+        ]
+        + [
+            AtwDeviceZoneFlowClimate(
+                mel_device, mel_device.device, zone, HVAC_MODE_HEAT
+            )
+            for mel_device in mel_devices[DEVICE_TYPE_ATW]
+            for zone in mel_device.device.zones
+            if atw.ZONE_OPERATION_MODE_HEAT_FLOW in zone.operation_modes
+        ]
+        + [
+            AtwDeviceZoneFlowClimate(
+                mel_device, mel_device.device, zone, HVAC_MODE_COOL
+            )
+            for mel_device in mel_devices[DEVICE_TYPE_ATW]
+            for zone in mel_device.device.zones
+            if atw.ZONE_OPERATION_MODE_COOL_FLOW in zone.operation_modes
         ],
         True,
     )
@@ -167,7 +185,7 @@ class AtaDeviceClimate(MelCloudClimate):
         mode = self._device.operation_mode
         if not self._device.power or mode is None:
             return HVAC_MODE_OFF
-        return ATA_HVAC_MODE_LOOKUP.get(mode)
+        return ATA_HVAC_MODE_LOOKUP.get(mode, HVAC_MODE_OFF)
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
@@ -179,7 +197,7 @@ class AtaDeviceClimate(MelCloudClimate):
         if operation_mode is None:
             raise ValueError(f"Invalid hvac_mode [{hvac_mode}]")
 
-        props = {"operation_mode": operation_mode}
+        props: dict[str, Any] = {"operation_mode": operation_mode}
         if self.hvac_mode == HVAC_MODE_OFF:
             props["power"] = True
         await self._device.set(props)
@@ -188,7 +206,9 @@ class AtaDeviceClimate(MelCloudClimate):
     def hvac_modes(self) -> list[str]:
         """Return the list of available hvac operation modes."""
         return [HVAC_MODE_OFF] + [
-            ATA_HVAC_MODE_LOOKUP.get(mode) for mode in self._device.operation_modes
+            ATA_HVAC_MODE_LOOKUP[mode]
+            for mode in self._device.operation_modes
+            if mode in ATA_HVAC_MODE_LOOKUP
         ]
 
     @property
@@ -223,7 +243,11 @@ class AtaDeviceClimate(MelCloudClimate):
 
     async def async_set_vane_horizontal(self, position: str) -> None:
         """Set horizontal vane position."""
-        if position not in self._device.vane_horizontal_positions:
+        positions = self._device.vane_horizontal_positions
+        if positions is None:
+            raise ValueError("No horizontal vane positions availabile")
+
+        if position not in positions:
             raise ValueError(
                 f"Invalid horizontal vane position {position}. Valid positions: [{self._device.vane_horizontal_positions}]."
             )
@@ -231,7 +255,11 @@ class AtaDeviceClimate(MelCloudClimate):
 
     async def async_set_vane_vertical(self, position: str) -> None:
         """Set vertical vane position."""
-        if position not in self._device.vane_vertical_positions:
+        positions = self._device.vane_vertical_positions
+        if positions is None:
+            raise ValueError("No vertical vane positions availabile")
+
+        if position not in positions:
             raise ValueError(
                 f"Invalid vertical vane position {position}. Valid positions: [{self._device.vane_vertical_positions}]."
             )
@@ -247,7 +275,7 @@ class AtaDeviceClimate(MelCloudClimate):
         await self.async_set_vane_vertical(swing_mode)
 
     @property
-    def swing_modes(self) -> str | None:
+    def swing_modes(self) -> list[str] | None:
         """Return a list of available vertical vane positions and modes."""
         return self._device.vane_vertical_positions
 
@@ -279,10 +307,8 @@ class AtaDeviceClimate(MelCloudClimate):
 
 
 class AtwDeviceZoneClimate(MelCloudClimate):
-    """Air-to-Water zone climate device."""
+    """Air-to-Water base zone climate device."""
 
-    _attr_max_temp = 30
-    _attr_min_temp = 10
     _attr_supported_features = SUPPORT_TARGET_TEMPERATURE
 
     def __init__(
@@ -292,9 +318,6 @@ class AtwDeviceZoneClimate(MelCloudClimate):
         super().__init__(device)
         self._device = atw_device
         self._zone = atw_zone
-
-        self._attr_name = f"{device.name} {self._zone.name}"
-        self._attr_unique_id = f"{self.api.device.serial}-{atw_zone.zone_index}"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -306,28 +329,51 @@ class AtwDeviceZoneClimate(MelCloudClimate):
         }
         return data
 
+
+class AtwDeviceZoneThermostatClimate(AtwDeviceZoneClimate):
+    """Air-to-Water zone thermostat mode climate device."""
+
+    _attr_max_temp = 30
+    _attr_min_temp = 10
+
+    def __init__(
+        self, device: MelCloudDevice, atw_device: AtwDevice, atw_zone: Zone
+    ) -> None:
+        """Initialize the climate."""
+        super().__init__(device, atw_device, atw_zone)
+
+        self._attr_name = f"{device.name} {self._zone.name}"
+        self._attr_unique_id = f"{self.api.device.serial}-{atw_zone.zone_index}"
+
     @property
     def hvac_mode(self) -> str:
         """Return hvac operation ie. heat, cool mode."""
         mode = self._zone.operation_mode
         if not self._device.power or mode is None:
             return HVAC_MODE_OFF
-        return ATW_ZONE_HVAC_MODE_LOOKUP.get(mode, HVAC_MODE_OFF)
+
+        if mode == atw.ZONE_OPERATION_MODE_HEAT_THERMOSTAT:
+            return HVAC_MODE_HEAT
+
+        if mode == atw.ZONE_OPERATION_MODE_COOL_THERMOSTAT:
+            return HVAC_MODE_COOL
+
+        return HVAC_MODE_OFF
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVAC_MODE_OFF:
-            await self._device.set({"power": False})
-            return
-
-        operation_mode = ATW_ZONE_HVAC_MODE_REVERSE_LOOKUP.get(hvac_mode)
-        if operation_mode is None:
-            raise ValueError(f"Invalid hvac_mode [{hvac_mode}]")
+        if hvac_mode == HVAC_MODE_HEAT:
+            operation_mode = atw.ZONE_OPERATION_MODE_HEAT_THERMOSTAT
+        elif hvac_mode == HVAC_MODE_COOL:
+            operation_mode = atw.ZONE_OPERATION_MODE_COOL_THERMOSTAT
+        else:
+            raise ValueError(f"Invalid hvac_mode '{hvac_mode}'")
 
         if self._zone.zone_index == 1:
-            props = {PROPERTY_ZONE_1_OPERATION_MODE: operation_mode}
+            props: dict[str, Any] = {PROPERTY_ZONE_1_OPERATION_MODE: operation_mode}
         else:
-            props = {PROPERTY_ZONE_2_OPERATION_MODE: operation_mode}
+            props: dict[str, Any] = {PROPERTY_ZONE_2_OPERATION_MODE: operation_mode}
+
         if self.hvac_mode == HVAC_MODE_OFF:
             props["power"] = True
         await self._device.set(props)
@@ -335,7 +381,19 @@ class AtwDeviceZoneClimate(MelCloudClimate):
     @property
     def hvac_modes(self) -> list[str]:
         """Return the list of available hvac operation modes."""
-        return [self.hvac_mode]
+        modes = []
+        zone_modes = self._zone.operation_modes
+
+        if atw.ZONE_OPERATION_MODE_HEAT_THERMOSTAT in zone_modes:
+            modes.append(HVAC_MODE_HEAT)
+
+        if atw.ZONE_OPERATION_MODE_COOL_THERMOSTAT in zone_modes:
+            modes.append(HVAC_MODE_COOL)
+
+        if self.hvac_mode == HVAC_MODE_OFF:
+            modes.append(HVAC_MODE_OFF)
+
+        return modes
 
     @property
     def current_temperature(self) -> float | None:
@@ -348,7 +406,150 @@ class AtwDeviceZoneClimate(MelCloudClimate):
         return self._zone.target_temperature
 
     async def async_set_temperature(self, **kwargs) -> None:
-        """Set new target temperature."""
-        await self._zone.set_target_temperature(
-            kwargs.get("temperature", self.target_temperature)
+        """
+        Set new target temperature and optionally the hvac mode.
+
+        The client library rate limits writes and these two operations are actually performed with
+        a single write.
+        """
+        set_ops = [
+            self._zone.set_target_temperature(
+                kwargs.get(ATTR_TEMPERATURE, self.target_temperature)
+            )
+        ]
+
+        if ATTR_HVAC_MODE in kwargs:
+            set_ops.append(self.async_set_hvac_mode(kwargs[ATTR_HVAC_MODE]))
+
+        await asyncio.gather(*set_ops)
+
+
+class AtwDeviceZoneFlowClimate(AtwDeviceZoneClimate):
+    """Air-to-Water zone flow mode climate device."""
+
+    def __init__(
+        self,
+        device: MelCloudDevice,
+        atw_device: AtwDevice,
+        atw_zone: atw.Zone,
+        flow_mode: str,
+    ) -> None:
+        """Initialize the climate."""
+        super().__init__(device, atw_device, atw_zone)
+        self._flow_mode = flow_mode
+
+        if self._flow_mode == HVAC_MODE_HEAT:
+            id_suffix = "heat-flow"
+            name_suffix = "Heat Flow"
+        else:
+            id_suffix = "cool-flow"
+            name_suffix = "Cool Flow"
+
+        self._attr_name = f"{device.name} {self._zone.name} {name_suffix}"
+        self._attr_unique_id = (
+            f"{self.api.device.serial}-{atw_zone.zone_index}-{id_suffix}"
         )
+
+        if self._flow_mode == HVAC_MODE_HEAT:
+            self._attr_max_temp = 60
+            self._attr_min_temp = 25
+        else:
+            self._attr_max_temp = 25
+            self._attr_min_temp = 5
+
+    @property
+    def hvac_mode(self) -> str:
+        """Return hvac operation ie. heat, cool mode."""
+        op_mode = self._zone.operation_mode
+        if not self._device.power or op_mode is None:
+            return HVAC_MODE_OFF
+
+        if (
+            self._flow_mode == HVAC_MODE_HEAT
+            and op_mode == atw.ZONE_OPERATION_MODE_HEAT_FLOW
+        ):
+            return HVAC_MODE_HEAT
+
+        if (
+            self._flow_mode == HVAC_MODE_COOL
+            and op_mode == atw.ZONE_OPERATION_MODE_COOL_FLOW
+        ):
+            return HVAC_MODE_COOL
+
+        return HVAC_MODE_OFF
+
+    async def async_set_hvac_mode(self, hvac_mode: str) -> None:
+        """Set new target hvac mode."""
+        if self._flow_mode == HVAC_MODE_HEAT and hvac_mode == HVAC_MODE_HEAT:
+            operation_mode = atw.ZONE_OPERATION_MODE_HEAT_FLOW
+        elif self._flow_mode == HVAC_MODE_COOL and hvac_mode == HVAC_MODE_COOL:
+            operation_mode = atw.ZONE_OPERATION_MODE_COOL_FLOW
+        else:
+            raise ValueError(f"Invalid hvac_mode '{hvac_mode}'")
+
+        if self._zone.zone_index == 1:
+            props: dict[str, Any] = {atw.PROPERTY_ZONE_1_OPERATION_MODE: operation_mode}
+        else:
+            props: dict[str, Any] = {atw.PROPERTY_ZONE_2_OPERATION_MODE: operation_mode}
+
+        if self.hvac_mode == HVAC_MODE_OFF:
+            props["power"] = True
+        await self._device.set(props)
+
+    @property
+    def hvac_modes(self) -> list[str]:
+        """Return the list of available hvac operation modes."""
+        modes = []
+        zone_modes = self._zone.operation_modes
+
+        if (
+            self._flow_mode == HVAC_MODE_HEAT
+            and atw.ZONE_OPERATION_MODE_HEAT_FLOW in zone_modes
+        ):
+            modes.append(HVAC_MODE_HEAT)
+
+        if (
+            self._flow_mode == HVAC_MODE_COOL
+            and atw.ZONE_OPERATION_MODE_COOL_FLOW in zone_modes
+        ):
+            modes.append(HVAC_MODE_COOL)
+
+        if self.hvac_mode == HVAC_MODE_OFF:
+            modes.append(HVAC_MODE_OFF)
+
+        return modes
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+        return self._zone.flow_temperature
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the temperature we try to reach."""
+        if self._flow_mode == HVAC_MODE_HEAT:
+            return self._zone.target_heat_flow_temperature
+
+        return self._zone.target_cool_flow_temperature
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        """Set new target temperature."""
+        set_ops = []
+        if self._flow_mode == HVAC_MODE_HEAT:
+            set_ops.append(
+                self._zone.set_target_heat_flow_temperature(
+                    kwargs.get(ATTR_TEMPERATURE, self.target_temperature)
+                )
+            )
+        else:
+            set_ops.append(
+                self._zone.set_target_cool_flow_temperature(
+                    kwargs.get(ATTR_TEMPERATURE, self.target_temperature)
+                )
+            )
+
+        if ATTR_HVAC_MODE in kwargs:
+            set_ops.append(self.async_set_hvac_mode(kwargs[ATTR_HVAC_MODE]))
+
+        if len(set_ops) > 0:
+            asyncio.gather(*set_ops)

--- a/homeassistant/components/melcloud/manifest.json
+++ b/homeassistant/components/melcloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "MELCloud",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/melcloud",
-  "requirements": ["pymelcloud==2.5.3"],
+  "requirements": ["pymelcloud==2.10.2"],
   "codeowners": ["@vilppuvuorinen"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/melcloud/manifest.json
+++ b/homeassistant/components/melcloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "MELCloud",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/melcloud",
-  "requirements": ["pymelcloud==2.10.2"],
+  "requirements": ["pymelcloud==2.11.0"],
   "codeowners": ["@vilppuvuorinen"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -75,6 +75,33 @@ ATW_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
         value_fn=lambda x: x.device.tank_temperature,
         enabled=lambda x: True,
     ),
+    MelcloudSensorEntityDescription(
+        key="flow_temperature_boiler",
+        name="Boiler Flow Temperature",
+        icon="mdi:thermometer",
+        native_unit_of_measurement=TEMP_CELSIUS,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        value_fn=lambda x: x.device.flow_temperature_boiler,
+        enabled=lambda x: True,
+    ),
+    MelcloudSensorEntityDescription(
+        key="return_temperature_boiler",
+        name="Boiler Return Temperature",
+        icon="mdi:thermometer",
+        native_unit_of_measurement=TEMP_CELSIUS,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        value_fn=lambda x: x.device.return_temperature_boiler,
+        enabled=lambda x: True,
+    ),
+    MelcloudSensorEntityDescription(
+        key="mixing_tank_temperature",
+        name="Mixing Tank Temperature",
+        icon="mdi:thermometer",
+        native_unit_of_measurement=TEMP_CELSIUS,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        value_fn=lambda x: x.device.mixing_tank_temperature,
+        enabled=lambda x: True,
+    ),
 )
 ATW_ZONE_SENSORS: tuple[MelcloudSensorEntityDescription, ...] = (
     MelcloudSensorEntityDescription(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1605,7 +1605,7 @@ pymazda==0.2.1
 pymediaroom==0.6.4.1
 
 # homeassistant.components.melcloud
-pymelcloud==2.5.3
+pymelcloud==2.10.2
 
 # homeassistant.components.meteoclimatic
 pymeteoclimatic==0.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1605,7 +1605,7 @@ pymazda==0.2.1
 pymediaroom==0.6.4.1
 
 # homeassistant.components.melcloud
-pymelcloud==2.10.2
+pymelcloud==2.11.0
 
 # homeassistant.components.meteoclimatic
 pymeteoclimatic==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -924,7 +924,7 @@ pymata-express==1.19
 pymazda==0.2.1
 
 # homeassistant.components.melcloud
-pymelcloud==2.5.3
+pymelcloud==2.10.2
 
 # homeassistant.components.meteoclimatic
 pymeteoclimatic==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -924,7 +924,7 @@ pymata-express==1.19
 pymazda==0.2.1
 
 # homeassistant.components.melcloud
-pymelcloud==2.10.2
+pymelcloud==2.11.0
 
 # homeassistant.components.meteoclimatic
 pymeteoclimatic==0.0.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This change remove operation mode control and feedback for ATW zone climates. None of these modes have been properly previously properly controllable.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MELCloud ATW devices offer external thermostat and flow tempreature control modes. A single installation rarely switches between these modes and the states of these control modes are stored separately for thremostat, heat flow and cool flow. This PR splits the different control modes out to different climate entities that offer mode specific controls.

One arguable side of this change is the split of the heat/cool mode flow climates. They could reasonably be merged into a single climate with both heat and cool modes. Any feedback on this issue is welcome.

I opened this PR a bit early because I'm hoping to recruit folks to test this feature out and I'm hoping having this PR open will help with this effort.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
