### PR TITLE
Update template/test_lock.py to use pytest

### DIFF
--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -5,42 +5,30 @@ from homeassistant import setup
 from homeassistant.components import lock
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 
-from tests.common import assert_setup_component, async_mock_service
 
-
-@pytest.fixture
-def calls(hass):
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
-
-
-async def test_template_state(hass):
-    """Test template."""
-    with assert_setup_component(1, lock.DOMAIN):
-        assert await setup.async_setup_component(
-            hass,
-            lock.DOMAIN,
-            {
+@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            lock.DOMAIN: {
+                "platform": "template",
+                "name": "Test template lock",
+                "value_template": "{{ states.switch.test_state.state }}",
                 "lock": {
-                    "platform": "template",
-                    "name": "Test template lock",
-                    "value_template": "{{ states.switch.test_state.state }}",
-                    "lock": {
-                        "service": "switch.turn_on",
-                        "entity_id": "switch.test_state",
-                    },
-                    "unlock": {
-                        "service": "switch.turn_off",
-                        "entity_id": "switch.test_state",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+                    "service": "switch.turn_on",
+                    "entity_id": "switch.test_state",
+                },
+                "unlock": {
+                    "service": "switch.turn_off",
+                    "entity_id": "switch.test_state",
+                },
+            }
+        },
+    ],
+)
+async def test_template_state(hass, start_ha):
+    """Test template."""
     hass.states.async_set("switch.test_state", STATE_ON)
     await hass.async_block_till_done()
 
@@ -54,196 +42,135 @@ async def test_template_state(hass):
     assert state.state == lock.STATE_UNLOCKED
 
 
-async def test_template_state_boolean_on(hass):
-    """Test the setting of the state with boolean on."""
-    with assert_setup_component(1, lock.DOMAIN):
-        assert await setup.async_setup_component(
-            hass,
-            lock.DOMAIN,
-            {
+@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            lock.DOMAIN: {
+                "platform": "template",
+                "value_template": "{{ 1 == 1 }}",
                 "lock": {
-                    "platform": "template",
-                    "value_template": "{{ 1 == 1 }}",
-                    "lock": {
-                        "service": "switch.turn_on",
-                        "entity_id": "switch.test_state",
-                    },
-                    "unlock": {
-                        "service": "switch.turn_off",
-                        "entity_id": "switch.test_state",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+                    "service": "switch.turn_on",
+                    "entity_id": "switch.test_state",
+                },
+                "unlock": {
+                    "service": "switch.turn_off",
+                    "entity_id": "switch.test_state",
+                },
+            }
+        },
+    ],
+)
+async def test_template_state_boolean_on(hass, start_ha):
+    """Test the setting of the state with boolean on."""
     state = hass.states.get("lock.template_lock")
     assert state.state == lock.STATE_LOCKED
 
 
-async def test_template_state_boolean_off(hass):
-    """Test the setting of the state with off."""
-    with assert_setup_component(1, lock.DOMAIN):
-        assert await setup.async_setup_component(
-            hass,
-            lock.DOMAIN,
-            {
+@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            lock.DOMAIN: {
+                "platform": "template",
+                "value_template": "{{ 1 == 2 }}",
                 "lock": {
-                    "platform": "template",
-                    "value_template": "{{ 1 == 2 }}",
-                    "lock": {
-                        "service": "switch.turn_on",
-                        "entity_id": "switch.test_state",
-                    },
-                    "unlock": {
-                        "service": "switch.turn_off",
-                        "entity_id": "switch.test_state",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+                    "service": "switch.turn_on",
+                    "entity_id": "switch.test_state",
+                },
+                "unlock": {
+                    "service": "switch.turn_off",
+                    "entity_id": "switch.test_state",
+                },
+            }
+        },
+    ],
+)
+async def test_template_state_boolean_off(hass, start_ha):
+    """Test the setting of the state with off."""
     state = hass.states.get("lock.template_lock")
     assert state.state == lock.STATE_UNLOCKED
 
 
-async def test_template_syntax_error(hass):
+@pytest.mark.parametrize("count,domain", [(0, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            lock.DOMAIN: {
+                "platform": "template",
+                "value_template": "{% if rubbish %}",
+                "lock": {
+                    "service": "switch.turn_on",
+                    "entity_id": "switch.test_state",
+                },
+                "unlock": {
+                    "service": "switch.turn_off",
+                    "entity_id": "switch.test_state",
+                },
+            }
+        },
+        {
+            "switch": {
+                "platform": "lock",
+                "name": "{{%}",
+                "value_template": "{{ rubbish }",
+                "lock": {
+                    "service": "switch.turn_on",
+                    "entity_id": "switch.test_state",
+                },
+                "unlock": {
+                    "service": "switch.turn_off",
+                    "entity_id": "switch.test_state",
+                },
+            },
+        },
+        {lock.DOMAIN: {"platform": "template", "value_template": "Invalid"}},
+        {
+            lock.DOMAIN: {
+                "platform": "template",
+                "not_value_template": "{{ states.switch.test_state.state }}",
+                "lock": {
+                    "service": "switch.turn_on",
+                    "entity_id": "switch.test_state",
+                },
+                "unlock": {
+                    "service": "switch.turn_off",
+                    "entity_id": "switch.test_state",
+                },
+            }
+        },
+    ],
+)
+async def test_template_syntax_error(hass, start_ha):
     """Test templating syntax error."""
-    with assert_setup_component(0, lock.DOMAIN):
-        assert await setup.async_setup_component(
-            hass,
-            lock.DOMAIN,
-            {
+    assert hass.states.async_all() == []
+
+
+@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            lock.DOMAIN: {
+                "platform": "template",
+                "value_template": "{{ 1 + 1 }}",
                 "lock": {
-                    "platform": "template",
-                    "value_template": "{% if rubbish %}",
-                    "lock": {
-                        "service": "switch.turn_on",
-                        "entity_id": "switch.test_state",
-                    },
-                    "unlock": {
-                        "service": "switch.turn_off",
-                        "entity_id": "switch.test_state",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert hass.states.async_all() == []
-
-
-async def test_invalid_name_does_not_create(hass):
-    """Test invalid name."""
-    with assert_setup_component(0, lock.DOMAIN):
-        assert await setup.async_setup_component(
-            hass,
-            lock.DOMAIN,
-            {
-                "switch": {
-                    "platform": "lock",
-                    "name": "{{%}",
-                    "value_template": "{{ rubbish }",
-                    "lock": {
-                        "service": "switch.turn_on",
-                        "entity_id": "switch.test_state",
-                    },
-                    "unlock": {
-                        "service": "switch.turn_off",
-                        "entity_id": "switch.test_state",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert hass.states.async_all() == []
-
-
-async def test_invalid_lock_does_not_create(hass):
-    """Test invalid lock."""
-    with assert_setup_component(0, lock.DOMAIN):
-        assert await setup.async_setup_component(
-            hass,
-            lock.DOMAIN,
-            {"lock": {"platform": "template", "value_template": "Invalid"}},
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert hass.states.async_all() == []
-
-
-async def test_missing_template_does_not_create(hass):
-    """Test missing template."""
-    with assert_setup_component(0, lock.DOMAIN):
-        assert await setup.async_setup_component(
-            hass,
-            lock.DOMAIN,
-            {
-                "lock": {
-                    "platform": "template",
-                    "not_value_template": "{{ states.switch.test_state.state }}",
-                    "lock": {
-                        "service": "switch.turn_on",
-                        "entity_id": "switch.test_state",
-                    },
-                    "unlock": {
-                        "service": "switch.turn_off",
-                        "entity_id": "switch.test_state",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert hass.states.async_all() == []
-
-
-async def test_template_static(hass, caplog):
+                    "service": "switch.turn_on",
+                    "entity_id": "switch.test_state",
+                },
+                "unlock": {
+                    "service": "switch.turn_off",
+                    "entity_id": "switch.test_state",
+                },
+            }
+        },
+    ],
+)
+async def test_template_static(hass, start_ha):
     """Test that we allow static templates."""
-    with assert_setup_component(1, lock.DOMAIN):
-        assert await setup.async_setup_component(
-            hass,
-            lock.DOMAIN,
-            {
-                "lock": {
-                    "platform": "template",
-                    "value_template": "{{ 1 + 1 }}",
-                    "lock": {
-                        "service": "switch.turn_on",
-                        "entity_id": "switch.test_state",
-                    },
-                    "unlock": {
-                        "service": "switch.turn_off",
-                        "entity_id": "switch.test_state",
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
     state = hass.states.get("lock.template_lock")
     assert state.state == lock.STATE_UNLOCKED
 
@@ -253,13 +180,12 @@ async def test_template_static(hass, caplog):
     assert state.state == lock.STATE_LOCKED
 
 
-async def test_lock_action(hass, calls):
-    """Test lock action."""
-    assert await setup.async_setup_component(
-        hass,
-        lock.DOMAIN,
+@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
         {
-            "lock": {
+            lock.DOMAIN: {
                 "platform": "template",
                 "value_template": "{{ states.switch.test_state.state }}",
                 "lock": {"service": "test.automation"},
@@ -269,12 +195,10 @@ async def test_lock_action(hass, calls):
                 },
             }
         },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+    ],
+)
+async def test_lock_action(hass, start_ha, calls):
+    """Test lock action."""
     hass.states.async_set("switch.test_state", STATE_OFF)
     await hass.async_block_till_done()
 
@@ -289,13 +213,12 @@ async def test_lock_action(hass, calls):
     assert len(calls) == 1
 
 
-async def test_unlock_action(hass, calls):
-    """Test unlock action."""
-    assert await setup.async_setup_component(
-        hass,
-        lock.DOMAIN,
+@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
         {
-            "lock": {
+            lock.DOMAIN: {
                 "platform": "template",
                 "value_template": "{{ states.switch.test_state.state }}",
                 "lock": {
@@ -305,12 +228,10 @@ async def test_unlock_action(hass, calls):
                 "unlock": {"service": "test.automation"},
             }
         },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+    ],
+)
+async def test_unlock_action(hass, start_ha, calls):
+    """Test unlock action."""
     hass.states.async_set("switch.test_state", STATE_ON)
     await hass.async_block_till_done()
 
@@ -325,92 +246,38 @@ async def test_unlock_action(hass, calls):
     assert len(calls) == 1
 
 
-async def test_unlocking(hass, calls):
+@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            lock.DOMAIN: {
+                "platform": "template",
+                "value_template": "{{ states.input_select.test_state.state }}",
+                "lock": {"service": "test.automation"},
+                "unlock": {"service": "test.automation"},
+            }
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    "test_state", [lock.STATE_UNLOCKING, lock.STATE_LOCKING, lock.STATE_JAMMED]
+)
+async def test_lock_state(hass, test_state, start_ha):
     """Test unlocking."""
-    assert await setup.async_setup_component(
-        hass,
-        lock.DOMAIN,
-        {
-            "lock": {
-                "platform": "template",
-                "value_template": "{{ states.input_select.test_state.state }}",
-                "lock": {"service": "test.automation"},
-                "unlock": {"service": "test.automation"},
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    hass.states.async_set("input_select.test_state", lock.STATE_UNLOCKING)
+    hass.states.async_set("input_select.test_state", test_state)
     await hass.async_block_till_done()
 
     state = hass.states.get("lock.template_lock")
-    assert state.state == lock.STATE_UNLOCKING
+    assert state.state == test_state
 
 
-async def test_locking(hass, calls):
-    """Test unlocking."""
-    assert await setup.async_setup_component(
-        hass,
-        lock.DOMAIN,
+@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
         {
-            "lock": {
-                "platform": "template",
-                "value_template": "{{ states.input_select.test_state.state }}",
-                "lock": {"service": "test.automation"},
-                "unlock": {"service": "test.automation"},
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    hass.states.async_set("input_select.test_state", lock.STATE_LOCKING)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("lock.template_lock")
-    assert state.state == lock.STATE_LOCKING
-
-
-async def test_jammed(hass, calls):
-    """Test jammed."""
-    assert await setup.async_setup_component(
-        hass,
-        lock.DOMAIN,
-        {
-            "lock": {
-                "platform": "template",
-                "value_template": "{{ states.input_select.test_state.state }}",
-                "lock": {"service": "test.automation"},
-                "unlock": {"service": "test.automation"},
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    hass.states.async_set("input_select.test_state", lock.STATE_JAMMED)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("lock.template_lock")
-    assert state.state == lock.STATE_JAMMED
-
-
-async def test_available_template_with_entities(hass):
-    """Test availability templates with values from other entities."""
-
-    await setup.async_setup_component(
-        hass,
-        lock.DOMAIN,
-        {
-            "lock": {
+            lock.DOMAIN: {
                 "platform": "template",
                 "value_template": "{{ states('switch.test_state') }}",
                 "lock": {"service": "switch.turn_on", "entity_id": "switch.test_state"},
@@ -421,12 +288,10 @@ async def test_available_template_with_entities(hass):
                 "availability_template": "{{ is_state('availability_state.state', 'on') }}",
             }
         },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+    ],
+)
+async def test_available_template_with_entities(hass, start_ha):
+    """Test availability templates with values from other entities."""
     # When template returns true..
     hass.states.async_set("availability_state.state", STATE_ON)
     await hass.async_block_till_done()
@@ -442,13 +307,12 @@ async def test_available_template_with_entities(hass):
     assert hass.states.get("lock.template_lock").state == STATE_UNAVAILABLE
 
 
-async def test_invalid_availability_template_keeps_component_available(hass, caplog):
-    """Test that an invalid availability keeps the device available."""
-    await setup.async_setup_component(
-        hass,
-        lock.DOMAIN,
+@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
         {
-            "lock": {
+            lock.DOMAIN: {
                 "platform": "template",
                 "value_template": "{{ 1 + 1 }}",
                 "availability_template": "{{ x - 12 }}",
@@ -459,23 +323,22 @@ async def test_invalid_availability_template_keeps_component_available(hass, cap
                 },
             }
         },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+    ],
+)
+async def test_invalid_availability_template_keeps_component_available(
+    hass, start_ha, caplog_setup_text
+):
+    """Test that an invalid availability keeps the device available."""
     assert hass.states.get("lock.template_lock").state != STATE_UNAVAILABLE
-    assert ("UndefinedError: 'x' is undefined") in caplog.text
+    assert ("UndefinedError: 'x' is undefined") in caplog_setup_text
 
 
-async def test_unique_id(hass):
-    """Test unique_id option only creates one lock per id."""
-    await setup.async_setup_component(
-        hass,
-        lock.DOMAIN,
+@pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
         {
-            "lock": {
+            lock.DOMAIN: {
                 "platform": "template",
                 "name": "test_template_lock_01",
                 "unique_id": "not-so-unique-anymore",
@@ -485,10 +348,12 @@ async def test_unique_id(hass):
                     "service": "switch.turn_off",
                     "entity_id": "switch.test_state",
                 },
-            },
+            }
         },
-    )
-
+    ],
+)
+async def test_unique_id(hass, start_ha):
+    """Test unique_id option only creates one lock per id."""
     await setup.async_setup_component(
         hass,
         lock.DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
template/test_lock did use pytest, but not very efficient using fixtures and parametrisation.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
#40899
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
