### PR TITLE
Define `unit_of_measurement` of all `utility_meter` sensors on HA start

### DIFF
--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_TARIFF,
     CONF_TARIFF_ENTITY,
     CONF_TARIFFS,
+    DATA_TARIFF_SENSORS,
     DATA_UTILITY,
     DOMAIN,
     METER_TYPES,
@@ -98,6 +99,7 @@ async def async_setup(hass, config):
         _LOGGER.debug("Setup %s.%s", DOMAIN, meter)
 
         hass.data[DATA_UTILITY][meter] = conf
+        hass.data[DATA_UTILITY][meter][DATA_TARIFF_SENSORS] = []
 
         if not conf[CONF_TARIFFS]:
             # only one entity is required

--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -22,6 +22,7 @@ METER_TYPES = [
 ]
 
 DATA_UTILITY = "utility_meter_data"
+DATA_TARIFF_SENSORS = "utility_meter_sensors"
 
 CONF_METER = "meter"
 CONF_SOURCE_SENSOR = "source"

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     DEVICE_CLASS_ENERGY,
     ENERGY_KILO_WATT_HOUR,
     ENERGY_WATT_HOUR,
-    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STARTED,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
@@ -137,7 +137,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
     ):
         """Initialize the Utility Meter sensor."""
         self._sensor_source_id = source_entity
-        self._state = 0
+        self._state = None
         self._last_period = 0
         self._last_reset = dt_util.utcnow()
         self._collecting = None
@@ -322,6 +322,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
                 self._unit_of_measurement = source_state.attributes.get(
                     ATTR_UNIT_OF_MEASUREMENT
                 )
+                self._state = 0
                 self.async_write_ha_state()
             if self._tariff_entity is not None:
                 _LOGGER.debug(
@@ -346,7 +347,7 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
             )
 
         self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_START, async_source_tracking
+            EVENT_HOMEASSISTANT_STARTED, async_source_tracking
         )
 
     @property

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -317,6 +317,12 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         @callback
         def async_source_tracking(event):
             """Wait for source to be ready, then start meter."""
+            source_state = self.hass.states.get(self._sensor_source_id)
+            if self._unit_of_measurement is None and source_state:
+                self._unit_of_measurement = source_state.attributes.get(
+                    ATTR_UNIT_OF_MEASUREMENT
+                )
+                self.async_write_ha_state()
             if self._tariff_entity is not None:
                 _LOGGER.debug(
                     "<%s> tracks utility meter %s", self.name, self._tariff_entity
@@ -329,7 +335,12 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
                 self._change_status(tariff_entity_state.state)
                 return
 
-            _LOGGER.debug("<%s> collecting from %s", self.name, self._sensor_source_id)
+            _LOGGER.debug(
+                "<%s> collecting %s from %s",
+                self.name,
+                self._unit_of_measurement,
+                self._sensor_source_id,
+            )
             self._collecting = async_track_state_change_event(
                 self.hass, [self._sensor_source_id], self.async_reading
             )

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -318,7 +318,9 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         def async_source_tracking(event):
             """Wait for source to be ready, then start meter."""
             source_state = self.hass.states.get(self._sensor_source_id)
-            if self._unit_of_measurement is None and source_state:
+            if (
+                self._unit_of_measurement is None or self._state is None
+            ) and source_state:
                 self._unit_of_measurement = source_state.attributes.get(
                     ATTR_UNIT_OF_MEASUREMENT
                 )

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -169,9 +169,8 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         old_state = event.data.get("old_state")
         new_state = event.data.get("new_state")
 
-        if (
-            self._unit_of_measurement is None or self._state is None
-        ) and new_state.state:
+        if self._state is None and new_state.state:
+            # First state update initializes the utility_meter sensors
             source_state = self.hass.states.get(self._sensor_source_id)
             for sensor in self.hass.data[DATA_UTILITY][self._parent_meter][
                 DATA_TARIFF_SENSORS

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_PLATFORM,
     ENERGY_KILO_WATT_HOUR,
-    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STARTED,
 )
 from homeassistant.core import State
 from homeassistant.setup import async_setup_component
@@ -70,7 +70,7 @@ async def test_services(hass):
     assert await async_setup_component(hass, SENSOR_DOMAIN, config)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     entity_id = config[DOMAIN]["energy_bill"]["source"]
     hass.states.async_set(
         entity_id, 1, {ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR}

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_PLATFORM,
     ENERGY_KILO_WATT_HOUR,
-    EVENT_HOMEASSISTANT_STARTED,
+    EVENT_HOMEASSISTANT_START,
 )
 from homeassistant.core import State
 from homeassistant.setup import async_setup_component
@@ -70,7 +70,7 @@ async def test_services(hass):
     assert await async_setup_component(hass, SENSOR_DOMAIN, config)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     entity_id = config[DOMAIN]["energy_bill"]["source"]
     hass.states.async_set(
         entity_id, 1, {ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR}

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_UNIT_OF_MEASUREMENT,
     ENERGY_KILO_WATT_HOUR,
-    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STARTED,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import State
@@ -67,7 +67,7 @@ async def test_state(hass):
     hass.states.async_set(
         entity_id, 2, {ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR}
     )
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.energy_bill_onpeak")
@@ -215,7 +215,7 @@ async def test_device_class(hass):
     hass.states.async_set(
         entity_id_gas, 2, {ATTR_UNIT_OF_MEASUREMENT: "some_archaic_unit"}
     )
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.energy_meter")
@@ -285,7 +285,7 @@ async def test_restore_state(hass):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == ENERGY_KILO_WATT_HOUR
 
     # utility_meter is loaded, now set sensors according to utility_meter:
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     state = hass.states.get("utility_meter.energy_bill")
@@ -309,7 +309,7 @@ async def test_net_consumption(hass):
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     entity_id = config[DOMAIN]["energy_bill"]["source"]
     hass.states.async_set(
         entity_id, 2, {ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR}
@@ -343,7 +343,7 @@ async def test_non_net_consumption(hass):
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     entity_id = config[DOMAIN]["energy_bill"]["source"]
     hass.states.async_set(
         entity_id, 2, {ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR}
@@ -387,7 +387,7 @@ async def _test_self_reset(hass, config, start_time, expect_reset=True):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
 
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         entity_id = config[DOMAIN]["energy_bill"]["source"]
 
         async_fire_time_changed(hass, now)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Defines `unit_of_measurement` of all `utility_meter` sensors on HA start

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #56081
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
