### PR TITLE
Fix listener leak in HomeKit on reload

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -554,7 +554,7 @@ class HomeKit:
         acc = self.driver.accessory
         if acc.entity_id not in entity_ids:
             return
-        acc.async_stop()
+        await acc.stop()
         if not (state := self.hass.states.get(acc.entity_id)):
             _LOGGER.warning(
                 "The underlying entity %s disappeared during reset", acc.entity
@@ -577,7 +577,7 @@ class HomeKit:
                 self._name,
                 entity_id,
             )
-            acc = self.remove_bridge_accessory(aid)
+            acc = await self.async_remove_bridge_accessory(aid)
             if state := self.hass.states.get(acc.entity_id):
                 new.append(state)
             else:
@@ -670,11 +670,11 @@ class HomeKit:
             )
         )
 
-    def remove_bridge_accessory(self, aid):
+    async def async_remove_bridge_accessory(self, aid):
         """Try adding accessory to bridge if configured beforehand."""
         acc = self.bridge.accessories.pop(aid, None)
         if acc:
-            acc.async_stop()
+            await acc.stop()
         return acc
 
     async def async_configure_accessories(self):
@@ -866,11 +866,6 @@ class HomeKit:
         self.status = STATUS_STOPPED
         _LOGGER.debug("Driver stop for %s", self._name)
         await self.driver.async_stop()
-        if self.bridge:
-            for acc in self.bridge.accessories.values():
-                acc.async_stop()
-        else:
-            self.driver.accessory.async_stop()
 
     @callback
     def _async_configure_linked_sensors(self, ent_reg_ent, device_lookup, state):

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -499,8 +499,7 @@ class HomeAccessory(Accessory):
             )
         )
 
-    @ha_callback
-    def async_stop(self):
+    async def stop(self):
         """Cancel any subscriptions when the bridge is stopped."""
         while self._subscriptions:
             self._subscriptions.pop(0)()

--- a/homeassistant/components/homekit/type_cameras.py
+++ b/homeassistant/components/homekit/type_cameras.py
@@ -438,12 +438,11 @@ class Camera(HomeAccessory, PyhapCamera):
         self.sessions[session_id].pop(FFMPEG_WATCHER)()
         self.sessions[session_id].pop(FFMPEG_LOGGER).cancel()
 
-    @callback
-    def async_stop(self):
+    async def stop(self):
         """Stop any streams when the accessory is stopped."""
         for session_info in self.sessions.values():
             asyncio.create_task(self.stop_stream(session_info))
-        super().async_stop()
+        await super().stop()
 
     async def stop_stream(self, session_info):
         """Stop the stream for the given ``session_id``."""

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -122,10 +122,12 @@ class GarageDoorOpener(HomeAccessory):
         Run inside the Home Assistant event loop.
         """
         if self.linked_obstruction_sensor:
-            async_track_state_change_event(
-                self.hass,
-                [self.linked_obstruction_sensor],
-                self._async_update_obstruction_event,
+            self._subscriptions.append(
+                async_track_state_change_event(
+                    self.hass,
+                    [self.linked_obstruction_sensor],
+                    self._async_update_obstruction_event,
+                )
             )
 
         await super().run()

--- a/homeassistant/components/homekit/type_humidifiers.py
+++ b/homeassistant/components/homekit/type_humidifiers.py
@@ -149,10 +149,12 @@ class HumidifierDehumidifier(HomeAccessory):
         Run inside the Home Assistant event loop.
         """
         if self.linked_humidity_sensor:
-            async_track_state_change_event(
-                self.hass,
-                [self.linked_humidity_sensor],
-                self.async_update_current_humidity_event,
+            self._subscriptions.append(
+                async_track_state_change_event(
+                    self.hass,
+                    [self.linked_humidity_sensor],
+                    self.async_update_current_humidity_event,
+                )
             )
 
         await super().run()

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -60,7 +60,7 @@ async def test_accessory_cancels_track_state_change_on_stop(hass, hk_driver):
     ):
         await acc.run()
     assert len(hass.data[TRACK_STATE_CHANGE_CALLBACKS][entity_id]) == 1
-    acc.async_stop()
+    await acc.stop()
     assert entity_id not in hass.data[TRACK_STATE_CHANGE_CALLBACKS]
 
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -442,11 +442,12 @@ async def test_homekit_remove_accessory(hass, mock_zeroconf):
     homekit.driver = "driver"
     homekit.bridge = _mock_pyhap_bridge()
     acc_mock = MagicMock()
+    acc_mock.stop = AsyncMock()
     homekit.bridge.accessories = {6: acc_mock}
 
-    acc = homekit.remove_bridge_accessory(6)
+    acc = await homekit.async_remove_bridge_accessory(6)
     assert acc is acc_mock
-    assert acc_mock.async_stop.called
+    assert acc_mock.stop.called
     assert len(homekit.bridge.accessories) == 0
 
 
@@ -695,9 +696,11 @@ async def test_homekit_reset_accessories(hass, mock_zeroconf):
 
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
         aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
         homekit.bridge.accessories = {aid: acc_mock}
         homekit.status = STATUS_RUNNING
+        homekit.driver.aio_stop_event = MagicMock()
 
         await hass.services.async_call(
             DOMAIN,
@@ -730,9 +733,12 @@ async def test_homekit_unpair(hass, device_reg, mock_zeroconf):
 
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
+
         aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
         homekit.bridge.accessories = {aid: acc_mock}
         homekit.status = STATUS_RUNNING
+        homekit.driver.aio_stop_event = MagicMock()
 
         state = homekit.driver.state
         state.add_paired_client("client1", "any", b"1")
@@ -769,9 +775,12 @@ async def test_homekit_unpair_missing_device_id(hass, device_reg, mock_zeroconf)
 
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
+
         aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
         homekit.bridge.accessories = {aid: acc_mock}
         homekit.status = STATUS_RUNNING
+        homekit.driver.aio_stop_event = MagicMock()
 
         state = homekit.driver.state
         state.add_paired_client("client1", "any", b"1")
@@ -807,6 +816,8 @@ async def test_homekit_unpair_not_homekit_device(hass, device_reg, mock_zeroconf
 
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
+
         aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
         homekit.bridge.accessories = {aid: acc_mock}
         homekit.status = STATUS_RUNNING
@@ -856,9 +867,12 @@ async def test_homekit_reset_accessories_not_supported(hass, mock_zeroconf):
 
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
+
         aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
         homekit.bridge.accessories = {aid: acc_mock}
         homekit.status = STATUS_RUNNING
+        homekit.driver.aio_stop_event = MagicMock()
 
         await hass.services.async_call(
             DOMAIN,
@@ -896,9 +910,12 @@ async def test_homekit_reset_accessories_state_missing(hass, mock_zeroconf):
 
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
+
         aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
         homekit.bridge.accessories = {aid: acc_mock}
         homekit.status = STATUS_RUNNING
+        homekit.driver.aio_stop_event = MagicMock()
 
         await hass.services.async_call(
             DOMAIN,
@@ -935,9 +952,12 @@ async def test_homekit_reset_accessories_not_bridged(hass, mock_zeroconf):
 
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
+
         aid = homekit.aid_storage.get_or_allocate_aid_for_entity_id(entity_id)
         homekit.bridge.accessories = {aid: acc_mock}
         homekit.status = STATUS_RUNNING
+        homekit.driver.aio_stop_event = MagicMock()
 
         await hass.services.async_call(
             DOMAIN,
@@ -974,7 +994,10 @@ async def test_homekit_reset_single_accessory(hass, mock_zeroconf):
         homekit.status = STATUS_RUNNING
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
+
         homekit.driver.accessory = acc_mock
+        homekit.driver.aio_stop_event = MagicMock()
 
         await hass.services.async_call(
             DOMAIN,
@@ -1008,7 +1031,10 @@ async def test_homekit_reset_single_accessory_unsupported(hass, mock_zeroconf):
         homekit.status = STATUS_RUNNING
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
+
         homekit.driver.accessory = acc_mock
+        homekit.driver.aio_stop_event = MagicMock()
 
         await hass.services.async_call(
             DOMAIN,
@@ -1041,7 +1067,10 @@ async def test_homekit_reset_single_accessory_state_missing(hass, mock_zeroconf)
         homekit.status = STATUS_RUNNING
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
+
         homekit.driver.accessory = acc_mock
+        homekit.driver.aio_stop_event = MagicMock()
 
         await hass.services.async_call(
             DOMAIN,
@@ -1074,7 +1103,10 @@ async def test_homekit_reset_single_accessory_no_match(hass, mock_zeroconf):
         homekit.status = STATUS_RUNNING
         acc_mock = MagicMock()
         acc_mock.entity_id = entity_id
+        acc_mock.stop = AsyncMock()
+
         homekit.driver.accessory = acc_mock
+        homekit.driver.aio_stop_event = MagicMock()
 
         await hass.services.async_call(
             DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix listener leak in HomeKit on reload

Switch to using built-in HAP-python `.stop()` support instead of our own (note that HAP-python does not prefix with `async_`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
