### PR TITLE
Add WattTime integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1170,6 +1170,7 @@ omit =
     homeassistant/components/waterfurnace/*
     homeassistant/components/watson_iot/*
     homeassistant/components/watson_tts/tts.py
+    homeassistant/components/watttime/__init__.py
     homeassistant/components/waze_travel_time/__init__.py
     homeassistant/components/waze_travel_time/helpers.py
     homeassistant/components/waze_travel_time/sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1171,6 +1171,7 @@ omit =
     homeassistant/components/watson_iot/*
     homeassistant/components/watson_tts/tts.py
     homeassistant/components/watttime/__init__.py
+    homeassistant/components/watttime/sensor.py
     homeassistant/components/waze_travel_time/__init__.py
     homeassistant/components/waze_travel_time/helpers.py
     homeassistant/components/waze_travel_time/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -571,6 +571,7 @@ homeassistant/components/wake_on_lan/* @ntilley905
 homeassistant/components/wallbox/* @hesselonline
 homeassistant/components/waqi/* @andrey-git
 homeassistant/components/watson_tts/* @rutkai
+homeassistant/components/watttime/* @bachya
 homeassistant/components/weather/* @fabaff
 homeassistant/components/webostv/* @bendavid @thecode
 homeassistant/components/websocket_api/* @home-assistant/core

--- a/homeassistant/components/watttime/__init__.py
+++ b/homeassistant/components/watttime/__init__.py
@@ -53,9 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 f"Error while requesting data from WattTime: {err}"
             ) from err
 
-    coordinator = hass.data[DOMAIN][DATA_COORDINATOR][
-        entry.entry_id
-    ] = DataUpdateCoordinator(
+    coordinator = DataUpdateCoordinator(
         hass,
         LOGGER,
         name=entry.title,
@@ -64,6 +62,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     await coordinator.async_config_entry_first_refresh()
+    hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id] = coordinator
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/watttime/__init__.py
+++ b/homeassistant/components/watttime/__init__.py
@@ -73,6 +73,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN][DATA_COORDINATOR].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/watttime/__init__.py
+++ b/homeassistant/components/watttime/__init__.py
@@ -1,0 +1,30 @@
+"""The WattTime integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+# TODO List the platforms that you want to support.
+# For your initial PR, limit it to 1 platform.
+PLATFORMS: list[str] = ["light"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up WattTime from a config entry."""
+    # TODO Store an API object for your platforms to access
+    # hass.data[DOMAIN][entry.entry_id] = MyApi(...)
+
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/watttime/__init__.py
+++ b/homeassistant/components/watttime/__init__.py
@@ -30,12 +30,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {DATA_COORDINATOR: {}})
 
     session = aiohttp_client.async_get_clientsession(hass)
-    client = await Client.async_login(
-        entry.data[CONF_USERNAME],
-        entry.data[CONF_PASSWORD],
-        session=session,
-        logger=LOGGER,
-    )
+
+    try:
+        client = await Client.async_login(
+            entry.data[CONF_USERNAME],
+            entry.data[CONF_PASSWORD],
+            session=session,
+            logger=LOGGER,
+        )
+    except WattTimeError as err:
+        LOGGER.error("Error while authenticating with WattTime: %s", err)
+        return False
 
     async def async_update_data() -> RealTimeEmissionsResponseType:
         """Get the latest realtime emissions data."""

--- a/homeassistant/components/watttime/config_flow.py
+++ b/homeassistant/components/watttime/config_flow.py
@@ -60,7 +60,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize."""
         self._client: Client | None = None
-        self._location_type_step: str | None = None
         self._password: str | None = None
         self._username: str | None = None
 

--- a/homeassistant/components/watttime/config_flow.py
+++ b/homeassistant/components/watttime/config_flow.py
@@ -1,0 +1,212 @@
+"""Config flow for WattTime integration."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from aiowatttime import Client
+from aiowatttime.errors import (
+    CoordinatesNotFoundError,
+    InvalidCredentialsError,
+    RequestError,
+    UsernameTakenError,
+)
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_EMAIL,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import aiohttp_client, config_validation as cv
+
+from .const import AUTH_TYPE_LOGIN, AUTH_TYPE_REGISTER, DOMAIN, LOGGER
+
+CONF_AUTH_TYPE = "auth_type"
+CONF_ORGANIZATION = "organization"
+
+STEP_LOGIN_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+STEP_REGISTER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_EMAIL): str,
+        vol.Required(CONF_ORGANIZATION): str,
+    }
+)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_AUTH_TYPE): vol.In([AUTH_TYPE_LOGIN, AUTH_TYPE_REGISTER]),
+    }
+)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for WattTime."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize."""
+        self._client: Client | None = None
+        self._password: str | None = None
+        self._username: str | None = None
+
+    @property
+    def coordinates_schema(self) -> vol.Schema:
+        """Return the coordinates schema."""
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_LATITUDE, default=self.hass.config.latitude
+                ): cv.latitude,
+                vol.Required(
+                    CONF_LONGITUDE, default=self.hass.config.longitude
+                ): cv.longitude,
+            }
+        )
+
+    async def async_step_coordinates(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the latitude/longitude step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="coordinates", data_schema=self.coordinates_schema
+            )
+
+        unique_id = f"{user_input[CONF_LATITUDE]}, {user_input[CONF_LONGITUDE]}"
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        errors = {}
+
+        if TYPE_CHECKING:
+            assert self._client
+
+        try:
+            await self._client.emissions.async_get_grid_region(
+                user_input[CONF_LATITUDE], user_input[CONF_LONGITUDE]
+            )
+        except CoordinatesNotFoundError:
+            errors["base"] = "unknown_coordinates"
+        except RequestError as err:
+            LOGGER.exception("Unexpected request error while getting region: %s", err)
+            errors["base"] = "unknown"
+        except Exception as err:  # pylint: disable=broad-except
+            LOGGER.exception("Unexpected exception while getting region: %s", err)
+            errors["base"] = "unknown"
+        else:
+            return self.async_create_entry(
+                title=unique_id,
+                data={
+                    CONF_USERNAME: self._username,
+                    CONF_PASSWORD: self._password,
+                    CONF_LATITUDE: user_input[CONF_LATITUDE],
+                    CONF_LONGITUDE: user_input[CONF_LONGITUDE],
+                },
+            )
+
+        return self.async_show_form(
+            step_id="coordinates", data_schema=self.coordinates_schema, errors=errors
+        )
+
+    async def async_step_login(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the login step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="login", data_schema=STEP_LOGIN_DATA_SCHEMA
+            )
+
+        errors = {}
+        session = aiohttp_client.async_get_clientsession(self.hass)
+
+        try:
+            self._client = await Client.async_login(
+                user_input[CONF_USERNAME], user_input[CONF_PASSWORD], session=session
+            )
+        except InvalidCredentialsError:
+            errors["base"] = "invalid_auth"
+        except RequestError as err:
+            LOGGER.exception("Unexpected request error while logging in: %s", err)
+            errors["base"] = "unknown"
+        except Exception as err:  # pylint: disable=broad-except
+            LOGGER.exception("Unexpected exception while logging in: %s", err)
+            errors["base"] = "unknown"
+        else:
+            self._username = user_input[CONF_USERNAME]
+            self._password = user_input[CONF_PASSWORD]
+            return await self.async_step_coordinates()
+
+        return self.async_show_form(
+            step_id="login", data_schema=STEP_LOGIN_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_register(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the user registration step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="register", data_schema=STEP_REGISTER_DATA_SCHEMA
+            )
+
+        errors = {}
+        session = aiohttp_client.async_get_clientsession(self.hass)
+
+        try:
+            await Client.async_register_new_username(
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+                user_input[CONF_EMAIL],
+                user_input[CONF_ORGANIZATION],
+                session=session,
+            )
+        except UsernameTakenError:
+            errors["base"] = "username_taken"
+        except RequestError as err:
+            LOGGER.exception("Unexpected request error while registering: %s", err)
+            errors["base"] = "unknown"
+        except Exception as err:  # pylint: disable=broad-except
+            LOGGER.exception("Unexpected exception while registering: %s", err)
+            errors["base"] = "unknown"
+        else:
+            return await self.async_step_login(
+                {
+                    CONF_USERNAME: user_input[CONF_USERNAME],
+                    CONF_PASSWORD: user_input[CONF_PASSWORD],
+                }
+            )
+
+        return self.async_show_form(
+            step_id="register", data_schema=STEP_REGISTER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+
+        if user_input[CONF_AUTH_TYPE] == AUTH_TYPE_LOGIN:
+            return self.async_show_form(
+                step_id="login", data_schema=STEP_LOGIN_DATA_SCHEMA
+            )
+        return self.async_show_form(
+            step_id="register", data_schema=STEP_REGISTER_DATA_SCHEMA
+        )

--- a/homeassistant/components/watttime/config_flow.py
+++ b/homeassistant/components/watttime/config_flow.py
@@ -90,7 +90,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data_schema=STEP_COORDINATES_DATA_SCHEMA,
                 errors={CONF_LATITUDE: "unknown_coordinates"},
             )
-
         except Exception as err:  # pylint: disable=broad-except
             LOGGER.exception("Unexpected exception while getting region: %s", err)
             return self.async_show_form(

--- a/homeassistant/components/watttime/config_flow.py
+++ b/homeassistant/components/watttime/config_flow.py
@@ -26,9 +26,7 @@ from homeassistant.helpers import aiohttp_client, config_validation as cv
 from .const import (
     AUTH_TYPE_LOGIN,
     AUTH_TYPE_REGISTER,
-    CONF_BALANCING_AUTHORITY,
     CONF_BALANCING_AUTHORITY_ABBREV,
-    CONF_BALANCING_AUTHORITY_ID,
     DOMAIN,
     LOGGER,
 )
@@ -126,9 +124,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_PASSWORD: self._password,
                 CONF_LATITUDE: user_input[CONF_LATITUDE],
                 CONF_LONGITUDE: user_input[CONF_LONGITUDE],
-                CONF_BALANCING_AUTHORITY: grid_region["name"],
                 CONF_BALANCING_AUTHORITY_ABBREV: grid_region["abbrev"],
-                CONF_BALANCING_AUTHORITY_ID: grid_region["id"],
             },
         )
 

--- a/homeassistant/components/watttime/config_flow.py
+++ b/homeassistant/components/watttime/config_flow.py
@@ -23,7 +23,15 @@ from homeassistant.const import (
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import AUTH_TYPE_LOGIN, AUTH_TYPE_REGISTER, DOMAIN, LOGGER
+from .const import (
+    AUTH_TYPE_LOGIN,
+    AUTH_TYPE_REGISTER,
+    CONF_BALANCING_AUTHORITY,
+    CONF_BALANCING_AUTHORITY_ABBREV,
+    CONF_BALANCING_AUTHORITY_ID,
+    DOMAIN,
+    LOGGER,
+)
 
 CONF_AUTH_TYPE = "auth_type"
 CONF_ORGANIZATION = "organization"
@@ -93,7 +101,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         try:
-            await self._client.emissions.async_get_grid_region(
+            grid_region = await self._client.emissions.async_get_grid_region(
                 user_input[CONF_LATITUDE], user_input[CONF_LONGITUDE]
             )
         except CoordinatesNotFoundError:
@@ -118,6 +126,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_PASSWORD: self._password,
                 CONF_LATITUDE: user_input[CONF_LATITUDE],
                 CONF_LONGITUDE: user_input[CONF_LONGITUDE],
+                CONF_BALANCING_AUTHORITY: grid_region["name"],
+                CONF_BALANCING_AUTHORITY_ABBREV: grid_region["abbrev"],
+                CONF_BALANCING_AUTHORITY_ID: grid_region["id"],
             },
         )
 

--- a/homeassistant/components/watttime/const.py
+++ b/homeassistant/components/watttime/const.py
@@ -5,9 +5,6 @@ DOMAIN = "watttime"
 
 LOGGER = logging.getLogger(__package__)
 
-AUTH_TYPE_LOGIN = "Login with an existing username"
-AUTH_TYPE_REGISTER = "Register a new username"
-
 CONF_BALANCING_AUTHORITY = "balancing_authority"
 CONF_BALANCING_AUTHORITY_ABBREV = "balancing_authority_abbreviation"
 

--- a/homeassistant/components/watttime/const.py
+++ b/homeassistant/components/watttime/const.py
@@ -8,4 +8,6 @@ LOGGER = logging.getLogger(__package__)
 AUTH_TYPE_LOGIN = "Login with an existing username"
 AUTH_TYPE_REGISTER = "Register a new username"
 
+CONF_BALANCING_AUTHORITY_ABBREV = "balancing_authority_abbreviation"
+
 DATA_COORDINATOR = "coordinator"

--- a/homeassistant/components/watttime/const.py
+++ b/homeassistant/components/watttime/const.py
@@ -7,3 +7,9 @@ LOGGER = logging.getLogger(__package__)
 
 AUTH_TYPE_LOGIN = "Login with an existing username"
 AUTH_TYPE_REGISTER = "Register a new username"
+
+CONF_BALANCING_AUTHORITY = "balancing_authority"
+CONF_BALANCING_AUTHORITY_ABBREV = "balancing_authority_abbreviation"
+CONF_BALANCING_AUTHORITY_ID = "balancing_authority_id"
+
+DATA_COORDINATOR = "coordinator"

--- a/homeassistant/components/watttime/const.py
+++ b/homeassistant/components/watttime/const.py
@@ -1,0 +1,9 @@
+"""Constants for the WattTime integration."""
+import logging
+
+DOMAIN = "watttime"
+
+LOGGER = logging.getLogger(__package__)
+
+AUTH_TYPE_LOGIN = "Login with an existing username"
+AUTH_TYPE_REGISTER = "Register a new username"

--- a/homeassistant/components/watttime/const.py
+++ b/homeassistant/components/watttime/const.py
@@ -8,8 +8,4 @@ LOGGER = logging.getLogger(__package__)
 AUTH_TYPE_LOGIN = "Login with an existing username"
 AUTH_TYPE_REGISTER = "Register a new username"
 
-CONF_BALANCING_AUTHORITY = "balancing_authority"
-CONF_BALANCING_AUTHORITY_ABBREV = "balancing_authority_abbreviation"
-CONF_BALANCING_AUTHORITY_ID = "balancing_authority_id"
-
 DATA_COORDINATOR = "coordinator"

--- a/homeassistant/components/watttime/const.py
+++ b/homeassistant/components/watttime/const.py
@@ -8,6 +8,7 @@ LOGGER = logging.getLogger(__package__)
 AUTH_TYPE_LOGIN = "Login with an existing username"
 AUTH_TYPE_REGISTER = "Register a new username"
 
+CONF_BALANCING_AUTHORITY = "balancing_authority"
 CONF_BALANCING_AUTHORITY_ABBREV = "balancing_authority_abbreviation"
 
 DATA_COORDINATOR = "coordinator"

--- a/homeassistant/components/watttime/manifest.json
+++ b/homeassistant/components/watttime/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/watttime",
   "requirements": [
-    "aiowatttime==0.1.0"
+    "aiowatttime==0.1.1"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/homeassistant/components/watttime/manifest.json
+++ b/homeassistant/components/watttime/manifest.json
@@ -1,0 +1,17 @@
+{
+  "domain": "watttime",
+  "name": "WattTime",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/watttime",
+  "requirements": [
+    "aiowatttime==0.1.0"
+  ],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@bachya"
+  ],
+  "iot_class": "cloud_polling"
+}

--- a/homeassistant/components/watttime/sensor.py
+++ b/homeassistant/components/watttime/sensor.py
@@ -23,7 +23,14 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import CONF_BALANCING_AUTHORITY_ABBREV, DATA_COORDINATOR, DOMAIN
+from .const import (
+    CONF_BALANCING_AUTHORITY,
+    CONF_BALANCING_AUTHORITY_ABBREV,
+    DATA_COORDINATOR,
+    DOMAIN,
+)
+
+ATTR_BALANCING_AUTHORITY = "balancing_authority"
 
 DEFAULT_ATTRIBUTION = "Pickup data provided by WattTime"
 
@@ -97,6 +104,9 @@ class RealtimeEmissionsSensor(CoordinatorEntity, SensorEntity):
 
         self._attr_extra_state_attributes = {
             ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION,
+            ATTR_BALANCING_AUTHORITY: coordinator.config_entry.data[
+                CONF_BALANCING_AUTHORITY
+            ],
             ATTR_LATITUDE: coordinator.config_entry.data[ATTR_LATITUDE],
             ATTR_LONGITUDE: coordinator.config_entry.data[ATTR_LONGITUDE],
         }

--- a/homeassistant/components/watttime/sensor.py
+++ b/homeassistant/components/watttime/sensor.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import DATA_COORDINATOR, DOMAIN
+from .const import CONF_BALANCING_AUTHORITY_ABBREV, DATA_COORDINATOR, DOMAIN
 
 DEFAULT_ATTRIBUTION = "Pickup data provided by WattTime"
 
@@ -100,9 +100,7 @@ class RealtimeEmissionsSensor(CoordinatorEntity, SensorEntity):
             ATTR_LATITUDE: coordinator.config_entry.data[ATTR_LATITUDE],
             ATTR_LONGITUDE: coordinator.config_entry.data[ATTR_LONGITUDE],
         }
-        self._attr_name = (
-            f"{description.name} ({coordinator.config_entry.data['abbrev']})"
-        )
+        self._attr_name = f"{description.name} ({coordinator.config_entry.data[CONF_BALANCING_AUTHORITY_ABBREV]})"
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
         self.entity_description = description
 

--- a/homeassistant/components/watttime/sensor.py
+++ b/homeassistant/components/watttime/sensor.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    STATE_CLASS_MEASUREMENT,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, PERCENTAGE
 from homeassistant.core import HomeAssistant, callback
@@ -52,6 +56,7 @@ REALTIME_EMISSIONS_SENSOR_DESCRIPTIONS = (
         name="Marginal Operating Emissions Rate",
         icon="mdi:blur",
         native_unit_of_measurement="lbs CO2/MWh",
+        state_class=STATE_CLASS_MEASUREMENT,
         data_key="moer",
     ),
     RealtimeEmissionsSensorEntityDescription(
@@ -59,6 +64,7 @@ REALTIME_EMISSIONS_SENSOR_DESCRIPTIONS = (
         name="Relative Marginal Emissions Intensity",
         icon="mdi:blur",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
         data_key="percent",
     ),
 )

--- a/homeassistant/components/watttime/sensor.py
+++ b/homeassistant/components/watttime/sensor.py
@@ -34,7 +34,7 @@ SENSOR_TYPE_REALTIME_EMISSIONS_PERCENT = "realtime_emissions_percent"
 
 @dataclass
 class RealtimeEmissionsSensorDescriptionMixin:
-    """Define an entity description mixin realtime emissions sensors."""
+    """Define an entity description mixin for realtime emissions sensors."""
 
     data_key: str
 

--- a/homeassistant/components/watttime/sensor.py
+++ b/homeassistant/components/watttime/sensor.py
@@ -23,17 +23,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import (
-    CONF_BALANCING_AUTHORITY,
-    CONF_BALANCING_AUTHORITY_ABBREV,
-    CONF_BALANCING_AUTHORITY_ID,
-    DATA_COORDINATOR,
-    DOMAIN,
-)
-
-ATTR_BALANCING_AUTHORITY = "balancing_authority"
-ATTR_BALANCING_AUTHORITY_ABBREV = "balancing_authority_abbreviation"
-ATTR_BALANCING_AUTHORITY_ID = "balancing_authority_id"
+from .const import DATA_COORDINATOR, DOMAIN
 
 DEFAULT_ATTRIBUTION = "Pickup data provided by WattTime"
 
@@ -105,21 +95,14 @@ class RealtimeEmissionsSensor(CoordinatorEntity, SensorEntity):
         if TYPE_CHECKING:
             assert coordinator.config_entry
 
-        ba_abbrev = coordinator.config_entry.data[CONF_BALANCING_AUTHORITY_ABBREV]
-
         self._attr_extra_state_attributes = {
             ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION,
-            ATTR_BALANCING_AUTHORITY: coordinator.config_entry.data[
-                CONF_BALANCING_AUTHORITY
-            ],
-            ATTR_BALANCING_AUTHORITY_ABBREV: ba_abbrev,
-            ATTR_BALANCING_AUTHORITY_ID: coordinator.config_entry.data[
-                CONF_BALANCING_AUTHORITY_ID
-            ],
             ATTR_LATITUDE: coordinator.config_entry.data[ATTR_LATITUDE],
             ATTR_LONGITUDE: coordinator.config_entry.data[ATTR_LONGITUDE],
         }
-        self._attr_name = f"{description.name} ({ba_abbrev})"
+        self._attr_name = (
+            f"{description.name} ({coordinator.config_entry.data['abbrev']})"
+        )
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
         self.entity_description = description
 

--- a/homeassistant/components/watttime/sensor.py
+++ b/homeassistant/components/watttime/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    MASS_POUNDS,
     PERCENTAGE,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -57,7 +58,7 @@ REALTIME_EMISSIONS_SENSOR_DESCRIPTIONS = (
         key=SENSOR_TYPE_REALTIME_EMISSIONS_MOER,
         name="Marginal Operating Emissions Rate",
         icon="mdi:blur",
-        native_unit_of_measurement="lbs CO2/MWh",
+        native_unit_of_measurement=f"{MASS_POUNDS} CO2/MWh",
         state_class=STATE_CLASS_MEASUREMENT,
         data_key="moer",
     ),

--- a/homeassistant/components/watttime/sensor.py
+++ b/homeassistant/components/watttime/sensor.py
@@ -1,0 +1,128 @@
+"""Support for WattTime sensors."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ATTRIBUTION, PERCENTAGE
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import (
+    CONF_BALANCING_AUTHORITY,
+    CONF_BALANCING_AUTHORITY_ABBREV,
+    CONF_BALANCING_AUTHORITY_ID,
+    DATA_COORDINATOR,
+    DOMAIN,
+)
+
+ATTR_BALANCING_AUTHORITY = "balancing_authority"
+ATTR_BALANCING_AUTHORITY_ABBREV = "balancing_authority_abbreviation"
+ATTR_BALANCING_AUTHORITY_ID = "balancing_authority_id"
+
+DEFAULT_ATTRIBUTION = "Pickup data provided by WattTime"
+
+SENSOR_TYPE_REALTIME_EMISSIONS_MOER = "realtime_emissions_moer"
+SENSOR_TYPE_REALTIME_EMISSIONS_PERCENT = "realtime_emissions_percent"
+
+
+@dataclass
+class RealtimeEmissionsSensorDescriptionMixin:
+    """Define an entity description mixin realtime emissions sensors."""
+
+    data_key: str
+
+
+@dataclass
+class RealtimeEmissionsSensorEntityDescription(
+    SensorEntityDescription, RealtimeEmissionsSensorDescriptionMixin
+):
+    """Describe a realtime emissions sensor."""
+
+
+REALTIME_EMISSIONS_SENSOR_DESCRIPTIONS = (
+    RealtimeEmissionsSensorEntityDescription(
+        key=SENSOR_TYPE_REALTIME_EMISSIONS_MOER,
+        name="Marginal Operating Emissions Rate",
+        icon="mdi:blur",
+        native_unit_of_measurement="lbs CO2/MWh",
+        data_key="moer",
+    ),
+    RealtimeEmissionsSensorEntityDescription(
+        key=SENSOR_TYPE_REALTIME_EMISSIONS_PERCENT,
+        name="Relative Marginal Emissions Intensity",
+        icon="mdi:blur",
+        native_unit_of_measurement=PERCENTAGE,
+        data_key="percent",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up WattTime sensors based on a config entry."""
+    coordinator = hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id]
+    async_add_entities(
+        [
+            RealtimeEmissionsSensor(coordinator, description)
+            for description in REALTIME_EMISSIONS_SENSOR_DESCRIPTIONS
+            if description.data_key in coordinator.data
+        ]
+    )
+
+
+class RealtimeEmissionsSensor(CoordinatorEntity, SensorEntity):
+    """Define a realtime emissions sensor."""
+
+    entity_description: RealtimeEmissionsSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        description: RealtimeEmissionsSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+
+        if TYPE_CHECKING:
+            assert coordinator.config_entry
+
+        self._attr_extra_state_attributes = {
+            ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION,
+            ATTR_BALANCING_AUTHORITY: coordinator.config_entry.data[
+                CONF_BALANCING_AUTHORITY
+            ],
+            ATTR_BALANCING_AUTHORITY_ABBREV: coordinator.config_entry.data[
+                CONF_BALANCING_AUTHORITY_ABBREV
+            ],
+            ATTR_BALANCING_AUTHORITY_ID: coordinator.config_entry.data[
+                CONF_BALANCING_AUTHORITY_ID
+            ],
+        }
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
+        self.entity_description = description
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Respond to a DataUpdateCoordinator update."""
+        self.update_from_latest_data()
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        self.update_from_latest_data()
+
+    @callback
+    def update_from_latest_data(self) -> None:
+        """Update the state."""
+        self._attr_native_value = self.coordinator.data[
+            self.entity_description.data_key
+        ]

--- a/homeassistant/components/watttime/sensor.py
+++ b/homeassistant/components/watttime/sensor.py
@@ -10,7 +10,12 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ATTRIBUTION, PERCENTAGE
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    PERCENTAGE,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -100,18 +105,21 @@ class RealtimeEmissionsSensor(CoordinatorEntity, SensorEntity):
         if TYPE_CHECKING:
             assert coordinator.config_entry
 
+        ba_abbrev = coordinator.config_entry.data[CONF_BALANCING_AUTHORITY_ABBREV]
+
         self._attr_extra_state_attributes = {
             ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION,
             ATTR_BALANCING_AUTHORITY: coordinator.config_entry.data[
                 CONF_BALANCING_AUTHORITY
             ],
-            ATTR_BALANCING_AUTHORITY_ABBREV: coordinator.config_entry.data[
-                CONF_BALANCING_AUTHORITY_ABBREV
-            ],
+            ATTR_BALANCING_AUTHORITY_ABBREV: ba_abbrev,
             ATTR_BALANCING_AUTHORITY_ID: coordinator.config_entry.data[
                 CONF_BALANCING_AUTHORITY_ID
             ],
+            ATTR_LATITUDE: coordinator.config_entry.data[ATTR_LATITUDE],
+            ATTR_LONGITUDE: coordinator.config_entry.data[ATTR_LONGITUDE],
         }
+        self._attr_name = f"{description.name} ({ba_abbrev})"
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
         self.entity_description = description
 

--- a/homeassistant/components/watttime/strings.json
+++ b/homeassistant/components/watttime/strings.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "step": {
+      "coordinates": {
+        "title": "Input your latitude and longitude",
+        "data": {
+          "latitude": "[%key:common::config_flow::data::latitude%]",
+          "longitude": "[%key:common::config_flow::data::longitude%]"
+        }
+      },
+      "login": {
+        "title": "Login to WattTime",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
+      "register": {
+        "title": "Register for a WattTime Account",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "email": "[%key:common::config_flow::data::email%]",
+          "organization": "Organization Name"
+        }
+      },
+      "user": {
+        "title": "Configure WattTime",
+        "description": "How you would like to authenticate with WattTime?"
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "unknown_coordinates": "No data for latitude/longitude",
+      "username_taken": "Username already registered"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/watttime/strings.json
+++ b/homeassistant/components/watttime/strings.json
@@ -2,21 +2,27 @@
   "config": {
     "step": {
       "coordinates": {
-        "title": "Input your latitude and longitude",
+        "description": "Input the latitude and longitude to monitor:",
         "data": {
           "latitude": "[%key:common::config_flow::data::latitude%]",
           "longitude": "[%key:common::config_flow::data::longitude%]"
         }
       },
+      "location": {
+        "description": "Pick a location to monitor:",
+        "data": {
+          "location_type": "[%key:common::config_flow::data::location%]"
+        }
+      },
       "login": {
-        "title": "Login to WattTime",
+        "description": "Input your username and password:",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
       },
       "register": {
-        "title": "Register for a WattTime Account",
+        "description": "Register for a WattTime account:",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
@@ -25,7 +31,6 @@
         }
       },
       "user": {
-        "title": "Configure WattTime",
         "description": "How you would like to authenticate with WattTime?"
       }
     },

--- a/homeassistant/components/watttime/strings.json
+++ b/homeassistant/components/watttime/strings.json
@@ -14,32 +14,18 @@
           "location_type": "[%key:common::config_flow::data::location%]"
         }
       },
-      "login": {
+      "user": {
         "description": "Input your username and password:",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
-      },
-      "register": {
-        "description": "Register for a WattTime account:",
-        "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "email": "[%key:common::config_flow::data::email%]",
-          "organization": "Organization Name"
-        }
-      },
-      "user": {
-        "description": "How you would like to authenticate with WattTime?"
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "unknown_coordinates": "No data for latitude/longitude",
-      "username_taken": "Username already registered"
+      "unknown_coordinates": "No data for latitude/longitude"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/watttime/translations/en.json
+++ b/homeassistant/components/watttime/translations/en.json
@@ -1,0 +1,43 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error",
+            "unknown_coordinates": "No data for latitude/longitude",
+            "username_taken": "Username already registered"
+        },
+        "step": {
+            "coordinates": {
+                "data": {
+                    "latitude": "Latitude",
+                    "longitude": "Longitude"
+                },
+                "title": "Input your latitude and longitude"
+            },
+            "login": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username"
+                },
+                "title": "Login to WattTime"
+            },
+            "register": {
+                "data": {
+                    "email": "Email",
+                    "organization": "Organization Name",
+                    "password": "Password",
+                    "username": "Username"
+                },
+                "title": "Register for a WattTime Account"
+            },
+            "user": {
+                "description": "How you would like to authenticate with WattTime?",
+                "title": "Configure WattTime"
+            }
+        }
+    }
+}

--- a/homeassistant/components/watttime/translations/en.json
+++ b/homeassistant/components/watttime/translations/en.json
@@ -4,11 +4,9 @@
             "already_configured": "Device is already configured"
         },
         "error": {
-            "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error",
-            "unknown_coordinates": "No data for latitude/longitude",
-            "username_taken": "Username already registered"
+            "unknown_coordinates": "No data for latitude/longitude"
         },
         "step": {
             "coordinates": {
@@ -24,24 +22,12 @@
                 },
                 "description": "Pick a location to monitor:"
             },
-            "login": {
+            "user": {
                 "data": {
                     "password": "Password",
                     "username": "Username"
                 },
                 "description": "Input your username and password:"
-            },
-            "register": {
-                "data": {
-                    "email": "Email",
-                    "organization": "Organization Name",
-                    "password": "Password",
-                    "username": "Username"
-                },
-                "description": "Register for a WattTime account:"
-            },
-            "user": {
-                "description": "How you would like to authenticate with WattTime?"
             }
         }
     }

--- a/homeassistant/components/watttime/translations/en.json
+++ b/homeassistant/components/watttime/translations/en.json
@@ -16,14 +16,20 @@
                     "latitude": "Latitude",
                     "longitude": "Longitude"
                 },
-                "title": "Input your latitude and longitude"
+                "description": "Input the latitude and longitude to monitor:"
+            },
+            "location": {
+                "data": {
+                    "location_type": "Location"
+                },
+                "description": "Pick a location to monitor:"
             },
             "login": {
                 "data": {
                     "password": "Password",
                     "username": "Username"
                 },
-                "title": "Login to WattTime"
+                "description": "Input your username and password:"
             },
             "register": {
                 "data": {
@@ -32,11 +38,10 @@
                     "password": "Password",
                     "username": "Username"
                 },
-                "title": "Register for a WattTime Account"
+                "description": "Register for a WattTime account:"
             },
             "user": {
-                "description": "How you would like to authenticate with WattTime?",
-                "title": "Configure WattTime"
+                "description": "How you would like to authenticate with WattTime?"
             }
         }
     }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -298,6 +298,7 @@ FLOWS = [
     "vizio",
     "volumio",
     "wallbox",
+    "watttime",
     "waze_travel_time",
     "wemo",
     "wiffi",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -254,6 +254,9 @@ aiotractive==0.5.2
 # homeassistant.components.unifi
 aiounifi==26
 
+# homeassistant.components.watttime
+aiowatttime==0.1.0
+
 # homeassistant.components.yandex_transport
 aioymaps==1.1.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -255,7 +255,7 @@ aiotractive==0.5.2
 aiounifi==26
 
 # homeassistant.components.watttime
-aiowatttime==0.1.0
+aiowatttime==0.1.1
 
 # homeassistant.components.yandex_transport
 aioymaps==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -175,6 +175,9 @@ aiotractive==0.5.2
 # homeassistant.components.unifi
 aiounifi==26
 
+# homeassistant.components.watttime
+aiowatttime==0.1.0
+
 # homeassistant.components.yandex_transport
 aioymaps==1.1.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -176,7 +176,7 @@ aiotractive==0.5.2
 aiounifi==26
 
 # homeassistant.components.watttime
-aiowatttime==0.1.0
+aiowatttime==0.1.1
 
 # homeassistant.components.yandex_transport
 aioymaps==1.1.0

--- a/tests/components/watttime/__init__.py
+++ b/tests/components/watttime/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the WattTime integration."""

--- a/tests/components/watttime/test_config_flow.py
+++ b/tests/components/watttime/test_config_flow.py
@@ -13,6 +13,9 @@ from homeassistant.components.watttime.config_flow import CONF_ORGANIZATION
 from homeassistant.components.watttime.const import (
     AUTH_TYPE_LOGIN,
     AUTH_TYPE_REGISTER,
+    CONF_BALANCING_AUTHORITY,
+    CONF_BALANCING_AUTHORITY_ABBREV,
+    CONF_BALANCING_AUTHORITY_ID,
     DOMAIN,
 )
 from homeassistant.const import (
@@ -51,7 +54,7 @@ def client_login_fixture(client):
 @pytest.fixture(name="get_grid_region")
 def get_grid_region_fixture():
     """Define a fixture for getting grid region data."""
-    return AsyncMock()
+    return AsyncMock(return_value={"abbrev": "AUTH_1", "id": 1, "name": "Authority 1"})
 
 
 async def test_duplicate_error(hass: HomeAssistant, client_login):
@@ -155,7 +158,7 @@ async def test_step_coordinates_unknown_coordinates(
     await hass.async_block_till_done()
 
     assert result["type"] == RESULT_TYPE_FORM
-    assert result["errors"] == {"base": "unknown_coordinates"}
+    assert result["errors"] == {"latitude": "unknown_coordinates"}
 
 
 @pytest.mark.parametrize("get_grid_region", [AsyncMock(side_effect=Exception)])
@@ -212,6 +215,9 @@ async def test_step_login(hass: HomeAssistant, client_login) -> None:
         CONF_PASSWORD: "password",
         CONF_LATITUDE: 51.528308,
         CONF_LONGITUDE: -0.3817765,
+        CONF_BALANCING_AUTHORITY: "Authority 1",
+        CONF_BALANCING_AUTHORITY_ABBREV: "AUTH_1",
+        CONF_BALANCING_AUTHORITY_ID: 1,
     }
 
 
@@ -234,7 +240,7 @@ async def test_step_login_invalid_credentials(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result["type"] == RESULT_TYPE_FORM
-    assert result["errors"] == {"base": "invalid_auth"}
+    assert result["errors"] == {"username": "invalid_auth"}
 
 
 @pytest.mark.parametrize("get_grid_region", [AsyncMock(side_effect=Exception)])
@@ -296,6 +302,9 @@ async def test_step_register(hass: HomeAssistant, client_login) -> None:
         CONF_PASSWORD: "password",
         CONF_LATITUDE: 51.528308,
         CONF_LONGITUDE: -0.3817765,
+        CONF_BALANCING_AUTHORITY: "Authority 1",
+        CONF_BALANCING_AUTHORITY_ABBREV: "AUTH_1",
+        CONF_BALANCING_AUTHORITY_ID: 1,
     }
 
 
@@ -350,4 +359,4 @@ async def test_step_register_username_taken(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result["type"] == RESULT_TYPE_FORM
-    assert result["errors"] == {"base": "username_taken"}
+    assert result["errors"] == {"username": "username_taken"}

--- a/tests/components/watttime/test_config_flow.py
+++ b/tests/components/watttime/test_config_flow.py
@@ -1,90 +1,353 @@
 """Test the WattTime config flow."""
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+
+from aiowatttime.errors import (
+    CoordinatesNotFoundError,
+    InvalidCredentialsError,
+    UsernameTakenError,
+)
+import pytest
 
 from homeassistant import config_entries, setup
-from homeassistant.components.watttime.config_flow import CannotConnect, InvalidAuth
-from homeassistant.components.watttime.const import DOMAIN
+from homeassistant.components.watttime.config_flow import CONF_ORGANIZATION
+from homeassistant.components.watttime.const import (
+    AUTH_TYPE_LOGIN,
+    AUTH_TYPE_REGISTER,
+    DOMAIN,
+)
+from homeassistant.const import (
+    CONF_EMAIL,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+from tests.common import MockConfigEntry
 
 
-async def test_form(hass: HomeAssistant) -> None:
-    """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+@pytest.fixture(name="client")
+def client_fixture(get_grid_region):
+    """Define a fixture for an aiowatttime client."""
+    client = AsyncMock(return_value=None)
+    client.emissions.async_get_grid_region = get_grid_region
+    return client
+
+
+@pytest.fixture(name="client_login")
+def client_login_fixture(client):
+    """Define a fixture for patching the aiowatttime coroutine to get a client."""
+    with patch("homeassistant.components.watttime.config_flow.Client.async_login") as m:
+        m.return_value = client
+        yield m
+
+
+@pytest.fixture(name="get_grid_region")
+def get_grid_region_fixture():
+    """Define a fixture for getting grid region data."""
+    return AsyncMock()
+
+
+async def test_duplicate_error(hass: HomeAssistant, client_login):
+    """Test that errors are shown when duplicate entries are added."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="51.528308, -0.3817765",
+        data={
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "password",
+            CONF_LATITUDE: 51.528308,
+            CONF_LONGITUDE: -0.3817765,
+        },
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={"auth_type": AUTH_TYPE_LOGIN},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USERNAME: "user", CONF_PASSWORD: "password"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_LATITUDE: 51.528308, CONF_LONGITUDE: -0.3817765},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_show_form_login(hass: HomeAssistant) -> None:
+    """Test showing the form to login."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"auth_type": AUTH_TYPE_LOGIN},
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "login"
+    assert result["errors"] is None
+
+
+async def test_show_form_register(hass: HomeAssistant) -> None:
+    """Test showing the form to register a new user."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"auth_type": AUTH_TYPE_REGISTER},
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "register"
+    assert result["errors"] is None
+
+
+async def test_show_form_user(hass: HomeAssistant) -> None:
+    """Test showing the form to select the authentication type."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    await hass.async_block_till_done()
+
     assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] is None
 
+
+@pytest.mark.parametrize(
+    "get_grid_region", [AsyncMock(side_effect=CoordinatesNotFoundError)]
+)
+async def test_step_coordinates_unknown_coordinates(
+    hass: HomeAssistant, client_login
+) -> None:
+    """Test that providing coordinates with no data is handled."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={"auth_type": AUTH_TYPE_LOGIN},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USERNAME: "user", CONF_PASSWORD: "password"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_LATITUDE: "0", CONF_LONGITUDE: "0"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "unknown_coordinates"}
+
+
+@pytest.mark.parametrize("get_grid_region", [AsyncMock(side_effect=Exception)])
+async def test_step_coordinates_unknown_error(
+    hass: HomeAssistant, client_login
+) -> None:
+    """Test that providing coordinates with no data is handled."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={"auth_type": AUTH_TYPE_LOGIN},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USERNAME: "user", CONF_PASSWORD: "password"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_LATITUDE: "0", CONF_LONGITUDE: "0"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_step_login(hass: HomeAssistant, client_login) -> None:
+    """Test a full login flow."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "homeassistant.components.watttime.config_flow.PlaceholderHub.authenticate",
+        "homeassistant.components.watttime.async_setup_entry",
         return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={"auth_type": AUTH_TYPE_LOGIN},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_USERNAME: "user", CONF_PASSWORD: "password"},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_LATITUDE: 51.528308, CONF_LONGITUDE: -0.3817765},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "51.528308, -0.3817765"
+    assert result["data"] == {
+        CONF_USERNAME: "user",
+        CONF_PASSWORD: "password",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+    }
+
+
+async def test_step_login_invalid_credentials(hass: HomeAssistant) -> None:
+    """Test that invalid credentials are handled."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    with patch(
+        "homeassistant.components.watttime.config_flow.Client.async_login",
+        AsyncMock(side_effect=InvalidCredentialsError),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={"auth_type": AUTH_TYPE_LOGIN},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_USERNAME: "user", CONF_PASSWORD: "password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+@pytest.mark.parametrize("get_grid_region", [AsyncMock(side_effect=Exception)])
+async def test_step_login_unknown_error(hass: HomeAssistant, client_login) -> None:
+    """Test that an unknown error during the login step is handled."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    with patch(
+        "homeassistant.components.watttime.config_flow.Client.async_login",
+        AsyncMock(side_effect=Exception),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={"auth_type": AUTH_TYPE_LOGIN},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_USERNAME: "user", CONF_PASSWORD: "password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_step_register(hass: HomeAssistant, client_login) -> None:
+    """Test a full user registration flow."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    with patch(
+        "homeassistant.components.watttime.config_flow.Client.async_register_new_username",
     ), patch(
         "homeassistant.components.watttime.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={"auth_type": AUTH_TYPE_REGISTER},
+        )
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
+            user_input={
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "password",
+                CONF_EMAIL: "email@address.com",
+                CONF_ORGANIZATION: "My Organization",
+            },
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_LATITUDE: 51.528308, CONF_LONGITUDE: -0.3817765},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "51.528308, -0.3817765"
+    assert result["data"] == {
+        CONF_USERNAME: "user",
+        CONF_PASSWORD: "password",
+        CONF_LATITUDE: 51.528308,
+        CONF_LONGITUDE: -0.3817765,
+    }
+
+
+async def test_step_register_unknown_error(hass: HomeAssistant) -> None:
+    """Test that an unknown error during the register step is handled."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    with patch(
+        "homeassistant.components.watttime.config_flow.Client.async_register_new_username",
+        AsyncMock(side_effect=Exception),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={"auth_type": AUTH_TYPE_REGISTER},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "password",
+                CONF_EMAIL: "email@address.com",
+                CONF_ORGANIZATION: "My Organization",
             },
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == "Name of the device"
-    assert result2["data"] == {
-        "host": "1.1.1.1",
-        "username": "test-username",
-        "password": "test-password",
-    }
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "unknown"}
 
 
-async def test_form_invalid_auth(hass: HomeAssistant) -> None:
-    """Test we handle invalid auth."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
+async def test_step_register_username_taken(hass: HomeAssistant) -> None:
+    """Test that a username being already taken the register step is handled."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "homeassistant.components.watttime.config_flow.PlaceholderHub.authenticate",
-        side_effect=InvalidAuth,
+        "homeassistant.components.watttime.config_flow.Client.async_register_new_username",
+        AsyncMock(side_effect=UsernameTakenError),
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={"auth_type": AUTH_TYPE_REGISTER},
+        )
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
+            user_input={
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "password",
+                CONF_EMAIL: "email@address.com",
+                CONF_ORGANIZATION: "My Organization",
             },
         )
+        await hass.async_block_till_done()
 
-    assert result2["type"] == RESULT_TYPE_FORM
-    assert result2["errors"] == {"base": "invalid_auth"}
-
-
-async def test_form_cannot_connect(hass: HomeAssistant) -> None:
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with patch(
-        "homeassistant.components.watttime.config_flow.PlaceholderHub.authenticate",
-        side_effect=CannotConnect,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-
-    assert result2["type"] == RESULT_TYPE_FORM
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "username_taken"}

--- a/tests/components/watttime/test_config_flow.py
+++ b/tests/components/watttime/test_config_flow.py
@@ -1,0 +1,90 @@
+"""Test the WattTime config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.watttime.config_flow import CannotConnect, InvalidAuth
+from homeassistant.components.watttime.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.watttime.config_flow.PlaceholderHub.authenticate",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.watttime.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "Name of the device"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.watttime.config_flow.PlaceholderHub.authenticate",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.watttime.config_flow.PlaceholderHub.authenticate",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "cannot_connect"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the [WattTime](https://www.watttime.org) integration to monitor realtime emissions data for a latitude/longitude.

There are a few nice-to-haves that I will tackle in future PRs:

- [x] Add config entry re-auth (https://github.com/home-assistant/core/pull/56582)
- ~[ ] Add API key leveling (so multiple config entries with the same account can be used without overrunning the rate limit)~ The API limits are are 10 concurrent requests per second; highly unlikely a user will have 10 instances all running at exactly the same time, so going to forego this unless we actually hear we need it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19315

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
