### PR TITLE
Enable template icons for template numbers

### DIFF
--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -18,7 +18,13 @@ from homeassistant.components.number.const import (
     DOMAIN as NUMBER_DOMAIN,
 )
 from homeassistant.components.template import TriggerUpdateCoordinator
-from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC, CONF_STATE, CONF_UNIQUE_ID
+from homeassistant.const import (
+    CONF_ICON,
+    CONF_NAME,
+    CONF_OPTIMISTIC,
+    CONF_STATE,
+    CONF_UNIQUE_ID,
+)
 from homeassistant.core import Config, HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -47,6 +53,7 @@ NUMBER_SCHEMA = vol.Schema(
         vol.Optional(CONF_AVAILABILITY): cv.template,
         vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_ICON): cv.template,
     }
 )
 
@@ -72,6 +79,7 @@ async def _async_create_entities(
                 definition[ATTR_MAX],
                 definition[CONF_OPTIMISTIC],
                 unique_id,
+                definition.get(CONF_ICON),
             )
         )
     return entities
@@ -119,9 +127,12 @@ class TemplateNumber(TemplateEntity, NumberEntity):
         maximum_template: Template | None,
         optimistic: bool,
         unique_id: str | None,
+        icon_template: Template | None,
     ) -> None:
         """Initialize the number."""
-        super().__init__(availability_template=availability_template)
+        super().__init__(
+            availability_template=availability_template, icon_template=icon_template
+        )
         self._attr_name = DEFAULT_NAME
         self._name_template = name_template
         name_template.hass = hass

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -35,6 +35,16 @@ _MAXIMUM_INPUT_NUMBER = "input_number.maximum"
 # Represent for number's step
 _STEP_INPUT_NUMBER = "input_number.step"
 
+_VALUE_INPUT_NUMBER_CONFIG = {
+    "value": {
+        "min": 0.0,
+        "max": 100.0,
+        "name": "Value",
+        "step": 1.0,
+        "mode": "slider",
+    }
+}
+
 
 @pytest.fixture
 def calls(hass):
@@ -135,13 +145,7 @@ async def test_templates_with_entities(hass, calls):
             "input_number",
             {
                 "input_number": {
-                    "value": {
-                        "min": 0.0,
-                        "max": 100.0,
-                        "name": "Value",
-                        "step": 1.0,
-                        "mode": "slider",
-                    },
+                    **_VALUE_INPUT_NUMBER_CONFIG,
                     "step": {
                         "min": 0.0,
                         "max": 100.0,
@@ -342,17 +346,7 @@ async def test_icon_template(hass):
         assert await setup.async_setup_component(
             hass,
             "input_number",
-            {
-                "input_number": {
-                    "value": {
-                        "min": 0.0,
-                        "max": 100.0,
-                        "name": "Value",
-                        "step": 1.0,
-                        "mode": "slider",
-                    },
-                }
-            },
+            {"input_number": _VALUE_INPUT_NUMBER_CONFIG},
         )
 
     with assert_setup_component(1, "template"):
@@ -409,17 +403,7 @@ async def test_icon_template_with_trigger(hass):
         assert await setup.async_setup_component(
             hass,
             "input_number",
-            {
-                "input_number": {
-                    "value": {
-                        "min": 0.0,
-                        "max": 100.0,
-                        "name": "Value",
-                        "step": 1.0,
-                        "mode": "slider",
-                    },
-                }
-            },
+            {"input_number": _VALUE_INPUT_NUMBER_CONFIG},
         )
 
     with assert_setup_component(1, "template"):

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -364,9 +364,9 @@ async def test_icon_template(hass):
                     "unique_id": "b",
                     "number": {
                         "state": f"{{{{ states('{_VALUE_INPUT_NUMBER}') }}}}",
-                        "step": 1,  # f"{{{{ states('{_STEP_INPUT_NUMBER}') }}}}",
-                        "min": 0,  # f"{{{{ states('{_MINIMUM_INPUT_NUMBER}') }}}}",
-                        "max": 100,  # f"{{{{ states('{_MAXIMUM_INPUT_NUMBER}') }}}}",
+                        "step": 1,
+                        "min": 0,
+                        "max": 100,
                         "set_value": {
                             "service": "input_number.set_value",
                             "data_template": {
@@ -375,8 +375,6 @@ async def test_icon_template(hass):
                             },
                         },
                         "icon": "{% if ((states.input_number.value.state or 0) | int) > 50 %}mdi:greater{% else %}mdi:less{% endif %}",
-                        # "optimistic": True,
-                        # "unique_id": "a",
                     },
                 }
             },

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -35,6 +35,7 @@ _MAXIMUM_INPUT_NUMBER = "input_number.maximum"
 # Represent for number's step
 _STEP_INPUT_NUMBER = "input_number.step"
 
+# Config for `_VALUE_INPUT_NUMBER`
 _VALUE_INPUT_NUMBER_CONFIG = {
     "value": {
         "min": 0.0,

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -374,7 +374,7 @@ async def test_icon_template(hass):
                                 "value": "{{ value }}",
                             },
                         },
-                        "icon": "{% if ((states.input_number.value or 0) | int) > 50 %}mdi:greater{% else %}mdi:less{% endif %}",
+                        "icon": "{% if ((states.input_number.value.state or 0) | int) > 50 %}mdi:greater{% else %}mdi:less{% endif %}",
                         # "optimistic": True,
                         # "unique_id": "a",
                     },

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -431,7 +431,7 @@ async def test_icon_template_with_trigger(hass):
                     "trigger": {"platform": "state", "entity_id": _VALUE_INPUT_NUMBER},
                     "unique_id": "b",
                     "number": {
-                        "state": f"{{{{ states('{_VALUE_INPUT_NUMBER}') }}}}",
+                        "state": "{{ trigger.to_state.state }}",
                         "step": 1,
                         "min": 0,
                         "max": 100,
@@ -442,7 +442,7 @@ async def test_icon_template_with_trigger(hass):
                                 "value": "{{ value }}",
                             },
                         },
-                        "icon": "{% if ((states.input_number.value.state or 0) | int) > 50 %}mdi:greater{% else %}mdi:less{% endif %}",
+                        "icon": "{% if ((trigger.to_state.state or 0) | int) > 50 %}mdi:greater{% else %}mdi:less{% endif %}",
                     },
                 }
             },


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enable templating the icon for template numbers. (Maybe template select should be done, too.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: TODO

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
