### PR TITLE
Create Dynalite config entries from the user flow - step 1

### DIFF
--- a/homeassistant/components/dynalite/__init__.py
+++ b/homeassistant/components/dynalite/__init__.py
@@ -299,7 +299,10 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         save_data = config_entry.data
         config_keys = [CONF_HOST, CONF_PORT]
         config_entry.data = MappingProxyType(
-            {key: value for (key, value) in save_data.items() if key in config_keys}
+            {
+                CONF_HOST: save_data[CONF_HOST],
+                CONF_PORT: save_data.get(CONF_PORT, DEFAULT_PORT),
+            }
         )
         config_entry.options = MappingProxyType(
             {key: value for (key, value) in save_data.items() if key not in config_keys}

--- a/homeassistant/components/dynalite/bridge.py
+++ b/homeassistant/components/dynalite/bridge.py
@@ -45,10 +45,17 @@ class DynaliteBridge:
         LOGGER.debug("Setting up bridge - host %s", self.host)
         return await self.dynalite_devices.async_setup()
 
-    def reload_config(self, config: MappingProxyType[str, Any]) -> None:
+    def reload_config(
+        self, config: MappingProxyType[str, Any], options: MappingProxyType[str, Any]
+    ) -> None:
         """Reconfigure a bridge when config changes."""
-        LOGGER.debug("Reloading bridge - host %s, config %s", self.host, config)
-        self.dynalite_devices.configure(convert_config(config))
+        LOGGER.debug(
+            "Reloading bridge - host %s, config %s options %s",
+            self.host,
+            config,
+            options,
+        )
+        self.dynalite_devices.configure(convert_config(config, options))
 
     def update_signal(self, device: DynaliteBaseDevice | None = None) -> str:
         """Create signal to use to trigger entity update."""

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -1,40 +1,98 @@
 """Config flow to configure Dynalite hub."""
 from __future__ import annotations
 
+import copy
 from typing import Any
 
+import voluptuous as vol
+
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
 
 from .bridge import DynaliteBridge
-from .const import DOMAIN, LOGGER
+from .const import DEFAULT_PORT, DOMAIN, LOGGER
 from .convert_config import convert_config
 
 
 class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Dynalite config flow."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the Dynalite flow."""
         self.host = None
 
+    async def _validate_connection(
+        self, config: dict[str, Any], options: dict[str, Any]
+    ) -> None:
+        bridge = DynaliteBridge(self.hass, convert_config(config, options))
+        if not await bridge.async_setup():
+            raise CannotConnect
+
     async def async_step_import(self, import_info: dict[str, Any]) -> Any:
         """Import a new bridge as a config entry."""
         LOGGER.debug("Starting async_step_import - %s", import_info)
         host = import_info[CONF_HOST]
+        data = {CONF_HOST: host, CONF_PORT: import_info.get(CONF_PORT, DEFAULT_PORT)}
+        options = copy.deepcopy(import_info)
+        options.pop(CONF_HOST)
+        if CONF_PORT in options:
+            options.pop(CONF_PORT)
         for entry in self._async_current_entries():
             if entry.data[CONF_HOST] == host:
                 self.hass.config_entries.async_update_entry(
-                    entry, data=dict(import_info)
+                    entry, data=data, options=options
                 )
                 return self.async_abort(reason="already_configured")
 
         # New entry
-        bridge = DynaliteBridge(self.hass, convert_config(import_info))
-        if not await bridge.async_setup():
+        try:
+            await self._validate_connection(data, options)
+        except CannotConnect:
             LOGGER.error("Unable to setup bridge - import info=%s", import_info)
             return self.async_abort(reason="no_connection")
-        LOGGER.debug("Creating entry for the bridge - %s", import_info)
-        return self.async_create_entry(title=host, data=import_info)
+        else:
+            LOGGER.debug("Creating entry for the bridge - %s", import_info)
+            return self.async_create_entry(title=host, data=data, options=options)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+
+        step_schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST): cv.string,
+                vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
+            }
+        )
+
+        if user_input is None:
+            return self.async_show_form(step_id="user", data_schema=step_schema)
+
+        errors = {}
+
+        try:
+            host = user_input[CONF_HOST]
+            data = {CONF_HOST: host, CONF_PORT: user_input[CONF_PORT]}
+            options: dict[str, Any] = {}
+            await self._validate_connection(data, options)
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            return self.async_create_entry(title=host, data=data, options=options)
+
+        return self.async_show_form(
+            step_id="user", data_schema=step_schema, errors=errors
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/dynalite/config_flow.py
+++ b/homeassistant/components/dynalite/config_flow.py
@@ -64,10 +64,15 @@ class DynaliteFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the initial step."""
 
+        dict_input = user_input or {}
         step_schema = vol.Schema(
             {
-                vol.Required(CONF_HOST): cv.string,
-                vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
+                vol.Required(
+                    CONF_HOST, default=dict_input.get(CONF_HOST, "")
+                ): cv.string,
+                vol.Required(
+                    CONF_PORT, default=dict_input.get(CONF_PORT, DEFAULT_PORT)
+                ): cv.positive_int,
             }
         )
 

--- a/homeassistant/components/dynalite/convert_config.py
+++ b/homeassistant/components/dynalite/convert_config.py
@@ -149,24 +149,24 @@ def convert_config(
         CONF_AUTO_DISCOVER: dyn_const.CONF_AUTO_DISCOVER,
         CONF_POLL_TIMER: dyn_const.CONF_POLL_TIMER,
     }
-    result = convert_with_map(config, my_map)
-    if CONF_AREA in config:
+    result = {**convert_with_map(config, my_map), **convert_with_map(options, my_map)}
+    if CONF_AREA in options:
         result[dyn_const.CONF_AREA] = {
             area: convert_area(area_conf)
-            for (area, area_conf) in config[CONF_AREA].items()
+            for (area, area_conf) in options[CONF_AREA].items()
         }
-    if CONF_DEFAULT in config:
-        result[dyn_const.CONF_DEFAULT] = convert_default(config[CONF_DEFAULT])
-    if CONF_ACTIVE in config:
-        result[dyn_const.CONF_ACTIVE] = ACTIVE_MAP[config[CONF_ACTIVE]]
-    if CONF_PRESET in config:
+    if CONF_DEFAULT in options:
+        result[dyn_const.CONF_DEFAULT] = convert_default(options[CONF_DEFAULT])
+    if CONF_ACTIVE in options:
+        result[dyn_const.CONF_ACTIVE] = ACTIVE_MAP[options[CONF_ACTIVE]]
+    if CONF_PRESET in options:
         result[dyn_const.CONF_PRESET] = {
             preset: convert_preset(preset_conf)
-            for (preset, preset_conf) in config[CONF_PRESET].items()
+            for (preset, preset_conf) in options[CONF_PRESET].items()
         }
-    if CONF_TEMPLATE in config:
+    if CONF_TEMPLATE in options:
         result[dyn_const.CONF_TEMPLATE] = {
             TEMPLATE_MAP[template]: convert_template(template_conf)
-            for (template, template_conf) in config[CONF_TEMPLATE].items()
+            for (template, template_conf) in options[CONF_TEMPLATE].items()
         }
     return result

--- a/homeassistant/components/dynalite/convert_config.py
+++ b/homeassistant/components/dynalite/convert_config.py
@@ -138,7 +138,8 @@ def convert_template(config: dict[str, Any]) -> dict[str, Any]:
 
 
 def convert_config(
-    config: dict[str, Any] | MappingProxyType[str, Any]
+    config: dict[str, Any] | MappingProxyType[str, Any],
+    options: dict[str, Any] | MappingProxyType[str, Any],
 ) -> dict[str, Any]:
     """Convert a config dict by replacing component consts with library consts."""
     my_map = {

--- a/homeassistant/components/dynalite/strings.json
+++ b/homeassistant/components/dynalite/strings.json
@@ -1,0 +1,22 @@
+{
+    "config": {
+        "flow_title": "Configure Dynalite",
+        "step": {
+            "user": {
+                "data": {
+                    "host": "[%key:common::config_flow::data::host%]",
+                    "port": "[%key:common::config_flow::data::port%]"
+                },
+                "title": "Configure Dynalite",
+                "description": "Please provide the host IP and port to connect to Dynalite"
+            }
+        },
+        "error": {
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "unknown": "[%key:common::config_flow::error::unknown%]"
+        },
+        "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+        }
+    }
+}

--- a/tests/components/dynalite/common.py
+++ b/tests/components/dynalite/common.py
@@ -33,7 +33,9 @@ async def get_entry_id_from_hass(hass):
 async def create_entity_from_device(hass, device):
     """Set up the component and platform and create a light based on the device provided."""
     host = "1.2.3.4"
-    entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})
+    entry = MockConfigEntry(
+        domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host}, version=2
+    )
     entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices"

--- a/tests/components/dynalite/test_bridge.py
+++ b/tests/components/dynalite/test_bridge.py
@@ -26,7 +26,9 @@ from tests.common import MockConfigEntry
 async def test_update_device(hass):
     """Test that update works."""
     host = "1.2.3.4"
-    entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})
+    entry = MockConfigEntry(
+        domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host}, version=2
+    )
     entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices"
@@ -56,7 +58,9 @@ async def test_update_device(hass):
 async def test_add_devices_then_register(hass):
     """Test that add_devices work."""
     host = "1.2.3.4"
-    entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})
+    entry = MockConfigEntry(
+        domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host}, version=2
+    )
     entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices"
@@ -89,7 +93,9 @@ async def test_add_devices_then_register(hass):
 async def test_register_then_add_devices(hass):
     """Test that add_devices work after register_add_entities."""
     host = "1.2.3.4"
-    entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})
+    entry = MockConfigEntry(
+        domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host}, version=2
+    )
     entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices"
@@ -116,7 +122,9 @@ async def test_register_then_add_devices(hass):
 async def test_notifications(hass):
     """Test that update works."""
     host = "1.2.3.4"
-    entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})
+    entry = MockConfigEntry(
+        domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host}, version=2
+    )
     entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices"

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -42,7 +42,7 @@ async def test_existing(hass):
     """Test when the entry exists with the same config."""
     host = "1.2.3.4"
     MockConfigEntry(
-        domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host}
+        domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host}, version=2
     ).add_to_hass(hass)
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",
@@ -65,6 +65,7 @@ async def test_existing_update(hass):
     entry = MockConfigEntry(
         domain=dynalite.DOMAIN,
         data={dynalite.CONF_HOST: host, dynalite.CONF_PORT: port1},
+        version=2,
     )
     entry.add_to_hass(hass)
     with patch(

--- a/tests/components/dynalite/test_init.py
+++ b/tests/components/dynalite/test_init.py
@@ -263,7 +263,7 @@ async def test_async_setup_bad_config2(hass):
 async def test_unload_entry(hass):
     """Test being able to unload an entry."""
     host = "1.2.3.4"
-    entry = MockConfigEntry(domain=dynalite.DOMAIN, data={CONF_HOST: host})
+    entry = MockConfigEntry(domain=dynalite.DOMAIN, data={CONF_HOST: host}, version=2)
     entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.dynalite.bridge.DynaliteDevices.async_setup",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not a breaking change

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is the first step in moving dynalite from YAML to a user flow. It includes the user step as well as separating the basic parameters (host, port) needed to set up the entry vs. the rest which will be added as an options flow in the next steps

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
