### PR TITLE
ESPHome Noise Transport Encryption support

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 from collections import OrderedDict
 from typing import Any
 
-from aioesphomeapi import APIClient, APIConnectionError, DeviceInfo
+from aioesphomeapi import (
+    APIClient,
+    APIConnectionError,
+    DeviceInfo,
+    InvalidAuthAPIError,
+    InvalidEncryptionKeyAPIError,
+    RequiresEncryptionAPIError,
+    ResolveAPIError,
+)
 import voluptuous as vol
 
 from homeassistant.components import zeroconf
@@ -14,7 +22,9 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from . import DOMAIN, DomainData
+from . import CONF_NOISE_PSK, DOMAIN, DomainData
+
+ERROR_REQUIRES_ENCRYPTION_KEY = "requires_encryption_key"
 
 
 class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -27,12 +37,14 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         self._host: str | None = None
         self._port: int | None = None
         self._password: str | None = None
+        self._noise_psk: str | None = None
+        self._device_info: DeviceInfo | None = None
 
     async def _async_step_user_base(
         self, user_input: dict[str, Any] | None = None, error: str | None = None
     ) -> FlowResult:
         if user_input is not None:
-            return await self._async_authenticate_or_add(user_input)
+            return await self._async_try_fetch_device_info(user_input)
 
         fields: dict[Any, type] = OrderedDict()
         fields[vol.Required(CONF_HOST, default=self._host or vol.UNDEFINED)] = str
@@ -52,6 +64,36 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         return await self._async_step_user_base(user_input=user_input)
 
+    async def async_step_reauth(self, data: dict[str, Any] | None = None) -> FlowResult:
+        """Handle a flow initialized by a reauth event."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        assert entry is not None
+        self._host = entry.data[CONF_HOST]
+        self._port = entry.data[CONF_PORT]
+        self._password = entry.data[CONF_PASSWORD]
+        self._noise_psk = entry.data.get(CONF_NOISE_PSK)
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle reauthorization flow."""
+        errors = {}
+
+        if user_input is not None:
+            self._noise_psk = user_input[CONF_NOISE_PSK]
+            error = await self.fetch_device_info()
+            if error is None:
+                return await self._async_authenticate_or_add()
+            errors["base"] = error
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_NOISE_PSK): str}),
+            errors=errors,
+            description_placeholders={"name": self._name},
+        )
+
     @property
     def _name(self) -> str | None:
         return self.context.get(CONF_NAME)
@@ -67,18 +109,21 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         self._host = user_input[CONF_HOST]
         self._port = user_input[CONF_PORT]
 
-    async def _async_authenticate_or_add(
+    async def _async_try_fetch_device_info(
         self, user_input: dict[str, Any] | None
     ) -> FlowResult:
         self._set_user_input(user_input)
-        error, device_info = await self.fetch_device_info()
+        error = await self.fetch_device_info()
+        if error == ERROR_REQUIRES_ENCRYPTION_KEY:
+            return await self.async_step_encryption_key()
         if error is not None:
             return await self._async_step_user_base(error=error)
-        assert device_info is not None
-        self._name = device_info.name
+        return await self._async_authenticate_or_add()
 
+    async def _async_authenticate_or_add(self) -> FlowResult:
         # Only show authentication step if device uses password
-        if device_info.uses_password:
+        assert self._device_info is not None
+        if self._device_info.uses_password:
             return await self.async_step_authenticate()
 
         return self._async_get_entry()
@@ -88,7 +133,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle user-confirmation of discovered node."""
         if user_input is not None:
-            return await self._async_authenticate_or_add(None)
+            return await self._async_try_fetch_device_info(None)
         return self.async_show_form(
             step_id="discovery_confirm", description_placeholders={"name": self._name}
         )
@@ -144,15 +189,47 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @callback
     def _async_get_entry(self) -> FlowResult:
+        config_data = {
+            CONF_HOST: self._host,
+            CONF_PORT: self._port,
+            # The API uses protobuf, so empty string denotes absence
+            CONF_PASSWORD: self._password or "",
+            CONF_NOISE_PSK: self._noise_psk or "",
+        }
+        if "entry_id" in self.context:
+            entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+            assert entry is not None
+            self.hass.config_entries.async_update_entry(entry, data=config_data)
+            # Reload the config entry to notify of updated config
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(entry.entry_id)
+            )
+
+            return self.async_abort(reason="reauth_successful")
+
         assert self._name is not None
         return self.async_create_entry(
             title=self._name,
-            data={
-                CONF_HOST: self._host,
-                CONF_PORT: self._port,
-                # The API uses protobuf, so empty string denotes absence
-                CONF_PASSWORD: self._password or "",
-            },
+            data=config_data,
+        )
+
+    async def async_step_encryption_key(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle getting psk for transport encryption."""
+        errors = {}
+        if user_input is not None:
+            self._noise_psk = user_input[CONF_NOISE_PSK]
+            error = await self.fetch_device_info()
+            if error is None:
+                return await self._async_authenticate_or_add()
+            errors["base"] = error
+
+        return self.async_show_form(
+            step_id="encryption_key",
+            data_schema=vol.Schema({vol.Required(CONF_NOISE_PSK): str}),
+            errors=errors,
+            description_placeholders={"name": self._name},
         )
 
     async def async_step_authenticate(
@@ -177,7 +254,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def fetch_device_info(self) -> tuple[str | None, DeviceInfo | None]:
+    async def fetch_device_info(self) -> str | None:
         """Fetch device info from API and return any errors."""
         zeroconf_instance = await zeroconf.async_get_instance(self.hass)
         assert self._host is not None
@@ -188,19 +265,26 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             self._port,
             "",
             zeroconf_instance=zeroconf_instance,
+            noise_psk=self._noise_psk,
         )
 
         try:
             await cli.connect()
-            device_info = await cli.device_info()
-        except APIConnectionError as err:
-            if "resolving" in str(err):
-                return "resolve_error", None
-            return "connection_error", None
+            self._device_info = await cli.device_info()
+        except RequiresEncryptionAPIError:
+            return ERROR_REQUIRES_ENCRYPTION_KEY
+        except InvalidEncryptionKeyAPIError:
+            return "invalid_psk"
+        except ResolveAPIError:
+            return "resolve_error"
+        except APIConnectionError:
+            return "connection_error"
         finally:
             await cli.disconnect(force=True)
 
-        return None, device_info
+        self._name = self._device_info.name
+
+        return None
 
     async def try_login(self) -> str | None:
         """Try logging in to device and return any errors."""
@@ -213,12 +297,16 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             self._port,
             self._password,
             zeroconf_instance=zeroconf_instance,
+            noise_psk=self._noise_psk,
         )
 
         try:
             await cli.connect(login=True)
-        except APIConnectionError:
-            await cli.disconnect(force=True)
+        except InvalidAuthAPIError:
             return "invalid_auth"
+        except APIConnectionError:
+            return "connection_error"
+        finally:
+            await cli.disconnect(force=True)
 
         return None

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -3,7 +3,7 @@
   "name": "ESPHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
-  "requirements": ["aioesphomeapi==8.0.0"],
+  "requirements": ["aioesphomeapi==9.1.0"],
   "zeroconf": ["_esphomelib._tcp.local."],
   "codeowners": ["@OttoWinter", "@jesserockz"],
   "after_dependencies": ["zeroconf", "tag"],

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -2,12 +2,14 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]"
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "resolve_error": "Can't resolve address of the ESP. If this error persists, please set a static IP address: https://esphomelib.com/esphomeyaml/components/wifi.html#manual-ips",
       "connection_error": "Can't connect to ESP. Please make sure your YAML file contains an 'api:' line.",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_psk": "The transport encryption key is invalid. Please ensure it matches what you have in your configuration"
     },
     "step": {
       "user": {
@@ -22,6 +24,18 @@
           "password": "[%key:common::config_flow::data::password%]"
         },
         "description": "Please enter the password you set in your configuration for {name}."
+      },
+      "encryption_key": {
+        "data": {
+          "noise_psk": "Encryption key"
+        },
+        "description": "Please enter the encryption key you set in your configuration for {name}."
+      },
+      "reauth_confirm": {
+        "data": {
+          "noise_psk": "Encryption key"
+        },
+        "description": "The ESPHome device {name} enabled transport encryption or changed the encryption key. Please enter the updated key."
       },
       "discovery_confirm": {
         "description": "Do you want to add the ESPHome node `{name}` to Home Assistant?",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -164,7 +164,7 @@ aioeagle==1.1.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==8.0.0
+aioesphomeapi==9.1.0
 
 # homeassistant.components.flo
 aioflo==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -106,7 +106,7 @@ aioeagle==1.1.0
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==8.0.0
+aioesphomeapi==9.1.0
 
 # homeassistant.components.flo
 aioflo==0.4.1

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -2,10 +2,17 @@
 from collections import namedtuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aioesphomeapi import (
+    APIConnectionError,
+    InvalidAuthAPIError,
+    InvalidEncryptionKeyAPIError,
+    RequiresEncryptionAPIError,
+    ResolveAPIError,
+)
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.esphome import DOMAIN, DomainData
+from homeassistant.components.esphome import CONF_NOISE_PSK, DOMAIN, DomainData
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
@@ -16,6 +23,8 @@ from homeassistant.data_entry_flow import (
 from tests.common import MockConfigEntry
 
 MockDeviceInfo = namedtuple("DeviceInfo", ["uses_password", "name"])
+VALID_NOISE_PSK = "bOFFzzvfpg5DB94DuBGLXD/hMnhpDKgP9UQyBulwWVU="
+INVALID_NOISE_PSK = "lSYBYEjQI1bVL8s2Vask4YytGMj1f1epNtmoim2yuTM="
 
 
 @pytest.fixture
@@ -23,12 +32,15 @@ def mock_client():
     """Mock APIClient."""
     with patch("homeassistant.components.esphome.config_flow.APIClient") as mock_client:
 
-        def mock_constructor(loop, host, port, password, zeroconf_instance=None):
+        def mock_constructor(
+            loop, host, port, password, zeroconf_instance=None, noise_psk=None
+        ):
             """Fake the client constructor."""
             mock_client.host = host
             mock_client.port = port
             mock_client.password = password
             mock_client.zeroconf_instance = zeroconf_instance
+            mock_client.noise_psk = noise_psk
             return mock_client
 
         mock_client.side_effect = mock_constructor
@@ -36,16 +48,6 @@ def mock_client():
         mock_client.disconnect = AsyncMock()
 
         yield mock_client
-
-
-@pytest.fixture(autouse=True)
-def mock_api_connection_error():
-    """Mock out the try login method."""
-    with patch(
-        "homeassistant.components.esphome.config_flow.APIConnectionError",
-        new_callable=lambda: OSError,
-    ) as mock_error:
-        yield mock_error
 
 
 @pytest.fixture(autouse=True)
@@ -75,7 +77,12 @@ async def test_user_connection_works(hass, mock_client, mock_zeroconf):
     )
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["data"] == {CONF_HOST: "127.0.0.1", CONF_PORT: 80, CONF_PASSWORD: ""}
+    assert result["data"] == {
+        CONF_HOST: "127.0.0.1",
+        CONF_PORT: 80,
+        CONF_PASSWORD: "",
+        CONF_NOISE_PSK: "",
+    }
     assert result["title"] == "test"
 
     assert len(mock_client.connect.mock_calls) == 1
@@ -84,23 +91,15 @@ async def test_user_connection_works(hass, mock_client, mock_zeroconf):
     assert mock_client.host == "127.0.0.1"
     assert mock_client.port == 80
     assert mock_client.password == ""
+    assert mock_client.noise_psk is None
 
 
-async def test_user_resolve_error(
-    hass, mock_api_connection_error, mock_client, mock_zeroconf
-):
+async def test_user_resolve_error(hass, mock_client, mock_zeroconf):
     """Test user step with IP resolve error."""
-
-    class MockResolveError(mock_api_connection_error):
-        """Create an exception with a specific error message."""
-
-        def __init__(self):
-            """Initialize."""
-            super().__init__("Error resolving IP address")
 
     with patch(
         "homeassistant.components.esphome.config_flow.APIConnectionError",
-        new_callable=lambda: MockResolveError,
+        new_callable=lambda: ResolveAPIError,
     ) as exc:
         mock_client.device_info.side_effect = exc
         result = await hass.config_entries.flow.async_init(
@@ -118,11 +117,9 @@ async def test_user_resolve_error(
     assert len(mock_client.disconnect.mock_calls) == 1
 
 
-async def test_user_connection_error(
-    hass, mock_api_connection_error, mock_client, mock_zeroconf
-):
+async def test_user_connection_error(hass, mock_client, mock_zeroconf):
     """Test user step with connection error."""
-    mock_client.device_info.side_effect = mock_api_connection_error
+    mock_client.device_info.side_effect = APIConnectionError
 
     result = await hass.config_entries.flow.async_init(
         "esphome",
@@ -161,13 +158,12 @@ async def test_user_with_password(hass, mock_client, mock_zeroconf):
         CONF_HOST: "127.0.0.1",
         CONF_PORT: 6053,
         CONF_PASSWORD: "password1",
+        CONF_NOISE_PSK: "",
     }
     assert mock_client.password == "password1"
 
 
-async def test_user_invalid_password(
-    hass, mock_api_connection_error, mock_client, mock_zeroconf
-):
+async def test_user_invalid_password(hass, mock_client, mock_zeroconf):
     """Test user step with invalid password."""
     mock_client.device_info = AsyncMock(return_value=MockDeviceInfo(True, "test"))
 
@@ -180,7 +176,7 @@ async def test_user_invalid_password(
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "authenticate"
 
-    mock_client.connect.side_effect = mock_api_connection_error
+    mock_client.connect.side_effect = InvalidAuthAPIError
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_PASSWORD: "invalid"}
@@ -189,6 +185,30 @@ async def test_user_invalid_password(
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "authenticate"
     assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_login_connection_error(hass, mock_client, mock_zeroconf):
+    """Test user step with connection error on login attempt."""
+    mock_client.device_info = AsyncMock(return_value=MockDeviceInfo(True, "test"))
+
+    result = await hass.config_entries.flow.async_init(
+        "esphome",
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "authenticate"
+
+    mock_client.connect.side_effect = APIConnectionError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_PASSWORD: "valid"}
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "authenticate"
+    assert result["errors"] == {"base": "connection_error"}
 
 
 async def test_discovery_initiation(hass, mock_client, mock_zeroconf):
@@ -345,3 +365,151 @@ async def test_discovery_updates_unique_id(hass, mock_client):
     assert result["reason"] == "already_configured"
 
     assert entry.unique_id == "test8266"
+
+
+async def test_user_requires_psk(hass, mock_client, mock_zeroconf):
+    """Test user step with requiring encryption key."""
+    mock_client.device_info.side_effect = RequiresEncryptionAPIError
+
+    result = await hass.config_entries.flow.async_init(
+        "esphome",
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "encryption_key"
+    assert result["errors"] == {}
+
+    assert len(mock_client.connect.mock_calls) == 1
+    assert len(mock_client.device_info.mock_calls) == 1
+    assert len(mock_client.disconnect.mock_calls) == 1
+
+
+async def test_encryption_key_valid_psk(hass, mock_client, mock_zeroconf):
+    """Test encryption key step with valid key."""
+
+    mock_client.device_info.side_effect = RequiresEncryptionAPIError
+
+    result = await hass.config_entries.flow.async_init(
+        "esphome",
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "encryption_key"
+
+    mock_client.device_info = AsyncMock(return_value=MockDeviceInfo(False, "test"))
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_NOISE_PSK: VALID_NOISE_PSK}
+    )
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == {
+        CONF_HOST: "127.0.0.1",
+        CONF_PORT: 6053,
+        CONF_PASSWORD: "",
+        CONF_NOISE_PSK: VALID_NOISE_PSK,
+    }
+    assert mock_client.noise_psk == VALID_NOISE_PSK
+
+
+async def test_encryption_key_invalid_psk(hass, mock_client, mock_zeroconf):
+    """Test encryption key step with invalid key."""
+
+    mock_client.device_info.side_effect = RequiresEncryptionAPIError
+
+    result = await hass.config_entries.flow.async_init(
+        "esphome",
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053},
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "encryption_key"
+
+    mock_client.device_info.side_effect = InvalidEncryptionKeyAPIError
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_NOISE_PSK: INVALID_NOISE_PSK}
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "encryption_key"
+    assert result["errors"] == {"base": "invalid_psk"}
+    assert mock_client.noise_psk == INVALID_NOISE_PSK
+
+
+async def test_reauth_initiation(hass, mock_client, mock_zeroconf):
+    """Test reauth initiation shows form."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053, CONF_PASSWORD: ""},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        "esphome",
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+            "unique_id": entry.unique_id,
+        },
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "reauth_confirm"
+
+
+async def test_reauth_confirm_valid(hass, mock_client, mock_zeroconf):
+    """Test reauth initiation with valid PSK."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053, CONF_PASSWORD: ""},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        "esphome",
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+            "unique_id": entry.unique_id,
+        },
+    )
+
+    mock_client.device_info = AsyncMock(return_value=MockDeviceInfo(False, "test"))
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_NOISE_PSK: VALID_NOISE_PSK}
+    )
+
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_NOISE_PSK] == VALID_NOISE_PSK
+
+
+async def test_reauth_confirm_invalid(hass, mock_client, mock_zeroconf):
+    """Test reauth initiation with invalid PSK."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "127.0.0.1", CONF_PORT: 6053, CONF_PASSWORD: ""},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        "esphome",
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+            "unique_id": entry.unique_id,
+        },
+    )
+
+    mock_client.device_info.side_effect = InvalidEncryptionKeyAPIError
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_NOISE_PSK: INVALID_NOISE_PSK}
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"]
+    assert result["errors"]["base"] == "invalid_psk"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add transport encryption support to the ESPHome integration

This system allows for all messages between the ESP and HA to be transport encrypted using the noise protocol with (base64 32byte) pre-shared key.

The config flow detects when encryption is used, and redirects the user to the encryption step.

When an existing device enables encryption, we detect this in the connect method and initiate a reauth flow.

References:
- https://github.com/esphome/esphome/pull/2254
- https://github.com/esphome/aioesphomeapi/pull/100
- https://github.com/esphome/aioesphomeapi/pull/102
- https://github.com/esphome/aioesphomeapi/releases/tag/v9.1.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
