### PR TITLE
Update template/test_weather.py to use pytest

### DIFF
--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -1,4 +1,6 @@
 """The tests for the Template Weather platform."""
+import pytest
+
 from homeassistant.components.weather import (
     ATTR_WEATHER_ATTRIBUTION,
     ATTR_WEATHER_HUMIDITY,
@@ -10,14 +12,12 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
     DOMAIN,
 )
-from homeassistant.setup import async_setup_component
 
 
-async def test_template_state_text(hass):
-    """Test the state text of a template."""
-    await async_setup_component(
-        hass,
-        DOMAIN,
+@pytest.mark.parametrize("count,domain", [(1, DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
         {
             "weather": [
                 {"weather": {"platform": "demo"}},
@@ -37,40 +37,27 @@ async def test_template_state_text(hass):
                 },
             ]
         },
-    )
-    await hass.async_block_till_done()
-
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    hass.states.async_set("sensor.attribution", "The custom attribution")
-    await hass.async_block_till_done()
-    hass.states.async_set("sensor.temperature", 22.3)
-    await hass.async_block_till_done()
-    hass.states.async_set("sensor.humidity", 60)
-    await hass.async_block_till_done()
-    hass.states.async_set("sensor.pressure", 1000)
-    await hass.async_block_till_done()
-    hass.states.async_set("sensor.windspeed", 20)
-    await hass.async_block_till_done()
-    hass.states.async_set("sensor.windbearing", 180)
-    await hass.async_block_till_done()
-    hass.states.async_set("sensor.ozone", 25)
-    await hass.async_block_till_done()
-    hass.states.async_set("sensor.visibility", 4.6)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("weather.test")
-    assert state is not None
-
-    assert state.state == "sunny"
-
-    data = state.attributes
-    assert data.get(ATTR_WEATHER_ATTRIBUTION) == "The custom attribution"
-    assert data.get(ATTR_WEATHER_TEMPERATURE) == 22.3
-    assert data.get(ATTR_WEATHER_HUMIDITY) == 60
-    assert data.get(ATTR_WEATHER_PRESSURE) == 1000
-    assert data.get(ATTR_WEATHER_WIND_SPEED) == 20
-    assert data.get(ATTR_WEATHER_WIND_BEARING) == 180
-    assert data.get(ATTR_WEATHER_OZONE) == 25
-    assert data.get(ATTR_WEATHER_VISIBILITY) == 4.6
+    ],
+)
+async def test_template_state_text(hass, start_ha):
+    """Test the state text of a template."""
+    for attr, v_attr, value in [
+        (
+            "sensor.attribution",
+            ATTR_WEATHER_ATTRIBUTION,
+            "The custom attribution",
+        ),
+        ("sensor.temperature", ATTR_WEATHER_TEMPERATURE, 22.3),
+        ("sensor.humidity", ATTR_WEATHER_HUMIDITY, 60),
+        ("sensor.pressure", ATTR_WEATHER_PRESSURE, 1000),
+        ("sensor.windspeed", ATTR_WEATHER_WIND_SPEED, 20),
+        ("sensor.windbearing", ATTR_WEATHER_WIND_BEARING, 180),
+        ("sensor.ozone", ATTR_WEATHER_OZONE, 25),
+        ("sensor.visibility", ATTR_WEATHER_VISIBILITY, 4.6),
+    ]:
+        hass.states.async_set(attr, value)
+        await hass.async_block_till_done()
+        state = hass.states.get("weather.test")
+        assert state is not None
+        assert state.state == "sunny"
+        assert state.attributes.get(v_attr) == value


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
template/test_weather did not use pytest fixtures..


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
#40899
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
