### PR TITLE
Update template/alarm_control_panel.py to use pytest

### DIFF
--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -1,5 +1,6 @@
 """The tests for the Template alarm control panel platform."""
-from homeassistant import setup
+import pytest
+
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
@@ -10,21 +11,80 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
 )
 
-from tests.common import async_mock_service
 from tests.components.alarm_control_panel import common
 
+TEMPLATE_NAME = "alarm_control_panel.test_template_panel"
+PANEL_NAME = "alarm_control_panel.test"
 
-async def test_template_state_text(hass):
+
+@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "alarm_control_panel": {
+                "platform": "template",
+                "panels": {
+                    "test_template_panel": {
+                        "value_template": "{{ states('alarm_control_panel.test') }}",
+                        "arm_away": {
+                            "service": "alarm_control_panel.alarm_arm_away",
+                            "entity_id": "alarm_control_panel.test",
+                            "data": {"code": "1234"},
+                        },
+                        "arm_home": {
+                            "service": "alarm_control_panel.alarm_arm_home",
+                            "entity_id": "alarm_control_panel.test",
+                            "data": {"code": "1234"},
+                        },
+                        "arm_night": {
+                            "service": "alarm_control_panel.alarm_arm_night",
+                            "entity_id": "alarm_control_panel.test",
+                            "data": {"code": "1234"},
+                        },
+                        "disarm": {
+                            "service": "alarm_control_panel.alarm_disarm",
+                            "entity_id": "alarm_control_panel.test",
+                            "data": {"code": "1234"},
+                        },
+                    }
+                },
+            }
+        },
+    ],
+)
+async def test_template_state_text(hass, start_ha):
     """Test the state text of a template."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
+
+    for set_state in [
+        STATE_ALARM_ARMED_HOME,
+        STATE_ALARM_ARMED_AWAY,
+        STATE_ALARM_ARMED_NIGHT,
+        STATE_ALARM_ARMING,
+        STATE_ALARM_DISARMED,
+        STATE_ALARM_PENDING,
+        STATE_ALARM_TRIGGERED,
+    ]:
+        hass.states.async_set(PANEL_NAME, set_state)
+        await hass.async_block_till_done()
+        state = hass.states.get(TEMPLATE_NAME)
+        assert state.state == set_state
+
+    hass.states.async_set(PANEL_NAME, "invalid_state")
+    await hass.async_block_till_done()
+    state = hass.states.get(TEMPLATE_NAME)
+    assert state.state == "unknown"
+
+
+@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(
+    "config",
+    [
         {
             "alarm_control_panel": {
                 "platform": "template",
                 "panels": {
                     "test_template_panel": {
-                        "value_template": "{{ states('alarm_control_panel.test') }}",
                         "arm_away": {
                             "service": "alarm_control_panel.alarm_arm_away",
                             "entity_id": "alarm_control_panel.test",
@@ -49,140 +109,30 @@ async def test_template_state_text(hass):
                 },
             }
         },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    hass.states.async_set("alarm_control_panel.test", STATE_ALARM_ARMED_HOME)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    assert state.state == STATE_ALARM_ARMED_HOME
-
-    hass.states.async_set("alarm_control_panel.test", STATE_ALARM_ARMED_AWAY)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    assert state.state == STATE_ALARM_ARMED_AWAY
-
-    hass.states.async_set("alarm_control_panel.test", STATE_ALARM_ARMED_NIGHT)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    assert state.state == STATE_ALARM_ARMED_NIGHT
-
-    hass.states.async_set("alarm_control_panel.test", STATE_ALARM_ARMING)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    assert state.state == STATE_ALARM_ARMING
-
-    hass.states.async_set("alarm_control_panel.test", STATE_ALARM_DISARMED)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    assert state.state == STATE_ALARM_DISARMED
-
-    hass.states.async_set("alarm_control_panel.test", STATE_ALARM_PENDING)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    assert state.state == STATE_ALARM_PENDING
-
-    hass.states.async_set("alarm_control_panel.test", STATE_ALARM_TRIGGERED)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    assert state.state == STATE_ALARM_TRIGGERED
-
-    hass.states.async_set("alarm_control_panel.test", "invalid_state")
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    assert state.state == "unknown"
-
-
-async def test_optimistic_states(hass):
+    ],
+)
+async def test_optimistic_states(hass, start_ha):
     """Test the optimistic state."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
-        {
-            "alarm_control_panel": {
-                "platform": "template",
-                "panels": {
-                    "test_template_panel": {
-                        "arm_away": {
-                            "service": "alarm_control_panel.alarm_arm_away",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "arm_home": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "arm_night": {
-                            "service": "alarm_control_panel.alarm_arm_night",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "disarm": {
-                            "service": "alarm_control_panel.alarm_disarm",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                    }
-                },
-            }
-        },
-    )
 
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_template_panel")
+    state = hass.states.get(TEMPLATE_NAME)
     await hass.async_block_till_done()
     assert state.state == "unknown"
 
-    await common.async_alarm_arm_away(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    await hass.async_block_till_done()
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    await hass.async_block_till_done()
-    assert state.state == STATE_ALARM_ARMED_AWAY
-
-    await common.async_alarm_arm_home(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    await hass.async_block_till_done()
-    assert state.state == STATE_ALARM_ARMED_HOME
-
-    await common.async_alarm_arm_night(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    await hass.async_block_till_done()
-    assert state.state == STATE_ALARM_ARMED_NIGHT
-
-    await common.async_alarm_disarm(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    await hass.async_block_till_done()
-    assert state.state == STATE_ALARM_DISARMED
+    for func, set_state in [
+        (common.async_alarm_arm_away, STATE_ALARM_ARMED_AWAY),
+        (common.async_alarm_arm_home, STATE_ALARM_ARMED_HOME),
+        (common.async_alarm_arm_night, STATE_ALARM_ARMED_NIGHT),
+        (common.async_alarm_disarm, STATE_ALARM_DISARMED),
+    ]:
+        await func(hass, entity_id=TEMPLATE_NAME)
+        await hass.async_block_till_done()
+        assert hass.states.get(TEMPLATE_NAME).state == set_state
 
 
-async def test_no_action_scripts(hass):
-    """Test no action scripts per state."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
+@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(
+    "config",
+    [
         {
             "alarm_control_panel": {
                 "platform": "template",
@@ -193,180 +143,121 @@ async def test_no_action_scripts(hass):
                 },
             }
         },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+    ],
+)
+async def test_no_action_scripts(hass, start_ha):
+    """Test no action scripts per state."""
     hass.states.async_set("alarm_control_panel.test", STATE_ALARM_ARMED_AWAY)
     await hass.async_block_till_done()
 
-    await common.async_alarm_arm_away(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    await hass.async_block_till_done()
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    await hass.async_block_till_done()
-    assert state.state == STATE_ALARM_ARMED_AWAY
-
-    await common.async_alarm_arm_home(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    await hass.async_block_till_done()
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    await hass.async_block_till_done()
-    assert state.state == STATE_ALARM_ARMED_AWAY
-
-    await common.async_alarm_arm_night(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    await hass.async_block_till_done()
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    await hass.async_block_till_done()
-    assert state.state == STATE_ALARM_ARMED_AWAY
-
-    await common.async_alarm_disarm(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    await hass.async_block_till_done()
-    state = hass.states.get("alarm_control_panel.test_template_panel")
-    await hass.async_block_till_done()
-    assert state.state == STATE_ALARM_ARMED_AWAY
+    for func, set_state in [
+        (common.async_alarm_arm_away, STATE_ALARM_ARMED_AWAY),
+        (common.async_alarm_arm_home, STATE_ALARM_ARMED_AWAY),
+        (common.async_alarm_arm_night, STATE_ALARM_ARMED_AWAY),
+        (common.async_alarm_disarm, STATE_ALARM_ARMED_AWAY),
+    ]:
+        await func(hass, entity_id=TEMPLATE_NAME)
+        await hass.async_block_till_done()
+        assert hass.states.get(TEMPLATE_NAME).state == set_state
 
 
-async def test_template_syntax_error(hass, caplog):
+@pytest.mark.parametrize("count,domain", [(0, "alarm_control_panel")])
+@pytest.mark.parametrize(
+    "config,msg",
+    [
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "test_template_panel": {
+                            "value_template": "{% if blah %}",
+                            "arm_away": {
+                                "service": "alarm_control_panel.alarm_arm_away",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "arm_home": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "arm_night": {
+                                "service": "alarm_control_panel.alarm_arm_night",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "disarm": {
+                                "service": "alarm_control_panel.alarm_disarm",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                        }
+                    },
+                }
+            },
+            "invalid template",
+        ),
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "bad name here": {
+                            "value_template": "{{ disarmed }}",
+                            "arm_away": {
+                                "service": "alarm_control_panel.alarm_arm_away",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "arm_home": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "arm_night": {
+                                "service": "alarm_control_panel.alarm_arm_night",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "disarm": {
+                                "service": "alarm_control_panel.alarm_disarm",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                        }
+                    },
+                }
+            },
+            "invalid slug bad name",
+        ),
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "wibble": {"test_panel": "Invalid"},
+                }
+            },
+            "[wibble] is an invalid option",
+        ),
+        (
+            {
+                "alarm_control_panel": {"platform": "template"},
+            },
+            "required key not provided @ data['panels']",
+        ),
+    ],
+)
+async def test_template_syntax_error(hass, msg, start_ha, caplog_setup_text):
     """Test templating syntax error."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
-        {
-            "alarm_control_panel": {
-                "platform": "template",
-                "panels": {
-                    "test_template_panel": {
-                        "value_template": "{% if blah %}",
-                        "arm_away": {
-                            "service": "alarm_control_panel.alarm_arm_away",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "arm_home": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "arm_night": {
-                            "service": "alarm_control_panel.alarm_arm_night",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "disarm": {
-                            "service": "alarm_control_panel.alarm_disarm",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                    }
-                },
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 0
-    assert ("invalid template") in caplog.text
+    assert (msg) in caplog_setup_text
 
 
-async def test_invalid_name_does_not_create(hass, caplog):
-    """Test invalid name."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
-        {
-            "alarm_control_panel": {
-                "platform": "template",
-                "panels": {
-                    "bad name here": {
-                        "value_template": "{{ disarmed }}",
-                        "arm_away": {
-                            "service": "alarm_control_panel.alarm_arm_away",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "arm_home": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "arm_night": {
-                            "service": "alarm_control_panel.alarm_arm_night",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "disarm": {
-                            "service": "alarm_control_panel.alarm_disarm",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                    }
-                },
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 0
-    assert ("invalid slug bad name") in caplog.text
-
-
-async def test_invalid_panel_does_not_create(hass, caplog):
-    """Test invalid alarm control panel."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
-        {
-            "alarm_control_panel": {
-                "platform": "template",
-                "wibble": {"test_panel": "Invalid"},
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 0
-    assert ("[wibble] is an invalid option") in caplog.text
-
-
-async def test_no_panels_does_not_create(hass, caplog):
-    """Test if there are no panels -> no creation."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
-        {"alarm_control_panel": {"platform": "template"}},
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert len(hass.states.async_all()) == 0
-    assert ("required key not provided @ data['panels']") in caplog.text
-
-
-async def test_name(hass):
-    """Test the accessibility of the name attribute."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
+@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(
+    "config",
+    [
         {
             "alarm_control_panel": {
                 "platform": "template",
@@ -398,211 +289,148 @@ async def test_name(hass):
                 },
             }
         },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    state = hass.states.get("alarm_control_panel.test_template_panel")
+    ],
+)
+async def test_name(hass, start_ha):
+    """Test the accessibility of the name attribute."""
+    state = hass.states.get(TEMPLATE_NAME)
     assert state is not None
-
     assert state.attributes.get("friendly_name") == "Template Alarm Panel"
 
 
-async def test_arm_home_action(hass):
+@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(
+    "config,func",
+    [
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "test_template_panel": {
+                            "value_template": "{{ states('alarm_control_panel.test') }}",
+                            "arm_away": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "arm_home": {"service": "test.automation"},
+                            "arm_night": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "disarm": {
+                                "service": "alarm_control_panel.alarm_disarm",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                        }
+                    },
+                }
+            },
+            common.async_alarm_arm_home,
+        ),
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "test_template_panel": {
+                            "value_template": "{{ states('alarm_control_panel.test') }}",
+                            "arm_home": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "arm_away": {"service": "test.automation"},
+                            "arm_night": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "disarm": {
+                                "service": "alarm_control_panel.alarm_disarm",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                        }
+                    },
+                },
+            },
+            common.async_alarm_arm_away,
+        ),
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "test_template_panel": {
+                            "value_template": "{{ states('alarm_control_panel.test') }}",
+                            "arm_home": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "arm_night": {"service": "test.automation"},
+                            "arm_away": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "disarm": {
+                                "service": "alarm_control_panel.alarm_disarm",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                        }
+                    },
+                }
+            },
+            common.async_alarm_arm_night,
+        ),
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "test_template_panel": {
+                            "value_template": "{{ states('alarm_control_panel.test') }}",
+                            "arm_home": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "disarm": {"service": "test.automation"},
+                            "arm_away": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "arm_night": {
+                                "service": "alarm_control_panel.alarm_disarm",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                        }
+                    },
+                }
+            },
+            common.async_alarm_disarm,
+        ),
+    ],
+)
+async def test_arm_home_action(hass, func, start_ha, calls):
     """Test arm home action."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
-        {
-            "alarm_control_panel": {
-                "platform": "template",
-                "panels": {
-                    "test_template_panel": {
-                        "value_template": "{{ states('alarm_control_panel.test') }}",
-                        "arm_away": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "arm_home": {"service": "test.automation"},
-                        "arm_night": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "disarm": {
-                            "service": "alarm_control_panel.alarm_disarm",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                    }
-                },
-            }
-        },
-    )
-
+    await func(hass, entity_id=TEMPLATE_NAME)
     await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    service_calls = async_mock_service(hass, "test", "automation")
-
-    await common.async_alarm_arm_home(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    await hass.async_block_till_done()
-
-    assert len(service_calls) == 1
+    assert len(calls) == 1
 
 
-async def test_arm_away_action(hass):
-    """Test arm away action."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
-        {
-            "alarm_control_panel": {
-                "platform": "template",
-                "panels": {
-                    "test_template_panel": {
-                        "value_template": "{{ states('alarm_control_panel.test') }}",
-                        "arm_home": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "arm_away": {"service": "test.automation"},
-                        "arm_night": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "disarm": {
-                            "service": "alarm_control_panel.alarm_disarm",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                    }
-                },
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    service_calls = async_mock_service(hass, "test", "automation")
-
-    await common.async_alarm_arm_away(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    await hass.async_block_till_done()
-
-    assert len(service_calls) == 1
-
-
-async def test_arm_night_action(hass):
-    """Test arm night action."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
-        {
-            "alarm_control_panel": {
-                "platform": "template",
-                "panels": {
-                    "test_template_panel": {
-                        "value_template": "{{ states('alarm_control_panel.test') }}",
-                        "arm_home": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "arm_night": {"service": "test.automation"},
-                        "arm_away": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "disarm": {
-                            "service": "alarm_control_panel.alarm_disarm",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                    }
-                },
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    service_calls = async_mock_service(hass, "test", "automation")
-
-    await common.async_alarm_arm_night(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    await hass.async_block_till_done()
-
-    assert len(service_calls) == 1
-
-
-async def test_disarm_action(hass):
-    """Test disarm action."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
-        {
-            "alarm_control_panel": {
-                "platform": "template",
-                "panels": {
-                    "test_template_panel": {
-                        "value_template": "{{ states('alarm_control_panel.test') }}",
-                        "arm_home": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "disarm": {"service": "test.automation"},
-                        "arm_away": {
-                            "service": "alarm_control_panel.alarm_arm_home",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                        "arm_night": {
-                            "service": "alarm_control_panel.alarm_disarm",
-                            "entity_id": "alarm_control_panel.test",
-                            "data": {"code": "1234"},
-                        },
-                    }
-                },
-            }
-        },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    service_calls = async_mock_service(hass, "test", "automation")
-
-    await common.async_alarm_disarm(
-        hass, entity_id="alarm_control_panel.test_template_panel"
-    )
-    await hass.async_block_till_done()
-
-    assert len(service_calls) == 1
-
-
-async def test_unique_id(hass):
-    """Test unique_id option only creates one alarm control panel per id."""
-    await setup.async_setup_component(
-        hass,
-        "alarm_control_panel",
+@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(
+    "config",
+    [
         {
             "alarm_control_panel": {
                 "platform": "template",
@@ -618,10 +446,8 @@ async def test_unique_id(hass):
                 },
             },
         },
-    )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
+    ],
+)
+async def test_unique_id(hass, start_ha):
+    """Test unique_id option only creates one alarm control panel per id."""
     assert len(hass.states.async_all()) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
template/test_alarm_control_panel did use pytest, but not very efficient using fixtures and parametrisation.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
#40899
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
