### PR TITLE
Refactor ZHA HVAC thermostat channel

### DIFF
--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -149,110 +149,114 @@ class ThermostatChannel(ZigbeeChannel):
     @property
     def abs_max_cool_setpoint_limit(self) -> int:
         """Absolute maximum cooling setpoint."""
-        return self._abs_max_cool_setpoint_limit
+        return self.cluster.get("abs_max_cool_setpoint_limit", 3200)
 
     @property
     def abs_min_cool_setpoint_limit(self) -> int:
         """Absolute minimum cooling setpoint."""
-        return self._abs_min_cool_setpoint_limit
+        return self.cluster.get("abs_min_cool_setpoint_limit", 1600)
 
     @property
     def abs_max_heat_setpoint_limit(self) -> int:
         """Absolute maximum heating setpoint."""
-        return self._abs_max_heat_setpoint_limit
+        return self.cluster.get("abs_max_heat_setpoint_limit", 3000)
 
     @property
     def abs_min_heat_setpoint_limit(self) -> int:
         """Absolute minimum heating setpoint."""
-        return self._abs_min_heat_setpoint_limit
+        return self.cluster.get("abs_min_heat_setpoint_limit", 700)
 
     @property
     def ctrl_seqe_of_oper(self) -> int:
         """Control Sequence of operations attribute."""
-        return self._ctrl_seqe_of_oper
+        return self.cluster.get("ctrl_seqe_of_oper", 0xFF)
 
     @property
     def max_cool_setpoint_limit(self) -> int:
         """Maximum cooling setpoint."""
-        if self._max_cool_setpoint_limit is None:
+        sp_limit = self.cluster.get("max_cool_setpoint_limit")
+        if sp_limit is None:
             return self.abs_max_cool_setpoint_limit
-        return self._max_cool_setpoint_limit
+        return sp_limit
 
     @property
     def min_cool_setpoint_limit(self) -> int:
         """Minimum cooling setpoint."""
-        if self._min_cool_setpoint_limit is None:
+        sp_limit = self.cluster.get("min_cool_setpoint_limit")
+        if sp_limit is None:
             return self.abs_min_cool_setpoint_limit
-        return self._min_cool_setpoint_limit
+        return sp_limit
 
     @property
     def max_heat_setpoint_limit(self) -> int:
         """Maximum heating setpoint."""
-        if self._max_heat_setpoint_limit is None:
+        sp_limit = self.cluster.get("max_heat_setpoint_limit")
+        if sp_limit is None:
             return self.abs_max_heat_setpoint_limit
-        return self._max_heat_setpoint_limit
+        return sp_limit
 
     @property
     def min_heat_setpoint_limit(self) -> int:
         """Minimum heating setpoint."""
-        if self._min_heat_setpoint_limit is None:
+        sp_limit = self.cluster.get("min_heat_setpoint_limit")
+        if sp_limit is None:
             return self.abs_min_heat_setpoint_limit
-        return self._min_heat_setpoint_limit
+        return sp_limit
 
     @property
     def local_temp(self) -> int | None:
         """Thermostat temperature."""
-        return self._local_temp
+        return self.cluster.get("local_temp")
 
     @property
     def occupancy(self) -> int | None:
         """Is occupancy detected."""
-        return self._occupancy
+        return self.cluster.get("occupancy")
 
     @property
     def occupied_cooling_setpoint(self) -> int | None:
         """Temperature when room is occupied."""
-        return self._occupied_cooling_setpoint
+        return self.cluster.get("occupied_cooling_setpoint")
 
     @property
     def occupied_heating_setpoint(self) -> int | None:
         """Temperature when room is occupied."""
-        return self._occupied_heating_setpoint
+        return self.cluster.get("occupied_heating_setpoint")
 
     @property
     def pi_cooling_demand(self) -> int:
         """Cooling demand."""
-        return self._pi_cooling_demand
+        return self.cluster.get("pi_cooling_demand")
 
     @property
     def pi_heating_demand(self) -> int:
         """Heating demand."""
-        return self._pi_heating_demand
+        return self.cluster.get("pi_heating_demand")
 
     @property
     def running_mode(self) -> int | None:
         """Thermostat running mode."""
-        return self._running_mode
+        return self.cluster.get("running_mode")
 
     @property
     def running_state(self) -> int | None:
         """Thermostat running state, state of heat, cool, fan relays."""
-        return self._running_state
+        return self.cluster.get("running_state")
 
     @property
     def system_mode(self) -> int | None:
         """System mode."""
-        return self._system_mode
+        return self.cluster.get("system_mode")
 
     @property
     def unoccupied_cooling_setpoint(self) -> int | None:
         """Temperature when room is not occupied."""
-        return self._unoccupied_cooling_setpoint
+        return self.cluster.get("unoccupied_cooling_setpoint")
 
     @property
     def unoccupied_heating_setpoint(self) -> int | None:
         """Temperature when room is not occupied."""
-        return self._unoccupied_heating_setpoint
+        return self.cluster.get("unoccupied_heating_setpoint")
 
     @callback
     def attribute_updated(self, attrid, value):
@@ -261,7 +265,6 @@ class ThermostatChannel(ZigbeeChannel):
         self.debug(
             "Attribute report '%s'[%s] = %s", self.cluster.name, attr_name, value
         )
-        setattr(self, f"_{attr_name}", value)
         self.async_send_signal(
             f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
             AttributeUpdateRecord(attrid, attr_name, value),

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -125,26 +125,6 @@ class ThermostatChannel(ZigbeeChannel):
             "unoccupied_heating_setpoint": False,
             "unoccupied_cooling_setpoint": False,
         }
-        self._abs_max_cool_setpoint_limit = 3200  # 32C
-        self._abs_min_cool_setpoint_limit = 1600  # 16C
-        self._ctrl_seqe_of_oper = 0xFF
-        self._abs_max_heat_setpoint_limit = 3000  # 30C
-        self._abs_min_heat_setpoint_limit = 700  # 7C
-        self._running_mode = None
-        self._max_cool_setpoint_limit = None
-        self._max_heat_setpoint_limit = None
-        self._min_cool_setpoint_limit = None
-        self._min_heat_setpoint_limit = None
-        self._local_temp = None
-        self._occupancy = None
-        self._occupied_cooling_setpoint = None
-        self._occupied_heating_setpoint = None
-        self._pi_cooling_demand = None
-        self._pi_heating_demand = None
-        self._running_state = None
-        self._system_mode = None
-        self._unoccupied_cooling_setpoint = None
-        self._unoccupied_heating_setpoint = None
 
     @property
     def abs_max_cool_setpoint_limit(self) -> int:
@@ -279,8 +259,6 @@ class ThermostatChannel(ZigbeeChannel):
                 self._init_attrs.pop(attr, None)
                 if attr in fail:
                     continue
-                if isinstance(attr, str):
-                    setattr(self, f"_{attr}", res[attr])
                 self.async_send_signal(
                     f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
                     AttributeUpdateRecord(None, attr, res[attr]),
@@ -304,7 +282,6 @@ class ThermostatChannel(ZigbeeChannel):
             self.debug("couldn't set '%s' operation mode", mode)
             return False
 
-        self._system_mode = mode
         self.debug("set system to %s", mode)
         return True
 
@@ -320,11 +297,6 @@ class ThermostatChannel(ZigbeeChannel):
             self.debug("couldn't set heating setpoint")
             return False
 
-        if is_away:
-            self._unoccupied_heating_setpoint = temperature
-        else:
-            self._occupied_heating_setpoint = temperature
-        self.debug("set heating setpoint to %s", temperature)
         return True
 
     async def async_set_cooling_setpoint(
@@ -338,10 +310,6 @@ class ThermostatChannel(ZigbeeChannel):
         if not await self.write_attributes(data):
             self.debug("couldn't set cooling setpoint")
             return False
-        if is_away:
-            self._unoccupied_cooling_setpoint = temperature
-        else:
-            self._occupied_cooling_setpoint = temperature
         self.debug("set cooling setpoint to %s", temperature)
         return True
 
@@ -352,7 +320,6 @@ class ThermostatChannel(ZigbeeChannel):
             self.debug("read 'occupancy' attr, success: %s, fail: %s", res, fail)
             if "occupancy" not in res:
                 return None
-            self._occupancy = res["occupancy"]
             return bool(self.occupancy)
         except ZigbeeException as ex:
             self.debug("Couldn't read 'occupancy' attribute: %s", ex)

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -76,13 +76,16 @@ def send_attribute_report(hass, cluster, attrid, value):
     return send_attributes_report(hass, cluster, {attrid: value})
 
 
-async def send_attributes_report(hass, cluster: int, attributes: dict):
+async def send_attributes_report(hass, cluster: zigpy.zcl.Cluster, attributes: dict):
     """Cause the sensor to receive an attribute report from the network.
 
     This is to simulate the normal device communication that happens when a
     device is paired to the zigbee network.
     """
-    attrs = [make_attribute(attrid, value) for attrid, value in attributes.items()]
+    attrs = [
+        make_attribute(cluster.attridx.get(attr, attr), value)
+        for attr, value in attributes.items()
+    ]
     hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
     hdr.frame_control.disable_default_response = True
     cluster.handle_message(hdr, [attrs])

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -47,7 +47,8 @@ def patch_cluster(cluster):
     cluster.read_attributes = AsyncMock(wraps=cluster.read_attributes)
     cluster.read_attributes_raw = AsyncMock(side_effect=_read_attribute_raw)
     cluster.unbind = AsyncMock(return_value=[0])
-    cluster.write_attributes = AsyncMock(
+    cluster.write_attributes = AsyncMock(wraps=cluster.write_attributes)
+    cluster._write_attributes = AsyncMock(
         return_value=[zcl_f.WriteAttributesResponse.deserialize(b"\x00")[0]]
     )
     if cluster.cluster_id == 4:

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -3,6 +3,7 @@ import asyncio
 import math
 from unittest.mock import AsyncMock, Mock
 
+import zigpy.zcl
 import zigpy.zcl.foundation as zcl_f
 
 import homeassistant.components.zha.core.const as zha_const


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor ZHA thermostat channel to used Zigpy Cached attribute values directly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
