### PR TITLE
Simplify cloud request connection handling

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -193,6 +193,16 @@ async def async_setup(hass, config):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown)
 
+    # Sync remote connection with prefs
+    async def remote_prefs_updated(prefs):
+        """Update remote status."""
+        if prefs.remote_enabled and not cloud.remote.is_connected:
+            await cloud.remote.connect()
+        elif not prefs.remote_enabled and cloud.remote.is_connected:
+            await cloud.remote.disconnect()
+
+    prefs.async_listen_updates(remote_prefs_updated)
+
     async def _service_handler(service):
         """Handle service for cloud."""
         if service.service == SERVICE_REMOTE_CONNECT:

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -1,4 +1,6 @@
 """Component to integrate the Home Assistant cloud."""
+import asyncio
+
 from hass_nabucasa import Cloud
 import voluptuous as vol
 
@@ -193,23 +195,13 @@ async def async_setup(hass, config):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown)
 
-    # Sync remote connection with prefs
-    async def remote_prefs_updated(prefs):
-        """Update remote status."""
-        if prefs.remote_enabled and not cloud.remote.is_connected:
-            await cloud.remote.connect()
-        elif not prefs.remote_enabled and cloud.remote.is_connected:
-            await cloud.remote.disconnect()
-
-    prefs.async_listen_updates(remote_prefs_updated)
+    _remote_handle_prefs_updated(cloud)
 
     async def _service_handler(service):
         """Handle service for cloud."""
         if service.service == SERVICE_REMOTE_CONNECT:
-            await cloud.remote.connect()
             await prefs.async_update(remote_enabled=True)
         elif service.service == SERVICE_REMOTE_DISCONNECT:
-            await cloud.remote.disconnect()
             await prefs.async_update(remote_enabled=False)
 
     hass.helpers.service.async_register_admin_service(
@@ -244,3 +236,28 @@ async def async_setup(hass, config):
     account_link.async_setup(hass)
 
     return True
+
+
+@callback
+def _remote_handle_prefs_updated(cloud: Cloud) -> None:
+    """Handle remote preferences updated."""
+    cur_pref = cloud.client.prefs.remote_enabled
+    lock = asyncio.Lock()
+
+    # Sync remote connection with prefs
+    async def remote_prefs_updated(prefs: CloudPreferences) -> None:
+        """Update remote status."""
+        nonlocal cur_pref
+
+        async with lock:
+            if prefs.remote_enabled == cur_pref:
+                return
+
+            cur_pref = prefs.remote_enabled
+
+            if cur_pref:
+                await cloud.remote.connect()
+            else:
+                await cloud.remote.disconnect()
+
+    cloud.client.prefs.async_listen_updates(remote_prefs_updated)

--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -172,6 +172,10 @@ class CloudClient(Interface):
         if identifier.startswith("remote_"):
             async_dispatcher_send(self._hass, DISPATCHER_REMOTE_UPDATE, data)
 
+    async def async_cloud_connect_update(self, connect: bool) -> None:
+        """Process cloud remote message to client."""
+        await self._prefs.async_update(remote_enabled=connect)
+
     async def async_alexa_message(self, payload: dict[Any, Any]) -> dict[Any, Any]:
         """Process cloud alexa message to client."""
         cloud_user = await self._prefs.get_cloud_user()

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -452,7 +452,6 @@ async def websocket_remote_connect(hass, connection, msg):
     """Handle request for connect remote."""
     cloud = hass.data[DOMAIN]
     await cloud.client.prefs.async_update(remote_enabled=True)
-    await cloud.remote.connect()
     connection.send_result(msg["id"], await _account_data(cloud))
 
 
@@ -465,7 +464,6 @@ async def websocket_remote_disconnect(hass, connection, msg):
     """Handle request for disconnect remote."""
     cloud = hass.data[DOMAIN]
     await cloud.client.prefs.async_update(remote_enabled=False)
-    await cloud.remote.disconnect()
     connection.send_result(msg["id"], await _account_data(cloud))
 
 

--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -2,7 +2,7 @@
   "domain": "cloud",
   "name": "Home Assistant Cloud",
   "documentation": "https://www.home-assistant.io/integrations/cloud",
-  "requirements": ["hass-nabucasa==0.49.0"],
+  "requirements": ["hass-nabucasa==0.50.0"],
   "dependencies": ["http", "webhook"],
   "after_dependencies": ["google_assistant", "alexa"],
   "codeowners": ["@home-assistant/cloud"],

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -15,7 +15,7 @@ ciso8601==2.1.3
 cryptography==3.3.2
 defusedxml==0.7.1
 emoji==1.2.0
-hass-nabucasa==0.49.0
+hass-nabucasa==0.50.0
 home-assistant-frontend==20210911.0
 httpx==0.19.0
 ifaddr==0.1.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -766,7 +766,7 @@ habitipy==0.2.0
 hangups==0.4.14
 
 # homeassistant.components.cloud
-hass-nabucasa==0.49.0
+hass-nabucasa==0.50.0
 
 # homeassistant.components.splunk
 hass_splunk==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -450,7 +450,7 @@ habitipy==0.2.0
 hangups==0.4.14
 
 # homeassistant.components.cloud
-hass-nabucasa==0.49.0
+hass-nabucasa==0.50.0
 
 # homeassistant.components.tasmota
 hatasmota==0.2.20

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -549,14 +549,8 @@ async def test_enabling_remote(hass, hass_ws_client, setup_api, mock_cloud_login
 
     assert len(mock_connect.mock_calls) == 1
 
-
-async def test_disabling_remote(hass, hass_ws_client, setup_api, mock_cloud_login):
-    """Test we call right code to disable remote UI."""
-    client = await hass_ws_client(hass)
-    cloud = hass.data[DOMAIN]
-
     with patch("hass_nabucasa.remote.RemoteUI.disconnect") as mock_disconnect:
-        await client.send_json({"id": 5, "type": "cloud/remote/disconnect"})
+        await client.send_json({"id": 6, "type": "cloud/remote/disconnect"})
         response = await client.receive_json()
     assert response["success"]
     assert not cloud.client.remote_autostart

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -163,7 +163,9 @@ async def test_remote_ui_url(hass, mock_cloud_fixture):
         with pytest.raises(cloud.CloudNotAvailable):
             cloud.async_remote_ui_url(hass)
 
-        await cl.client.prefs.async_update(remote_enabled=True)
+        with patch.object(cl.remote, "connect"):
+            await cl.client.prefs.async_update(remote_enabled=True)
+            await hass.async_block_till_done()
 
         # No instance domain
         with pytest.raises(cloud.CloudNotAvailable):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify request connection handling for HA Cloud.

To do:

- [x] Dependency bump of hass-nabucasa that includes https://github.com/NabuCasa/hass-nabucasa/pull/278

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
