### PR TITLE
Energy validation: Require last_reset attribute to be set for state_class measurement energy and cost sensors

### DIFF
--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -142,7 +142,7 @@ def _async_validate_usage_stat(
         )
 
     if (
-        state_class == sensor.STATE_CLASS_TOTAL_INCREASING
+        state_class == sensor.STATE_CLASS_MEASUREMENT
         and sensor.ATTR_LAST_RESET not in state.attributes
     ):
         result.append(ValidationIssue("entity_measurement_no_last_reset", stat_value))
@@ -224,7 +224,7 @@ def _async_validate_cost_stat(
         )
 
     if (
-        state_class == sensor.STATE_CLASS_TOTAL_INCREASING
+        state_class == sensor.STATE_CLASS_MEASUREMENT
         and sensor.ATTR_LAST_RESET not in state.attributes
     ):
         result.append(ValidationIssue("entity_measurement_no_last_reset", stat_id))

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -135,11 +135,17 @@ def _async_validate_usage_stat(
     if state_class not in allowed_state_classes:
         result.append(
             ValidationIssue(
-                "entity_unexpected_state_class_total_increasing",
+                "entity_unexpected_state_class",
                 stat_value,
                 state_class,
             )
         )
+
+    if (
+        state_class == sensor.STATE_CLASS_TOTAL_INCREASING
+        and sensor.ATTR_LAST_RESET not in state.attributes
+    ):
+        result.append(ValidationIssue("entity_measurement_no_last_reset", stat_value))
 
 
 @callback
@@ -213,9 +219,15 @@ def _async_validate_cost_stat(
     if state_class not in supported_state_classes:
         result.append(
             ValidationIssue(
-                "entity_unexpected_state_class_total_increasing", stat_id, state_class
+                "entity_unexpected_state_class", stat_id, state_class
             )
         )
+
+    if (
+        state_class == sensor.STATE_CLASS_TOTAL_INCREASING
+        and sensor.ATTR_LAST_RESET not in state.attributes
+    ):
+        result.append(ValidationIssue("entity_measurement_no_last_reset", stat_id))
 
 
 @callback

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -145,7 +145,9 @@ def _async_validate_usage_stat(
         state_class == sensor.STATE_CLASS_MEASUREMENT
         and sensor.ATTR_LAST_RESET not in state.attributes
     ):
-        result.append(ValidationIssue("entity_measurement_no_last_reset", stat_value))
+        result.append(
+            ValidationIssue("entity_state_class_measurement_no_last_reset", stat_value)
+        )
 
 
 @callback
@@ -227,7 +229,9 @@ def _async_validate_cost_stat(
         state_class == sensor.STATE_CLASS_MEASUREMENT
         and sensor.ATTR_LAST_RESET not in state.attributes
     ):
-        result.append(ValidationIssue("entity_measurement_no_last_reset", stat_id))
+        result.append(
+            ValidationIssue("entity_state_class_measurement_no_last_reset", entity_id)
+        )
 
 
 @callback

--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -220,9 +220,7 @@ def _async_validate_cost_stat(
     ]
     if state_class not in supported_state_classes:
         result.append(
-            ValidationIssue(
-                "entity_unexpected_state_class", stat_id, state_class
-            )
+            ValidationIssue("entity_unexpected_state_class", stat_id, state_class)
         )
 
     if (
@@ -230,7 +228,7 @@ def _async_validate_cost_stat(
         and sensor.ATTR_LAST_RESET not in state.attributes
     ):
         result.append(
-            ValidationIssue("entity_state_class_measurement_no_last_reset", entity_id)
+            ValidationIssue("entity_state_class_measurement_no_last_reset", stat_id)
         )
 
 

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -39,7 +39,16 @@ async def test_validation_empty_config(hass):
     }
 
 
-async def test_validation(hass, mock_energy_manager):
+@pytest.mark.parametrize(
+    "state_class, extra",
+    [
+        ("total_increasing", {}),
+        ("total", {}),
+        ("total", {"last_reset": "abc"}),
+        ("measurement", {"last_reset": "abc"}),
+    ],
+)
+async def test_validation(hass, mock_energy_manager, state_class, extra):
     """Test validating success."""
     for key in ("device_cons", "battery_import", "battery_export", "solar_production"):
         hass.states.async_set(
@@ -48,7 +57,8 @@ async def test_validation(hass, mock_energy_manager):
             {
                 "device_class": "energy",
                 "unit_of_measurement": "kWh",
-                "state_class": "total_increasing",
+                "state_class": state_class,
+                **extra,
             },
         )
 
@@ -183,6 +193,35 @@ async def test_validation_device_consumption_recorder_not_tracked(
                 {
                     "type": "recorder_untracked",
                     "identifier": "sensor.not_recorded",
+                    "value": None,
+                }
+            ]
+        ],
+    }
+
+
+async def test_validation_device_consumption_no_last_reset(hass, mock_energy_manager):
+    """Test validating device based on untracked entity."""
+    await mock_energy_manager.async_update(
+        {"device_consumption": [{"stat_consumption": "sensor.no_last_reset"}]}
+    )
+    hass.states.async_set(
+        "sensor.no_last_reset",
+        "10.10",
+        {
+            "device_class": "energy",
+            "unit_of_measurement": "kWh",
+            "state_class": "measurement",
+        },
+    )
+
+    assert (await validate.async_validate(hass)).as_dict() == {
+        "energy_sources": [],
+        "device_consumption": [
+            [
+                {
+                    "type": "entity_state_class_measurement_no_last_reset",
+                    "identifier": "sensor.no_last_reset",
                     "value": None,
                 }
             ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Energy validation: Require last_reset attribute to be set for state_class measurement energy and cost sensors
Note: Depends on frontend PR https://github.com/home-assistant/frontend/pull/10037

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
