### PR TITLE
Allow IntegrationNotFound when checking config in safe mode

### DIFF
--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -125,7 +125,11 @@ async def async_check_ha_config_file(  # noqa: C901
     for domain in components:
         try:
             integration = await async_get_integration_with_requirements(hass, domain)
-        except (RequirementsNotFound, loader.IntegrationNotFound) as ex:
+        except loader.IntegrationNotFound as ex:
+            if not hass.config.safe_mode:
+                result.add_error(f"Component error: {domain} - {ex}")
+            continue
+        except RequirementsNotFound as ex:
             result.add_error(f"Component error: {domain} - {ex}")
             continue
 
@@ -210,8 +214,11 @@ async def async_check_ha_config_file(  # noqa: C901
                     hass, p_name
                 )
                 platform = p_integration.get_platform(domain)
+            except loader.IntegrationNotFound as ex:
+                if not hass.config.safe_mode:
+                    result.add_error(f"Platform error {domain}.{p_name} - {ex}")
+                continue
             except (
-                loader.IntegrationNotFound,
                 RequirementsNotFound,
                 ImportError,
             ) as ex:

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -130,7 +130,7 @@ async def async_check_ha_config_file(  # noqa: C901
                 result.add_error(f"Integration error: {domain} - {ex}")
             continue
         except RequirementsNotFound as ex:
-            result.add_error(f"Component error: {domain} - {ex}")
+            result.add_error(f"Integration error: {domain} - {ex}")
             continue
 
         try:

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -127,7 +127,7 @@ async def async_check_ha_config_file(  # noqa: C901
             integration = await async_get_integration_with_requirements(hass, domain)
         except loader.IntegrationNotFound as ex:
             if not hass.config.safe_mode:
-                result.add_error(f"Component error: {domain} - {ex}")
+                result.add_error(f"Integration error: {domain} - {ex}")
             continue
         except RequirementsNotFound as ex:
             result.add_error(f"Component error: {domain} - {ex}")

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -75,11 +75,24 @@ async def test_component_platform_not_found(hass):
 
         assert res.keys() == {"homeassistant"}
         assert res.errors[0] == CheckConfigError(
-            "Component error: beer - Integration 'beer' not found.", None, None
+            "Integration error: beer - Integration 'beer' not found.", None, None
         )
 
         # Only 1 error expected
         res.errors.pop(0)
+        assert not res.errors
+
+
+async def test_component_not_found_safe_mode(hass):
+    """Test no errors if component not found in safe mode."""
+    # Make sure they don't exist
+    files = {YAML_CONFIG_FILE: BASE_CONFIG + "beer:"}
+    hass.config.safe_mode = True
+    with patch("os.path.isfile", return_value=True), patch_yaml_files(files):
+        res = await async_check_ha_config_file(hass)
+        log_ha_config(res)
+
+        assert res.keys() == {"homeassistant"}
         assert not res.errors
 
 
@@ -100,6 +113,21 @@ async def test_component_platform_not_found_2(hass):
 
         # Only 1 error expected
         res.errors.pop(0)
+        assert not res.errors
+
+
+async def test_platform_not_found_safe_mode(hass):
+    """Test no errors if platform not found in safe_mode."""
+    # Make sure they don't exist
+    files = {YAML_CONFIG_FILE: BASE_CONFIG + "light:\n  platform: beer"}
+    hass.config.safe_mode = True
+    with patch("os.path.isfile", return_value=True), patch_yaml_files(files):
+        res = await async_check_ha_config_file(hass)
+        log_ha_config(res)
+
+        assert res.keys() == {"homeassistant", "light"}
+        assert res["light"] == []
+
         assert not res.errors
 
 

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -74,7 +74,7 @@ def test_component_platform_not_found(mock_is_file, loop):
         assert res["components"].keys() == {"homeassistant"}
         assert res["except"] == {
             check_config.ERROR_STR: [
-                "Component error: beer - Integration 'beer' not found."
+                "Integration error: beer - Integration 'beer' not found."
             ]
         }
         assert res["secret_cache"] == {}


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Its expected that some integrations will not be loaded in safe mode
  and we should not treat this as fatal since it will prevent a
  restart

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
