### PR TITLE
Fix creating `cert_expiry` configs during runtime

### DIFF
--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STARTED
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DEFAULT_PORT, DOMAIN
@@ -38,9 +38,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.async_refresh()
         hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
-    entry.async_on_unload(
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, async_finish_startup)
-    )
+    if hass.state == CoreState.running:
+        await async_finish_startup(None)
+    else:
+        entry.async_on_unload(
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STARTED, async_finish_startup
+            )
+        )
 
     return True
 

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import CoreState
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -107,3 +108,26 @@ async def test_unload_config_entry(mock_now, hass):
     await hass.async_block_till_done()
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
     assert state is None
+
+
+async def test_delay_load_during_startup(hass):
+    """Test loading a new config entry during runtime."""
+    hass.state = CoreState.starting
+
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: HOST, CONF_PORT: PORT})
+    entry.add_to_hass(hass)
+
+    timestamp = future_timestamp(100)
+    with patch(
+        "homeassistant.components.cert_expiry.get_cert_expiry_timestamp",
+        return_value=timestamp,
+    ):
+        assert await async_setup_component(hass, DOMAIN, {}) is True
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
+    assert state.state == timestamp.isoformat()
+    assert state.attributes.get("error") == "None"
+    assert state.attributes.get("is_valid")

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -24,6 +24,8 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_setup_with_config(hass):
     """Test setup component with config."""
+    assert hass.state is CoreState.running
+
     config = {
         SENSOR_DOMAIN: [
             {"platform": DOMAIN, CONF_HOST: HOST, CONF_PORT: PORT},
@@ -50,6 +52,8 @@ async def test_setup_with_config(hass):
 
 async def test_update_unique_id(hass):
     """Test updating a config entry without a unique_id."""
+    assert hass.state is CoreState.running
+
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: HOST, CONF_PORT: PORT})
     entry.add_to_hass(hass)
 
@@ -72,6 +76,8 @@ async def test_update_unique_id(hass):
 @patch("homeassistant.util.dt.utcnow", return_value=static_datetime())
 async def test_unload_config_entry(mock_now, hass):
     """Test unloading a config entry."""
+    assert hass.state is CoreState.running
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: HOST, CONF_PORT: PORT},
@@ -111,8 +117,8 @@ async def test_unload_config_entry(mock_now, hass):
 
 
 async def test_delay_load_during_startup(hass):
-    """Test loading a new config entry during runtime."""
-    hass.state = CoreState.starting
+    """Test delayed loading of a config entry during startup."""
+    hass.state = CoreState.not_running
 
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: HOST, CONF_PORT: PORT})
     entry.add_to_hass(hass)

--- a/tests/components/cert_expiry/test_sensors.py
+++ b/tests/components/cert_expiry/test_sensors.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from homeassistant.components.cert_expiry.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import CoreState
 from homeassistant.util.dt import utcnow
 
 from .const import HOST, PORT
@@ -17,6 +18,8 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 @patch("homeassistant.util.dt.utcnow", return_value=static_datetime())
 async def test_async_setup_entry(mock_now, hass):
     """Test async_setup_entry."""
+    assert hass.state is CoreState.running
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: HOST, CONF_PORT: PORT},
@@ -43,6 +46,8 @@ async def test_async_setup_entry(mock_now, hass):
 
 async def test_async_setup_entry_bad_cert(hass):
     """Test async_setup_entry with a bad/expired cert."""
+    assert hass.state is CoreState.running
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: HOST, CONF_PORT: PORT},
@@ -66,6 +71,8 @@ async def test_async_setup_entry_bad_cert(hass):
 
 async def test_update_sensor(hass):
     """Test async_update for sensor."""
+    assert hass.state is CoreState.running
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: HOST, CONF_PORT: PORT},
@@ -108,6 +115,8 @@ async def test_update_sensor(hass):
 
 async def test_update_sensor_network_errors(hass):
     """Test async_update for sensor."""
+    assert hass.state is CoreState.running
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: HOST, CONF_PORT: PORT},

--- a/tests/components/cert_expiry/test_sensors.py
+++ b/tests/components/cert_expiry/test_sensors.py
@@ -5,13 +5,7 @@ import ssl
 from unittest.mock import patch
 
 from homeassistant.components.cert_expiry.const import DOMAIN
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PORT,
-    EVENT_HOMEASSISTANT_STARTED,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import CONF_HOST, CONF_PORT, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.util.dt import utcnow
 
 from .const import HOST, PORT
@@ -37,7 +31,6 @@ async def test_async_setup_entry(mock_now, hass):
     ):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
@@ -62,7 +55,6 @@ async def test_async_setup_entry_bad_cert(hass):
     ):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
@@ -89,7 +81,6 @@ async def test_update_sensor(hass):
     ):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")
@@ -132,7 +123,6 @@ async def test_update_sensor_network_errors(hass):
     ):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.cert_expiry_timestamp_example_com")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes an oversight from #56266 which didn't consider loading config entries during normal runtime.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
