### PR TITLE
WIP: Fix entity platform to not schedule scan_interval <= 0

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -84,7 +84,7 @@ NEW_DEVICE_DEFAULTS_SCHEMA = vol.Any(
 )
 PLATFORM_SCHEMA: Final = cv.PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
+        vol.Optional(CONF_SCAN_INTERVAL): cv.scan_interval_time_period,
         vol.Optional(CONF_TRACK_NEW): cv.boolean,
         vol.Optional(CONF_CONSIDER_HOME, default=DEFAULT_CONSIDER_HOME): vol.All(
             cv.time_period, cv.positive_timedelta

--- a/homeassistant/components/iperf3/__init__.py
+++ b/homeassistant/components/iperf3/__init__.py
@@ -79,9 +79,9 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_KEYS): vol.All(
                     cv.ensure_list, [vol.In(SENSOR_KEYS)]
                 ),
-                vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL): vol.All(
-                    cv.time_period, cv.positive_timedelta
-                ),
+                vol.Optional(
+                    CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL
+                ): cv.scan_interval_time_period,
                 vol.Optional(CONF_MANUAL, default=False): cv.boolean,
             }
         )

--- a/homeassistant/components/rest/schema.py
+++ b/homeassistant/components/rest/schema.py
@@ -82,7 +82,7 @@ BINARY_SENSOR_SCHEMA = {
 
 COMBINED_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
+        vol.Optional(CONF_SCAN_INTERVAL): cv.scan_interval_time_period,
         **RESOURCE_SCHEMA,
         vol.Optional(SENSOR_DOMAIN): vol.All(
             cv.ensure_list, [vol.Schema(SENSOR_SCHEMA)]

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -442,6 +442,16 @@ positive_time_period_dict = vol.All(time_period_dict, positive_timedelta)
 positive_time_period = vol.All(time_period, positive_timedelta)
 
 
+def scan_interval_timedelta(value: timedelta) -> timedelta:
+    """Validate timedelta is >= 5 sec."""
+    if value < timedelta(seconds=5):
+        raise vol.Invalid("Scan interval should be minimum 5s")
+    return value
+
+
+scan_interval_time_period = vol.All(time_period, scan_interval_timedelta)
+
+
 def remove_falsy(value: list[T]) -> list[T]:
     """Remove falsy values from a list."""
     return [v for v in value if v]
@@ -851,7 +861,7 @@ PLATFORM_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_PLATFORM): string,
         vol.Optional(CONF_ENTITY_NAMESPACE): string,
-        vol.Optional(CONF_SCAN_INTERVAL): time_period,
+        vol.Optional(CONF_SCAN_INTERVAL): scan_interval_time_period,
     }
 )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking

Likely to break configurations where scan interval was between 1 and 4 seconds.
I'm not sure HA could handle it (surely not <= 0), but I assume it could on certain hardware.

## Proposed change

Do not allow scan_interval below 5 seconds.

There is currently no systematic validation of the `scan_interval` setting, so negative or zero intervals can percolate up to the actual scheduling.

Example:

```
- platform: command_line  
  name: CLI test
  scan_interval: 0
  command: "date"
```

This results in 
- a log flood ("Updating command_line sensor took longer than the scheduled update interval")
- a 100% CPU usage
- impossibility to "soft restart" HA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
