### PR TITLE
Prevent 3rd party lib from opening sockets in samsungtv tests

### DIFF
--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -112,3 +112,10 @@ def delay_fixture():
 def mock_now():
     """Fixture for dtutil.now."""
     return dt_util.utcnow()
+
+
+@pytest.fixture(name="no_mac_address")
+def mac_address_fixture():
+    """Patch getmac.get_mac_address."""
+    with patch("getmac.get_mac_address", return_value=None) as mac:
+        yield mac

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -389,7 +389,9 @@ async def test_ssdp_legacy_not_supported(hass: HomeAssistant, remote: Mock):
 
 
 async def test_ssdp_websocket_success_populates_mac_address(
-    hass: HomeAssistant, remotews: Mock
+    hass: HomeAssistant,
+    remote: Mock,
+    remotews: Mock,
 ):
     """Test starting a flow from ssdp for a supported device populates the mac."""
     result = await hass.config_entries.flow.async_init(
@@ -441,7 +443,9 @@ async def test_ssdp_model_not_supported(hass: HomeAssistant, remote: Mock):
     assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
-async def test_ssdp_not_successful(hass: HomeAssistant, remote: Mock):
+async def test_ssdp_not_successful(
+    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
+):
     """Test starting a flow from discovery but no device found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -469,7 +473,9 @@ async def test_ssdp_not_successful(hass: HomeAssistant, remote: Mock):
         assert result["reason"] == RESULT_CANNOT_CONNECT
 
 
-async def test_ssdp_not_successful_2(hass: HomeAssistant, remote: Mock):
+async def test_ssdp_not_successful_2(
+    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
+):
     """Test starting a flow from discovery but no device found."""
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
@@ -564,7 +570,9 @@ async def test_import_legacy(hass: HomeAssistant, remote: Mock):
     assert entries[0].data[CONF_PORT] == LEGACY_PORT
 
 
-async def test_import_legacy_without_name(hass: HomeAssistant, remote: Mock):
+async def test_import_legacy_without_name(
+    hass: HomeAssistant, remote: Mock, no_mac_address: Mock
+):
     """Test importing from yaml without a name."""
     with patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -651,7 +659,7 @@ async def test_import_unknown_host(hass: HomeAssistant, remotews: Mock):
     assert result["reason"] == RESULT_UNKNOWN_HOST
 
 
-async def test_dhcp(hass: HomeAssistant, remotews: Mock):
+async def test_dhcp(hass: HomeAssistant, remote: Mock, remotews: Mock):
     """Test starting a flow from dhcp."""
     # confirm to add the entry
     result = await hass.config_entries.flow.async_init(
@@ -677,7 +685,7 @@ async def test_dhcp(hass: HomeAssistant, remotews: Mock):
     assert result["result"].unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
 
 
-async def test_zeroconf(hass: HomeAssistant, remotews: Mock):
+async def test_zeroconf(hass: HomeAssistant, remote: Mock, remotews: Mock):
     """Test starting a flow from zeroconf."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -715,7 +723,7 @@ async def test_zeroconf_ignores_soundbar(hass: HomeAssistant, remotews_soundbar:
 
 
 async def test_zeroconf_no_device_info(
-    hass: HomeAssistant, remotews_no_device_info: Mock
+    hass: HomeAssistant, remote: Mock, remotews_no_device_info: Mock
 ):
     """Test starting a flow from zeroconf where device_info returns None."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -53,7 +53,7 @@ REMOTE_CALL = {
 }
 
 
-async def test_setup(hass: HomeAssistant, remote: Mock):
+async def test_setup(hass: HomeAssistant, remote: Mock, no_mac_address: Mock):
     """Test Samsung TV integration is setup."""
     with patch("homeassistant.components.samsungtv.bridge.Remote") as remote, patch(
         "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
@@ -129,7 +129,9 @@ async def test_setup_duplicate_config(hass: HomeAssistant, remote: Mock, caplog)
     assert "duplicate host entries found" in caplog.text
 
 
-async def test_setup_duplicate_entries(hass: HomeAssistant, remote: Mock, caplog):
+async def test_setup_duplicate_entries(
+    hass: HomeAssistant, remote: Mock, no_mac_address: Mock, caplog
+):
     """Test duplicate setup of platform."""
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -127,10 +127,9 @@ def delay_fixture():
         yield delay
 
 
-@pytest.fixture
-def mock_now():
-    """Fixture for dtutil.now."""
-    return dt_util.utcnow()
+@pytest.fixture(autouse=True)
+def mock_no_mac_address(no_mac_address):
+    """Fake mac address in all mediaplayer tests."""
 
 
 async def setup_samsungtv(hass, config):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prevent 3rd party lib from opening sockets in samsungtv tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
