### PR TITLE
Fix netgear strings

### DIFF
--- a/homeassistant/components/netgear/strings.json
+++ b/homeassistant/components/netgear/strings.json
@@ -2,8 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Netgear",
-        "description": "Default host: {host}\n Default port: {port}\n Default username: {username}",
+        "description": "Default host: {host}\nDefault port: {port}\nDefault username: {username}",
         "data": {
           "host": "[%key:common::config_flow::data::host%] (Optional)",
           "port": "[%key:common::config_flow::data::port%] (Optional)",
@@ -23,7 +22,6 @@
   "options": {
     "step": {
       "init": {
-        "title": "Netgear",
         "description": "Specify optional settings",
         "data": {
           "consider_home": "Consider home time (seconds)"

--- a/homeassistant/components/netgear/translations/en.json
+++ b/homeassistant/components/netgear/translations/en.json
@@ -15,15 +15,13 @@
                     "ssl": "Use SSL (Optional)",
                     "username": "Username (Optional)"
                 },
-                "description": "Default host: {host}\n Default port: {port}\n Default username: {username}",
-                "title": "Netgear"
+                "description": "Default host: {host}\nDefault port: {port}\nDefault username: {username}"
             }
         }
     },
     "options": {
         "step": {
           "init": {
-            "title": "Netgear",
             "description": "Specify optional settings",
             "data": {
               "consider_home": "Consider home time (seconds)"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- [x] Remove the space at the beginning of a new line in the description string
    - Spaces at the beginning of a new line are not shown in Lovelace, but this could be a problem for another frontend.
    - This is confusing for translators in Lokalise as Lokalise does show these spaces.
https://app.lokalise.com/project/130246255a974bd3b5e8a1.51616605/?view=multi&search=component::netgear::config::step::user::description

|![netgear](https://user-images.githubusercontent.com/15276289/133807324-9afe977f-42ac-448b-bae4-5c8503fa61ad.png)|![lokalise-netgear](https://user-images.githubusercontent.com/15276289/133807405-5c647304-15c6-40cc-998c-0d8e72c5b6b5.png)|
|-|-|
- [x] Delete title string config flow user step
    - NETGEAR should not be translated
    - The title of the configuration flow step is the manifest title by default
    - All letters must be uppercase
 - [x] Delete title string options flow
    - Using the default title saves a translation.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
