### PR TITLE
Update deCONZ integration based on changes in pydeconz v84

### DIFF
--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -55,7 +55,7 @@ DECONZ_TO_ALARM_STATE = {
 
 def get_alarm_system_for_unique_id(gateway, unique_id: str):
     """Retrieve alarm system unique ID is registered to."""
-    for alarm_system in gateway.api.alarm_systems.values():
+    for alarm_system in gateway.api.alarmsystems.values():
         if unique_id in alarm_system.devices:
             return alarm_system
 
@@ -77,8 +77,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
 
             if (
                 sensor.type in AncillaryControl.ZHATYPE
-                and sensor.uniqueid not in gateway.entities[DOMAIN]
-                and get_alarm_system_for_unique_id(gateway, sensor.uniqueid)
+                and sensor.unique_id not in gateway.entities[DOMAIN]
+                and get_alarm_system_for_unique_id(gateway, sensor.unique_id)
             ):
 
                 entities.append(DeconzAlarmControlPanel(sensor, gateway))
@@ -110,7 +110,7 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     def __init__(self, device, gateway) -> None:
         """Set up alarm control panel device."""
         super().__init__(device, gateway)
-        self.alarm_system = get_alarm_system_for_unique_id(gateway, device.uniqueid)
+        self.alarm_system = get_alarm_system_for_unique_id(gateway, device.unique_id)
 
     @callback
     def async_update_callback(self, force_update: bool = False) -> None:

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -48,7 +48,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             if (
                 sensor.BINARY
-                and sensor.uniqueid not in gateway.entities[DOMAIN]
+                and sensor.unique_id not in gateway.entities[DOMAIN]
                 and (
                     gateway.option_allow_clip_sensor
                     or not sensor.type.startswith("CLIP")
@@ -116,8 +116,8 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
 
         elif self._device.type in Vibration.ZHATYPE:
             attr[ATTR_ORIENTATION] = self._device.orientation
-            attr[ATTR_TILTANGLE] = self._device.tiltangle
-            attr[ATTR_VIBRATIONSTRENGTH] = self._device.vibrationstrength
+            attr[ATTR_TILTANGLE] = self._device.tilt_angle
+            attr[ATTR_VIBRATIONSTRENGTH] = self._device.vibration_strength
 
         return attr
 

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -86,7 +86,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             if (
                 sensor.type in Thermostat.ZHATYPE
-                and sensor.uniqueid not in gateway.entities[DOMAIN]
+                and sensor.unique_id not in gateway.entities[DOMAIN]
                 and (
                     gateway.option_allow_clip_sensor
                     or not sensor.type.startswith("CLIP")
@@ -142,7 +142,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     def fan_mode(self) -> str:
         """Return fan operation."""
         return DECONZ_TO_FAN_MODE.get(
-            self._device.fanmode, FAN_ON if self._device.state_on else FAN_OFF
+            self._device.fan_mode, FAN_ON if self._device.state_on else FAN_OFF
         )
 
     @property
@@ -155,9 +155,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         if fan_mode not in FAN_MODE_TO_DECONZ:
             raise ValueError(f"Unsupported fan mode {fan_mode}")
 
-        data = {"fanmode": FAN_MODE_TO_DECONZ[fan_mode]}
-
-        await self._device.async_set_config(data)
+        await self._device.set_config(fan_mode=FAN_MODE_TO_DECONZ[fan_mode])
 
     # HVAC control
 
@@ -186,7 +184,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         if len(self._hvac_mode_to_deconz) == 2:  # Only allow turn on and off thermostat
             data = {"on": self._hvac_mode_to_deconz[hvac_mode]}
 
-        await self._device.async_set_config(data)
+        await self._device.set_config(**data)
 
     # Preset control
 
@@ -205,9 +203,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         if preset_mode not in PRESET_MODE_TO_DECONZ:
             raise ValueError(f"Unsupported preset mode {preset_mode}")
 
-        data = {"preset": PRESET_MODE_TO_DECONZ[preset_mode]}
-
-        await self._device.async_set_config(data)
+        await self._device.set_config(preset=PRESET_MODE_TO_DECONZ[preset_mode])
 
     # Temperature control
 
@@ -220,19 +216,19 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     def target_temperature(self) -> float:
         """Return the target temperature."""
         if self._device.mode == "cool":
-            return self._device.coolsetpoint
-        return self._device.heatsetpoint
+            return self._device.cooling_setpoint
+        return self._device.heating_setpoint
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         if ATTR_TEMPERATURE not in kwargs:
             raise ValueError(f"Expected attribute {ATTR_TEMPERATURE}")
 
-        data = {"heatsetpoint": kwargs[ATTR_TEMPERATURE] * 100}
+        data = {"heating_setpoint": kwargs[ATTR_TEMPERATURE] * 100}
         if self._device.mode == "cool":
-            data = {"coolsetpoint": kwargs[ATTR_TEMPERATURE] * 100}
+            data = {"cooling_setpoint": kwargs[ATTR_TEMPERATURE] * 100}
 
-        await self._device.async_set_config(data)
+        await self._device.set_config(**data)
 
     @property
     def extra_state_attributes(self):

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -48,7 +48,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for light in lights:
             if (
                 light.type in COVER_TYPES
-                and light.uniqueid not in gateway.entities[DOMAIN]
+                and light.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzCover(light, gateway))
 

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -18,15 +18,15 @@ class DeconzBase:
     @property
     def unique_id(self):
         """Return a unique identifier for this device."""
-        return self._device.uniqueid
+        return self._device.unique_id
 
     @property
     def serial(self):
         """Return a serial number for this device."""
-        if self._device.uniqueid is None or self._device.uniqueid.count(":") != 7:
+        if self._device.unique_id is None or self._device.unique_id.count(":") != 7:
             return None
 
-        return self._device.uniqueid.split("-", 1)[0]
+        return self._device.unique_id.split("-", 1)[0]
 
     @property
     def device_info(self):
@@ -38,10 +38,10 @@ class DeconzBase:
             "connections": {(CONNECTION_ZIGBEE, self.serial)},
             "identifiers": {(DECONZ_DOMAIN, self.serial)},
             "manufacturer": self._device.manufacturer,
-            "model": self._device.modelid,
+            "model": self._device.model_id,
             "name": self._device.name,
-            "sw_version": self._device.swversion,
-            "via_device": (DECONZ_DOMAIN, self.gateway.api.config.bridgeid),
+            "sw_version": self._device.software_version,
+            "via_device": (DECONZ_DOMAIN, self.gateway.api.config.bridge_id),
         }
 
 

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -47,7 +47,7 @@ async def async_setup_events(gateway) -> None:
 
             if (
                 sensor.type not in Switch.ZHATYPE + AncillaryControl.ZHATYPE
-                or sensor.uniqueid in {event.unique_id for event in gateway.events}
+                or sensor.unique_id in {event.unique_id for event in gateway.events}
             ):
                 continue
 

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
 
         for light in lights:
 
-            if light.type in FANS and light.uniqueid not in gateway.entities[DOMAIN]:
+            if light.type in FANS and light.unique_id not in gateway.entities[DOMAIN]:
                 entities.append(DeconzFan(light, gateway))
 
         if entities:

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -151,11 +151,11 @@ class DeconzGateway:
         # Gateway service
         device_registry.async_get_or_create(
             config_entry_id=self.config_entry.entry_id,
-            identifiers={(DECONZ_DOMAIN, self.api.config.bridgeid)},
+            identifiers={(DECONZ_DOMAIN, self.api.config.bridge_id)},
             manufacturer="Dresden Elektronik",
-            model=self.api.config.modelid,
+            model=self.api.config.model_id,
             name=self.api.config.name,
-            sw_version=self.api.config.swversion,
+            sw_version=self.api.config.software_version,
             via_device=(CONNECTION_NETWORK_MAC, self.api.config.mac),
         )
 
@@ -266,12 +266,12 @@ async def get_gateway(
         config[CONF_HOST],
         config[CONF_PORT],
         config[CONF_API_KEY],
-        async_add_device=async_add_device_callback,
+        add_device=async_add_device_callback,
         connection_status=async_connection_status_callback,
     )
     try:
         with async_timeout.timeout(10):
-            await deconz.initialize()
+            await deconz.refresh_state()
         return deconz
 
     except errors.Unauthorized as err:

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -22,7 +22,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             if (
                 light.type in LOCK_TYPES
-                and light.uniqueid not in gateway.entities[DOMAIN]
+                and light.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzLock(light, gateway))
 
@@ -44,7 +44,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             if (
                 sensor.type in LOCK_TYPES
-                and sensor.uniqueid not in gateway.entities[DOMAIN]
+                and sensor.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzLock(sensor, gateway))
 

--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -153,9 +153,9 @@ def async_describe_events(
         interface = None
         data = event.data.get(CONF_EVENT) or event.data.get(CONF_GESTURE, "")
 
-        if data and deconz_event.device.modelid in REMOTES:
+        if data and deconz_event.device.model_id in REMOTES:
             action, interface = _get_device_event_description(
-                deconz_event.device.modelid, data
+                deconz_event.device.model_id, data
             )
 
         # Unknown event

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
   "requirements": [
-    "pydeconz==83"
+    "pydeconz==84"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/deconz/scene.py
+++ b/homeassistant/components/deconz/scene.py
@@ -51,4 +51,4 @@ class DeconzScene(Scene):
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
-        await self._scene.async_set_state({})
+        await self._scene.recall()

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -124,7 +124,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 + DoorLock.ZHATYPE
                 + Switch.ZHATYPE
                 + Thermostat.ZHATYPE
-                and sensor.uniqueid not in gateway.entities[DOMAIN]
+                and sensor.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzSensor(sensor, gateway))
 
@@ -273,7 +273,7 @@ class DeconzBattery(DeconzDevice, SensorEntity):
         Normally there should only be one battery sensor per device from deCONZ.
         With specific Danfoss devices each endpoint can report its own battery state.
         """
-        if self._device.manufacturer == "Danfoss" and self._device.modelid in [
+        if self._device.manufacturer == "Danfoss" and self._device.model_id in [
             "0x8030",
             "0x8031",
             "0x8034",

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -185,7 +185,7 @@ async def async_remove_orphaned_entries_service(gateway):
 
     # Don't remove the Gateway service entry
     gateway_service = device_registry.async_get_device(
-        identifiers={(DOMAIN, gateway.api.config.bridgeid)}, connections=set()
+        identifiers={(DOMAIN, gateway.api.config.bridge_id)}, connections=set()
     )
     if gateway_service.id in devices_to_be_removed:
         devices_to_be_removed.remove(gateway_service.id)

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -25,12 +25,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
             if (
                 light.type in POWER_PLUGS
-                and light.uniqueid not in gateway.entities[DOMAIN]
+                and light.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzPowerPlug(light, gateway))
 
             elif (
-                light.type in SIRENS and light.uniqueid not in gateway.entities[DOMAIN]
+                light.type in SIRENS and light.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzSiren(light, gateway))
 
@@ -58,13 +58,11 @@ class DeconzPowerPlug(DeconzDevice, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn on switch."""
-        data = {"on": True}
-        await self._device.async_set_state(data)
+        await self._device.set_state(on=True)
 
     async def async_turn_off(self, **kwargs):
         """Turn off switch."""
-        data = {"on": False}
-        await self._device.async_set_state(data)
+        await self._device.set_state(on=False)
 
 
 class DeconzSiren(DeconzDevice, SwitchEntity):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1406,7 +1406,7 @@ pydaikin==2.4.4
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==83
+pydeconz==84
 
 # homeassistant.components.delijn
 pydelijn==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -806,7 +806,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.4.4
 
 # homeassistant.components.deconz
-pydeconz==83
+pydeconz==84
 
 # homeassistant.components.dexcom
 pydexcom==0.2.0

--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from pydeconz.websocket import SIGNAL_CONNECTION_STATE, SIGNAL_DATA
 import pytest
 
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
@@ -19,10 +20,10 @@ def mock_deconz_websocket():
 
             if data:
                 mock.return_value.data = data
-                await pydeconz_gateway_session_handler(signal="data")
+                await pydeconz_gateway_session_handler(signal=SIGNAL_DATA)
             elif state:
                 mock.return_value.state = state
-                await pydeconz_gateway_session_handler(signal="state")
+                await pydeconz_gateway_session_handler(signal=SIGNAL_CONNECTION_STATE)
             else:
                 raise NotImplementedError
 

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -267,14 +267,14 @@ async def test_reset_after_successful_setup(hass, aioclient_mock):
 
 async def test_get_gateway(hass):
     """Successful call."""
-    with patch("pydeconz.DeconzSession.initialize", return_value=True):
+    with patch("pydeconz.DeconzSession.refresh_state", return_value=True):
         assert await get_gateway(hass, ENTRY_CONFIG, Mock(), Mock())
 
 
 async def test_get_gateway_fails_unauthorized(hass):
     """Failed call."""
     with patch(
-        "pydeconz.DeconzSession.initialize",
+        "pydeconz.DeconzSession.refresh_state",
         side_effect=pydeconz.errors.Unauthorized,
     ), pytest.raises(AuthenticationRequired):
         assert await get_gateway(hass, ENTRY_CONFIG, Mock(), Mock()) is False
@@ -283,7 +283,7 @@ async def test_get_gateway_fails_unauthorized(hass):
 async def test_get_gateway_fails_cannot_connect(hass):
     """Failed call."""
     with patch(
-        "pydeconz.DeconzSession.initialize",
+        "pydeconz.DeconzSession.refresh_state",
         side_effect=pydeconz.errors.RequestError,
     ), pytest.raises(CannotConnect):
         assert await get_gateway(hass, ENTRY_CONFIG, Mock(), Mock()) is False

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -44,14 +44,16 @@ async def setup_entry(hass, entry):
 
 async def test_setup_entry_fails(hass):
     """Test setup entry fails if deCONZ is not available."""
-    with patch("pydeconz.DeconzSession.initialize", side_effect=Exception):
+    with patch("pydeconz.DeconzSession.refresh_state", side_effect=Exception):
         await setup_deconz_integration(hass)
     assert not hass.data[DECONZ_DOMAIN]
 
 
 async def test_setup_entry_no_available_bridge(hass):
     """Test setup entry fails if deCONZ is not available."""
-    with patch("pydeconz.DeconzSession.initialize", side_effect=asyncio.TimeoutError):
+    with patch(
+        "pydeconz.DeconzSession.refresh_state", side_effect=asyncio.TimeoutError
+    ):
         await setup_deconz_integration(hass)
     assert not hass.data[DECONZ_DOMAIN]
 


### PR DESCRIPTION
A lot of minor things changed:
* Mostly snake case conversions, typing and consolidation
* But also a change in retry mechanism
* Added a more complete set_* call to most types to remove the direct relation to rest API of deCONZ

https://github.com/Kane610/deconz/compare/v83...v84

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
