### PR TITLE
Standardize yeelight exception handling

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -650,30 +649,6 @@ class YeelightDevice:
             self._device_type = self.bulb.bulb_type
 
         return self._device_type
-
-    async def async_turn_on(
-        self, duration=DEFAULT_TRANSITION, light_type=None, power_mode=None
-    ):
-        """Turn on device."""
-        try:
-            await self.bulb.async_turn_on(
-                duration=duration, light_type=light_type, power_mode=power_mode
-            )
-        except BULB_EXCEPTIONS as ex:
-            self.async_mark_unavailable()
-            raise HomeAssistantError(
-                f"Unable to turn the bulb {self.name} at {self._host} on: {ex}"
-            )
-
-    async def async_turn_off(self, duration=DEFAULT_TRANSITION, light_type=None):
-        """Turn off device."""
-        try:
-            await self.bulb.async_turn_off(duration=duration, light_type=light_type)
-        except BULB_EXCEPTIONS as ex:
-            self.async_mark_unavailable()
-            raise HomeAssistantError(
-                f"Unable to turn the bulb {self.name} at {self._host} off: {ex}"
-            )
 
     async def _async_update_properties(self):
         """Read new properties from the device."""

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -250,12 +250,12 @@ def _async_cmd(func):
             self.async_write_ha_state()
             raise HomeAssistantError(
                 f"Error when calling {func.__name__} for bulb {self.device.name} at {self.device.host}: {ex}"
-            )
+            ) from ex
         except BulbException as ex:
             # The bulb likely responded but had an error
             raise HomeAssistantError(
                 f"Error when calling {func.__name__} for bulb {self.device.name} at {self.device.host}: {ex}"
-            )
+            ) from ex
 
     return _async_wrap
 
@@ -587,7 +587,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         except AssertionError as ex:
             raise HomeAssistantError(
                 f"Error when calling start_music for bulb {self.device.name} at {self.device.host}: {ex}"
-            )
+            ) from ex
 
     @_async_cmd
     async def async_set_brightness(self, brightness, duration) -> None:

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -520,9 +520,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
     @property
     def effect(self):
         """Return the current effect."""
-        if not self.device.is_color_flow_enabled:
-            return None
-        return self._effect
+        return self._effect if self.device.is_color_flow_enabled else None
 
     @property
     def _bulb(self) -> Bulb:
@@ -530,9 +528,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
 
     @property
     def _properties(self) -> dict:
-        if self._bulb is None:
-            return {}
-        return self._bulb.last_properties
+        return self._bulb.last_properties if self._bulb else {}
 
     def _get_property(self, prop, default=None):
         return self._properties.get(prop, default)

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -6,7 +6,7 @@ import math
 
 import voluptuous as vol
 import yeelight
-from yeelight import Bulb, Flow, RGBTransition, SleepTransition, flows
+from yeelight import Bulb, BulbException, Flow, RGBTransition, SleepTransition, flows
 from yeelight.enums import BulbType, LightType, PowerMode, SceneClass
 
 from homeassistant.components.light import (
@@ -34,6 +34,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -50,6 +51,7 @@ from . import (
     ATTR_MODE_MUSIC,
     ATTR_TRANSITIONS,
     BULB_EXCEPTIONS,
+    BULB_NETWORK_EXCEPTIONS,
     CONF_FLOW_PARAMS,
     CONF_MODE_MUSIC,
     CONF_NIGHTLIGHT_SWITCH,
@@ -242,8 +244,18 @@ def _async_cmd(func):
         try:
             _LOGGER.debug("Calling %s with %s %s", func, args, kwargs)
             return await func(self, *args, **kwargs)
-        except BULB_EXCEPTIONS as ex:
-            _LOGGER.error("Error when calling %s: %s", func, ex)
+        except BULB_NETWORK_EXCEPTIONS as ex:
+            # A network error happened, the bulb is likely offline now
+            self.device.async_mark_unavailable()
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                f"Error when calling {func.__name__} for bulb {self.device.name} at {self.device.host}: {ex}"
+            )
+        except BulbException as ex:
+            # The bulb likely responded but had an error
+            raise HomeAssistantError(
+                f"Error when calling {func.__name__} for bulb {self.device.name} at {self.device.host}: {ex}"
+            )
 
     return _async_wrap
 
@@ -566,81 +578,85 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
 
     def set_music_mode(self, music_mode) -> None:
         """Set the music mode on or off."""
-        if music_mode:
-            try:
-                self._bulb.start_music()
-            except AssertionError as ex:
-                _LOGGER.error(ex)
-        else:
+        if not music_mode:
             self._bulb.stop_music()
+            return
+
+        try:
+            self._bulb.start_music()
+        except AssertionError as ex:
+            raise HomeAssistantError(
+                f"Error when calling start_music for bulb {self.device.name} at {self.device.host}: {ex}"
+            )
 
     @_async_cmd
     async def async_set_brightness(self, brightness, duration) -> None:
         """Set bulb brightness."""
-        if brightness:
-            if math.floor(self.brightness) == math.floor(brightness):
-                _LOGGER.debug("brightness already set to: %s", brightness)
-                # Already set, and since we get pushed updates
-                # we avoid setting it again to ensure we do not
-                # hit the rate limit
-                return
+        if not brightness:
+            return
+        if math.floor(self.brightness) == math.floor(brightness):
+            _LOGGER.debug("brightness already set to: %s", brightness)
+            # Already set, and since we get pushed updates
+            # we avoid setting it again to ensure we do not
+            # hit the rate limit
+            return
 
-            _LOGGER.debug("Setting brightness: %s", brightness)
-            await self._bulb.async_set_brightness(
-                brightness / 255 * 100, duration=duration, light_type=self.light_type
-            )
+        _LOGGER.debug("Setting brightness: %s", brightness)
+        await self._bulb.async_set_brightness(
+            brightness / 255 * 100, duration=duration, light_type=self.light_type
+        )
 
     @_async_cmd
     async def async_set_hs(self, hs_color, duration) -> None:
         """Set bulb's color."""
-        if hs_color and COLOR_MODE_HS in self.supported_color_modes:
-            if self.color_mode == COLOR_MODE_HS and self.hs_color == hs_color:
-                _LOGGER.debug("HS already set to: %s", hs_color)
-                # Already set, and since we get pushed updates
-                # we avoid setting it again to ensure we do not
-                # hit the rate limit
-                return
+        if not hs_color or COLOR_MODE_HS not in self.supported_color_modes:
+            return
+        if self.color_mode == COLOR_MODE_HS and self.hs_color == hs_color:
+            _LOGGER.debug("HS already set to: %s", hs_color)
+            # Already set, and since we get pushed updates
+            # we avoid setting it again to ensure we do not
+            # hit the rate limit
+            return
 
-            _LOGGER.debug("Setting HS: %s", hs_color)
-            await self._bulb.async_set_hsv(
-                hs_color[0], hs_color[1], duration=duration, light_type=self.light_type
-            )
+        _LOGGER.debug("Setting HS: %s", hs_color)
+        await self._bulb.async_set_hsv(
+            hs_color[0], hs_color[1], duration=duration, light_type=self.light_type
+        )
 
     @_async_cmd
     async def async_set_rgb(self, rgb, duration) -> None:
         """Set bulb's color."""
-        if rgb and COLOR_MODE_RGB in self.supported_color_modes:
-            if self.color_mode == COLOR_MODE_RGB and self.rgb_color == rgb:
-                _LOGGER.debug("RGB already set to: %s", rgb)
-                # Already set, and since we get pushed updates
-                # we avoid setting it again to ensure we do not
-                # hit the rate limit
-                return
+        if not rgb or COLOR_MODE_RGB not in self.supported_color_modes:
+            return
+        if self.color_mode == COLOR_MODE_RGB and self.rgb_color == rgb:
+            _LOGGER.debug("RGB already set to: %s", rgb)
+            # Already set, and since we get pushed updates
+            # we avoid setting it again to ensure we do not
+            # hit the rate limit
+            return
 
-            _LOGGER.debug("Setting RGB: %s", rgb)
-            await self._bulb.async_set_rgb(
-                *rgb, duration=duration, light_type=self.light_type
-            )
+        _LOGGER.debug("Setting RGB: %s", rgb)
+        await self._bulb.async_set_rgb(
+            *rgb, duration=duration, light_type=self.light_type
+        )
 
     @_async_cmd
     async def async_set_colortemp(self, colortemp, duration) -> None:
         """Set bulb's color temperature."""
-        if colortemp and COLOR_MODE_COLOR_TEMP in self.supported_color_modes:
-            temp_in_k = mired_to_kelvin(colortemp)
+        if not colortemp or COLOR_MODE_COLOR_TEMP not in self.supported_color_modes:
+            return
+        temp_in_k = mired_to_kelvin(colortemp)
 
-            if (
-                self.color_mode == COLOR_MODE_COLOR_TEMP
-                and self.color_temp == colortemp
-            ):
-                _LOGGER.debug("Color temp already set to: %s", temp_in_k)
-                # Already set, and since we get pushed updates
-                # we avoid setting it again to ensure we do not
-                # hit the rate limit
-                return
+        if self.color_mode == COLOR_MODE_COLOR_TEMP and self.color_temp == colortemp:
+            _LOGGER.debug("Color temp already set to: %s", temp_in_k)
+            # Already set, and since we get pushed updates
+            # we avoid setting it again to ensure we do not
+            # hit the rate limit
+            return
 
-            await self._bulb.async_set_color_temp(
-                temp_in_k, duration=duration, light_type=self.light_type
-            )
+        await self._bulb.async_set_color_temp(
+            temp_in_k, duration=duration, light_type=self.light_type
+        )
 
     @_async_cmd
     async def async_set_default(self) -> None:
@@ -650,37 +666,33 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
     @_async_cmd
     async def async_set_flash(self, flash) -> None:
         """Activate flash."""
-        if flash:
-            if int(self._bulb.last_properties["color_mode"]) != 1:
-                _LOGGER.error("Flash supported currently only in RGB mode")
-                return
+        if not flash:
+            return
+        if int(self._bulb.last_properties["color_mode"]) != 1:
+            _LOGGER.error("Flash supported currently only in RGB mode")
+            return
 
-            transition = int(self.config[CONF_TRANSITION])
-            if flash == FLASH_LONG:
-                count = 1
-                duration = transition * 5
-            if flash == FLASH_SHORT:
-                count = 1
-                duration = transition * 2
+        transition = int(self.config[CONF_TRANSITION])
+        if flash == FLASH_LONG:
+            count = 1
+            duration = transition * 5
+        if flash == FLASH_SHORT:
+            count = 1
+            duration = transition * 2
 
-            red, green, blue = color_util.color_hs_to_RGB(*self.hs_color)
+        red, green, blue = color_util.color_hs_to_RGB(*self.hs_color)
 
-            transitions = []
-            transitions.append(
-                RGBTransition(255, 0, 0, brightness=10, duration=duration)
+        transitions = []
+        transitions.append(RGBTransition(255, 0, 0, brightness=10, duration=duration))
+        transitions.append(SleepTransition(duration=transition))
+        transitions.append(
+            RGBTransition(
+                red, green, blue, brightness=self.brightness, duration=duration
             )
-            transitions.append(SleepTransition(duration=transition))
-            transitions.append(
-                RGBTransition(
-                    red, green, blue, brightness=self.brightness, duration=duration
-                )
-            )
+        )
 
-            flow = Flow(count=count, transitions=transitions)
-            try:
-                await self._bulb.async_start_flow(flow, light_type=self.light_type)
-            except BULB_EXCEPTIONS as ex:
-                _LOGGER.error("Unable to set flash: %s", ex)
+        flow = Flow(count=count, transitions=transitions)
+        await self._bulb.async_start_flow(flow, light_type=self.light_type)
 
     @_async_cmd
     async def async_set_effect(self, effect) -> None:
@@ -707,11 +719,8 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         else:
             return
 
-        try:
-            await self._bulb.async_start_flow(flow, light_type=self.light_type)
-            self._effect = effect
-        except BULB_EXCEPTIONS as ex:
-            _LOGGER.error("Unable to set effect: %s", ex)
+        await self._bulb.async_start_flow(flow, light_type=self.light_type)
+        self._effect = effect
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the bulb on."""
@@ -743,25 +752,16 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
                     "Unable to turn on music mode, consider disabling it: %s", ex
                 )
 
-        try:
-            # values checked for none in methods
-            await self.async_set_hs(hs_color, duration)
-            await self.async_set_rgb(rgb, duration)
-            await self.async_set_colortemp(colortemp, duration)
-            await self.async_set_brightness(brightness, duration)
-            await self.async_set_flash(flash)
-            await self.async_set_effect(effect)
-        except BULB_EXCEPTIONS as ex:
-            _LOGGER.error("Unable to set bulb properties: %s", ex)
-            return
+        await self.async_set_hs(hs_color, duration)
+        await self.async_set_rgb(rgb, duration)
+        await self.async_set_colortemp(colortemp, duration)
+        await self.async_set_brightness(brightness, duration)
+        await self.async_set_flash(flash)
+        await self.async_set_effect(effect)
 
         # save the current state if we had a manual change.
         if self.config[CONF_SAVE_ON_CHANGE] and (brightness or colortemp or rgb):
-            try:
-                await self.async_set_default()
-            except BULB_EXCEPTIONS as ex:
-                _LOGGER.error("Unable to set the defaults: %s", ex)
-                return
+            await self.async_set_default()
 
         # Some devices (mainly nightlights) will not send back the on state so we need to force a refresh
         if not self.is_on:
@@ -781,34 +781,25 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         if self.is_on:
             await self.device.async_update(True)
 
+    @_async_cmd
     async def async_set_mode(self, mode: str):
         """Set a power mode."""
-        try:
-            await self._bulb.async_set_power_mode(PowerMode[mode.upper()])
-        except BULB_EXCEPTIONS as ex:
-            _LOGGER.error("Unable to set the power mode: %s", ex)
+        await self._bulb.async_set_power_mode(PowerMode[mode.upper()])
 
+    @_async_cmd
     async def async_start_flow(self, transitions, count=0, action=ACTION_RECOVER):
         """Start flow."""
-        try:
-            flow = Flow(
-                count=count, action=Flow.actions[action], transitions=transitions
-            )
+        flow = Flow(count=count, action=Flow.actions[action], transitions=transitions)
+        await self._bulb.async_start_flow(flow, light_type=self.light_type)
 
-            await self._bulb.async_start_flow(flow, light_type=self.light_type)
-        except BULB_EXCEPTIONS as ex:
-            _LOGGER.error("Unable to set effect: %s", ex)
-
+    @_async_cmd
     async def async_set_scene(self, scene_class, *args):
         """
         Set the light directly to the specified state.
 
         If the light is off, it will first be turned on.
         """
-        try:
-            await self._bulb.async_set_scene(scene_class, *args)
-        except BULB_EXCEPTIONS as ex:
-            _LOGGER.error("Unable to set scene: %s", ex)
+        await self._bulb.async_set_scene(scene_class, *args)
 
 
 class YeelightColorLightSupport(YeelightGenericLight):

--- a/tests/components/yeelight/__init__.py
+++ b/tests/components/yeelight/__init__.py
@@ -125,6 +125,7 @@ def _mocked_bulb(cannot_connect=False):
     )
     type(bulb).get_model_specs = MagicMock(return_value=_MODEL_SPECS[MODEL])
     bulb.capabilities = CAPABILITIES.copy()
+    bulb.available = True
     bulb.last_properties = PROPERTIES.copy()
     bulb.music_mode = False
     bulb.async_get_properties = AsyncMock()

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -404,11 +404,16 @@ async def test_services(hass: HomeAssistant, caplog):
     )
 
     # set_music_mode failure enable
-    await _async_test_service(
+    mocked_bulb.start_music = MagicMock(side_effect=AssertionError)
+    assert "Unable to turn on music mode, consider disabling it" not in caplog.text
+    await hass.services.async_call(
+        DOMAIN,
         SERVICE_SET_MUSIC_MODE,
         {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_MODE_MUSIC: "true"},
-        "start_music",
+        blocking=True,
     )
+    assert mocked_bulb.start_music.mock_calls == [call()]
+    assert "Unable to turn on music mode, consider disabling it" in caplog.text
 
     # set_music_mode disable
     await _async_test_service(

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -30,6 +30,7 @@ from homeassistant.components.light import (
     ATTR_RGB_COLOR,
     ATTR_TRANSITION,
     FLASH_LONG,
+    FLASH_SHORT,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
@@ -289,6 +290,50 @@ async def test_services(hass: HomeAssistant, caplog):
             ATTR_BRIGHTNESS: brightness,
             ATTR_COLOR_TEMP: color_temp,
             ATTR_FLASH: FLASH_LONG,
+            ATTR_EFFECT: EFFECT_STOP,
+            ATTR_TRANSITION: transition,
+        },
+        blocking=True,
+    )
+    mocked_bulb.async_turn_on.assert_called_once_with(
+        duration=transition * 1000,
+        light_type=LightType.Main,
+        power_mode=PowerMode.NORMAL,
+    )
+    mocked_bulb.async_turn_on.reset_mock()
+    mocked_bulb.start_music.assert_called_once()
+    mocked_bulb.async_set_brightness.assert_called_once_with(
+        brightness / 255 * 100, duration=transition * 1000, light_type=LightType.Main
+    )
+    mocked_bulb.async_set_color_temp.assert_called_once_with(
+        color_temperature_mired_to_kelvin(color_temp),
+        duration=transition * 1000,
+        light_type=LightType.Main,
+    )
+    mocked_bulb.async_set_hsv.assert_not_called()
+    mocked_bulb.async_set_rgb.assert_not_called()
+    mocked_bulb.async_start_flow.assert_called_once()  # flash
+    mocked_bulb.async_stop_flow.assert_called_once_with(light_type=LightType.Main)
+
+    # turn_on color_temp - flash short
+    brightness = 100
+    color_temp = 200
+    transition = 1
+    mocked_bulb.start_music.reset_mock()
+    mocked_bulb.async_set_brightness.reset_mock()
+    mocked_bulb.async_set_color_temp.reset_mock()
+    mocked_bulb.async_start_flow.reset_mock()
+    mocked_bulb.async_stop_flow.reset_mock()
+
+    mocked_bulb.last_properties["power"] = "off"
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: ENTITY_LIGHT,
+            ATTR_BRIGHTNESS: brightness,
+            ATTR_COLOR_TEMP: color_temp,
+            ATTR_FLASH: FLASH_SHORT,
             ATTR_EFFECT: EFFECT_STOP,
             ATTR_TRANSITION: transition,
         },


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Ensure the bulb gets marked as unavailable when there is a network exception


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #56333
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
