### PR TITLE
Update pylint to 2.11.1

### DIFF
--- a/homeassistant/components/ambiclimate/config_flow.py
+++ b/homeassistant/components/ambiclimate/config_flow.py
@@ -142,6 +142,7 @@ class AmbiclimateAuthCallbackView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> str:
         """Receive authorization token."""
+        # pylint: disable=no-self-use
         code = request.query.get("code")
         if code is None:
             return "No code"

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -358,6 +358,7 @@ def adb_decorator(override_available=False):
         @functools.wraps(func)
         async def _adb_exception_catcher(self, *args, **kwargs):
             """Call an ADB-related method and catch exceptions."""
+            # pylint: disable=protected-access
             if not self.available and not override_available:
                 return None
 

--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -93,6 +93,7 @@ class APIEventStream(HomeAssistantView):
 
     async def get(self, request):
         """Provide a streaming interface for the event bus."""
+        # pylint: disable=no-self-use
         if not request["hass_user"].is_admin:
             raise Unauthorized()
         hass = request.app["hass"]
@@ -414,6 +415,7 @@ class APIErrorLog(HomeAssistantView):
 
     async def get(self, request):
         """Retrieve API error log."""
+        # pylint: disable=no-self-use
         if not request["hass_user"].is_admin:
             raise Unauthorized()
         return web.FileResponse(request.app["hass"].data[DATA_LOGGING])

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -264,6 +264,8 @@ class TokenView(HomeAssistantView):
 
     async def _async_handle_revoke_token(self, hass, data):
         """Handle revoke token request."""
+        # pylint: disable=no-self-use
+
         # OAuth 2.0 Token Revocation [RFC7009]
         # 2.2 The authorization server responds with HTTP status code 200
         # if the token has been revoked successfully or if the client

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -157,6 +157,7 @@ class LoginFlowIndexView(HomeAssistantView):
 
     async def get(self, request):
         """Do not allow index of flows in progress."""
+        # pylint: disable=no-self-use
         return web.Response(status=HTTP_METHOD_NOT_ALLOWED)
 
     @RequestDataValidator(

--- a/homeassistant/components/awair/__init__.py
+++ b/homeassistant/components/awair/__init__.py
@@ -74,6 +74,7 @@ class AwairDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _fetch_air_data(self, device):
         """Fetch latest air quality data."""
+        # pylint: disable=no-self-use
         LOGGER.debug("Fetching data for %s", device.uuid)
         air_data = await device.air_data_latest()
         LOGGER.debug(air_data)

--- a/homeassistant/components/blueprint/models.py
+++ b/homeassistant/components/blueprint/models.py
@@ -316,7 +316,7 @@ class DomainBlueprints:
             raise FileAlreadyExists(self.domain, blueprint_path)
 
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(blueprint.yaml())
+        path.write_text(blueprint.yaml(), encoding="utf-8")
 
     async def async_add_blueprint(
         self, blueprint: Blueprint, blueprint_path: str

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -434,6 +434,7 @@ class Camera(Entity):
 
     async def stream_source(self) -> str | None:
         """Return the source of the stream."""
+        # pylint: disable=no-self-use
         return None
 
     def camera_image(

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -116,6 +116,7 @@ class ConfigManagerFlowIndexView(FlowManagerIndexView):
 
     async def get(self, request):
         """Not implemented."""
+        # pylint: disable=no-self-use
         raise aiohttp.web_exceptions.HTTPMethodNotAllowed("GET", ["POST"])
 
     # pylint: disable=arguments-differ

--- a/homeassistant/components/conversation/agent.py
+++ b/homeassistant/components/conversation/agent.py
@@ -17,10 +17,12 @@ class AbstractConversationAgent(ABC):
 
     async def async_get_onboarding(self):
         """Get onboard data."""
+        # pylint: disable=no-self-use
         return None
 
     async def async_set_onboarding(self, shown):
         """Set onboard data."""
+        # pylint: disable=no-self-use
         return True
 
     @abstractmethod

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -309,10 +309,7 @@ class DenonDevice(MediaPlayerEntity):
     @property
     def media_content_type(self):
         """Content type of current playing media."""
-        if (
-            self._receiver.state == STATE_PLAYING
-            or self._receiver.state == STATE_PAUSED
-        ):
+        if self._receiver.state in (STATE_PLAYING, STATE_PAUSED):
             return MEDIA_TYPE_MUSIC
         return MEDIA_TYPE_CHANNEL
 

--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -324,6 +324,7 @@ class DoorBirdRequestView(HomeAssistantView):
 
     async def get(self, request, event):
         """Respond to requests from the device."""
+        # pylint: disable=no-self-use
         hass = request.app["hass"]
 
         token = request.query.get("token")

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -676,7 +676,7 @@ class Thermostat(ClimateEntity):
         heatCoolMinDelta property.
         https://www.ecobee.com/home/developer/api/examples/ex5.shtml
         """
-        if self.hvac_mode == HVAC_MODE_HEAT or self.hvac_mode == HVAC_MODE_COOL:
+        if self.hvac_mode in (HVAC_MODE_HEAT, HVAC_MODE_COOL):
             heat_temp = temp
             cool_temp = temp
         else:

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -65,8 +65,9 @@ class ElkThermostat(ElkEntity, ClimateEntity):
     @property
     def target_temperature(self):
         """Return the temperature we are trying to reach."""
-        if (self._element.mode == ThermostatMode.HEAT.value) or (
-            self._element.mode == ThermostatMode.EMERGENCY_HEAT.value
+        if self._element.mode in (
+            ThermostatMode.HEAT.value,
+            ThermostatMode.EMERGENCY_HEAT.value,
         ):
             return self._element.heat_setpoint
         if self._element.mode == ThermostatMode.COOL.value:

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -805,6 +805,7 @@ def esphome_state_property(func: _PropT) -> _PropT:
     @property  # type: ignore[misc]
     @functools.wraps(func)
     def _wrapper(self):  # type: ignore[no-untyped-def]
+        # pylint: disable=protected-access
         if not self._has_state:
             return None
         val = func(self)

--- a/homeassistant/components/fibaro/climate.py
+++ b/homeassistant/components/fibaro/climate.py
@@ -136,7 +136,7 @@ class FibaroThermostat(FibaroDevice, ClimateEntity):
                     "value" in device.properties
                     or "heatingThermostatSetpoint" in device.properties
                 )
-                and (device.properties.unit == "C" or device.properties.unit == "F")
+                and device.properties.unit in ("C", "F")
             ):
                 self._temp_sensor_device = FibaroDevice(device)
                 tempunit = device.properties.unit

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -114,9 +114,9 @@ class FritzboxThermostat(FritzBoxEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> str:
         """Return the current operation mode."""
-        if (
-            self.device.target_temperature == OFF_REPORT_SET_TEMPERATURE
-            or self.device.target_temperature == OFF_API_TEMPERATURE
+        if self.device.target_temperature in (
+            OFF_REPORT_SET_TEMPERATURE,
+            OFF_API_TEMPERATURE,
         ):
             return HVAC_MODE_OFF
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -963,6 +963,7 @@ class HomeKitPairingQRView(HomeAssistantView):
 
     async def get(self, request):
         """Retrieve the pairing QRCode image."""
+        # pylint: disable=no-self-use
         if not request.query_string:
             raise Unauthorized()
         entry_id, secret = request.query_string.split("-")

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -59,6 +59,7 @@ class HomematicipAuth:
 
     async def get_auth(self, hass: HomeAssistant, hapid, pin):
         """Create a HomematicIP access point object."""
+        # pylint: disable=no-self-use
         auth = AsyncAuth(hass.loop, async_get_clientsession(hass))
         try:
             await auth.init(hapid)

--- a/homeassistant/components/huisbaasje/config_flow.py
+++ b/homeassistant/components/huisbaasje/config_flow.py
@@ -69,6 +69,7 @@ class HuisbaasjeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         Data has the keys from DATA_SCHEMA with values provided by the user.
         """
+        # pylint: disable=no-self-use
         username = user_input[CONF_USERNAME]
         password = user_input[CONF_PASSWORD]
 

--- a/homeassistant/components/limitlessled/light.py
+++ b/homeassistant/components/limitlessled/light.py
@@ -179,6 +179,7 @@ def state(new_state):
 
         def wrapper(self, **kwargs):
             """Wrap a group state change."""
+            # pylint: disable=protected-access
 
             pipeline = Pipeline()
             transition_time = DEFAULT_TRANSITION

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -69,10 +69,12 @@ class LovelaceConfig(ABC):
 
     async def async_save(self, config):
         """Save config."""
+        # pylint: disable=no-self-use
         raise HomeAssistantError("Not supported")
 
     async def async_delete(self):
         """Delete config."""
+        # pylint: disable=no-self-use
         raise HomeAssistantError("Not supported")
 
     @callback

--- a/homeassistant/components/manual/alarm_control_panel.py
+++ b/homeassistant/components/manual/alarm_control_panel.py
@@ -412,7 +412,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        if self.state == STATE_ALARM_PENDING or self.state == STATE_ALARM_ARMING:
+        if self.state in (STATE_ALARM_PENDING, STATE_ALARM_ARMING):
             return {
                 ATTR_PREVIOUS_STATE: self._previous_state,
                 ATTR_NEXT_STATE: self._state,
@@ -430,10 +430,7 @@ class ManualAlarm(alarm.AlarmControlPanelEntity, RestoreEntity):
         state = await self.async_get_last_state()
         if state:
             if (
-                (
-                    state.state == STATE_ALARM_PENDING
-                    or state.state == STATE_ALARM_ARMING
-                )
+                state.state in (STATE_ALARM_PENDING, STATE_ALARM_ARMING)
                 and hasattr(state, "attributes")
                 and state.attributes[ATTR_PREVIOUS_STATE]
             ):

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -507,6 +507,7 @@ class MediaPlayerEntity(Entity):
 
         Must be implemented by integration.
         """
+        # pylint: disable=no-self-use
         return None, None
 
     @property

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -60,7 +60,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     self.hass.helpers.aiohttp_client.async_get_clientsession(),
                 )
         except ClientResponseError as err:
-            if err.status == HTTP_UNAUTHORIZED or err.status == HTTP_FORBIDDEN:
+            if err.status in (HTTP_UNAUTHORIZED, HTTP_FORBIDDEN):
                 return self.async_abort(reason="invalid_auth")
             return self.async_abort(reason="cannot_connect")
         except (asyncio.TimeoutError, ClientError):

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -222,6 +222,7 @@ class NestCamera(Camera):
         self, trait: EventImageGenerator
     ) -> bytes | None:
         """Return image bytes for an active event."""
+        # pylint: disable=no-self-use
         try:
             event_image = await trait.generate_active_event_image()
         except GoogleNestException as err:

--- a/homeassistant/components/openweathermap/weather_update_coordinator.py
+++ b/homeassistant/components/openweathermap/weather_update_coordinator.py
@@ -83,9 +83,9 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
 
     async def _get_owm_weather(self):
         """Poll weather data from OWM."""
-        if (
-            self._forecast_mode == FORECAST_MODE_ONECALL_HOURLY
-            or self._forecast_mode == FORECAST_MODE_ONECALL_DAILY
+        if self._forecast_mode in (
+            FORECAST_MODE_ONECALL_HOURLY,
+            FORECAST_MODE_ONECALL_DAILY,
         ):
             weather = await self.hass.async_add_executor_job(
                 self._owm_client.one_call, self._latitude, self._longitude

--- a/homeassistant/components/ozw/__init__.py
+++ b/homeassistant/components/ozw/__init__.py
@@ -370,7 +370,7 @@ async def async_handle_node_update(hass: HomeAssistant, node: OZWNode):
         return
     # update device in device registry with (updated) info
     for item in dev_registry.devices.values():
-        if item.id != device.id and item.via_device_id != device.id:
+        if device.id not in (item.id, item.via_device_id):
             continue
         dev_name = create_device_name(node)
         dev_registry.async_update_device(

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -422,6 +422,7 @@ class PlexAuthorizationCallbackView(HomeAssistantView):
 
     async def get(self, request):
         """Receive authorization confirmation."""
+        # pylint: disable=no-self-use
         hass = request.app["hass"]
         await hass.config_entries.flow.async_configure(
             flow_id=request.query["flow_id"], user_input=None

--- a/homeassistant/components/sensehat/sensor.py
+++ b/homeassistant/components/sensehat/sensor.py
@@ -62,7 +62,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def get_cpu_temp():
     """Get CPU temperature."""
-    t_cpu = Path("/sys/class/thermal/thermal_zone0/temp").read_text().strip()
+    t_cpu = (
+        Path("/sys/class/thermal/thermal_zone0/temp")
+        .read_text(encoding="utf-8")
+        .strip()
+    )
     return float(t_cpu) * 0.001
 
 

--- a/homeassistant/components/smarttub/controller.py
+++ b/homeassistant/components/smarttub/controller.py
@@ -93,6 +93,7 @@ class SmartTubController:
         return data
 
     async def _get_spa_data(self, spa):
+        # pylint: disable=no-self-use
         full_status, reminders, errors = await asyncio.gather(
             spa.get_status_full(),
             spa.get_reminders(),

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -903,10 +903,7 @@ class SonosSpeaker:
             for speaker in (s for s in speakers if s.snapshot_group):
                 assert speaker.snapshot_group is not None
                 if speaker.snapshot_group[0] == speaker:
-                    if (
-                        speaker.snapshot_group != speaker.sonos_group
-                        and speaker.snapshot_group != [speaker]
-                    ):
+                    if speaker.snapshot_group not in (speaker.sonos_group, [speaker]):
                         speaker.join(speaker.snapshot_group)
                     groups.append(speaker.snapshot_group.copy())
 

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -207,6 +207,7 @@ def spotify_exception_handler(func):
     """
 
     def wrapper(self, *args, **kwargs):
+        # pylint: disable=protected-access
         try:
             result = func(self, *args, **kwargs)
             self._attr_available = True

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -170,7 +170,6 @@ class Segment:
         # Preload hints help save round trips by informing the client about the next part.
         # The next part will usually be in this segment but will be first part of the next
         # segment if this segment is already complete.
-        # pylint: disable=undefined-loop-variable
         if self.complete:  # Next part belongs to next segment
             sequence = self.sequence + 1
             part_num = 0

--- a/homeassistant/components/tank_utility/sensor.py
+++ b/homeassistant/components/tank_utility/sensor.py
@@ -111,11 +111,9 @@ class TankUtilitySensor(SensorEntity):
         try:
             data = tank_monitor.get_device_data(self._token, self.device)
         except requests.exceptions.HTTPError as http_error:
-            if (
-                http_error.response.status_code
-                == requests.codes.unauthorized  # pylint: disable=no-member
-                or http_error.response.status_code
-                == requests.codes.bad_request  # pylint: disable=no-member
+            if http_error.response.status_code in (
+                requests.codes.unauthorized,  # pylint: disable=no-member
+                requests.codes.bad_request,  # pylint: disable=no-member
             ):
                 _LOGGER.info("Getting new token")
                 self._token = auth.get_token(self._email, self._password, force=True)

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -271,7 +271,7 @@ class Timer(RestoreEntity):
             newduration = duration
 
         event = EVENT_TIMER_STARTED
-        if self._state == STATUS_ACTIVE or self._state == STATUS_PAUSED:
+        if self._state in (STATUS_ACTIVE, STATUS_PAUSED):
             event = EVENT_TIMER_RESTARTED
 
         self._state = STATUS_ACTIVE

--- a/homeassistant/components/webhook/__init__.py
+++ b/homeassistant/components/webhook/__init__.py
@@ -131,6 +131,7 @@ class WebhookView(HomeAssistantView):
 
     async def _handle(self, request: Request, webhook_id):
         """Handle webhook call."""
+        # pylint: disable=no-self-use
         _LOGGER.debug("Handling webhook %s payload for %s", request.method, webhook_id)
         hass = request.app["hass"]
         return await async_handle_webhook(hass, webhook_id, request)

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -304,9 +304,7 @@ class LgWebOSMediaPlayerEntity(MediaPlayerEntity):
         """Flag media player features that are supported."""
         supported = SUPPORT_WEBOSTV
 
-        if (self._client.sound_output == "external_arc") or (
-            self._client.sound_output == "external_speaker"
-        ):
+        if self._client.sound_output in ("external_arc", "external_speaker"):
             supported = supported | SUPPORT_WEBOSTV_VOLUME
         elif self._client.sound_output != "lineout":
             supported = supported | SUPPORT_WEBOSTV_VOLUME | SUPPORT_VOLUME_SET

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -42,6 +42,7 @@ class WebsocketAPIView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.WebSocketResponse:
         """Handle an incoming websocket connection."""
+        # pylint: disable=no-self-use
         return await WebSocketHandler(request.app["hass"], request).async_handle()
 
 

--- a/homeassistant/components/whirlpool/config_flow.py
+++ b/homeassistant/components/whirlpool/config_flow.py
@@ -9,7 +9,7 @@ from whirlpool.auth import Auth
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -640,6 +640,7 @@ class DataManager:
 
         Withings' API occasionally and incorrectly throws errors. Retrying the call tends to work.
         """
+        # pylint: disable=no-self-use
         exception = None
         for attempt in range(1, attempts + 1):
             _LOGGER.debug("Attempt %s of %s", attempt, attempts)

--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -268,7 +268,7 @@ class ZWaveClimateBase(ZWaveDeviceEntity, ClimateEntity):
 
             # Default operation mode
             for mode in DEFAULT_HVAC_MODES:
-                if mode in self._hvac_mapping.keys():
+                if mode in self._hvac_mapping:
                     self._default_hvac_mode = mode
                     break
 
@@ -291,14 +291,14 @@ class ZWaveClimateBase(ZWaveDeviceEntity, ClimateEntity):
                 # The current mode is not a hvac mode
                 if (
                     "heat" in current_mode.lower()
-                    and HVAC_MODE_HEAT in self._hvac_mapping.keys()
+                    and HVAC_MODE_HEAT in self._hvac_mapping
                 ):
                     # The current preset modes maps to HVAC_MODE_HEAT
                     _LOGGER.debug("Mapped to HEAT")
                     self._hvac_mode = HVAC_MODE_HEAT
                 elif (
                     "cool" in current_mode.lower()
-                    and HVAC_MODE_COOL in self._hvac_mapping.keys()
+                    and HVAC_MODE_COOL in self._hvac_mapping
                 ):
                     # The current preset modes maps to HVAC_MODE_COOL
                     _LOGGER.debug("Mapped to COOL")

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1274,6 +1274,7 @@ class DumpView(HomeAssistantView):
 
     async def get(self, request: web.Request, config_entry_id: str) -> web.Response:
         """Dump the state of Z-Wave."""
+        # pylint: disable=no-self-use
         if not request["hass_user"].is_admin:
             raise Unauthorized()
         hass = request.app["hass"]

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -471,6 +471,7 @@ class ZWaveNodeStatusSensor(SensorEntity):
 
     async def async_poll_value(self, _: bool) -> None:
         """Poll a value."""
+        # pylint: disable=no-self-use
         raise ValueError("There is no value to poll for this entity")
 
     @callback

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -359,6 +359,7 @@ class ZWaveServices:
 
     async def async_set_config_parameter(self, service: ServiceCall) -> None:
         """Set a config value on a node."""
+        # pylint: disable=no-self-use
         nodes = service.data[const.ATTR_NODES]
         property_or_property_name = service.data[const.ATTR_CONFIG_PARAMETER]
         property_key = service.data.get(const.ATTR_CONFIG_PARAMETER_BITMASK)
@@ -386,6 +387,7 @@ class ZWaveServices:
         self, service: ServiceCall
     ) -> None:
         """Bulk set multiple partial config values on a node."""
+        # pylint: disable=no-self-use
         nodes = service.data[const.ATTR_NODES]
         property_ = service.data[const.ATTR_CONFIG_PARAMETER]
         new_value = service.data[const.ATTR_CONFIG_VALUE]
@@ -420,6 +422,7 @@ class ZWaveServices:
 
     async def async_set_value(self, service: ServiceCall) -> None:
         """Set a value on a node."""
+        # pylint: disable=no-self-use
         nodes = service.data[const.ATTR_NODES]
         command_class = service.data[const.ATTR_COMMAND_CLASS]
         property_ = service.data[const.ATTR_PROPERTY]
@@ -496,5 +499,6 @@ class ZWaveServices:
 
     async def async_ping(self, service: ServiceCall) -> None:
         """Ping node(s)."""
+        # pylint: disable=no-self-use
         nodes: set[ZwaveNode] = service.data[const.ATTR_NODES]
         await asyncio.gather(*(node.async_ping() for node in nodes))

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -488,6 +488,7 @@ class HomeAssistant:
 
     async def _await_and_log_pending(self, pending: Iterable[Awaitable[Any]]) -> None:
         """Await and log tasks that take a long time."""
+        # pylint: disable=no-self-use
         wait_time = 0
         while pending:
             _, pending = await asyncio.wait(pending, timeout=BLOCK_LOG_TIMEOUT)

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -406,6 +406,7 @@ class OAuth2AuthorizeCallbackView(http.HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Receive authorization code."""
+        # pylint: disable=no-self-use
         if "code" not in request.query or "state" not in request.query:
             return web.Response(
                 text=f"Missing code or state parameter in {request.url}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ forced_separate = [
 combine_as_imports = true
 
 [tool.pylint.MASTER]
+py-version = "3.8"
 ignore = [
     "tests",
 ]
@@ -72,6 +73,7 @@ good-names = [
 # ---
 # Enable once current issues are fixed:
 # consider-using-namedtuple-or-dataclass (Pylint CodeStyle extension)
+# consider-using-assignment-expr (Pylint CodeStyle extension)
 disable = [
     "format",
     "abstract-class-little-used",
@@ -95,6 +97,7 @@ disable = [
     "unused-argument",
     "wrong-import-order",
     "consider-using-namedtuple-or-dataclass",
+    "consider-using-assignment-expr",
 ]
 enable = [
     #"useless-suppression",  # temporarily every now and then to clean them up
@@ -120,8 +123,10 @@ overgeneral-exceptions = [
 ]
 
 [tool.pylint.TYPING]
-py-version = "3.8"
 runtime-typing = false
+
+[tool.pylint.CODE_STYLE]
+max-line-length-suggestions = 72
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ good-names = [
 # inconsistent-return-statements - doesn't handle raise
 # too-many-ancestors - it's too strict.
 # wrong-import-order - isort guards this
+# consider-using-f-string - str.format sometimes more readable
 # ---
 # Enable once current issues are fixed:
 # consider-using-namedtuple-or-dataclass (Pylint CodeStyle extension)
@@ -96,6 +97,7 @@ disable = [
     "too-many-boolean-expressions",
     "unused-argument",
     "wrong-import-order",
+    "consider-using-f-string",
     "consider-using-namedtuple-or-dataclass",
     "consider-using-assignment-expr",
 ]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,7 +13,7 @@ jsonpickle==1.4.1
 mock-open==1.4.0
 mypy==0.910
 pre-commit==2.14.0
-pylint==2.10.2
+pylint==2.11.1
 pipdeptree==1.0.0
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
## Proposed change
Update pylint to `2.11.1`.
Release summery: https://pylint.pycqa.org/en/latest/whatsnew/2.11.html
Full changelog: https://pylint.pycqa.org/en/latest/whatsnew/changelog.html#what-s-new-in-pylint-2-11-1
Full diff: https://github.com/PyCQA/pylint/compare/v2.10.2...v2.11.1

#### Notable changes
* Added `py-version` config key. Used by pylint to not suggest features that aren't supported by all project supported Python versions. E.g. not suggest assignment expressions if a project still supports Python 3.7, but pylint is run with Python 3.8
**This should be updated if minimum Python version for Home Assistant changes.**
* `consider-using-in` now also works for attributes: `self.x == 1 or self.x == 2`
* `no-self-use` is emitted for `async` function (added `pylint: disable` for that) -> we might want to consider if we disable this check completely
* Recognize unnecessary `dict.keys()` calls for `in` checks: `if key in dict.keys(): ...`
* New checks
  * `consider-using-f-string`: Emitted when `str.format` is used -> not really useful as sometimes `format()` might be more readable. **I've disabled the check.** There is some discussion about making the check optional in pylint itself https://github.com/PyCQA/pylint/issues/5039.
  * `consider-using-assignment-expr`: Suggest the use of assignment expressions. See https://github.com/home-assistant/architecture/discussions/617 for more details. Temporarily disabled as I wanted to keep the diff small here. Updating the existing code will be part of followup PR(s).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
