### PR TITLE
Use attrs in Xiaomi Miio humidifier platform

### DIFF
--- a/homeassistant/components/xiaomi_miio/humidifier.py
+++ b/homeassistant/components/xiaomi_miio/humidifier.py
@@ -176,25 +176,20 @@ class XiaomiAirHumidifier(XiaomiGenericHumidifier, HumidifierEntity):
     def __init__(self, name, device, entry, unique_id, coordinator):
         """Initialize the plug switch."""
         super().__init__(name, device, entry, unique_id, coordinator)
+
+        self._attr_min_humidity = 30
+        self._attr_max_humidity = 80
         if self._model in [MODEL_AIRHUMIDIFIER_CA1, MODEL_AIRHUMIDIFIER_CB1]:
             self._attr_available_modes = AVAILABLE_MODES_CA1_CB1
-            self._attr_min_humidity = 30
-            self._attr_max_humidity = 80
             self._humidity_steps = 10
         elif self._model in [MODEL_AIRHUMIDIFIER_CA4]:
             self._attr_available_modes = AVAILABLE_MODES_CA4
-            self._attr_min_humidity = 30
-            self._attr_max_humidity = 80
             self._humidity_steps = 100
         elif self._model in MODELS_HUMIDIFIER_MJJSQ:
             self._attr_available_modes = AVAILABLE_MODES_MJJSQ
-            self._attr_min_humidity = 30
-            self._attr_max_humidity = 80
             self._humidity_steps = 100
         else:
             self._attr_available_modes = AVAILABLE_MODES_OTHER
-            self._attr_min_humidity = 30
-            self._attr_max_humidity = 80
             self._humidity_steps = 10
 
         self._state = self.coordinator.data.is_on

--- a/homeassistant/components/xiaomi_miio/humidifier.py
+++ b/homeassistant/components/xiaomi_miio/humidifier.py
@@ -9,8 +9,6 @@ from miio.airhumidifier_mjjsq import OperationMode as AirhumidifierMjjsqOperatio
 
 from homeassistant.components.humidifier import HumidifierEntity
 from homeassistant.components.humidifier.const import (
-    DEFAULT_MAX_HUMIDITY,
-    DEFAULT_MIN_HUMIDITY,
     DEVICE_CLASS_HUMIDIFIER,
     SUPPORT_MODES,
 )
@@ -117,10 +115,7 @@ class XiaomiGenericHumidifier(XiaomiCoordinatedMiioEntity, HumidifierEntity):
 
         self._state = None
         self._attributes = {}
-        self._available_modes = []
         self._mode = None
-        self._min_humidity = DEFAULT_MIN_HUMIDITY
-        self._max_humidity = DEFAULT_MAX_HUMIDITY
         self._humidity_steps = 100
         self._target_humidity = None
 
@@ -138,24 +133,9 @@ class XiaomiGenericHumidifier(XiaomiCoordinatedMiioEntity, HumidifierEntity):
         return value
 
     @property
-    def available_modes(self) -> list:
-        """Get the list of available modes."""
-        return self._available_modes
-
-    @property
     def mode(self):
         """Get the current mode."""
         return self._mode
-
-    @property
-    def min_humidity(self):
-        """Return the minimum target humidity."""
-        return self._min_humidity
-
-    @property
-    def max_humidity(self):
-        """Return the maximum target humidity."""
-        return self._max_humidity
 
     async def async_turn_on(
         self,
@@ -197,24 +177,24 @@ class XiaomiAirHumidifier(XiaomiGenericHumidifier, HumidifierEntity):
         """Initialize the plug switch."""
         super().__init__(name, device, entry, unique_id, coordinator)
         if self._model in [MODEL_AIRHUMIDIFIER_CA1, MODEL_AIRHUMIDIFIER_CB1]:
-            self._available_modes = AVAILABLE_MODES_CA1_CB1
-            self._min_humidity = 30
-            self._max_humidity = 80
+            self._attr_available_modes = AVAILABLE_MODES_CA1_CB1
+            self._attr_min_humidity = 30
+            self._attr_max_humidity = 80
             self._humidity_steps = 10
         elif self._model in [MODEL_AIRHUMIDIFIER_CA4]:
-            self._available_modes = AVAILABLE_MODES_CA4
-            self._min_humidity = 30
-            self._max_humidity = 80
+            self._attr_available_modes = AVAILABLE_MODES_CA4
+            self._attr_min_humidity = 30
+            self._attr_max_humidity = 80
             self._humidity_steps = 100
         elif self._model in MODELS_HUMIDIFIER_MJJSQ:
-            self._available_modes = AVAILABLE_MODES_MJJSQ
-            self._min_humidity = 30
-            self._max_humidity = 80
+            self._attr_available_modes = AVAILABLE_MODES_MJJSQ
+            self._attr_min_humidity = 30
+            self._attr_max_humidity = 80
             self._humidity_steps = 100
         else:
-            self._available_modes = AVAILABLE_MODES_OTHER
-            self._min_humidity = 30
-            self._max_humidity = 80
+            self._attr_available_modes = AVAILABLE_MODES_OTHER
+            self._attr_min_humidity = 30
+            self._attr_max_humidity = 80
             self._humidity_steps = 10
 
         self._state = self.coordinator.data.is_on


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use attrs instead of `available_modes`, `min_humidity` and `max_humidity` properties.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
