### PR TITLE
Fix dangerous brackets

### DIFF
--- a/homeassistant/components/asuswrt/__init__.py
+++ b/homeassistant/components/asuswrt/__init__.py
@@ -81,7 +81,7 @@ async def async_setup(hass, config):
     options = {}
     mode = conf.get(CONF_MODE, MODE_ROUTER)
     for name, value in conf.items():
-        if name in ([CONF_DNSMASQ, CONF_INTERFACE, CONF_REQUIRE_IP]):
+        if name in [CONF_DNSMASQ, CONF_INTERFACE, CONF_REQUIRE_IP]:
             if name == CONF_REQUIRE_IP and mode != MODE_AP:
                 continue
             options[name] = value

--- a/homeassistant/components/asuswrt/router.py
+++ b/homeassistant/components/asuswrt/router.py
@@ -373,7 +373,7 @@ class AsusWrtRouter:
         """Update router options."""
         req_reload = False
         for name, new_opt in new_options.items():
-            if name in (CONF_REQ_RELOAD):
+            if name in CONF_REQ_RELOAD:
                 old_opt = self._options.get(name)
                 if not old_opt or old_opt != new_opt:
                     req_reload = True

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -371,7 +371,7 @@ class RadioThermostat(ClimateEntity):
 
     def set_preset_mode(self, preset_mode):
         """Set Preset mode (Home, Alternate, Away, Holiday)."""
-        if preset_mode in (PRESET_MODES):
+        if preset_mode in PRESET_MODES:
             self.device.program_mode = PRESET_MODE_TO_CODE[preset_mode]
         else:
             _LOGGER.error(

--- a/homeassistant/components/screenlogic/sensor.py
+++ b/homeassistant/components/screenlogic/sensor.py
@@ -85,7 +85,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for chem_sensor_name in coordinator.data[SL_DATA.KEY_CHEMISTRY]:
             enabled = True
             if equipment_flags & EQUIPMENT.FLAG_CHLORINATOR:
-                if chem_sensor_name in ("salt_tds_ppm"):
+                if chem_sensor_name in ("salt_tds_ppm",):
                     enabled = False
             if chem_sensor_name in SUPPORTED_CHEM_SENSORS:
                 entities.append(


### PR DESCRIPTION
## Proposed change
Remove or fix brackets that suggest the use of a tuple.

In most cases the brackets were ignored by the Python interpreter
```py
#  homeassistant/components/asuswrt/router.py
CONF_REQ_RELOAD = [CONF_DNSMASQ, CONF_INTERFACE, CONF_REQUIRE_IP]

if name in (CONF_REQ_RELOAD):
    ...
```

However at least in one case, it actually caused a bug as the `in` comparison happens with a string and not a tuple as intended. Here a trailing comma is missing.
```py
# homeassistant/components/screenlogic/sensor.py

if chem_sensor_name in ("salt_tds_ppm"):
    ...
```

--
Found with regular expressions:
```
in (\("[^"]+"\))
in (\(\w+\))
in (\(\[.+\]\))
```
for
```
in ("some text")
in (SOME_NAME)
in (instance.attribute)
in (instance.call())
in ([1, 2, 3])
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
