### PR TITLE
Fix Fibaro light features

### DIFF
--- a/homeassistant/components/fibaro/light.py
+++ b/homeassistant/components/fibaro/light.py
@@ -60,10 +60,25 @@ class FibaroLight(FibaroDevice, LightEntity):
         devconf = fibaro_device.device_config
         self._reset_color = devconf.get(CONF_RESET_COLOR, False)
         supports_color = (
-            "color" in fibaro_device.properties and "setColor" in fibaro_device.actions
+            "color" in fibaro_device.properties
+            or "colorComponents" in fibaro_device.properties
+            or "RGB" in fibaro_device.type
+            or "rgb" in fibaro_device.type
+            or "color" in fibaro_device.baseType
+        ) and (
+            "setColor" in fibaro_device.actions
+            or "setColorComponents" in fibaro_device.actions
         )
-        supports_dimming = "levelChange" in fibaro_device.interfaces
-        supports_white_v = "setW" in fibaro_device.actions
+        supports_white_v = (
+            "setW" in fibaro_device.actions
+            or "RGBW" in fibaro_device.type
+            or "rgbw" in fibaro_device.type
+        )
+        supports_dimming = (
+            "levelChange" in fibaro_device.interfaces
+            or supports_color
+            or supports_white_v
+        )
 
         # Configuration can override default capability detection
         if devconf.get(CONF_DIMMING, supports_dimming):


### PR DESCRIPTION
Updated logic that determines capabilities to fix a bug with RGB(W) and non-RGB(W) controllers connected using the Fibaro integration. (fixes: #55386, and probably also #54790)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Change the logic that determines if a light entity within the Fibaro integration can:
- change color
- change white-level
- change brightness

Because the current logic is broken for the current version(s) of Fibaro's Home Center products.  
Please see issue: #55386 for in-depth details.

### Current behavior
Currently, the code assumes a light entity coming from Fibaro has the above capabilities according to the following things:
- change color is determined by:
  - presence of `color` in the entity's `properties` array; AND
  - precense of `setColor` in the entity's `actions` array
- change white-level is determined by:
  -  presence of `setW` in the entity's `actions` array
- change brightness is determined by:
  - presence of `levelChange` in the entity's `interfaces` array

### Proposed changed behavior
The changes alter the assumptions to the following:
- change color is determined by:
  - presence of `color` or `colorComponents` in the entity's `properties`array; OR
  - presence of `rgb` or `RGB` in the entity's reported `type` property ; OR
  - presence of `color` in the entity's reported `baseType`; AND
  - presence of `setColor` in the entity's `actions` array; OR
  - presence of `setColorComponents` in the entity's `actions` array
- change white-level is determined by:
  - presence of `setW` in the entity's `actions` array; OR
  - presence of `RGBW` or `rgbw` in the entity's reported `type` property
- change brightness is determined by:
  - presence of `levelChange` in the entity's `interfaces` array; OR
  - entity supports color change; OR
  - entity supports white-level

### Reason
The current assumptions pose a problem with the most recent version(s) of Fibaros' home center products, the API with which the integration communicates will not satisfy the above mentioned conditions (anymore).  
This holds true for controlling the brightness, this was broken as of Fibaro software version v5.080.x.  
The control of the white-level when using an RGBW controller has been broken for longer, but it's unknown (to me anyways) since when.  
The logic for determining if color is supported does still work, though.

Not having the white-level control is annoying, but does not break the integration.  
However, the fact that the Fibaro API no longer reports the `levelChange` interface **will break** the integration (devices can't be added to the system or are not controllable), this is because the brightness value is never set but the code assumes it's there, which will make a function that's used later on throw an exception.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- This PR fixes or closes issue:
  - fixes #55386
  - fixes #54790
- This PR is related to issue(s):
  - #55386
  - #54790

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] ~~Local tests pass. **Your PR cannot be merged unless tests pass**~~ (fibaro has none)
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
