### PR TITLE
Improve Surepetcare set_pet_location service

### DIFF
--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -210,10 +210,10 @@ class SurePetcareDataCoordinator(DataUpdateCoordinator):
         """Call when setting the pet location."""
         pet_name = call.data[ATTR_PET_NAME]
         location = call.data[ATTR_LOCATION]
-        if device_id := self.get_pets().get(pet_name):
-            await self.surepy.sac.set_pet_location(
-                device_id, Location[location.upper()]
-            )
-            await self.async_request_refresh()
+        try:
+            device_id = self.get_pets()[pet_name]
+        except ValueError:
+            _LOGGER.error("Unknown pet %s", pet_name)
             return
-        _LOGGER.error("Unknown pet %s", pet_name)
+        await self.surepy.sac.set_pet_location(device_id, Location[location.upper()])
+        await self.async_request_refresh()

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -210,10 +210,6 @@ class SurePetcareDataCoordinator(DataUpdateCoordinator):
         """Call when setting the pet location."""
         pet_name = call.data[ATTR_PET_NAME]
         location = call.data[ATTR_LOCATION]
-        try:
-            device_id = self.get_pets()[pet_name]
-        except ValueError:
-            _LOGGER.error("Unknown pet %s", pet_name)
-            return
+        device_id = self.get_pets()[pet_name]
         await self.surepy.sac.set_pet_location(device_id, Location[location.upper()])
         await self.async_request_refresh()

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -200,11 +200,11 @@ class SurePetcareDataCoordinator(DataUpdateCoordinator):
 
     def get_pets(self) -> dict[str, int]:
         """Get pets."""
-        names = {}
+        pets = {}
         for surepy_entity in self.data.values():
             if surepy_entity.type == EntityType.PET and surepy_entity.name:
-                names[surepy_entity.name] = surepy_entity.id
-        return names
+                pets[surepy_entity.name] = surepy_entity.id
+        return pets
 
     async def handle_set_pet_location(self, call: ServiceCall) -> None:
         """Call when setting the pet location."""

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -131,7 +131,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     set_pet_location_schema = vol.Schema(
         {
-            vol.Optional(ATTR_PET_NAME): vol.In(coordinator.get_pets().keys()),
+            vol.Required(ATTR_PET_NAME): vol.In(coordinator.get_pets().keys()),
             vol.Required(ATTR_LOCATION): vol.In(
                 [
                     Location.INSIDE.name.title(),

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -131,7 +131,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     set_pet_location_schema = vol.Schema(
         {
-            vol.Optional(ATTR_PET_NAME): vol.In(coordinator.get_pets().values()),
+            vol.Optional(ATTR_PET_NAME): vol.In(coordinator.get_pets().keys()),
             vol.Required(ATTR_LOCATION): vol.In(
                 [
                     Location.INSIDE.name.title(),
@@ -198,23 +198,22 @@ class SurePetcareDataCoordinator(DataUpdateCoordinator):
         await self.lock_states[state](flap_id)
         await self.async_request_refresh()
 
-    def get_pets(self) -> dict[int, str]:
+    def get_pets(self) -> dict[str, int]:
         """Get pets."""
         names = {}
         for surepy_entity in self.data.values():
             if surepy_entity.type == EntityType.PET and surepy_entity.name:
-                names[surepy_entity.id] = surepy_entity.name
+                names[surepy_entity.name] = surepy_entity.id
         return names
 
     async def handle_set_pet_location(self, call: ServiceCall) -> None:
         """Call when setting the pet location."""
         pet_name = call.data[ATTR_PET_NAME]
         location = call.data[ATTR_LOCATION]
-        for device_id, device_name in self.get_pets().items():
-            if pet_name == device_name:
-                await self.surepy.sac.set_pet_location(
-                    device_id, Location[location.upper()]
-                )
-                await self.async_request_refresh()
-                return
+        if device_id := self.get_pets().get(pet_name):
+            await self.surepy.sac.set_pet_location(
+                device_id, Location[location.upper()]
+            )
+            await self.async_request_refresh()
+            return
         _LOGGER.error("Unknown pet %s", pet_name)


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Surepetcare, improve set_pet_location
https://github.com/home-assistant/core/pull/56198/files#r711614516

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
