### PR TITLE
Add Shelly RPC device trigger and logbook platforms

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -31,6 +31,7 @@ from .const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
     ATTR_DEVICE,
+    ATTR_GENERATION,
     BATTERY_DEVICES_WITH_PERMANENT_CONNECTION,
     BLOCK,
     CONF_COAP_PORT,
@@ -307,6 +308,7 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
                         ATTR_DEVICE: self.device.settings["device"]["hostname"],
                         ATTR_CHANNEL: channel,
                         ATTR_CLICK_TYPE: INPUTS_EVENTS_DICT[event_type],
+                        ATTR_GENERATION: 1,
                     },
                 )
             else:
@@ -524,6 +526,7 @@ class RpcDeviceWrapper(update_coordinator.DataUpdateCoordinator):
                     ATTR_DEVICE: self.device.hostname,
                     ATTR_CHANNEL: event["id"] + 1,
                     ATTR_CLICK_TYPE: event["event"],
+                    ATTR_GENERATION: 2,
                 },
             )
 

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -31,7 +31,6 @@ from .const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
     ATTR_DEVICE,
-    ATTR_EVENT,
     BATTERY_DEVICES_WITH_PERMANENT_CONNECTION,
     BLOCK,
     CONF_COAP_PORT,
@@ -39,7 +38,6 @@ from .const import (
     DEFAULT_COAP_PORT,
     DEVICE,
     DOMAIN,
-    EVENT_SHELLY_BUTTON,
     EVENT_SHELLY_CLICK,
     INPUTS_EVENTS_DICT,
     POLLING_TIMEOUT_SEC,
@@ -253,8 +251,8 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         self.entry = entry
         self.device = device
 
-        self._async_remove_device_updates_handler = self.async_add_listener(
-            self._async_device_updates_handler
+        entry.async_on_unload(
+            self.async_add_listener(self._async_device_updates_handler)
         )
         self._last_input_events_count: dict = {}
 
@@ -359,7 +357,6 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
     def shutdown(self) -> None:
         """Shutdown the wrapper."""
         self.device.shutdown()
-        self._async_remove_device_updates_handler()
 
     @callback
     def _handle_ha_stop(self, _event: Event) -> None:
@@ -495,8 +492,8 @@ class RpcDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         self.entry = entry
         self.device = device
 
-        self._async_remove_device_updates_handler = self.async_add_listener(
-            self._async_device_updates_handler
+        entry.async_on_unload(
+            self.async_add_listener(self._async_device_updates_handler)
         )
         self._last_event: dict[str, Any] | None = None
 
@@ -521,12 +518,12 @@ class RpcDeviceWrapper(update_coordinator.DataUpdateCoordinator):
                 continue
 
             self.hass.bus.async_fire(
-                EVENT_SHELLY_BUTTON,
+                EVENT_SHELLY_CLICK,
                 {
                     ATTR_DEVICE_ID: self.device_id,
                     ATTR_DEVICE: self.device.hostname,
                     ATTR_CHANNEL: event["id"] + 1,
-                    ATTR_EVENT: event["event"],
+                    ATTR_CLICK_TYPE: event["event"],
                 },
             )
 

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -70,6 +70,7 @@ EVENT_SHELLY_CLICK: Final = "shelly.click"
 ATTR_CLICK_TYPE: Final = "click_type"
 ATTR_CHANNEL: Final = "channel"
 ATTR_DEVICE: Final = "device"
+ATTR_GENERATION: Final = "generation"
 CONF_SUBTYPE: Final = "subtype"
 
 BASIC_INPUTS_EVENTS_TYPES: Final = {"single", "long"}

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -64,18 +64,31 @@ INPUTS_EVENTS_DICT: Final = {
 # List of battery devices that maintain a permanent WiFi connection
 BATTERY_DEVICES_WITH_PERMANENT_CONNECTION: Final = ["SHMOS-01"]
 
+# Click events for Block devices
 EVENT_SHELLY_CLICK: Final = "shelly.click"
+
+# Button events for RPC devices
+EVENT_SHELLY_BUTTON: Final = "shelly.button"
 
 ATTR_CLICK_TYPE: Final = "click_type"
 ATTR_CHANNEL: Final = "channel"
 ATTR_DEVICE: Final = "device"
+ATTR_EVENT = "event"
 CONF_SUBTYPE: Final = "subtype"
 
 BASIC_INPUTS_EVENTS_TYPES: Final = {"single", "long"}
 
 SHBTN_INPUTS_EVENTS_TYPES: Final = {"single", "double", "triple", "long"}
 
-SUPPORTED_INPUTS_EVENTS_TYPES: Final = {
+RPC_INPUTS_EVENTS_TYPES: Final = {
+    "btn_down",
+    "btn_up",
+    "single_push",
+    "double_push",
+    "long_push",
+}
+
+BLOCK_INPUTS_EVENTS_TYPES: Final = {
     "single",
     "double",
     "triple",
@@ -84,9 +97,15 @@ SUPPORTED_INPUTS_EVENTS_TYPES: Final = {
     "long_single",
 }
 
-SHIX3_1_INPUTS_EVENTS_TYPES = SUPPORTED_INPUTS_EVENTS_TYPES
+SHIX3_1_INPUTS_EVENTS_TYPES = BLOCK_INPUTS_EVENTS_TYPES
 
-INPUTS_EVENTS_SUBTYPES: Final = {"button": 1, "button1": 1, "button2": 2, "button3": 3}
+INPUTS_EVENTS_SUBTYPES: Final = {
+    "button": 1,
+    "button1": 1,
+    "button2": 2,
+    "button3": 3,
+    "button4": 4,
+}
 
 SHBTN_MODELS: Final = ["SHBTN-1", "SHBTN-2"]
 

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -64,16 +64,12 @@ INPUTS_EVENTS_DICT: Final = {
 # List of battery devices that maintain a permanent WiFi connection
 BATTERY_DEVICES_WITH_PERMANENT_CONNECTION: Final = ["SHMOS-01"]
 
-# Click events for Block devices
+# Button/Click events for Block & RPC devices
 EVENT_SHELLY_CLICK: Final = "shelly.click"
-
-# Button events for RPC devices
-EVENT_SHELLY_BUTTON: Final = "shelly.button"
 
 ATTR_CLICK_TYPE: Final = "click_type"
 ATTR_CHANNEL: Final = "channel"
 ATTR_DEVICE: Final = "device"
-ATTR_EVENT = "event"
 CONF_SUBTYPE: Final = "subtype"
 
 BASIC_INPUTS_EVENTS_TYPES: Final = {"single", "long"}

--- a/homeassistant/components/shelly/device_trigger.py
+++ b/homeassistant/components/shelly/device_trigger.py
@@ -29,11 +29,9 @@ from . import get_block_device_wrapper, get_rpc_device_wrapper
 from .const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
-    ATTR_EVENT,
     BLOCK_INPUTS_EVENTS_TYPES,
     CONF_SUBTYPE,
     DOMAIN,
-    EVENT_SHELLY_BUTTON,
     EVENT_SHELLY_CLICK,
     INPUTS_EVENTS_SUBTYPES,
     RPC_INPUTS_EVENTS_TYPES,
@@ -143,27 +141,15 @@ async def async_attach_trigger(
     automation_info: AutomationTriggerInfo,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
-    if config[CONF_TYPE] in RPC_INPUTS_EVENTS_TYPES:
-        event_config = {
-            event_trigger.CONF_PLATFORM: CONF_EVENT,
-            event_trigger.CONF_EVENT_TYPE: EVENT_SHELLY_BUTTON,
-            event_trigger.CONF_EVENT_DATA: {
-                ATTR_DEVICE_ID: config[CONF_DEVICE_ID],
-                ATTR_CHANNEL: INPUTS_EVENTS_SUBTYPES[config[CONF_SUBTYPE]],
-                ATTR_EVENT: config[CONF_TYPE],
-            },
-        }
-
-    elif config[CONF_TYPE] in BLOCK_INPUTS_EVENTS_TYPES:
-        event_config = {
-            event_trigger.CONF_PLATFORM: CONF_EVENT,
-            event_trigger.CONF_EVENT_TYPE: EVENT_SHELLY_CLICK,
-            event_trigger.CONF_EVENT_DATA: {
-                ATTR_DEVICE_ID: config[CONF_DEVICE_ID],
-                ATTR_CHANNEL: INPUTS_EVENTS_SUBTYPES[config[CONF_SUBTYPE]],
-                ATTR_CLICK_TYPE: config[CONF_TYPE],
-            },
-        }
+    event_config = {
+        event_trigger.CONF_PLATFORM: CONF_EVENT,
+        event_trigger.CONF_EVENT_TYPE: EVENT_SHELLY_CLICK,
+        event_trigger.CONF_EVENT_DATA: {
+            ATTR_DEVICE_ID: config[CONF_DEVICE_ID],
+            ATTR_CHANNEL: INPUTS_EVENTS_SUBTYPES[config[CONF_SUBTYPE]],
+            ATTR_CLICK_TYPE: config[CONF_TYPE],
+        },
+    }
 
     event_config = event_trigger.TRIGGER_SCHEMA(event_config)
     return await event_trigger.async_attach_trigger(

--- a/homeassistant/components/shelly/device_trigger.py
+++ b/homeassistant/components/shelly/device_trigger.py
@@ -25,26 +25,52 @@ from homeassistant.const import (
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from . import RpcDeviceWrapper, get_device_wrapper
+from . import get_block_device_wrapper, get_rpc_device_wrapper
 from .const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
+    ATTR_EVENT,
+    BLOCK_INPUTS_EVENTS_TYPES,
     CONF_SUBTYPE,
     DOMAIN,
+    EVENT_SHELLY_BUTTON,
     EVENT_SHELLY_CLICK,
     INPUTS_EVENTS_SUBTYPES,
-    SHBTN_INPUTS_EVENTS_TYPES,
+    RPC_INPUTS_EVENTS_TYPES,
     SHBTN_MODELS,
-    SUPPORTED_INPUTS_EVENTS_TYPES,
 )
-from .utils import get_input_triggers
+from .utils import (
+    get_block_input_triggers,
+    get_rpc_input_triggers,
+    get_shbtn_input_triggers,
+)
 
 TRIGGER_SCHEMA: Final = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_TYPE): vol.In(SUPPORTED_INPUTS_EVENTS_TYPES),
+        vol.Required(CONF_TYPE): vol.In(
+            RPC_INPUTS_EVENTS_TYPES | BLOCK_INPUTS_EVENTS_TYPES
+        ),
         vol.Required(CONF_SUBTYPE): vol.In(INPUTS_EVENTS_SUBTYPES),
     }
 )
+
+
+def append_input_triggers(
+    triggers: list[dict[str, Any]],
+    input_triggers: list[tuple[str, str]],
+    device_id: str,
+) -> None:
+    """Add trigger to triggers list."""
+    for trigger, subtype in input_triggers:
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_TYPE: trigger,
+                CONF_SUBTYPE: subtype,
+            }
+        )
 
 
 async def async_validate_trigger_config(
@@ -54,22 +80,28 @@ async def async_validate_trigger_config(
     config = TRIGGER_SCHEMA(config)
 
     # if device is available verify parameters against device capabilities
-    wrapper = get_device_wrapper(hass, config[CONF_DEVICE_ID])
-
-    if isinstance(wrapper, RpcDeviceWrapper):
-        return config
-
-    if not wrapper or not wrapper.device.initialized:
-        return config
-
     trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
 
-    assert wrapper.device.blocks
+    if config[CONF_TYPE] in RPC_INPUTS_EVENTS_TYPES:
+        rpc_wrapper = get_rpc_device_wrapper(hass, config[CONF_DEVICE_ID])
+        if not rpc_wrapper or not rpc_wrapper.device.initialized:
+            return config
 
-    for block in wrapper.device.blocks:
-        input_triggers = get_input_triggers(wrapper.device, block)
+        input_triggers = get_rpc_input_triggers(rpc_wrapper.device)
         if trigger in input_triggers:
             return config
+
+    elif config[CONF_TYPE] in BLOCK_INPUTS_EVENTS_TYPES:
+        block_wrapper = get_block_device_wrapper(hass, config[CONF_DEVICE_ID])
+        if not block_wrapper or not block_wrapper.device.initialized:
+            return config
+
+        assert block_wrapper.device.blocks
+
+        for block in block_wrapper.device.blocks:
+            input_triggers = get_block_input_triggers(block_wrapper.device, block)
+            if trigger in input_triggers:
+                return config
 
     raise InvalidDeviceAutomationConfig(
         f"Invalid ({CONF_TYPE},{CONF_SUBTYPE}): {trigger}"
@@ -80,45 +112,28 @@ async def async_get_triggers(
     hass: HomeAssistant, device_id: str
 ) -> list[dict[str, Any]]:
     """List device triggers for Shelly devices."""
-    wrapper = get_device_wrapper(hass, device_id)
-    if not wrapper:
-        raise InvalidDeviceAutomationConfig(f"Device not found: {device_id}")
+    triggers: list[dict[str, Any]] = []
 
-    if isinstance(wrapper, RpcDeviceWrapper):
-        return []
-
-    triggers = []
-
-    if wrapper.model in SHBTN_MODELS:
-        for trigger in SHBTN_INPUTS_EVENTS_TYPES:
-            triggers.append(
-                {
-                    CONF_PLATFORM: "device",
-                    CONF_DEVICE_ID: device_id,
-                    CONF_DOMAIN: DOMAIN,
-                    CONF_TYPE: trigger,
-                    CONF_SUBTYPE: "button",
-                }
-            )
+    if rpc_wrapper := get_rpc_device_wrapper(hass, device_id):
+        input_triggers = get_rpc_input_triggers(rpc_wrapper.device)
+        append_input_triggers(triggers, input_triggers, device_id)
         return triggers
 
-    assert wrapper.device.blocks
+    if block_wrapper := get_block_device_wrapper(hass, device_id):
+        if block_wrapper.model in SHBTN_MODELS:
+            input_triggers = get_shbtn_input_triggers()
+            append_input_triggers(triggers, input_triggers, device_id)
+            return triggers
 
-    for block in wrapper.device.blocks:
-        input_triggers = get_input_triggers(wrapper.device, block)
+        assert block_wrapper.device.blocks
 
-        for trigger, subtype in input_triggers:
-            triggers.append(
-                {
-                    CONF_PLATFORM: "device",
-                    CONF_DEVICE_ID: device_id,
-                    CONF_DOMAIN: DOMAIN,
-                    CONF_TYPE: trigger,
-                    CONF_SUBTYPE: subtype,
-                }
-            )
+        for block in block_wrapper.device.blocks:
+            input_triggers = get_block_input_triggers(block_wrapper.device, block)
+            append_input_triggers(triggers, input_triggers, device_id)
 
-    return triggers
+        return triggers
+
+    raise InvalidDeviceAutomationConfig(f"Device not found: {device_id}")
 
 
 async def async_attach_trigger(
@@ -128,15 +143,28 @@ async def async_attach_trigger(
     automation_info: AutomationTriggerInfo,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
-    event_config = {
-        event_trigger.CONF_PLATFORM: CONF_EVENT,
-        event_trigger.CONF_EVENT_TYPE: EVENT_SHELLY_CLICK,
-        event_trigger.CONF_EVENT_DATA: {
-            ATTR_DEVICE_ID: config[CONF_DEVICE_ID],
-            ATTR_CHANNEL: INPUTS_EVENTS_SUBTYPES[config[CONF_SUBTYPE]],
-            ATTR_CLICK_TYPE: config[CONF_TYPE],
-        },
-    }
+    if config[CONF_TYPE] in RPC_INPUTS_EVENTS_TYPES:
+        event_config = {
+            event_trigger.CONF_PLATFORM: CONF_EVENT,
+            event_trigger.CONF_EVENT_TYPE: EVENT_SHELLY_BUTTON,
+            event_trigger.CONF_EVENT_DATA: {
+                ATTR_DEVICE_ID: config[CONF_DEVICE_ID],
+                ATTR_CHANNEL: INPUTS_EVENTS_SUBTYPES[config[CONF_SUBTYPE]],
+                ATTR_EVENT: config[CONF_TYPE],
+            },
+        }
+
+    elif config[CONF_TYPE] in BLOCK_INPUTS_EVENTS_TYPES:
+        event_config = {
+            event_trigger.CONF_PLATFORM: CONF_EVENT,
+            event_trigger.CONF_EVENT_TYPE: EVENT_SHELLY_CLICK,
+            event_trigger.CONF_EVENT_DATA: {
+                ATTR_DEVICE_ID: config[CONF_DEVICE_ID],
+                ATTR_CHANNEL: INPUTS_EVENTS_SUBTYPES[config[CONF_SUBTYPE]],
+                ATTR_CLICK_TYPE: config[CONF_TYPE],
+            },
+        }
+
     event_config = event_trigger.TRIGGER_SCHEMA(event_config)
     return await event_trigger.async_attach_trigger(
         hass, event_config, action, automation_info, platform_type="device"

--- a/homeassistant/components/shelly/logbook.py
+++ b/homeassistant/components/shelly/logbook.py
@@ -7,15 +7,17 @@ from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.typing import EventType
 
-from . import RpcDeviceWrapper, get_device_wrapper
+from . import get_block_device_wrapper, get_rpc_device_wrapper
 from .const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
     ATTR_DEVICE,
+    ATTR_EVENT,
     DOMAIN,
+    EVENT_SHELLY_BUTTON,
     EVENT_SHELLY_CLICK,
 )
-from .utils import get_block_device_name
+from .utils import get_block_device_name, get_rpc_entity_name
 
 
 @callback
@@ -27,11 +29,8 @@ def async_describe_events(
 
     @callback
     def async_describe_shelly_click_event(event: EventType) -> dict[str, str]:
-        """Describe shelly.click logbook event."""
-        wrapper = get_device_wrapper(hass, event.data[ATTR_DEVICE_ID])
-
-        if isinstance(wrapper, RpcDeviceWrapper):
-            return {}
+        """Describe shelly.click logbook event (block device)."""
+        wrapper = get_block_device_wrapper(hass, event.data[ATTR_DEVICE_ID])
 
         if wrapper and wrapper.device.initialized:
             device_name = get_block_device_name(wrapper.device)
@@ -46,4 +45,26 @@ def async_describe_events(
             "message": f"'{click_type}' click event for {device_name} channel {channel} was fired.",
         }
 
+    @callback
+    def async_describe_shelly_button_event(event: EventType) -> dict[str, str]:
+        """Describe shelly.button logbook event (rpc device)."""
+        wrapper = get_rpc_device_wrapper(hass, event.data[ATTR_DEVICE_ID])
+
+        if wrapper and wrapper.device.initialized:
+            key = f"input:{event.data[ATTR_CHANNEL]-1}"
+            input_name = get_rpc_entity_name(wrapper.device, key, "Input")
+        else:
+            device_name = event.data[ATTR_DEVICE]
+            input_name = f"{device_name} switch_{event.data[ATTR_CHANNEL]} Input"
+
+        event = event.data[ATTR_EVENT]
+
+        return {
+            "name": "Shelly",
+            "message": f"'{event}' button event for {input_name} was fired.",
+        }
+
     async_describe_event(DOMAIN, EVENT_SHELLY_CLICK, async_describe_shelly_click_event)
+    async_describe_event(
+        DOMAIN, EVENT_SHELLY_BUTTON, async_describe_shelly_button_event
+    )

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -42,7 +42,12 @@
           "triple": "{subtype} triple clicked",
           "long": " {subtype} long clicked",
           "single_long": "{subtype} single clicked and then long clicked",
-          "long_single": "{subtype} long clicked and then single clicked"
+          "long_single": "{subtype} long clicked and then single clicked",
+          "btn_down": "{subtype} button down",
+          "btn_up": "{subtype} button up",
+          "single_push": "{subtype} single push",
+          "double_push": "{subtype} double push",
+          "long_push": " {subtype} long push"
       }
   }
 }

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -33,7 +33,8 @@
           "button": "Button",
           "button1": "First button",
           "button2": "Second button",
-          "button3": "Third button"
+          "button3": "Third button",
+          "button4": "Fourth button"
       },
       "trigger_type": {
           "single": "{subtype} single clicked",

--- a/homeassistant/components/shelly/translations/en.json
+++ b/homeassistant/components/shelly/translations/en.json
@@ -33,7 +33,8 @@
             "button": "Button",
             "button1": "First button",
             "button2": "Second button",
-            "button3": "Third button"
+            "button3": "Third button",
+            "button4": "Fourth button"
         },
         "trigger_type": {
             "double": "{subtype} double clicked",

--- a/homeassistant/components/shelly/translations/en.json
+++ b/homeassistant/components/shelly/translations/en.json
@@ -42,7 +42,12 @@
             "long_single": "{subtype} long clicked and then single clicked",
             "single": "{subtype} single clicked",
             "single_long": "{subtype} single clicked and then long clicked",
-            "triple": "{subtype} triple clicked"
+            "triple": "{subtype} triple clicked",
+            "btn_down": "{subtype} button down",
+            "btn_up": "{subtype} button up",
+            "single_push": "{subtype} single push",
+            "double_push": "{subtype} double push",
+            "long_push": " {subtype} long push"
         }
     }
 }

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -56,6 +56,7 @@ MOCK_BLOCKS = [
 ]
 
 MOCK_CONFIG = {
+    "input:0": {"id": 0, "type": "button"},
     "switch:0": {"name": "test switch_0"},
     "sys": {"ui_data": {}},
     "wifi": {
@@ -147,6 +148,7 @@ async def rpc_wrapper(hass):
     device = Mock(
         call_rpc=AsyncMock(),
         config=MOCK_CONFIG,
+        event={},
         shelly=MOCK_SHELLY,
         status=MOCK_STATUS,
         firmware_version="some fw string",

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -12,12 +12,10 @@ from homeassistant.components.shelly import BlockDeviceWrapper
 from homeassistant.components.shelly.const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
-    ATTR_EVENT,
     BLOCK,
     CONF_SUBTYPE,
     DATA_CONFIG_ENTRY,
     DOMAIN,
-    EVENT_SHELLY_BUTTON,
     EVENT_SHELLY_CLICK,
 )
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
@@ -254,10 +252,10 @@ async def test_if_fires_on_click_event_rpc_device(hass, calls, rpc_wrapper):
 
     message = {
         CONF_DEVICE_ID: rpc_wrapper.device_id,
-        ATTR_EVENT: "single_push",
+        ATTR_CLICK_TYPE: "single_push",
         ATTR_CHANNEL: 1,
     }
-    hass.bus.async_fire(EVENT_SHELLY_BUTTON, message)
+    hass.bus.async_fire(EVENT_SHELLY_CLICK, message)
     await hass.async_block_till_done()
 
     assert len(calls) == 1
@@ -330,10 +328,10 @@ async def test_validate_trigger_rpc_device_not_ready(hass, calls, rpc_wrapper):
     )
     message = {
         CONF_DEVICE_ID: "device_not_ready",
-        ATTR_EVENT: "single_push",
+        ATTR_CLICK_TYPE: "single_push",
         ATTR_CHANNEL: 1,
     }
-    hass.bus.async_fire(EVENT_SHELLY_BUTTON, message)
+    hass.bus.async_fire(EVENT_SHELLY_CLICK, message)
     await hass.async_block_till_done()
 
     assert len(calls) == 1

--- a/tests/components/shelly/test_logbook.py
+++ b/tests/components/shelly/test_logbook.py
@@ -4,9 +4,7 @@ from homeassistant.components.shelly.const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
     ATTR_DEVICE,
-    ATTR_EVENT,
     DOMAIN,
-    EVENT_SHELLY_BUTTON,
     EVENT_SHELLY_CLICK,
 )
 from homeassistant.const import ATTR_DEVICE_ID
@@ -53,14 +51,15 @@ async def test_humanify_shelly_click_event_block_device(hass, coap_wrapper):
     assert event1["name"] == "Shelly"
     assert event1["domain"] == DOMAIN
     assert (
-        event1["message"] == "'single' click event for Test name channel 1 was fired."
+        event1["message"]
+        == "'single' click event for Test name channel 1 Input was fired."
     )
 
     assert event2["name"] == "Shelly"
     assert event2["domain"] == DOMAIN
     assert (
         event2["message"]
-        == "'long' click event for shellyswitch25-12345678 channel 2 was fired."
+        == "'long' click event for shellyswitch25-12345678 channel 2 Input was fired."
     )
 
 
@@ -76,20 +75,20 @@ async def test_humanify_shelly_click_event_rpc_device(hass, rpc_wrapper):
             hass,
             [
                 MockLazyEventPartialState(
-                    EVENT_SHELLY_BUTTON,
+                    EVENT_SHELLY_CLICK,
                     {
                         ATTR_DEVICE_ID: rpc_wrapper.device_id,
                         ATTR_DEVICE: "shellyplus1pm-12345678",
-                        ATTR_EVENT: "single_push",
+                        ATTR_CLICK_TYPE: "single_push",
                         ATTR_CHANNEL: 1,
                     },
                 ),
                 MockLazyEventPartialState(
-                    EVENT_SHELLY_BUTTON,
+                    EVENT_SHELLY_CLICK,
                     {
                         ATTR_DEVICE_ID: "no_device_id",
                         ATTR_DEVICE: "shellypro4pm-12345678",
-                        ATTR_EVENT: "btn_down",
+                        ATTR_CLICK_TYPE: "btn_down",
                         ATTR_CHANNEL: 2,
                     },
                 ),
@@ -103,12 +102,12 @@ async def test_humanify_shelly_click_event_rpc_device(hass, rpc_wrapper):
     assert event1["domain"] == DOMAIN
     assert (
         event1["message"]
-        == "'single_push' button event for test switch_0 Input was fired."
+        == "'single_push' click event for test switch_0 Input was fired."
     )
 
     assert event2["name"] == "Shelly"
     assert event2["domain"] == DOMAIN
     assert (
         event2["message"]
-        == "'btn_down' button event for shellypro4pm-12345678 switch_2 Input was fired."
+        == "'btn_down' click event for shellypro4pm-12345678 channel 2 Input was fired."
     )

--- a/tests/components/shelly/test_logbook.py
+++ b/tests/components/shelly/test_logbook.py
@@ -4,7 +4,9 @@ from homeassistant.components.shelly.const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
     ATTR_DEVICE,
+    ATTR_EVENT,
     DOMAIN,
+    EVENT_SHELLY_BUTTON,
     EVENT_SHELLY_CLICK,
 )
 from homeassistant.const import ATTR_DEVICE_ID
@@ -13,8 +15,8 @@ from homeassistant.setup import async_setup_component
 from tests.components.logbook.test_init import MockLazyEventPartialState
 
 
-async def test_humanify_shelly_click_event(hass, coap_wrapper):
-    """Test humanifying Shelly click event."""
+async def test_humanify_shelly_click_event_block_device(hass, coap_wrapper):
+    """Test humanifying Shelly click event for block device."""
     assert coap_wrapper
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})
@@ -59,4 +61,54 @@ async def test_humanify_shelly_click_event(hass, coap_wrapper):
     assert (
         event2["message"]
         == "'long' click event for shellyswitch25-12345678 channel 2 was fired."
+    )
+
+
+async def test_humanify_shelly_click_event_rpc_device(hass, rpc_wrapper):
+    """Test humanifying Shelly click event for rpc device."""
+    assert rpc_wrapper
+    hass.config.components.add("recorder")
+    assert await async_setup_component(hass, "logbook", {})
+    entity_attr_cache = logbook.EntityAttributeCache(hass)
+
+    event1, event2 = list(
+        logbook.humanify(
+            hass,
+            [
+                MockLazyEventPartialState(
+                    EVENT_SHELLY_BUTTON,
+                    {
+                        ATTR_DEVICE_ID: rpc_wrapper.device_id,
+                        ATTR_DEVICE: "shellyplus1pm-12345678",
+                        ATTR_EVENT: "single_push",
+                        ATTR_CHANNEL: 1,
+                    },
+                ),
+                MockLazyEventPartialState(
+                    EVENT_SHELLY_BUTTON,
+                    {
+                        ATTR_DEVICE_ID: "no_device_id",
+                        ATTR_DEVICE: "shellypro4pm-12345678",
+                        ATTR_EVENT: "btn_down",
+                        ATTR_CHANNEL: 2,
+                    },
+                ),
+            ],
+            entity_attr_cache,
+            {},
+        )
+    )
+
+    assert event1["name"] == "Shelly"
+    assert event1["domain"] == DOMAIN
+    assert (
+        event1["message"]
+        == "'single_push' button event for test switch_0 Input was fired."
+    )
+
+    assert event2["name"] == "Shelly"
+    assert event2["domain"] == DOMAIN
+    assert (
+        event2["message"]
+        == "'btn_down' button event for shellypro4pm-12345678 switch_2 Input was fired."
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
### Last part for Shelly RPC device support
**- Add RPC device input events**

Example event:
```json
{
    "event_type": "shelly.click",
    "data": {
        "device_id": "feda53fd9851e5163db30d227f55f12b",
        "device": "shellyplus1pm-1234567890ab",
        "channel": 1,
        "click_type": "single_push",
        "generation": 2
    },
    "origin": "LOCAL",
    "time_fired": "2021-09-19T17:33:50.103364+00:00",
    "context": {
        "id": "5b7d3f2c82ad6b8efa3a3e49f3ddeb76",
        "parent_id": null,
        "user_id": null
    }
}
```
Possible values for `channel`: `1..4`
Possible values for `click_type`:   `btn_down`, `btn_up`, `single_push`, `double_push`, `long_push`

**- Add device trigger platform support for RPC input events**
**- Add logbook platform support for RPC `shelly.click` event**

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
