### PR TITLE
Add Surepetcare entity class

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1006,6 +1006,7 @@ omit =
     homeassistant/components/suez_water/*
     homeassistant/components/supervisord/sensor.py
     homeassistant/components/surepetcare/__init__.py
+    homeassistant/components/surepetcare/entity.py
     homeassistant/components/surepetcare/binary_sensor.py
     homeassistant/components/surepetcare/sensor.py
     homeassistant/components/swiss_hydrological_data/sensor.py

--- a/homeassistant/components/surepetcare/entity.py
+++ b/homeassistant/components/surepetcare/entity.py
@@ -1,0 +1,45 @@
+"""Entity for Surepetcare."""
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from surepy.entities import SurepyEntity
+
+from homeassistant.core import callback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import SurePetcareDataCoordinator
+
+
+class SurePetcareEntity(CoordinatorEntity):
+    """An implementation for Sure Petcare Entities."""
+
+    def __init__(
+        self,
+        _id: int,
+        coordinator: SurePetcareDataCoordinator,
+    ) -> None:
+        """Initialize a Sure Petcare entity."""
+        super().__init__(coordinator)
+
+        self._id = _id
+
+        surepy_entity: SurepyEntity = coordinator.data[_id]
+
+        self._device_name = surepy_entity.type.name.capitalize().replace("_", " ")
+        if surepy_entity.name:
+            self._device_name = f"{self._device_name} {surepy_entity.name.capitalize()}"
+
+        self._device_id = f"{surepy_entity.household_id}-{_id}"
+        self._update_attr(coordinator.data[_id])
+
+    @abstractmethod
+    @callback
+    def _update_attr(self, surepy_entity: SurepyEntity) -> None:
+        """Update the state and attributes."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Get the latest data and update the state."""
+        self._update_attr(self.coordinator.data[self._id])
+        self.async_write_ha_state()

--- a/homeassistant/components/surepetcare/entity.py
+++ b/homeassistant/components/surepetcare/entity.py
@@ -26,9 +26,10 @@ class SurePetcareEntity(CoordinatorEntity):
 
         surepy_entity: SurepyEntity = coordinator.data[_id]
 
-        self._device_name = surepy_entity.type.name.capitalize().replace("_", " ")
         if surepy_entity.name:
-            self._device_name = f"{self._device_name} {surepy_entity.name.capitalize()}"
+            self._device_name = surepy_entity.name.capitalize()
+        else:
+            self._device_name = surepy_entity.type.name.capitalize().replace("_", " ")
 
         self._device_id = f"{surepy_entity.household_id}-{_id}"
         self._update_attr(coordinator.data[_id])

--- a/homeassistant/components/surepetcare/entity.py
+++ b/homeassistant/components/surepetcare/entity.py
@@ -16,23 +16,23 @@ class SurePetcareEntity(CoordinatorEntity):
 
     def __init__(
         self,
-        _id: int,
+        surepetcare_id: int,
         coordinator: SurePetcareDataCoordinator,
     ) -> None:
         """Initialize a Sure Petcare entity."""
         super().__init__(coordinator)
 
-        self._id = _id
+        self._id = surepetcare_id
 
-        surepy_entity: SurepyEntity = coordinator.data[_id]
+        surepy_entity: SurepyEntity = coordinator.data[surepetcare_id]
 
         if surepy_entity.name:
             self._device_name = surepy_entity.name.capitalize()
         else:
             self._device_name = surepy_entity.type.name.capitalize().replace("_", " ")
 
-        self._device_id = f"{surepy_entity.household_id}-{_id}"
-        self._update_attr(coordinator.data[_id])
+        self._device_id = f"{surepy_entity.household_id}-{surepetcare_id}"
+        self._update_attr(coordinator.data[surepetcare_id])
 
     @abstractmethod
     @callback

--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -11,12 +11,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_VOLTAGE, DEVICE_CLASS_BATTERY, PERCENTAGE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
 
+from . import SurePetcareDataCoordinator
 from .const import DOMAIN, SURE_BATT_VOLTAGE_DIFF, SURE_BATT_VOLTAGE_LOW
+from .entity import SurePetcareEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +26,7 @@ async def async_setup_entry(
 
     entities: list[SureBattery] = []
 
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: SurePetcareDataCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     for surepy_entity in coordinator.data.values():
 
@@ -43,38 +41,22 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SureBattery(CoordinatorEntity, SensorEntity):
+class SureBattery(SurePetcareEntity, SensorEntity):
     """A sensor implementation for Sure Petcare Entities."""
 
-    def __init__(self, _id: int, coordinator: DataUpdateCoordinator) -> None:
-        """Initialize a Sure Petcare sensor."""
-        super().__init__(coordinator)
+    _attr_device_class = DEVICE_CLASS_BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
 
-        self._id = _id
+    def __init__(self, _id: int, coordinator: SurePetcareDataCoordinator) -> None:
+        """Initialize a Sure Petcare battery sensor."""
+        super().__init__(_id, coordinator)
 
-        surepy_entity: SurepyEntity = coordinator.data[_id]
-
-        self._attr_device_class = DEVICE_CLASS_BATTERY
-        if surepy_entity.name:
-            self._attr_name = f"{surepy_entity.type.name.capitalize()} {surepy_entity.name.capitalize()} Battery Level"
-        else:
-            self._attr_name = f"{surepy_entity.type.name.capitalize()}  Battery Level"
-        self._attr_native_unit_of_measurement = PERCENTAGE
-        self._attr_unique_id = (
-            f"{surepy_entity.household_id}-{surepy_entity.id}-battery"
-        )
-        self._update_attr()
+        self._attr_name = f"{self._device_name} Battery Level"
+        self._attr_unique_id = f"{self._device_id}-battery"
 
     @callback
-    def _handle_coordinator_update(self) -> None:
-        """Get the latest data and update the state."""
-        self._update_attr()
-        self.async_write_ha_state()
-
-    @callback
-    def _update_attr(self) -> None:
+    def _update_attr(self, surepy_entity: SurepyEntity) -> None:
         """Update the state and attributes."""
-        surepy_entity = self.coordinator.data[self._id]
         state = surepy_entity.raw_data()["status"]
 
         try:
@@ -94,4 +76,3 @@ class SureBattery(CoordinatorEntity, SensorEntity):
             }
         else:
             self._attr_extra_state_attributes = {}
-        _LOGGER.debug("%s -> state: %s", self.name, state)

--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -47,9 +47,11 @@ class SureBattery(SurePetcareEntity, SensorEntity):
     _attr_device_class = DEVICE_CLASS_BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
 
-    def __init__(self, _id: int, coordinator: SurePetcareDataCoordinator) -> None:
+    def __init__(
+        self, surepetcare_id: int, coordinator: SurePetcareDataCoordinator
+    ) -> None:
         """Initialize a Sure Petcare battery sensor."""
-        super().__init__(_id, coordinator)
+        super().__init__(surepetcare_id, coordinator)
 
         self._attr_name = f"{self._device_name} Battery Level"
         self._attr_unique_id = f"{self._device_id}-battery"

--- a/tests/components/surepetcare/test_sensor.py
+++ b/tests/components/surepetcare/test_sensor.py
@@ -6,9 +6,9 @@ from homeassistant.setup import async_setup_component
 from . import HOUSEHOLD_ID, MOCK_CONFIG
 
 EXPECTED_ENTITY_IDS = {
-    "sensor.pet_flap_pet_flap_battery_level": f"{HOUSEHOLD_ID}-13576-battery",
-    "sensor.cat_flap_cat_flap_battery_level": f"{HOUSEHOLD_ID}-13579-battery",
-    "sensor.feeder_feeder_battery_level": f"{HOUSEHOLD_ID}-12345-battery",
+    "sensor.pet_flap_battery_level": f"{HOUSEHOLD_ID}-13576-battery",
+    "sensor.cat_flap_battery_level": f"{HOUSEHOLD_ID}-13579-battery",
+    "sensor.feeder_battery_level": f"{HOUSEHOLD_ID}-12345-battery",
 }
 
 


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Surepetcare, add entity class
Simplify the names
(Will open another pull request for binary sensor when this is merged)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
