### PR TITLE
Use EntityDescription - sht31

### DIFF
--- a/homeassistant/components/sht31/sensor.py
+++ b/homeassistant/components/sht31/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS,
     CONF_NAME,
+    DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
     PERCENTAGE,
     TEMP_CELSIUS,
@@ -56,6 +57,7 @@ SENSOR_TYPES = (
     SHT31SensorEntityDescription(
         key="humidity",
         name="Humidity",
+        device_class=DEVICE_CLASS_HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda sensor: round(val) if (val := sensor.humidity) else None,
     ),

--- a/homeassistant/components/sht31/sensor.py
+++ b/homeassistant/components/sht31/sensor.py
@@ -82,6 +82,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
     name = config[CONF_NAME]
+    monitored_conditions = config[CONF_MONITORED_CONDITIONS]
     i2c_address = config[CONF_I2C_ADDRESS]
     sensor = SHT31(address=i2c_address)
 
@@ -94,7 +95,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     sensor_client = SHTClient(sensor)
 
     entities = [
-        SHTSensor(sensor_client, name, description) for description in SENSOR_TYPES
+        SHTSensor(sensor_client, name, description)
+        for description in SENSOR_TYPES
+        if description.key in monitored_conditions
     ]
 
     add_entities(entities)

--- a/homeassistant/components/sht31/sensor.py
+++ b/homeassistant/components/sht31/sensor.py
@@ -1,13 +1,20 @@
 """Support for Sensirion SHT31 temperature and humidity sensor."""
+from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 import math
+from typing import Callable
 
 from Adafruit_SHT31 import SHT31
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
+from homeassistant.components.sensor import (
+    PLATFORM_SCHEMA,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS,
     CONF_NAME,
@@ -25,9 +32,35 @@ CONF_I2C_ADDRESS = "i2c_address"
 DEFAULT_NAME = "SHT31"
 DEFAULT_I2C_ADDRESS = 0x44
 
-SENSOR_TEMPERATURE = "temperature"
-SENSOR_HUMIDITY = "humidity"
-SENSOR_TYPES = (SENSOR_TEMPERATURE, SENSOR_HUMIDITY)
+
+@dataclass
+class SHT31RequiredKeysMixin:
+    """Mixin for required keys."""
+
+    value_fn: Callable[[SHTClient], float | None]
+
+
+@dataclass
+class SHT31SensorEntityDescription(SensorEntityDescription, SHT31RequiredKeysMixin):
+    """Describes SHT31 sensor entity."""
+
+
+SENSOR_TYPES = (
+    SHT31SensorEntityDescription(
+        key="temperature",
+        name="Temperature",
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        native_unit_of_measurement=TEMP_CELSIUS,
+        value_fn=lambda sensor: sensor.temperature,
+    ),
+    SHT31SensorEntityDescription(
+        key="humidity",
+        name="Humidity",
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda sensor: round(val) if (val := sensor.humidity) else None,
+    ),
+)
+SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 
@@ -36,8 +69,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_I2C_ADDRESS, default=DEFAULT_I2C_ADDRESS): vol.All(
             vol.Coerce(int), vol.Range(min=0x44, max=0x45)
         ),
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_TYPES)]
+        vol.Optional(CONF_MONITORED_CONDITIONS, default=SENSOR_KEYS): vol.All(
+            cv.ensure_list, [vol.In(SENSOR_KEYS)]
         ),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
@@ -46,8 +79,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
-
-    i2c_address = config.get(CONF_I2C_ADDRESS)
+    name = config[CONF_NAME]
+    i2c_address = config[CONF_I2C_ADDRESS]
     sensor = SHT31(address=i2c_address)
 
     try:
@@ -58,17 +91,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
     sensor_client = SHTClient(sensor)
 
-    sensor_classes = {
-        SENSOR_TEMPERATURE: SHTSensorTemperature,
-        SENSOR_HUMIDITY: SHTSensorHumidity,
-    }
+    entities = [
+        SHTSensor(sensor_client, name, description) for description in SENSOR_TYPES
+    ]
 
-    devs = []
-    for sensor_type, sensor_class in sensor_classes.items():
-        name = f"{config.get(CONF_NAME)} {sensor_type.capitalize()}"
-        devs.append(sensor_class(sensor_client, name))
-
-    add_entities(devs)
+    add_entities(entities)
 
 
 class SHTClient:
@@ -77,8 +104,8 @@ class SHTClient:
     def __init__(self, adafruit_sht):
         """Initialize the sensor."""
         self.adafruit_sht = adafruit_sht
-        self.temperature = None
-        self.humidity = None
+        self.temperature: float | None = None
+        self.humidity: float | None = None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
@@ -94,50 +121,16 @@ class SHTClient:
 class SHTSensor(SensorEntity):
     """An abstract SHTSensor, can be either temperature or humidity."""
 
-    def __init__(self, sensor, name):
+    entity_description: SHT31SensorEntityDescription
+
+    def __init__(self, sensor, name, description: SHT31SensorEntityDescription):
         """Initialize the sensor."""
+        self.entity_description = description
         self._sensor = sensor
-        self._name = name
-        self._state = None
 
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def native_value(self):
-        """Return the state of the sensor."""
-        return self._state
+        self._attr_name = f"{name} {description.name}"
 
     def update(self):
         """Fetch temperature and humidity from the sensor."""
         self._sensor.update()
-
-
-class SHTSensorTemperature(SHTSensor):
-    """Representation of a temperature sensor."""
-
-    _attr_device_class = DEVICE_CLASS_TEMPERATURE
-    _attr_native_unit_of_measurement = TEMP_CELSIUS
-
-    def update(self):
-        """Fetch temperature from the sensor."""
-        super().update()
-        self._state = self._sensor.temperature
-
-
-class SHTSensorHumidity(SHTSensor):
-    """Representation of a humidity sensor."""
-
-    @property
-    def native_unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return PERCENTAGE
-
-    def update(self):
-        """Fetch humidity from the sensor."""
-        super().update()
-        humidity = self._sensor.humidity
-        if humidity is not None:
-            self._state = round(humidity)
+        self._attr_native_value = self.entity_description.value_fn(self._sensor)

--- a/homeassistant/components/sht31/sensor.py
+++ b/homeassistant/components/sht31/sensor.py
@@ -59,7 +59,11 @@ SENSOR_TYPES = (
         name="Humidity",
         device_class=DEVICE_CLASS_HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda sensor: round(val) if (val := sensor.humidity) else None,
+        value_fn=lambda sensor: (
+            round(val)  # pylint: disable=undefined-variable
+            if (val := sensor.humidity)
+            else None
+        ),
     ),
 )
 SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]


### PR DESCRIPTION
## Proposed change
Update `sht31` to use `EntityDescription` for sensor metadata.
-> #53201

This PR also fixes two minor issues:
* No device class for `humidity` sensor
* Setup didn't take `monitored_conditions` into account. Probably not a big issue as most users will use both sensors anyway (the default).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
