### PR TITLE
Improve Shelly light application/consumption type handling

### DIFF
--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -51,7 +51,13 @@ from .const import (
     STANDARD_RGB_EFFECTS,
 )
 from .entity import ShellyBlockEntity, ShellyRpcEntity
-from .utils import async_remove_shelly_entity, get_device_entry_gen, get_rpc_key_ids
+from .utils import (
+    async_remove_shelly_entity,
+    get_device_entry_gen,
+    get_rpc_key_ids,
+    is_block_channel_type_light,
+    is_rpc_channel_type_light,
+)
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -82,10 +88,9 @@ async def async_setup_block_entry(
         if block.type == "light":
             blocks.append(block)
         elif block.type == "relay":
-            app_type = wrapper.device.settings["relays"][int(block.channel)].get(
-                "appliance_type"
-            )
-            if not app_type or app_type.lower() != "light":
+            if not is_block_channel_type_light(
+                wrapper.device.settings, int(block.channel)
+            ):
                 continue
 
             blocks.append(block)
@@ -110,8 +115,7 @@ async def async_setup_rpc_entry(
 
     switch_ids = []
     for id_ in switch_key_ids:
-        con_types = wrapper.device.config["sys"]["ui_data"].get("consumption_types")
-        if con_types is None or con_types[id_] != "lights":
+        if not is_rpc_channel_type_light(wrapper.device.config, id_):
             continue
 
         switch_ids.append(id_)

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -302,3 +302,15 @@ def get_rpc_key_ids(keys_dict: dict[str, Any], key: str) -> list[int]:
 def is_rpc_momentary_input(config: dict[str, Any], key: str) -> bool:
     """Return true if rpc input button settings is set to a momentary type."""
     return cast(bool, config[key]["type"] == "button")
+
+
+def is_block_channel_type_light(settings: dict[str, Any], channel: int) -> bool:
+    """Return true if block channel appliance type is set to light."""
+    app_type = settings["relays"][channel].get("appliance_type")
+    return app_type is not None and app_type.lower().startswith("light")
+
+
+def is_rpc_channel_type_light(config: dict[str, Any], channel: int) -> bool:
+    """Return true if rpc channel consumption type is set to light."""
+    con_types = config["sys"]["ui_data"].get("consumption_types")
+    return con_types is not None and con_types[channel].lower().startswith("light")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For Shelly Gen1 (block) devices we create a light entity if channel application type is set to `Light` or `light`
Gen2 devices (RPC) has an option to select a value from a list and the offered value is `Lights` and it also allow setting your own type.

To align both Gen1 & Gen2 devices we allow anything which start with `light` and convert the input value to lowercase.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
