### PR TITLE
Correct Alexa scene activation

### DIFF
--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -2,6 +2,8 @@
 import logging
 import math
 
+import homeassistant.util.color as color_util
+import homeassistant.util.dt as dt_util
 from homeassistant import core as ha
 from homeassistant.components import (
     camera,
@@ -44,11 +46,8 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.helpers import network
-import homeassistant.util.color as color_util
 from homeassistant.util.decorator import Registry
-import homeassistant.util.dt as dt_util
 from homeassistant.util.temperature import convert as convert_temperature
-
 from .const import (
     API_TEMP_UNITS,
     API_THERMOSTAT_MODES,
@@ -56,6 +55,7 @@ from .const import (
     API_THERMOSTAT_PRESETS,
     Cause,
     Inputs,
+    DATE_FORMAT,
 )
 from .entities import async_get_entities
 from .errors import (
@@ -318,7 +318,7 @@ async def async_api_activate(hass, config, directive, context):
 
     payload = {
         "cause": {"type": Cause.VOICE_INTERACTION},
-        "timestamp": f"{dt_util.utcnow().replace(tzinfo=None).isoformat()}Z",
+        "timestamp": dt_util.utcnow().strftime(DATE_FORMAT),
     }
 
     return directive.response(
@@ -342,7 +342,7 @@ async def async_api_deactivate(hass, config, directive, context):
 
     payload = {
         "cause": {"type": Cause.VOICE_INTERACTION},
-        "timestamp": f"{dt_util.utcnow().replace(tzinfo=None).isoformat()}Z",
+        "timestamp": dt_util.utcnow().strftime(DATE_FORMAT),
     }
 
     return directive.response(

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -2,8 +2,6 @@
 import logging
 import math
 
-import homeassistant.util.color as color_util
-import homeassistant.util.dt as dt_util
 from homeassistant import core as ha
 from homeassistant.components import (
     camera,
@@ -46,16 +44,19 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.helpers import network
+import homeassistant.util.color as color_util
 from homeassistant.util.decorator import Registry
+import homeassistant.util.dt as dt_util
 from homeassistant.util.temperature import convert as convert_temperature
+
 from .const import (
     API_TEMP_UNITS,
     API_THERMOSTAT_MODES,
     API_THERMOSTAT_MODES_CUSTOM,
     API_THERMOSTAT_PRESETS,
+    DATE_FORMAT,
     Cause,
     Inputs,
-    DATE_FORMAT,
 )
 from .entities import async_get_entities
 from .errors import (

--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers.significant_change import create_checker
 import homeassistant.util.dt as dt_util
 
-from .const import API_CHANGE, DOMAIN, Cause
+from .const import API_CHANGE, DATE_FORMAT, DOMAIN, Cause
 from .entities import ENTITY_ADAPTERS, AlexaEntity, generate_alexa_id
 from .messages import AlexaResponse
 
@@ -252,7 +252,7 @@ async def async_send_doorbell_event_message(hass, config, alexa_entity):
         namespace="Alexa.DoorbellEventSource",
         payload={
             "cause": {"type": Cause.PHYSICAL_INTERACTION},
-            "timestamp": f"{dt_util.utcnow().replace(tzinfo=None).isoformat()}Z",
+            "timestamp": dt_util.utcnow().strftime(DATE_FORMAT),
         },
     )
 

--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -1,10 +1,11 @@
 """Tests for the Alexa integration."""
+import re
 from uuid import uuid4
 
 from homeassistant.components.alexa import config, smart_home
 from homeassistant.core import Context, callback
+
 from tests.common import async_mock_service
-import re
 
 TEST_URL = "https://api.amazonalexa.com/v3/events"
 TEST_TOKEN_URL = "https://api.amazon.com/auth/o2/token"

--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -163,7 +163,7 @@ async def assert_scene_controller_works(
     )
     assert response["event"]["payload"]["cause"]["type"] == "VOICE_INTERACTION"
     assert "timestamp" in response["event"]["payload"]
-    pattern = r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"
+    pattern = r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.0Z"
     assert re.search(pattern, response["event"]["payload"]["timestamp"])
     if deactivate_service:
         await assert_request_calls_service(

--- a/tests/components/alexa/__init__.py
+++ b/tests/components/alexa/__init__.py
@@ -3,8 +3,8 @@ from uuid import uuid4
 
 from homeassistant.components.alexa import config, smart_home
 from homeassistant.core import Context, callback
-
 from tests.common import async_mock_service
+import re
 
 TEST_URL = "https://api.amazonalexa.com/v3/events"
 TEST_TOKEN_URL = "https://api.amazon.com/auth/o2/token"
@@ -162,7 +162,8 @@ async def assert_scene_controller_works(
     )
     assert response["event"]["payload"]["cause"]["type"] == "VOICE_INTERACTION"
     assert "timestamp" in response["event"]["payload"]
-
+    pattern = r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"
+    assert re.search(pattern, response["event"]["payload"]["timestamp"])
     if deactivate_service:
         await assert_request_calls_service(
             "Alexa.SceneController",
@@ -175,6 +176,7 @@ async def assert_scene_controller_works(
         cause_type = response["event"]["payload"]["cause"]["type"]
         assert cause_type == "VOICE_INTERACTION"
         assert "timestamp" in response["event"]["payload"]
+        assert re.search(pattern, response["event"]["payload"]["timestamp"])
 
 
 async def reported_properties(hass, endpoint):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When using scenes and Alexa integration when i tell Alexa to be arriving home and activate a hassio scene, it works but Alexa tells that this scene is not responding.
As it's in [Alexa documentation](https://developer.amazon.com/es-ES/docs/alexa/device-apis/alexa-scenecontroller.html#activate-response-event) when responding to an Alexa.SceneController Activate/Deactivate we should return a parameter timestamp in ISO-8601 `YYYY-MM-DDThh:mm:ssZ`
This bugfix forces not to add millisecond or microsecond to the `datetime.isoformat()`


## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Related Forum discussion: https://community.home-assistant.io/t/alexa-executing-scene-even-though-says-not-responding/339621

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
