### PR TITLE
ZHA channel ZCL attributes initialization

### DIFF
--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -314,9 +314,14 @@ class ZigbeeChannel(LogMixin):
             return
 
         self.debug("initializing channel: from_cache: %s", from_cache)
-        attributes = [cfg["attr"] for cfg in self.REPORT_CONFIG]
-        if attributes:
-            await self.get_attributes(attributes, from_cache=from_cache)
+        cached = [a for a, cached in self.ZCL_INIT_ATTRS.items() if cached]
+        uncached = [a for a, cached in self.ZCL_INIT_ATTRS.items() if not cached]
+        uncached.extend([cfg["attr"] for cfg in self.REPORT_CONFIG])
+
+        if cached:
+            await self.get_attributes(cached, from_cache=True)
+        if uncached:
+            await self.get_attributes(uncached, from_cache=from_cache)
 
         ch_specific_init = getattr(self, "async_initialize_channel_specific", None)
         if ch_specific_init:

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -92,6 +92,11 @@ class ZigbeeChannel(LogMixin):
     REPORT_CONFIG: tuple[dict[int | str, tuple[int, int, int | float]]] = ()
     BIND: bool = True
 
+    # Dict of attributes to read on channel initialization.
+    # Dict keys -- attribute ID or names, with bool value indicating whether a cached
+    # attribute read is acceptable.
+    ZCL_INIT_ATTRS: dict[int | str, bool] = {}
+
     def __init__(
         self, cluster: zha_typing.ZigpyClusterType, ch_pool: zha_typing.ChannelPoolType
     ) -> None:

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -395,13 +395,13 @@ class ZigbeeChannel(LogMixin):
         result = {}
         while chunk:
             try:
-                r, _ = await self.cluster.read_attributes(
+                read, _ = await self.cluster.read_attributes(
                     attributes,
                     allow_cache=from_cache,
                     only_cache=from_cache and not self._ch_pool.is_mains_powered,
                     manufacturer=manufacturer,
                 )
-                result.update(r)
+                result.update(read)
             except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException) as ex:
                 self.debug(
                     "failed to get attributes '%s' on '%s' cluster: %s",

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -23,7 +23,6 @@ from ..const import (
     SIGNAL_SET_LEVEL,
     SIGNAL_UPDATE_DEVICE,
 )
-from ..helpers import retryable_req
 from .base import ClientChannel, ZigbeeChannel, parse_and_log_command
 
 
@@ -44,7 +43,16 @@ class AnalogInput(ZigbeeChannel):
 class AnalogOutput(ZigbeeChannel):
     """Analog Output channel."""
 
-    REPORT_CONFIG = [{"attr": "present_value", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = ({"attr": "present_value", "config": REPORT_CONFIG_DEFAULT},)
+    ZCL_INIT_ATTRS = {
+        "min_present_value": True,
+        "max_present_value": True,
+        "resolution": True,
+        "relinquish_default": True,
+        "description": True,
+        "engineering_units": True,
+        "application_type": True,
+    }
 
     @property
     def present_value(self) -> float | None:
@@ -98,25 +106,6 @@ class AnalogOutput(ZigbeeChannel):
         ):
             return True
         return False
-
-    @retryable_req(delays=(1, 1, 3))
-    def async_initialize_channel_specific(self, from_cache: bool) -> Coroutine:
-        """Initialize channel."""
-        return self.fetch_config(from_cache)
-
-    async def fetch_config(self, from_cache: bool) -> None:
-        """Get the channel configuration."""
-        attributes = [
-            "min_present_value",
-            "max_present_value",
-            "resolution",
-            "relinquish_default",
-            "description",
-            "engineering_units",
-            "application_type",
-        ]
-        # just populates the cache, if not already done
-        await self.get_attributes(attributes, from_cache=from_cache)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.AnalogValue.cluster_id)

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -1,8 +1,6 @@
 """Home automation channels module for Zigbee Home Automation."""
 from __future__ import annotations
 
-from collections.abc import Coroutine
-
 from zigpy.zcl.clusters import homeautomation
 
 from .. import registries
@@ -49,6 +47,12 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
     CHANNEL_NAME = CHANNEL_ELECTRICAL_MEASUREMENT
 
     REPORT_CONFIG = ({"attr": "active_power", "config": REPORT_CONFIG_DEFAULT},)
+    ZCL_INIT_ATTRS = {
+        "ac_power_divisor": True,
+        "power_divisor": True,
+        "ac_power_multiplier": True,
+        "power_multiplier": True,
+    }
 
     async def async_update(self):
         """Retrieve latest state."""
@@ -63,19 +67,6 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
                 "active_power",
                 result,
             )
-
-    def async_initialize_channel_specific(self, from_cache: bool) -> Coroutine:
-        """Initialize channel specific attributes."""
-
-        return self.get_attributes(
-            [
-                "ac_power_divisor",
-                "power_divisor",
-                "ac_power_multiplier",
-                "power_multiplier",
-            ],
-            from_cache=True,
-        )
 
     @property
     def divisor(self) -> int | None:

--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -42,11 +42,17 @@ class FanChannel(ZigbeeChannel):
     _value_attribute = 0
 
     REPORT_CONFIG = ({"attr": "fan_mode", "config": REPORT_CONFIG_OP},)
+    ZCL_INIT_ATTRS = {"fan_mode_sequence": True}
 
     @property
     def fan_mode(self) -> int | None:
         """Return current fan mode."""
         return self.cluster.get("fan_mode")
+
+    @property
+    def fan_mode_sequence(self) -> int | None:
+        """Return possible fan mode speeds."""
+        return self.cluster.get("fan_mode_sequence")
 
     async def async_set_speed(self, value) -> None:
         """Set the speed of the fan."""

--- a/homeassistant/components/zha/core/channels/lighting.py
+++ b/homeassistant/components/zha/core/channels/lighting.py
@@ -1,7 +1,6 @@
 """Lighting channels module for Zigbee Home Automation."""
 from __future__ import annotations
 
-from collections.abc import Coroutine
 from contextlib import suppress
 
 from zigpy.zcl.clusters import lighting
@@ -36,6 +35,12 @@ class ColorChannel(ZigbeeChannel):
     )
     MAX_MIREDS: int = 500
     MIN_MIREDS: int = 153
+    ZCL_INIT_ATTRS = {
+        "color_temp_physical_min": True,
+        "color_temp_physical_max": True,
+        "color_capabilities": True,
+        "color_loop_active": False,
+    }
 
     @property
     def color_capabilities(self) -> int:
@@ -75,22 +80,3 @@ class ColorChannel(ZigbeeChannel):
     def max_mireds(self) -> int:
         """Return the warmest color_temp that this channel supports."""
         return self.cluster.get("color_temp_physical_max", self.MAX_MIREDS)
-
-    def async_configure_channel_specific(self) -> Coroutine:
-        """Configure channel."""
-        return self.fetch_color_capabilities(False)
-
-    def async_initialize_channel_specific(self, from_cache: bool) -> Coroutine:
-        """Initialize channel."""
-        return self.fetch_color_capabilities(True)
-
-    async def fetch_color_capabilities(self, from_cache: bool) -> None:
-        """Get the color configuration."""
-        attributes = [
-            "color_temp_physical_min",
-            "color_temp_physical_max",
-            "color_capabilities",
-            "color_temperature",
-        ]
-        # just populates the cache, if not already done
-        await self.get_attributes(attributes, from_cache=from_cache)

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -7,7 +7,6 @@ https://home-assistant.io/integrations/zha/
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Coroutine
 import logging
 
 from zigpy.exceptions import ZigbeeException
@@ -345,6 +344,8 @@ class IasWd(ZigbeeChannel):
 class IASZoneChannel(ZigbeeChannel):
     """Channel for the IASZone Zigbee cluster."""
 
+    ZCL_INIT_ATTRS = {"zone_status": True, "zone_state": False, "zone_type": True}
+
     @callback
     def cluster_command(self, tsn, command_id, args):
         """Handle commands received to this cluster."""
@@ -404,8 +405,3 @@ class IASZoneChannel(ZigbeeChannel):
                 self.cluster.attributes.get(attrid, [attrid])[0],
                 value,
             )
-
-    def async_initialize_channel_specific(self, from_cache: bool) -> Coroutine:
-        """Initialize channel."""
-        attributes = ["zone_status", "zone_state", "zone_type"]
-        return self.get_attributes(attributes, from_cache=from_cache)

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -374,6 +374,7 @@ ZHA_CHANNEL_MSG_BIND = "zha_channel_bind"
 ZHA_CHANNEL_MSG_CFG_RPT = "zha_channel_configure_reporting"
 ZHA_CHANNEL_MSG_DATA = "zha_channel_msg_data"
 ZHA_CHANNEL_CFG_DONE = "zha_channel_cfg_done"
+ZHA_CHANNEL_READS_PER_REQ = 5
 ZHA_GW_MSG = "zha_gateway_message"
 ZHA_GW_MSG_DEVICE_FULL_INIT = "device_fully_initialized"
 ZHA_GW_MSG_DEVICE_INFO = "device_info"

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -56,6 +56,18 @@ def patch_cluster(cluster):
         cluster.add = AsyncMock(return_value=[0])
 
 
+def update_attribute_cache(cluster):
+    """Update attribute cache based on plugged attributes."""
+    if cluster.PLUGGED_ATTR_READS:
+        attrs = [
+            make_attribute(cluster.attridx.get(attr, attr), value)
+            for attr, value in cluster.PLUGGED_ATTR_READS.items()
+        ]
+        hdr = make_zcl_header(zcl_f.Command.Report_Attributes)
+        hdr.frame_control.disable_default_response = True
+        cluster.handle_message(hdr, [attrs])
+
+
 def get_zha_gateway(hass):
     """Return ZHA gateway from hass.data."""
     try:

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -476,7 +476,7 @@ async def test_fan_update_entity(
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == 0
     assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is None
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE_STEP] == 100 / 3
-    assert cluster.read_attributes.await_count == 1
+    assert cluster.read_attributes.await_count == 2
 
     await async_setup_component(hass, "homeassistant", {})
     await hass.async_block_till_done()
@@ -486,7 +486,7 @@ async def test_fan_update_entity(
     )
     assert hass.states.get(entity_id).state == STATE_OFF
     assert hass.states.get(entity_id).attributes[ATTR_SPEED] == SPEED_OFF
-    assert cluster.read_attributes.await_count == 2
+    assert cluster.read_attributes.await_count == 3
 
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 1}
     await hass.services.async_call(
@@ -497,4 +497,4 @@ async def test_fan_update_entity(
     assert hass.states.get(entity_id).attributes[ATTR_SPEED] == SPEED_LOW
     assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is None
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE_STEP] == 100 / 3
-    assert cluster.read_attributes.await_count == 3
+    assert cluster.read_attributes.await_count == 4

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -16,6 +16,7 @@ from .common import (
     async_test_rejoin,
     find_entity_id,
     send_attributes_report,
+    update_attribute_cache,
 )
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 
@@ -41,25 +42,30 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
 
     cluster = zigpy_analog_output_device.endpoints.get(1).analog_output
     cluster.PLUGGED_ATTR_READS = {
-        "present_value": 15.0,
         "max_present_value": 100.0,
-        "min_present_value": 0.0,
+        "min_present_value": 1.0,
         "relinquish_default": 50.0,
-        "resolution": 1.0,
+        "resolution": 1.1,
         "description": "PWM1",
         "engineering_units": 98,
         "application_type": 4 * 0x10000,
     }
+    update_attribute_cache(cluster)
+    cluster.PLUGGED_ATTR_READS["present_value"] = 15.0
+
     zha_device = await zha_device_joined_restored(zigpy_analog_output_device)
     # one for present_value and one for the rest configuration attributes
     assert cluster.read_attributes.call_count == 3
-    assert "max_present_value" in cluster.read_attributes.call_args[0][0]
-    assert "min_present_value" in cluster.read_attributes.call_args[0][0]
-    assert "relinquish_default" in cluster.read_attributes.call_args[0][0]
-    assert "resolution" in cluster.read_attributes.call_args[0][0]
-    assert "description" in cluster.read_attributes.call_args[0][0]
-    assert "engineering_units" in cluster.read_attributes.call_args[0][0]
-    assert "application_type" in cluster.read_attributes.call_args[0][0]
+    attr_reads = set()
+    for call_args in cluster.read_attributes.call_args_list:
+        attr_reads |= set(call_args[0][0])
+    assert "max_present_value" in attr_reads
+    assert "min_present_value" in attr_reads
+    assert "relinquish_default" in attr_reads
+    assert "resolution" in attr_reads
+    assert "description" in attr_reads
+    assert "engineering_units" in attr_reads
+    assert "application_type" in attr_reads
 
     entity_id = await find_entity_id(DOMAIN, zha_device, hass)
     assert entity_id is not None
@@ -78,9 +84,9 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
     assert hass.states.get(entity_id).state == "15.0"
 
     # test attributes
-    assert hass.states.get(entity_id).attributes.get("min") == 0.0
+    assert hass.states.get(entity_id).attributes.get("min") == 1.0
     assert hass.states.get(entity_id).attributes.get("max") == 100.0
-    assert hass.states.get(entity_id).attributes.get("step") == 1.0
+    assert hass.states.get(entity_id).attributes.get("step") == 1.1
     assert hass.states.get(entity_id).attributes.get("icon") == "mdi:percent"
     assert hass.states.get(entity_id).attributes.get("unit_of_measurement") == "%"
     assert (

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -52,7 +52,7 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
     }
     zha_device = await zha_device_joined_restored(zigpy_analog_output_device)
     # one for present_value and one for the rest configuration attributes
-    assert cluster.read_attributes.call_count == 2
+    assert cluster.read_attributes.call_count == 3
     assert "max_present_value" in cluster.read_attributes.call_args[0][0]
     assert "min_present_value" in cluster.read_attributes.call_args[0][0]
     assert "relinquish_default" in cluster.read_attributes.call_args[0][0]
@@ -69,10 +69,10 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # allow traffic to flow through the gateway and device
-    assert cluster.read_attributes.call_count == 2
+    assert cluster.read_attributes.call_count == 3
     await async_enable_traffic(hass, [zha_device])
     await hass.async_block_till_done()
-    assert cluster.read_attributes.call_count == 4
+    assert cluster.read_attributes.call_count == 6
 
     # test that the state has changed from unavailable to 15.0
     assert hass.states.get(entity_id).state == "15.0"
@@ -89,7 +89,7 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
     )
 
     # change value from device
-    assert cluster.read_attributes.call_count == 4
+    assert cluster.read_attributes.call_count == 6
     await send_attributes_report(hass, cluster, {0x0055: 15})
     assert hass.states.get(entity_id).state == "15.0"
 
@@ -111,10 +111,10 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
         cluster.PLUGGED_ATTR_READS["present_value"] = 30.0
 
     # test rejoin
-    assert cluster.read_attributes.call_count == 4
+    assert cluster.read_attributes.call_count == 6
     await async_test_rejoin(hass, zigpy_analog_output_device, [cluster], (1,))
     assert hass.states.get(entity_id).state == "30.0"
-    assert cluster.read_attributes.call_count == 6
+    assert cluster.read_attributes.call_count == 9
 
     # update device value with failed attribute report
     cluster.PLUGGED_ATTR_READS["present_value"] = 40.0
@@ -128,5 +128,5 @@ async def test_number(hass, zha_device_joined_restored, zigpy_analog_output_devi
         "homeassistant", "update_entity", {"entity_id": entity_id}, blocking=True
     )
     assert hass.states.get(entity_id).state == "40.0"
-    assert cluster.read_attributes.call_count == 7
+    assert cluster.read_attributes.call_count == 10
     assert "present_value" in cluster.read_attributes.call_args[0][0]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow each ZHA channel to define a list of ZCL attributes to query upon channel initialization. Currently most ZHA channels have channel specific initialization to refresh ZCL attributes required for channel operation. This PR unifies that under the shared "channel initialization" method and allows each channel to define "cached" and "uncached" ZCL attributes to refresh during initialization. Additionally, reported attributes are also refreshed as "uncached" attributes.  This was tested on `hvac` channel and now being rolled into all ZHA channels.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it intto multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
