### PR TITLE
Bump velbus-aio to 2021.9.4

### DIFF
--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -63,7 +63,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     controller = Velbus(
-        entry.data[CONF_PORT], cache_dir=f"{hass.config.config_dir}/velbuscache/"
+        entry.data[CONF_PORT],
+        cache_dir=f"{hass.config.config_dir}/.storage/velbuscache/",
     )
     hass.data[DOMAIN][entry.entry_id] = {}
     hass.data[DOMAIN][entry.entry_id]["cntrl"] = controller

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -62,7 +62,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Establish connection with velbus."""
     hass.data.setdefault(DOMAIN, {})
 
-    controller = Velbus(entry.data[CONF_PORT])
+    controller = Velbus(
+        entry.data[CONF_PORT], cache_dir=f"{hass.config.config_dir}/velbuscache/"
+    )
     hass.data[DOMAIN][entry.entry_id] = {}
     hass.data[DOMAIN][entry.entry_id]["cntrl"] = controller
     hass.data[DOMAIN][entry.entry_id]["tsk"] = hass.async_create_task(

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -64,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     controller = Velbus(
         entry.data[CONF_PORT],
-        cache_dir=hass.config.path("/.storage/velbuscache/"),
+        cache_dir=hass.config.path(".storage/velbuscache/"),
     )
     hass.data[DOMAIN][entry.entry_id] = {}
     hass.data[DOMAIN][entry.entry_id]["cntrl"] = controller

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -64,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     controller = Velbus(
         entry.data[CONF_PORT],
-        cache_dir=f"{hass.config.config_dir}/.storage/velbuscache/",
+        cache_dir=hass.config.path("/.storage/velbuscache/"),
     )
     hass.data[DOMAIN][entry.entry_id] = {}
     hass.data[DOMAIN][entry.entry_id]["cntrl"] = controller

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.9.1"],
+  "requirements": ["velbus-aio==2021.9.2"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.9.2"],
+  "requirements": ["velbus-aio==2021.9.3"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.9.3"],
+  "requirements": ["velbus-aio==2021.9.4"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2358,7 +2358,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.9.1
+velbus-aio==2021.9.2
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2358,7 +2358,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.9.3
+velbus-aio==2021.9.4
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2358,7 +2358,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.9.2
+velbus-aio==2021.9.3
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1329,7 +1329,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.9.1
+velbus-aio==2021.9.2
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1329,7 +1329,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.9.3
+velbus-aio==2021.9.4
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1329,7 +1329,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.9.2
+velbus-aio==2021.9.3
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14


### PR DESCRIPTION
## Proposed change
- Bump velbusaio lib to a new version:
       https://github.com/Cereal2nd/velbus-aio/releases/tag/2021.9.2
       https://github.com/Cereal2nd/velbus-aio/releases/tag/2021.9.3
        https://github.com/Cereal2nd/velbus-aio/releases/tag/2021.9.4
       https://github.com/Cereal2nd/velbus-aio/compare/2021.9.1...2021.9.4
- Set the velbusaio cache-dir to the home-assistant config directory

In the current version the velbuscache was stored on a fixed /tmp location, but if you run hass in a container this location is lost on every container restart, this fixes this problem.

## Type of change
- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
