### PR TITLE
Address Crownstone review comments

### DIFF
--- a/homeassistant/components/crownstone/__init__.py
+++ b/homeassistant/components/crownstone/__init__.py
@@ -12,6 +12,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Initiate setup for a Crownstone config entry."""
     manager = CrownstoneEntryManager(hass, entry)
 
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = manager
+
     return await manager.async_setup()
 
 

--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -1,7 +1,7 @@
 """Flow handler for Crownstone."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 from crownstone_cloud import CrownstoneCloud
 from crownstone_cloud.exceptions import (
@@ -16,7 +16,7 @@ from homeassistant.components import usb
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import FlowHandler, FlowResult
 from homeassistant.helpers import aiohttp_client
 
 from .const import (
@@ -30,74 +30,25 @@ from .const import (
     MANUAL_PATH,
     REFRESH_LIST,
 )
-from .entry_manager import CrownstoneEntryManager
 from .helpers import list_ports_as_str
 
+CONFIG_FLOW = "config_flow"
+OPTIONS_FLOW = "options_flow"
 
-class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Crownstone."""
 
-    VERSION = 1
+class BaseCrownstoneFlowHandler(FlowHandler):
+    """Represent the base flow for Crownstone."""
+
     cloud: CrownstoneCloud
 
-    @staticmethod
-    @callback
-    def async_get_options_flow(
-        config_entry: ConfigEntry,
-    ) -> CrownstoneOptionsFlowHandler:
-        """Return the Crownstone options."""
-        return CrownstoneOptionsFlowHandler(config_entry)
-
-    def __init__(self) -> None:
-        """Initialize the flow."""
-        self.login_info: dict[str, Any] = {}
+    def __init__(
+        self, flow_type: str, create_entry_cb: Callable[..., FlowResult]
+    ) -> None:
+        """Set up flow instance."""
+        self.flow_type = flow_type
+        self.create_entry_callback = create_entry_cb
         self.usb_path: str | None = None
         self.usb_sphere_id: str | None = None
-
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the initial step."""
-        errors: dict[str, str] = {}
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(
-                    {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
-                ),
-            )
-
-        self.cloud = CrownstoneCloud(
-            email=user_input[CONF_EMAIL],
-            password=user_input[CONF_PASSWORD],
-            clientsession=aiohttp_client.async_get_clientsession(self.hass),
-        )
-        # Login & sync all user data
-        try:
-            await self.cloud.async_initialize()
-        except CrownstoneAuthenticationError as auth_error:
-            if auth_error.type == "LOGIN_FAILED":
-                errors["base"] = "invalid_auth"
-            elif auth_error.type == "LOGIN_FAILED_EMAIL_NOT_VERIFIED":
-                errors["base"] = "account_not_verified"
-        except CrownstoneUnknownError:
-            errors["base"] = "unknown_error"
-
-        # show form again, with the errors
-        if errors:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(
-                    {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
-                ),
-                errors=errors,
-            )
-
-        await self.async_set_unique_id(self.cloud.cloud_data.user_id)
-        self._abort_if_unique_id_configured()
-
-        self.login_info = user_input
-        return await self.async_step_usb_config()
 
     async def async_step_usb_config(
         self, user_input: dict[str, Any] | None = None
@@ -106,19 +57,25 @@ class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         list_of_ports = await self.hass.async_add_executor_job(
             serial.tools.list_ports.comports
         )
-        ports_as_string = list_ports_as_str(list_of_ports)
+        if self.flow_type == CONFIG_FLOW:
+            ports_as_string = list_ports_as_str(list_of_ports)
+        else:
+            ports_as_string = list_ports_as_str(list_of_ports, False)
 
         if user_input is not None:
             selection = user_input[CONF_USB_PATH]
 
             if selection == DONT_USE_USB:
-                return self.async_create_new_entry()
+                return self.create_entry_callback()
             if selection == MANUAL_PATH:
                 return await self.async_step_usb_manual_config()
             if selection != REFRESH_LIST:
-                selected_port: ListPortInfo = list_of_ports[
-                    (ports_as_string.index(selection) - 1)
-                ]
+                if self.flow_type == OPTIONS_FLOW:
+                    index = ports_as_string.index(selection)
+                else:
+                    index = ports_as_string.index(selection) - 1
+
+                selected_port: ListPortInfo = list_of_ports[index]
                 self.usb_path = await self.hass.async_add_executor_job(
                     usb.get_serial_by_id, selected_port.device
                 )
@@ -165,11 +122,75 @@ class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         elif user_input:
             self.usb_sphere_id = spheres[user_input[CONF_USB_SPHERE]]
 
-        return self.async_create_new_entry()
+        return self.create_entry_callback()
+
+
+class CrownstoneConfigFlowHandler(BaseCrownstoneFlowHandler, ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Crownstone."""
+
+    VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> CrownstoneOptionsFlowHandler:
+        """Return the Crownstone options."""
+        return CrownstoneOptionsFlowHandler(config_entry)
+
+    def __init__(self) -> None:
+        """Initialize the flow."""
+        super().__init__(CONFIG_FLOW, self.async_create_new_entry)
+        self.login_info: dict[str, Any] = {}
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
+                ),
+            )
+
+        self.cloud = CrownstoneCloud(
+            email=user_input[CONF_EMAIL],
+            password=user_input[CONF_PASSWORD],
+            clientsession=aiohttp_client.async_get_clientsession(self.hass),
+        )
+        # Login & sync all user data
+        try:
+            await self.cloud.async_initialize()
+        except CrownstoneAuthenticationError as auth_error:
+            if auth_error.type == "LOGIN_FAILED":
+                errors["base"] = "invalid_auth"
+            elif auth_error.type == "LOGIN_FAILED_EMAIL_NOT_VERIFIED":
+                errors["base"] = "account_not_verified"
+        except CrownstoneUnknownError:
+            errors["base"] = "unknown_error"
+
+        # show form again, with the errors
+        if errors:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
+                ),
+                errors=errors,
+            )
+
+        await self.async_set_unique_id(self.cloud.cloud_data.user_id)
+        self._abort_if_unique_id_configured()
+
+        self.login_info = user_input
+        return await self.async_step_usb_config()
 
     def async_create_new_entry(self) -> FlowResult:
         """Create a new entry."""
-        return self.async_create_entry(
+        return super().async_create_entry(
             title=f"Account: {self.login_info[CONF_EMAIL]}",
             data={
                 CONF_EMAIL: self.login_info[CONF_EMAIL],
@@ -179,22 +200,22 @@ class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         )
 
 
-class CrownstoneOptionsFlowHandler(OptionsFlow):
+class CrownstoneOptionsFlowHandler(BaseCrownstoneFlowHandler, OptionsFlow):
     """Handle Crownstone options."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize Crownstone options."""
+        super().__init__(OPTIONS_FLOW, self.async_create_new_entry)
         self.entry = config_entry
         self.updated_options = config_entry.options.copy()
-        self.spheres: dict[str, str] = {}
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage Crownstone options."""
-        manager: CrownstoneEntryManager = self.hass.data[DOMAIN][self.entry.entry_id]
+        self.cloud: CrownstoneCloud = self.hass.data[DOMAIN][self.entry.entry_id].cloud
 
-        spheres = {sphere.name: sphere.cloud_id for sphere in manager.cloud.cloud_data}
+        spheres = {sphere.name: sphere.cloud_id for sphere in self.cloud.cloud_data}
         usb_path = self.entry.options.get(CONF_USB_PATH)
         usb_sphere = self.entry.options.get(CONF_USB_SPHERE)
 
@@ -206,15 +227,14 @@ class CrownstoneOptionsFlowHandler(OptionsFlow):
                 {
                     vol.Optional(
                         CONF_USB_SPHERE_OPTION,
-                        default=manager.cloud.cloud_data.spheres[usb_sphere].name,
+                        default=self.cloud.cloud_data.data[usb_sphere].name,
                     ): vol.In(spheres.keys())
                 }
             )
 
         if user_input is not None:
             if user_input[CONF_USE_USB_OPTION] and usb_path is None:
-                self.spheres = spheres
-                return await self.async_step_usb_config_option()
+                return await self.async_step_usb_config()
             if not user_input[CONF_USE_USB_OPTION] and usb_path is not None:
                 self.updated_options[CONF_USB_PATH] = None
                 self.updated_options[CONF_USB_SPHERE] = None
@@ -225,74 +245,15 @@ class CrownstoneOptionsFlowHandler(OptionsFlow):
                 sphere_id = spheres[user_input[CONF_USB_SPHERE_OPTION]]
                 self.updated_options[CONF_USB_SPHERE] = sphere_id
 
-            return self.async_create_entry(title="", data=self.updated_options)
+            return self.async_create_new_entry()
 
         return self.async_show_form(step_id="init", data_schema=options_schema)
 
-    async def async_step_usb_config_option(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Set up a Crownstone USB dongle."""
-        list_of_ports = await self.hass.async_add_executor_job(
-            serial.tools.list_ports.comports
-        )
-        ports_as_string = list_ports_as_str(list_of_ports, False)
+    def async_create_new_entry(self) -> FlowResult:
+        """Create a new entry."""
+        # these attributes will only change when a usb was configured
+        if self.usb_path is not None and self.usb_sphere_id is not None:
+            self.updated_options[CONF_USB_PATH] = self.usb_path
+            self.updated_options[CONF_USB_SPHERE] = self.usb_sphere_id
 
-        if user_input is not None:
-            selection = user_input[CONF_USB_PATH]
-
-            if selection == MANUAL_PATH:
-                return await self.async_step_usb_manual_config_option()
-            if selection != REFRESH_LIST:
-                selected_port: ListPortInfo = list_of_ports[
-                    ports_as_string.index(selection)
-                ]
-                usb_path = await self.hass.async_add_executor_job(
-                    usb.get_serial_by_id, selected_port.device
-                )
-                self.updated_options[CONF_USB_PATH] = usb_path
-                return await self.async_step_usb_sphere_config_option()
-
-        return self.async_show_form(
-            step_id="usb_config_option",
-            data_schema=vol.Schema(
-                {vol.Required(CONF_USB_PATH): vol.In(ports_as_string)}
-            ),
-        )
-
-    async def async_step_usb_manual_config_option(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Manually enter Crownstone USB dongle path."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="usb_manual_config_option",
-                data_schema=vol.Schema({vol.Required(CONF_USB_MANUAL_PATH): str}),
-            )
-
-        self.updated_options[CONF_USB_PATH] = user_input[CONF_USB_MANUAL_PATH]
-        return await self.async_step_usb_sphere_config_option()
-
-    async def async_step_usb_sphere_config_option(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Select a Crownstone sphere that the USB operates in."""
-        # no need to select if there's only 1 option
-        sphere_id: str | None = None
-        if len(self.spheres) == 1:
-            sphere_id = next(iter(self.spheres.values()))
-
-        if user_input is None and sphere_id is None:
-            return self.async_show_form(
-                step_id="usb_sphere_config_option",
-                data_schema=vol.Schema({CONF_USB_SPHERE: vol.In(self.spheres.keys())}),
-            )
-
-        if sphere_id:
-            self.updated_options[CONF_USB_SPHERE] = sphere_id
-        elif user_input:
-            self.updated_options[CONF_USB_SPHERE] = self.spheres[
-                user_input[CONF_USB_SPHERE]
-            ]
-
-        return self.async_create_entry(title="", data=self.updated_options)
+        return super().async_create_entry(title="", data=self.updated_options)

--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -223,7 +223,6 @@ class CrownstoneOptionsFlowHandler(OptionsFlow):
                 and spheres[user_input[CONF_USB_SPHERE_OPTION]] != usb_sphere
             ):
                 sphere_id = spheres[user_input[CONF_USB_SPHERE_OPTION]]
-                user_input[CONF_USB_SPHERE_OPTION] = sphere_id
                 self.updated_options[CONF_USB_SPHERE] = sphere_id
 
             return self.async_create_entry(title="", data=self.updated_options)

--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -19,9 +19,6 @@ SIG_CROWNSTONE_STATE_UPDATE: Final = "crownstone.crownstone_state_update"
 SIG_CROWNSTONE_UPDATE: Final = "crownstone.crownstone_update"
 SIG_UART_STATE_CHANGE: Final = "crownstone.uart_state_change"
 
-# Abilities state
-ABILITY_STATE: Final[dict[bool, str]] = {True: "Enabled", False: "Disabled"}
-
 # Config flow
 CONF_USB_PATH: Final = "usb_path"
 CONF_USB_MANUAL_PATH: Final = "usb_manual_path"

--- a/homeassistant/components/crownstone/devices.py
+++ b/homeassistant/components/crownstone/devices.py
@@ -10,13 +10,15 @@ from homeassistant.const import (
     ATTR_NAME,
     ATTR_SW_VERSION,
 )
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from .const import CROWNSTONE_INCLUDE_TYPES, DOMAIN
 
 
-class CrownstoneDevice:
-    """Representation of a Crownstone device."""
+class CrownstoneBaseEntity(Entity):
+    """Base entity class for Crownstone devices."""
+
+    _attr_should_poll = False
 
     def __init__(self, device: Crownstone) -> None:
         """Initialize the device."""

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -20,6 +20,7 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, EVENT_HOMEASSISTANT_S
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import (
     CONF_USB_PATH,
@@ -114,8 +115,7 @@ class CrownstoneEntryManager:
         async with sse_client as client:
             async for event in client:
                 if event is not None:
-                    # Make SSE updates, like ability change, available to the user
-                    self.hass.bus.async_fire(f"{DOMAIN}_{event.type}", event.data)
+                    async_dispatcher_send(self.hass, f"{DOMAIN}_{event.type}", event)
 
     async def async_setup_usb(self) -> None:
         """Attempt setup of a Crownstone usb dongle."""

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -97,7 +97,6 @@ class CrownstoneEntryManager:
         # Makes HA aware of the Crownstone environment HA is placed in, a user can have multiple
         self.usb_sphere_id = self.config_entry.options[CONF_USB_SPHERE]
 
-        self.hass.data.setdefault(DOMAIN, {})[self.config_entry.entry_id] = self
         self.hass.config_entries.async_setup_platforms(self.config_entry, PLATFORMS)
 
         # HA specific listeners

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -1,17 +1,12 @@
 """Support for Crownstone devices."""
 from __future__ import annotations
 
-from collections.abc import Mapping
 from functools import partial
 import logging
 from typing import TYPE_CHECKING, Any
 
 from crownstone_cloud.cloud_models.crownstones import Crownstone
-from crownstone_cloud.const import (
-    DIMMING_ABILITY,
-    SWITCHCRAFT_ABILITY,
-    TAP_TO_TOGGLE_ABILITY,
-)
+from crownstone_cloud.const import DIMMING_ABILITY
 from crownstone_cloud.exceptions import CrownstoneAbilityError
 from crownstone_uart import CrownstoneUart
 
@@ -26,7 +21,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
-    ABILITY_STATE,
     CROWNSTONE_INCLUDE_TYPES,
     CROWNSTONE_SUFFIX,
     DOMAIN,
@@ -111,29 +105,6 @@ class CrownstoneEntity(CrownstoneBaseEntity, LightEntity):
         if self.device.abilities.get(DIMMING_ABILITY).is_enabled:
             return SUPPORT_BRIGHTNESS
         return 0
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """State attributes for Crownstone devices."""
-        attributes: dict[str, Any] = {}
-        # switch method
-        if self.usb is not None and self.usb.is_ready():
-            attributes["switch_method"] = "Crownstone USB Dongle"
-        else:
-            attributes["switch_method"] = "Crownstone Cloud"
-
-        # crownstone abilities
-        attributes["dimming"] = ABILITY_STATE.get(
-            self.device.abilities.get(DIMMING_ABILITY).is_enabled
-        )
-        attributes["tap_to_toggle"] = ABILITY_STATE.get(
-            self.device.abilities.get(TAP_TO_TOGGLE_ABILITY).is_enabled
-        )
-        attributes["switchcraft"] = ABILITY_STATE.get(
-            self.device.abilities.get(SWITCHCRAFT_ABILITY).is_enabled
-        )
-
-        return attributes
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from functools import partial
-import logging
 from typing import TYPE_CHECKING, Any
 
 from crownstone_cloud.cloud_models.crownstones import Crownstone
@@ -33,8 +32,6 @@ from .helpers import map_from_to
 
 if TYPE_CHECKING:
     from .entry_manager import CrownstoneEntryManager
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -33,7 +33,7 @@ from .const import (
     SIG_CROWNSTONE_STATE_UPDATE,
     SIG_UART_STATE_CHANGE,
 )
-from .devices import CrownstoneDevice
+from .devices import CrownstoneBaseEntity
 from .helpers import map_from_to
 
 if TYPE_CHECKING:
@@ -76,14 +76,13 @@ def hass_to_crownstone_state(value: int) -> int:
     return map_from_to(value, 0, 255, 0, 100)
 
 
-class CrownstoneEntity(CrownstoneDevice, LightEntity):
+class CrownstoneEntity(CrownstoneBaseEntity, LightEntity):
     """
     Representation of a crownstone.
 
     Light platform is used to support dimming.
     """
 
-    _attr_should_poll = False
     _attr_icon = "mdi:power-socket-de"
 
     def __init__(self, crownstone_data: Crownstone, usb: CrownstoneUart = None) -> None:

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -17,6 +17,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -138,8 +139,7 @@ class CrownstoneEntity(CrownstoneBaseEntity, LightEntity):
                         hass_to_crownstone_state(kwargs[ATTR_BRIGHTNESS])
                     )
                 except CrownstoneAbilityError as ability_error:
-                    _LOGGER.error(ability_error)
-                    return
+                    raise HomeAssistantError(ability_error) from ability_error
 
             # assume brightness is set on device
             self.device.state = hass_to_crownstone_state(kwargs[ATTR_BRIGHTNESS])

--- a/homeassistant/components/crownstone/listeners.py
+++ b/homeassistant/components/crownstone/listeners.py
@@ -25,8 +25,12 @@ from crownstone_sse.events import AbilityChangeEvent, SwitchStateUpdateEvent
 from crownstone_uart import UartEventBus, UartTopics
 from crownstone_uart.topics.SystemTopics import SystemTopics
 
-from homeassistant.core import Event, callback
-from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+    dispatcher_send,
+)
 
 from .const import (
     DOMAIN,
@@ -42,10 +46,9 @@ if TYPE_CHECKING:
 
 @callback
 def async_update_crwn_state_sse(
-    manager: CrownstoneEntryManager, ha_event: Event
+    manager: CrownstoneEntryManager, switch_event: SwitchStateUpdateEvent
 ) -> None:
     """Update the state of a Crownstone when switched externally."""
-    switch_event = SwitchStateUpdateEvent(ha_event.data)
     try:
         updated_crownstone = manager.cloud.get_crownstone_by_id(switch_event.cloud_id)
     except KeyError:
@@ -58,9 +61,10 @@ def async_update_crwn_state_sse(
 
 
 @callback
-def async_update_crwn_ability(manager: CrownstoneEntryManager, ha_event: Event) -> None:
+def async_update_crwn_ability(
+    manager: CrownstoneEntryManager, ability_event: AbilityChangeEvent
+) -> None:
     """Update the ability information of a Crownstone."""
-    ability_event = AbilityChangeEvent(ha_event.data)
     try:
         updated_crownstone = manager.cloud.get_crownstone_by_id(ability_event.cloud_id)
     except KeyError:
@@ -117,11 +121,13 @@ def setup_sse_listeners(manager: CrownstoneEntryManager) -> None:
     """Set up SSE listeners."""
     # save unsub function for when entry removed
     manager.listeners[SSE_LISTENERS] = [
-        manager.hass.bus.async_listen(
+        async_dispatcher_connect(
+            manager.hass,
             f"{DOMAIN}_{EVENT_SWITCH_STATE_UPDATE}",
             partial(async_update_crwn_state_sse, manager),
         ),
-        manager.hass.bus.async_listen(
+        async_dispatcher_connect(
+            manager.hass,
             f"{DOMAIN}_{EVENT_ABILITY_CHANGE}",
             partial(async_update_crwn_ability, manager),
         ),

--- a/homeassistant/components/crownstone/listeners.py
+++ b/homeassistant/components/crownstone/listeners.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from functools import partial
 from typing import TYPE_CHECKING, cast
 
+from crownstone_cloud.exceptions import CrownstoneNotFoundError
 from crownstone_core.packets.serviceDataParsers.containers.AdvExternalCrownstoneState import (
     AdvExternalCrownstoneState,
 )
@@ -51,7 +52,7 @@ def async_update_crwn_state_sse(
     """Update the state of a Crownstone when switched externally."""
     try:
         updated_crownstone = manager.cloud.get_crownstone_by_id(switch_event.cloud_id)
-    except KeyError:
+    except CrownstoneNotFoundError:
         return
 
     # only update on change.
@@ -67,7 +68,7 @@ def async_update_crwn_ability(
     """Update the ability information of a Crownstone."""
     try:
         updated_crownstone = manager.cloud.get_crownstone_by_id(ability_event.cloud_id)
-    except KeyError:
+    except CrownstoneNotFoundError:
         return
 
     ability_type = ability_event.ability_type
@@ -104,7 +105,7 @@ def update_crwn_state_uart(
         updated_crownstone = manager.cloud.get_crownstone_by_uid(
             data.crownstoneId, manager.usb_sphere_id
         )
-    except KeyError:
+    except CrownstoneNotFoundError:
         return
 
     if data.switchState is None:

--- a/homeassistant/components/crownstone/manifest.json
+++ b/homeassistant/components/crownstone/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/crownstone",
   "requirements": [
-    "crownstone-cloud==1.4.7",
+    "crownstone-cloud==1.4.8",
     "crownstone-sse==2.0.2",
     "crownstone-uart==2.1.0",
     "pyserial==3.5"

--- a/homeassistant/components/crownstone/strings.json
+++ b/homeassistant/components/crownstone/strings.json
@@ -49,21 +49,21 @@
           "usb_sphere_option": "Crownstone Sphere where the USB is located"
         }
       },
-      "usb_config_option": {
+      "usb_config": {
         "data": {
           "usb_path": "[%key:common::config_flow::data::usb_path%]"
         },
         "title": "Crownstone USB dongle configuration",
         "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10C4 and PID EA60."
       },
-      "usb_manual_config_option": {
+      "usb_manual_config": {
         "data": {
           "usb_manual_path": "[%key:common::config_flow::data::usb_path%]"
         },
         "title": "Crownstone USB dongle manual path",
         "description": "Manually enter the path of a Crownstone USB dongle."
       },
-      "usb_sphere_config_option": {
+      "usb_sphere_config": {
         "data": {
           "usb_sphere": "Crownstone Sphere"
         },

--- a/homeassistant/components/crownstone/translations/en.json
+++ b/homeassistant/components/crownstone/translations/en.json
@@ -49,21 +49,21 @@
                     "use_usb_option": "Use a Crownstone USB dongle for local data transmission"
                 }
             },
-            "usb_config_option": {
+            "usb_config": {
                 "data": {
                     "usb_path": "USB Device Path"
                 },
                 "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10C4 and PID EA60.",
                 "title": "Crownstone USB dongle configuration"
             },
-            "usb_manual_config_option": {
+            "usb_manual_config": {
                 "data": {
                     "usb_manual_path": "USB Device Path"
                 },
                 "description": "Manually enter the path of a Crownstone USB dongle.",
                 "title": "Crownstone USB dongle manual path"
             },
-            "usb_sphere_config_option": {
+            "usb_sphere_config": {
                 "data": {
                     "usb_sphere": "Crownstone Sphere"
                 },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -487,7 +487,7 @@ coronavirus==1.1.1
 croniter==1.0.6
 
 # homeassistant.components.crownstone
-crownstone-cloud==1.4.7
+crownstone-cloud==1.4.8
 
 # homeassistant.components.crownstone
 crownstone-sse==2.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -289,7 +289,7 @@ coronavirus==1.1.1
 croniter==1.0.6
 
 # homeassistant.components.crownstone
-crownstone-cloud==1.4.7
+crownstone-cloud==1.4.8
 
 # homeassistant.components.crownstone
 crownstone-sse==2.0.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Address the extra review comments by @MartinHjelmare in https://github.com/home-assistant/core/pull/50677

I have not found a good way to deal with the use of persistent notification in `entry_manager.py`, line 143. After testing i'm sure that triggering a new flow is not a good idea here. Especially not without any context (notification) why it was triggered. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
