### PR TITLE
Pylint plugin to check return statements

### DIFF
--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -198,7 +198,7 @@ class AmcrestCam(Camera):
             )
             raise CannotSnapshot
 
-    async def _async_get_image(self) -> None:
+    async def _async_get_image(self) -> bytes | None:
         try:
             # Send the request to snap a picture and return raw jpg data
             # Snapshot command needs a much longer read timeout than other commands.
@@ -211,9 +211,9 @@ class AmcrestCam(Camera):
             )
         except AmcrestError as error:
             log_update_error(_LOGGER, "get image from", self.name, "camera", error)
-            return
         finally:
             self._snapshot_task = None
+        return None
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None

--- a/homeassistant/components/firmata/__init__.py
+++ b/homeassistant/components/firmata/__init__.py
@@ -209,7 +209,7 @@ async def async_setup_entry(
 
 async def async_unload_entry(
     hass: HomeAssistant, config_entry: config_entries.ConfigEntry
-) -> None:
+) -> bool:
     """Shutdown and close a Firmata board for a config entry."""
     _LOGGER.debug("Closing Firmata board %s", config_entry.data[CONF_NAME])
 

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -78,9 +78,9 @@ class FreeboxRouter:
 
         try:
             await self._api.open(self._host, self._port)
-        except HttpRequestError:
+        except HttpRequestError as ex:
             _LOGGER.exception("Failed to connect to Freebox")
-            raise ConfigEntryNotReady
+            raise ConfigEntryNotReady from ex
 
         # System
         fbx_config = await self._api.system.get_config()

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -80,7 +80,7 @@ class FreeboxRouter:
             await self._api.open(self._host, self._port)
         except HttpRequestError:
             _LOGGER.exception("Failed to connect to Freebox")
-            return ConfigEntryNotReady
+            raise ConfigEntryNotReady
 
         # System
         fbx_config = await self._api.system.get_config()

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -12,6 +12,7 @@ from homeassistant.components.device_tracker import (
     SOURCE_TYPE_ROUTER,
 )
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker.legacy import DeviceScanner
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
@@ -48,7 +49,9 @@ PLATFORM_SCHEMA = vol.All(
 )
 
 
-async def async_get_scanner(hass: HomeAssistant, config: ConfigType) -> None:
+async def async_get_scanner(
+    hass: HomeAssistant, config: ConfigType
+) -> DeviceScanner | None:
     """Import legacy FRITZ!Box configuration."""
     _LOGGER.debug("Import legacy FRITZ!Box configuration from YAML")
 
@@ -65,6 +68,7 @@ async def async_get_scanner(hass: HomeAssistant, config: ConfigType) -> None:
         "please remove it from configuration.yaml. "
         "Loading Fritz via scanner setup is now deprecated"
     )
+    return None
 
 
 async def async_setup_entry(

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -66,8 +66,6 @@ async def async_get_scanner(hass: HomeAssistant, config: ConfigType) -> None:
         "Loading Fritz via scanner setup is now deprecated"
     )
 
-    return None
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback

--- a/homeassistant/components/humidifier/device_action.py
+++ b/homeassistant/components/humidifier/device_action.py
@@ -82,9 +82,10 @@ async def async_call_action_from_config(
         service = const.SERVICE_SET_MODE
         service_data[ATTR_MODE] = config[ATTR_MODE]
     else:
-        return await toggle_entity.async_call_action_from_config(
+        await toggle_entity.async_call_action_from_config(
             hass, config, variables, context, DOMAIN
         )
+        return
 
     await hass.services.async_call(
         DOMAIN, service, service_data, blocking=True, context=context

--- a/homeassistant/components/litterrobot/hub.py
+++ b/homeassistant/components/litterrobot/hub.py
@@ -38,7 +38,7 @@ class LitterRobotHub:
             update_interval=timedelta(seconds=UPDATE_INTERVAL_SECONDS),
         )
 
-    async def login(self, load_robots: bool = False) -> None:
+    async def login(self, load_robots: bool = False) -> bool:
         """Login to Litter-Robot."""
         self.logged_in = False
         self.account = Account()
@@ -49,10 +49,10 @@ class LitterRobotHub:
                 load_robots=load_robots,
             )
             self.logged_in = True
-            return self.logged_in
         except LitterRobotLoginException as ex:
             _LOGGER.error("Invalid credentials")
             raise ex
         except LitterRobotException as ex:
             _LOGGER.error("Unable to connect to Litter-Robot API")
             raise ex
+        return self.logged_in

--- a/homeassistant/components/netatmo/webhook.py
+++ b/homeassistant/components/netatmo/webhook.py
@@ -37,7 +37,7 @@ async def async_handle_webhook(
         data = await request.json()
     except ValueError as err:
         _LOGGER.error("Error in data: %s", err)
-        return None
+        return
 
     _LOGGER.debug("Got webhook data: %s", data)
 

--- a/homeassistant/components/nmap_tracker/device_tracker.py
+++ b/homeassistant/components/nmap_tracker/device_tracker.py
@@ -18,6 +18,7 @@ from homeassistant.components.device_tracker.const import (
     CONF_SCAN_INTERVAL,
     DEFAULT_CONSIDER_HOME,
 )
+from homeassistant.components.device_tracker.legacy import DeviceScanner
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_EXCLUDE, CONF_HOSTS
 from homeassistant.core import HomeAssistant, callback
@@ -52,7 +53,9 @@ PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_get_scanner(hass: HomeAssistant, config: ConfigType) -> None:
+async def async_get_scanner(
+    hass: HomeAssistant, config: ConfigType
+) -> DeviceScanner | None:
     """Validate the configuration and return a Nmap scanner."""
     validated_config = config[DEVICE_TRACKER_DOMAIN]
 
@@ -87,6 +90,7 @@ async def async_get_scanner(hass: HomeAssistant, config: ConfigType) -> None:
         "Your Nmap Tracker configuration has been imported into the UI, "
         "please remove it from configuration.yaml. "
     )
+    return None
 
 
 async def async_setup_entry(

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -197,7 +197,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
             CONF_TIMEOUT: 1,
         }
 
-    def mac_from_device(self) -> None:
+    def mac_from_device(self) -> str | None:
         """Try to fetch the mac address of the TV."""
         return None
 
@@ -228,7 +228,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
             LOGGER.debug("Failing config: %s, error: %s", config, err)
             return RESULT_CANNOT_CONNECT
 
-    def device_info(self) -> None:
+    def device_info(self) -> dict[str, Any] | None:
         """Try to gather infos of this device."""
         return None
 

--- a/homeassistant/components/screenlogic/switch.py
+++ b/homeassistant/components/screenlogic/switch.py
@@ -38,11 +38,11 @@ class ScreenLogicSwitch(ScreenlogicEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Send the ON command."""
-        return await self._async_set_circuit(ON_OFF.ON)
+        await self._async_set_circuit(ON_OFF.ON)
 
     async def async_turn_off(self, **kwargs) -> None:
         """Send the OFF command."""
-        return await self._async_set_circuit(ON_OFF.OFF)
+        await self._async_set_circuit(ON_OFF.OFF)
 
     async def _async_set_circuit(self, circuit_value) -> None:
         async with self.coordinator.api_lock:

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -156,11 +156,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensors for device."""
     if get_device_entry_gen(config_entry) == 2:
-        return await async_setup_entry_rpc(
+        await async_setup_entry_rpc(
             hass, config_entry, async_add_entities, RPC_SENSORS, RpcBinarySensor
         )
-
-    if config_entry.data["sleep_period"]:
+    elif config_entry.data["sleep_period"]:
         await async_setup_entry_attribute_entities(
             hass,
             config_entry,

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -69,9 +69,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up lights for device."""
     if get_device_entry_gen(config_entry) == 2:
-        return await async_setup_rpc_entry(hass, config_entry, async_add_entities)
-
-    return await async_setup_block_entry(hass, config_entry, async_add_entities)
+        await async_setup_rpc_entry(hass, config_entry, async_add_entities)
+    else:
+        await async_setup_block_entry(hass, config_entry, async_add_entities)
 
 
 async def async_setup_block_entry(

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -305,11 +305,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensors for device."""
     if get_device_entry_gen(config_entry) == 2:
-        return await async_setup_entry_rpc(
+        await async_setup_entry_rpc(
             hass, config_entry, async_add_entities, RPC_SENSORS, RpcSensor
         )
-
-    if config_entry.data["sleep_period"]:
+    elif config_entry.data["sleep_period"]:
         await async_setup_entry_attribute_entities(
             hass, config_entry, async_add_entities, SENSORS, BlockSleepingSensor
         )

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -29,9 +29,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up switches for device."""
     if get_device_entry_gen(config_entry) == 2:
-        return await async_setup_rpc_entry(hass, config_entry, async_add_entities)
-
-    return await async_setup_block_entry(hass, config_entry, async_add_entities)
+        await async_setup_rpc_entry(hass, config_entry, async_add_entities)
+    else:
+        await async_setup_block_entry(hass, config_entry, async_add_entities)
 
 
 async def async_setup_block_entry(

--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -308,7 +308,7 @@ class SlackNotificationService(BaseNotificationService):
             else:
                 blocks = None
 
-            return await self._async_send_text_only_message(
+            await self._async_send_text_only_message(
                 targets,
                 message,
                 title,
@@ -318,8 +318,8 @@ class SlackNotificationService(BaseNotificationService):
             )
 
         # Message Type 2: A message that uploads a remote file
-        if ATTR_URL in data[ATTR_FILE]:
-            return await self._async_send_remote_file_message(
+        elif ATTR_URL in data[ATTR_FILE]:
+            await self._async_send_remote_file_message(
                 data[ATTR_FILE][ATTR_URL],
                 targets,
                 message,
@@ -329,6 +329,7 @@ class SlackNotificationService(BaseNotificationService):
             )
 
         # Message Type 3: A message that uploads a local file
-        return await self._async_send_local_file_message(
-            data[ATTR_FILE][ATTR_PATH], targets, message, title
-        )
+        else:
+            await self._async_send_local_file_message(
+                data[ATTR_FILE][ATTR_PATH], targets, message, title
+            )

--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -250,7 +250,6 @@ async def async_setup_entry(  # noqa: C901
             await api.async_update()
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
-        return None
 
     async def async_coordinator_update_data_switches() -> dict[
         str, dict[str, Any]

--- a/homeassistant/components/tradfri/switch.py
+++ b/homeassistant/components/tradfri/switch.py
@@ -64,11 +64,11 @@ class TradfriSwitch(TradfriBaseDevice, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the switch to turn off."""
         if not self._device_control:
-            return None
+            return
         await self._api(self._device_control.set_state(False))
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the switch to turn on."""
         if not self._device_control:
-            return None
+            return
         await self._api(self._device_control.set_state(True))

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.components import ssdp
 from homeassistant.components.ssdp import SsdpChange
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
     CONFIG_ENTRY_HOSTNAME,
@@ -287,7 +288,7 @@ class UpnpOptionsFlowHandler(config_entries.OptionsFlow):
         """Initialize."""
         self.config_entry = config_entry
 
-    async def async_step_init(self, user_input: Mapping = None) -> None:
+    async def async_step_init(self, user_input: Mapping = None) -> FlowResult:
         """Manage the options."""
         if user_input is not None:
             coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]

--- a/homeassistant/components/websocket_api/decorators.py
+++ b/homeassistant/components/websocket_api/decorators.py
@@ -111,7 +111,7 @@ def ws_require_user(
                 output_error("only_inactive_user", "Not allowed as active user")
                 return
 
-            return func(hass, connection, msg)
+            func(hass, connection, msg)
 
         return check_current_user
 

--- a/homeassistant/components/withings/common.py
+++ b/homeassistant/components/withings/common.py
@@ -657,7 +657,7 @@ class DataManager:
 
     async def async_subscribe_webhook(self) -> None:
         """Subscribe the webhook to withings data updates."""
-        return await self._do_retry(self._async_subscribe_webhook)
+        await self._do_retry(self._async_subscribe_webhook)
 
     async def _async_subscribe_webhook(self) -> None:
         _LOGGER.debug("Configuring withings webhook")
@@ -705,7 +705,7 @@ class DataManager:
 
     async def async_unsubscribe_webhook(self) -> None:
         """Unsubscribe webhook from withings data updates."""
-        return await self._do_retry(self._async_unsubscribe_webhook)
+        await self._do_retry(self._async_unsubscribe_webhook)
 
     async def _async_unsubscribe_webhook(self) -> None:
         # Get the current webhooks.

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -7,6 +7,7 @@ https://home-assistant.io/integrations/zha/
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable
 import logging
 
 from zigpy.exceptions import ZigbeeException
@@ -116,7 +117,7 @@ class IasAce(ZigbeeChannel):
             self.async_send_signal(f"{self.unique_id}_{SIGNAL_ARMED_STATE_CHANGED}")
         self._send_panel_status_changed()
 
-    def _disarm(self, code: str):
+    def _disarm(self, code: str) -> Awaitable:
         """Test the code and disarm the panel if the code is correct."""
         if (
             code != self.panel_code
@@ -147,7 +148,7 @@ class IasAce(ZigbeeChannel):
             self.alarm_status = AceCluster.AlarmStatus.No_Alarm
         return zigbee_reply
 
-    def _arm_day(self, code: str):
+    def _arm_day(self, code: str) -> Awaitable:
         """Arm the panel for day / home zones."""
         return self._handle_arm(
             code,
@@ -155,7 +156,7 @@ class IasAce(ZigbeeChannel):
             AceCluster.ArmNotification.Only_Day_Home_Zones_Armed,
         )
 
-    def _arm_night(self, code: str):
+    def _arm_night(self, code: str) -> Awaitable:
         """Arm the panel for night / sleep zones."""
         return self._handle_arm(
             code,
@@ -163,7 +164,7 @@ class IasAce(ZigbeeChannel):
             AceCluster.ArmNotification.Only_Night_Sleep_Zones_Armed,
         )
 
-    def _arm_away(self, code: str):
+    def _arm_away(self, code: str) -> Awaitable:
         """Arm the panel for away mode."""
         return self._handle_arm(
             code,
@@ -176,7 +177,7 @@ class IasAce(ZigbeeChannel):
         code: str,
         panel_status: AceCluster.PanelStatus,
         armed_type: AceCluster.ArmNotification,
-    ):
+    ) -> Awaitable:
         """Arm the panel with the specified statuses."""
         if self.code_required_arm_actions and code != self.panel_code:
             self.warning("Invalid code supplied to IAS ACE")

--- a/homeassistant/components/zha/core/channels/security.py
+++ b/homeassistant/components/zha/core/channels/security.py
@@ -147,7 +147,7 @@ class IasAce(ZigbeeChannel):
             self.alarm_status = AceCluster.AlarmStatus.No_Alarm
         return zigbee_reply
 
-    def _arm_day(self, code: str) -> None:
+    def _arm_day(self, code: str):
         """Arm the panel for day / home zones."""
         return self._handle_arm(
             code,
@@ -155,7 +155,7 @@ class IasAce(ZigbeeChannel):
             AceCluster.ArmNotification.Only_Day_Home_Zones_Armed,
         )
 
-    def _arm_night(self, code: str) -> None:
+    def _arm_night(self, code: str):
         """Arm the panel for night / sleep zones."""
         return self._handle_arm(
             code,
@@ -163,7 +163,7 @@ class IasAce(ZigbeeChannel):
             AceCluster.ArmNotification.Only_Night_Sleep_Zones_Armed,
         )
 
-    def _arm_away(self, code: str) -> None:
+    def _arm_away(self, code: str):
         """Arm the panel for away mode."""
         return self._handle_arm(
             code,
@@ -176,7 +176,7 @@ class IasAce(ZigbeeChannel):
         code: str,
         panel_status: AceCluster.PanelStatus,
         armed_type: AceCluster.ArmNotification,
-    ) -> None:
+    ):
         """Arm the panel with the specified statuses."""
         if self.code_required_arm_actions and code != self.panel_code:
             self.warning("Invalid code supplied to IAS ACE")

--- a/homeassistant/components/zwave/climate.py
+++ b/homeassistant/components/zwave/climate.py
@@ -588,7 +588,7 @@ class ZWaveClimateSingleSetpoint(ZWaveClimateBase):
         """Initialize the Z-Wave climate device."""
         ZWaveClimateBase.__init__(self, values, temp_unit)
 
-    def _mode(self) -> None:
+    def _mode(self):
         """Return thermostat mode Z-Wave value."""
         return self.values.mode
 
@@ -604,7 +604,7 @@ class ZWaveClimateMultipleSetpoint(ZWaveClimateBase):
         """Initialize the Z-Wave climate device."""
         ZWaveClimateBase.__init__(self, values, temp_unit)
 
-    def _mode(self) -> None:
+    def _mode(self):
         """Return thermostat mode Z-Wave value."""
         return self.values.primary
 

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -218,13 +218,13 @@ class Throttle:
 
             async def throttled_value() -> None:
                 """Stand-in function for when real func is being throttled."""
-                return None
+                return None  # pylint: disable=hass-return-none
 
         else:
 
             def throttled_value() -> None:  # type: ignore
                 """Stand-in function for when real func is being throttled."""
-                return None
+                return None  # pylint: disable=hass-return-none
 
         if self.limit_no_throttle is not None:
             method = Throttle(self.limit_no_throttle)(method)

--- a/pylint/plugins/hass_constructor.py
+++ b/pylint/plugins/hass_constructor.py
@@ -1,5 +1,5 @@
 """Plugin for constructor definitions."""
-from astroid import Const, FunctionDef
+from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
 from pylint.lint import PyLinter
@@ -22,7 +22,7 @@ class HassConstructorFormatChecker(BaseChecker):  # type: ignore[misc]
     }
     options = ()
 
-    def visit_functiondef(self, node: FunctionDef) -> None:
+    def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         """Called when a FunctionDef node is visited."""
         if not node.is_method() or node.name != "__init__":
             return
@@ -43,7 +43,7 @@ class HassConstructorFormatChecker(BaseChecker):  # type: ignore[misc]
             return
 
         # Check that return type is specified and it is "None".
-        if not isinstance(node.returns, Const) or node.returns.value is not None:
+        if not isinstance(node.returns, nodes.Const) or node.returns.value is not None:
             self.add_message("hass-constructor-return", node=node)
 
 

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -1,7 +1,7 @@
 """Plugin for checking imports."""
 from __future__ import annotations
 
-from astroid import Import, ImportFrom, Module
+from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
 from pylint.lint import PyLinter
@@ -27,17 +27,17 @@ class HassImportsFormatChecker(BaseChecker):  # type: ignore[misc]
         super().__init__(linter)
         self.current_module: str | None = None
 
-    def visit_module(self, node: Module) -> None:
+    def visit_module(self, node: nodes.Module) -> None:
         """Called when a Import node is visited."""
         self.current_module = node.name
 
-    def visit_import(self, node: Import) -> None:
+    def visit_import(self, node: nodes.Import) -> None:
         """Called when a Import node is visited."""
         for module, _alias in node.names:
             if module.startswith(f"{self.current_module}."):
                 self.add_message("hass-relative-import", node=node)
 
-    def visit_importfrom(self, node: ImportFrom) -> None:
+    def visit_importfrom(self, node: nodes.ImportFrom) -> None:
         """Called when a ImportFrom node is visited."""
         if node.level is not None:
             return

--- a/pylint/plugins/hass_logger.py
+++ b/pylint/plugins/hass_logger.py
@@ -1,5 +1,5 @@
 """Plugin for logger invocations."""
-import astroid
+from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
 from pylint.lint import PyLinter
@@ -29,10 +29,10 @@ class HassLoggerFormatChecker(BaseChecker):  # type: ignore[misc]
     }
     options = ()
 
-    def visit_call(self, node: astroid.Call) -> None:
+    def visit_call(self, node: nodes.Call) -> None:
         """Called when a Call node is visited."""
-        if not isinstance(node.func, astroid.Attribute) or not isinstance(
-            node.func.expr, astroid.Name
+        if not isinstance(node.func, nodes.Attribute) or not isinstance(
+            node.func.expr, nodes.Name
         ):
             return
 
@@ -44,7 +44,7 @@ class HassLoggerFormatChecker(BaseChecker):  # type: ignore[misc]
 
         first_arg = node.args[0]
 
-        if not isinstance(first_arg, astroid.Const) or not first_arg.value:
+        if not isinstance(first_arg, nodes.Const) or not first_arg.value:
             return
 
         log_message = first_arg.value

--- a/pylint/plugins/hass_return.py
+++ b/pylint/plugins/hass_return.py
@@ -1,0 +1,50 @@
+"""Plugin for return statements."""
+from __future__ import annotations
+
+from astroid import Const, FunctionDef, Return
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+from pylint.lint import PyLinter
+
+
+class HassReturnFormatChecker(BaseChecker):  # type: ignore[misc]
+    """Checker for return statements."""
+
+    __implements__ = IAstroidChecker
+
+    name = "hass_return"
+    priority = -1
+    msgs = {
+        "W0016": (
+            "Remove explicit None in return",
+            "hass-return-none",
+            "Used when function returns nothing but has explicit 'return None'",
+        ),
+    }
+    options = ()
+
+    def __init__(self, linter: PyLinter | None = None) -> None:
+        super().__init__(linter)
+        self.returns_none = False
+
+    def visit_functiondef(self, node: FunctionDef) -> None:
+        """Called when a FunctionDef node is visited."""
+
+        # Check that return type is specified and it is "None".
+        self.returns_none = (
+            isinstance(node.returns, Const) and node.returns.value is None
+        )
+
+    def visit_return(self, node: Return) -> None:
+        """Called when a Return node is visited."""
+        if (
+            self.returns_none
+            and isinstance(node.value, Const)
+            and node.value.value is None
+        ):
+            self.add_message("hass-return-none", node=node)
+
+
+def register(linter: PyLinter) -> None:
+    """Register the checker."""
+    linter.register_checker(HassReturnFormatChecker(linter))

--- a/pylint/plugins/hass_return.py
+++ b/pylint/plugins/hass_return.py
@@ -16,28 +16,30 @@ class HassReturnFormatChecker(BaseChecker):  # type: ignore[misc]
     priority = -1
     msgs = {
         "W0016": (
-            "Remove explicit None in return",
+            "Function annotated with return type 'None' returns value. "
+            "Consider changing function return type or removing return value.",
             "hass-return-none",
-            "Used when function returns nothing but has explicit 'return None'",
+            "Used when function returns some value while annotated with '-> None'",
         ),
     }
     options = ()
 
     def visit_return(self, node: Return) -> None:
         """Called when a Return node is visited."""
-        if isinstance(node.value, Const) and node.value.value is None:
-            # Find enclosing function
-            parent = node.parent
-            while (
-                parent is not None
-                and not isinstance(parent, FunctionDef)
-                and not isinstance(parent, AsyncFunctionDef)
-            ):
-                parent = parent.parent
-            if parent is None:
-                return
-            if isinstance(parent.returns, Const) and parent.returns.value is None:
-                self.add_message("hass-return-none", node=node)
+        if node.value is None:
+            return
+        # Find enclosing function
+        parent = node.parent
+        while (
+            parent is not None
+            and not isinstance(parent, FunctionDef)
+            and not isinstance(parent, AsyncFunctionDef)
+        ):
+            parent = parent.parent
+        if parent is None:
+            return
+        if isinstance(parent.returns, Const) and parent.returns.value is None:
+            self.add_message("hass-return-none", node=node)
 
 
 def register(linter: PyLinter) -> None:

--- a/pylint/plugins/hass_return.py
+++ b/pylint/plugins/hass_return.py
@@ -1,7 +1,7 @@
 """Plugin for return statements."""
 from __future__ import annotations
 
-from astroid import AsyncFunctionDef, Const, FunctionDef, Return
+from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
 from pylint.lint import PyLinter
@@ -24,7 +24,7 @@ class HassReturnFormatChecker(BaseChecker):  # type: ignore[misc]
     }
     options = ()
 
-    def visit_return(self, node: Return) -> None:
+    def visit_return(self, node: nodes.Return) -> None:
         """Called when a Return node is visited."""
         if node.value is None:
             return
@@ -32,13 +32,13 @@ class HassReturnFormatChecker(BaseChecker):  # type: ignore[misc]
         parent = node.parent
         while (
             parent is not None
-            and not isinstance(parent, FunctionDef)
-            and not isinstance(parent, AsyncFunctionDef)
+            and not isinstance(parent, nodes.FunctionDef)
+            and not isinstance(parent, nodes.AsyncFunctionDef)
         ):
             parent = parent.parent
         if parent is None:
             return
-        if isinstance(parent.returns, Const) and parent.returns.value is None:
+        if isinstance(parent.returns, nodes.Const) and parent.returns.value is None:
             self.add_message("hass-return-none", node=node)
 
 

--- a/pylint/plugins/hass_return.py
+++ b/pylint/plugins/hass_return.py
@@ -16,7 +16,7 @@ class HassReturnFormatChecker(BaseChecker):  # type: ignore[misc]
     priority = -1
     msgs = {
         "W0016": (
-            "Function annotated with return type 'None' returns value. "
+            "'%s' is annotated with return type 'None' and returns value. "
             "Consider changing function return type or removing return value.",
             "hass-return-none",
             "Used when function returns some value while annotated with '-> None'",
@@ -39,7 +39,7 @@ class HassReturnFormatChecker(BaseChecker):  # type: ignore[misc]
         if parent is None:
             return
         if isinstance(parent.returns, nodes.Const) and parent.returns.value is None:
-            self.add_message("hass-return-none", node=node)
+            self.add_message("hass-return-none", args=parent.name, node=node)
 
 
 def register(linter: PyLinter) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ load-plugins = [
     "hass_constructor",
     "hass_imports",
     "hass_logger",
+    "hass_return",
 ]
 persistent = false
 extension-pkg-allow-list = [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If function or method is annotated **explicit** return type `None`, `return` statements in it should be just `return` instead of `return None` or `return value`.

For example on:
```python3
def func():
    return None

def func2() -> None:
    return None

def func3() -> None:
    return

def func4() -> int | None:
    return None
```

This plugin will return:
> test.py:5:4: W0016: 'func2' is annotated with return type 'None' and returns value. Consider changing function return type or removing return value. (hass-return-none)

NOTE: In this example it only triggered on `func2` which has `-> None` but not on `func` or `func4`.

This can catch some cases when function is either having wrong return type annotation or some value is being returned without a need which in my opinion reduces code readability because such functions are meant to return nothing.

Inspired by https://github.com/home-assistant/core/pull/56390

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
