### PR TITLE
Switch to using constants wherever possible in zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -6,6 +6,10 @@ from typing import TypedDict
 
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import CommandClass
+from zwave_js_server.const.command_class.lock import DOOR_STATUS_PROPERTY
+from zwave_js_server.const.command_class.notification import (
+    CC_SPECIFIC_NOTIFICATION_TYPE,
+)
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_BATTERY,
@@ -196,9 +200,6 @@ NOTIFICATION_SENSOR_MAPPINGS: list[NotificationSensorMapping] = [
 ]
 
 
-PROPERTY_DOOR_STATUS = "doorStatus"
-
-
 class PropertySensorMapping(TypedDict, total=False):
     """Represent a property sensor mapping dict type."""
 
@@ -211,7 +212,7 @@ class PropertySensorMapping(TypedDict, total=False):
 # Mappings for property sensors
 PROPERTY_SENSOR_MAPPINGS: list[PropertySensorMapping] = [
     {
-        "property_name": PROPERTY_DOOR_STATUS,
+        "property_name": DOOR_STATUS_PROPERTY,
         "on_states": ["open"],
         "device_class": DEVICE_CLASS_DOOR,
         "enabled": True,
@@ -327,7 +328,9 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         for mapping in NOTIFICATION_SENSOR_MAPPINGS:
             if (
                 mapping["type"]
-                != self.info.primary_value.metadata.cc_specific["notificationType"]
+                != self.info.primary_value.metadata.cc_specific[
+                    CC_SPECIFIC_NOTIFICATION_TYPE
+                ]
             ):
                 continue
             if not mapping.get("states") or self.state_key in mapping["states"]:

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -7,6 +7,7 @@ from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import CommandClass
 from zwave_js_server.const.command_class.thermostat import (
     THERMOSTAT_CURRENT_TEMP_PROPERTY,
+    THERMOSTAT_HUMIDITY_PROPERTY,
     THERMOSTAT_MODE_PROPERTY,
     THERMOSTAT_MODE_SETPOINT_MAP,
     THERMOSTAT_MODES,
@@ -176,7 +177,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         if not self._unit_value:
             self._unit_value = self._current_temp
         self._current_humidity = self.get_zwave_value(
-            "Humidity",
+            THERMOSTAT_HUMIDITY_PROPERTY,
             command_class=CommandClass.SENSOR_MULTILEVEL,
             add_to_watched_value_ids=True,
             check_all_endpoints=True,

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -5,7 +5,16 @@ import logging
 from typing import Any
 
 from zwave_js_server.client import Client as ZwaveClient
+from zwave_js_server.const import TARGET_STATE_PROPERTY, TARGET_VALUE_PROPERTY
 from zwave_js_server.const.command_class.barrier_operator import BarrierState
+from zwave_js_server.const.command_class.multilevel_switch import (
+    COVER_CLOSE_PROPERTY,
+    COVER_DOWN_PROPERTY,
+    COVER_OFF_PROPERTY,
+    COVER_ON_PROPERTY,
+    COVER_OPEN_PROPERTY,
+    COVER_UP_PROPERTY,
+)
 from zwave_js_server.model.value import Value as ZwaveValue
 
 from homeassistant.components.cover import (
@@ -105,36 +114,36 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        target_value = self.get_zwave_value("targetValue")
+        target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
         await self.info.node.async_set_value(
             target_value, percent_to_zwave_position(kwargs[ATTR_POSITION])
         )
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        target_value = self.get_zwave_value("targetValue")
+        target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
         await self.info.node.async_set_value(target_value, 99)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        target_value = self.get_zwave_value("targetValue")
+        target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
         await self.info.node.async_set_value(target_value, 0)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover."""
         open_value = (
-            self.get_zwave_value("Open")
-            or self.get_zwave_value("Up")
-            or self.get_zwave_value("On")
+            self.get_zwave_value(COVER_OPEN_PROPERTY)
+            or self.get_zwave_value(COVER_UP_PROPERTY)
+            or self.get_zwave_value(COVER_ON_PROPERTY)
         )
         if open_value:
             # Stop the cover if it's opening
             await self.info.node.async_set_value(open_value, False)
 
         close_value = (
-            self.get_zwave_value("Close")
-            or self.get_zwave_value("Down")
-            or self.get_zwave_value("Off")
+            self.get_zwave_value(COVER_CLOSE_PROPERTY)
+            or self.get_zwave_value(COVER_DOWN_PROPERTY)
+            or self.get_zwave_value(COVER_OFF_PROPERTY)
         )
         if close_value:
             # Stop the cover if it's closing
@@ -156,7 +165,7 @@ class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):
         """Initialize a ZwaveMotorizedBarrier entity."""
         super().__init__(config_entry, client, info)
         self._target_state: ZwaveValue = self.get_zwave_value(
-            "targetState", add_to_watched_value_ids=False
+            TARGET_STATE_PROPERTY, add_to_watched_value_ids=False
         )
 
     @property

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -6,9 +6,32 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from awesomeversion import AwesomeVersion
-from zwave_js_server.const import CommandClass
+from zwave_js_server.const import (
+    CURRENT_STATE_PROPERTY,
+    CURRENT_VALUE_PROPERTY,
+    TARGET_STATE_PROPERTY,
+    TARGET_VALUE_PROPERTY,
+    CommandClass,
+)
+from zwave_js_server.const.command_class.barrier_operator import (
+    SIGNALING_STATE_PROPERTY,
+)
+from zwave_js_server.const.command_class.lock import (
+    CURRENT_MODE_PROPERTY,
+    DOOR_STATUS_PROPERTY,
+    LOCKED_PROPERTY,
+)
+from zwave_js_server.const.command_class.meter import VALUE_PROPERTY
+from zwave_js_server.const.command_class.protection import LOCAL_PROPERTY, RF_PROPERTY
+from zwave_js_server.const.command_class.sound_switch import (
+    DEFAULT_TONE_ID_PROPERTY,
+    DEFAULT_VOLUME_PROPERTY,
+    TONE_ID_PROPERTY,
+)
 from zwave_js_server.const.command_class.thermostat import (
     THERMOSTAT_CURRENT_TEMP_PROPERTY,
+    THERMOSTAT_MODE_PROPERTY,
+    THERMOSTAT_SETPOINT_PROPERTY,
 )
 from zwave_js_server.exceptions import UnknownValueData
 from zwave_js_server.model.device_class import DeviceClassItem
@@ -179,16 +202,18 @@ def get_config_parameter_discovery_schema(
 
 SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA = ZWaveValueDiscoverySchema(
     command_class={CommandClass.SWITCH_MULTILEVEL},
-    property={"currentValue"},
+    property={CURRENT_VALUE_PROPERTY},
     type={"number"},
 )
 
 SWITCH_BINARY_CURRENT_VALUE_SCHEMA = ZWaveValueDiscoverySchema(
-    command_class={CommandClass.SWITCH_BINARY}, property={"currentValue"}
+    command_class={CommandClass.SWITCH_BINARY}, property={CURRENT_VALUE_PROPERTY}
 )
 
 SIREN_TONE_SCHEMA = ZWaveValueDiscoverySchema(
-    command_class={CommandClass.SOUND_SWITCH}, property={"toneId"}, type={"number"}
+    command_class={CommandClass.SOUND_SWITCH},
+    property={TONE_ID_PROPERTY},
+    type={"number"},
 )
 
 # For device class mapping see:
@@ -229,7 +254,7 @@ DISCOVERY_SCHEMAS = [
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
             endpoint={2},
-            property={"currentValue"},
+            property={CURRENT_VALUE_PROPERTY},
             type={"number"},
         ),
     ),
@@ -287,7 +312,7 @@ DISCOVERY_SCHEMAS = [
         product_type={0x0003},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.THERMOSTAT_MODE},
-            property={"mode"},
+            property={THERMOSTAT_MODE_PROPERTY},
             type={"number"},
         ),
         data_template=DynamicCurrentTempClimateDataTemplate(
@@ -334,7 +359,7 @@ DISCOVERY_SCHEMAS = [
         firmware_version_range=FirmwareVersionRange(min="3.0"),
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.THERMOSTAT_MODE},
-            property={"mode"},
+            property={THERMOSTAT_MODE_PROPERTY},
             type={"number"},
         ),
         data_template=DynamicCurrentTempClimateDataTemplate(
@@ -393,7 +418,7 @@ DISCOVERY_SCHEMAS = [
                 CommandClass.LOCK,
                 CommandClass.DOOR_LOCK,
             },
-            property={"currentMode", "locked"},
+            property={CURRENT_MODE_PROPERTY, LOCKED_PROPERTY},
             type={"number", "boolean"},
         ),
     ),
@@ -406,7 +431,7 @@ DISCOVERY_SCHEMAS = [
                 CommandClass.LOCK,
                 CommandClass.DOOR_LOCK,
             },
-            property={"doorStatus"},
+            property={DOOR_STATUS_PROPERTY},
             type={"any"},
         ),
     ),
@@ -416,7 +441,7 @@ DISCOVERY_SCHEMAS = [
         platform="climate",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.THERMOSTAT_MODE},
-            property={"mode"},
+            property={THERMOSTAT_MODE_PROPERTY},
             type={"number"},
         ),
     ),
@@ -425,13 +450,13 @@ DISCOVERY_SCHEMAS = [
         platform="climate",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.THERMOSTAT_SETPOINT},
-            property={"setpoint"},
+            property={THERMOSTAT_SETPOINT_PROPERTY},
             type={"number"},
         ),
         absent_values=[  # mode must not be present to prevent dupes
             ZWaveValueDiscoverySchema(
                 command_class={CommandClass.THERMOSTAT_MODE},
-                property={"mode"},
+                property={THERMOSTAT_MODE_PROPERTY},
                 type={"number"},
             ),
         ],
@@ -532,7 +557,7 @@ DISCOVERY_SCHEMAS = [
                 CommandClass.METER,
             },
             type={"number"},
-            property={"value"},
+            property={VALUE_PROPERTY},
         ),
         data_template=NumericSensorDataTemplate(),
     ),
@@ -558,7 +583,7 @@ DISCOVERY_SCHEMAS = [
                 CommandClass.BASIC,
             },
             type={"number"},
-            property={"currentValue"},
+            property={CURRENT_VALUE_PROPERTY},
         ),
         required_values=[
             ZWaveValueDiscoverySchema(
@@ -566,7 +591,7 @@ DISCOVERY_SCHEMAS = [
                     CommandClass.BASIC,
                 },
                 type={"number"},
-                property={"targetValue"},
+                property={TARGET_VALUE_PROPERTY},
             )
         ],
         data_template=NumericSensorDataTemplate(),
@@ -584,7 +609,7 @@ DISCOVERY_SCHEMAS = [
         hint="barrier_event_signaling_state",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.BARRIER_OPERATOR},
-            property={"signalingState"},
+            property={SIGNALING_STATE_PROPERTY},
             type={"number"},
         ),
     ),
@@ -609,13 +634,13 @@ DISCOVERY_SCHEMAS = [
         hint="motorized_barrier",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.BARRIER_OPERATOR},
-            property={"currentState"},
+            property={CURRENT_STATE_PROPERTY},
             type={"number"},
         ),
         required_values=[
             ZWaveValueDiscoverySchema(
                 command_class={CommandClass.BARRIER_OPERATOR},
-                property={"targetState"},
+                property={TARGET_STATE_PROPERTY},
                 type={"number"},
             ),
         ],
@@ -657,7 +682,7 @@ DISCOVERY_SCHEMAS = [
         hint="Default tone",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SOUND_SWITCH},
-            property={"defaultToneId"},
+            property={DEFAULT_TONE_ID_PROPERTY},
             type={"number"},
         ),
         required_values=[SIREN_TONE_SCHEMA],
@@ -669,7 +694,7 @@ DISCOVERY_SCHEMAS = [
         hint="volume",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SOUND_SWITCH},
-            property={"defaultVolume"},
+            property={DEFAULT_VOLUME_PROPERTY},
             type={"number"},
         ),
         required_values=[SIREN_TONE_SCHEMA],
@@ -680,7 +705,7 @@ DISCOVERY_SCHEMAS = [
         platform="select",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.PROTECTION},
-            property={"local", "rf"},
+            property={LOCAL_PROPERTY, RF_PROPERTY},
             type={"number"},
         ),
     ),

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -5,6 +5,7 @@ import math
 from typing import Any
 
 from zwave_js_server.client import Client as ZwaveClient
+from zwave_js_server.const import TARGET_VALUE_PROPERTY
 
 from homeassistant.components.fan import (
     DOMAIN as FAN_DOMAIN,
@@ -59,7 +60,7 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int | None) -> None:
         """Set the speed percentage of the fan."""
-        target_value = self.get_zwave_value("targetValue")
+        target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
 
         if percentage is None:
             # Value 255 tells device to return to previous value
@@ -83,7 +84,7 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        target_value = self.get_zwave_value("targetValue")
+        target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
         await self.info.node.async_set_value(target_value, 0)
 
     @property

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -5,8 +5,24 @@ import logging
 from typing import Any
 
 from zwave_js_server.client import Client as ZwaveClient
-from zwave_js_server.const import CommandClass
-from zwave_js_server.const.command_class.color_switch import ColorComponent
+from zwave_js_server.const import (
+    TARGET_VALUE_PROPERTY,
+    TRANSITION_DURATION_OPTION,
+    CommandClass,
+)
+from zwave_js_server.const.command_class.color_switch import (
+    COLOR_SWITCH_COMBINED_AMBER,
+    COLOR_SWITCH_COMBINED_BLUE,
+    COLOR_SWITCH_COMBINED_COLD_WHITE,
+    COLOR_SWITCH_COMBINED_CYAN,
+    COLOR_SWITCH_COMBINED_GREEN,
+    COLOR_SWITCH_COMBINED_PURPLE,
+    COLOR_SWITCH_COMBINED_RED,
+    COLOR_SWITCH_COMBINED_WARM_WHITE,
+    CURRENT_COLOR_PROPERTY,
+    TARGET_COLOR_PROPERTY,
+    ColorComponent,
+)
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -35,17 +51,15 @@ from .entity import ZWaveBaseEntity
 LOGGER = logging.getLogger(__name__)
 
 MULTI_COLOR_MAP = {
-    ColorComponent.WARM_WHITE: "warmWhite",
-    ColorComponent.COLD_WHITE: "coldWhite",
-    ColorComponent.RED: "red",
-    ColorComponent.GREEN: "green",
-    ColorComponent.BLUE: "blue",
-    ColorComponent.AMBER: "amber",
-    ColorComponent.CYAN: "cyan",
-    ColorComponent.PURPLE: "purple",
+    ColorComponent.WARM_WHITE: COLOR_SWITCH_COMBINED_WARM_WHITE,
+    ColorComponent.COLD_WHITE: COLOR_SWITCH_COMBINED_COLD_WHITE,
+    ColorComponent.RED: COLOR_SWITCH_COMBINED_RED,
+    ColorComponent.GREEN: COLOR_SWITCH_COMBINED_GREEN,
+    ColorComponent.BLUE: COLOR_SWITCH_COMBINED_BLUE,
+    ColorComponent.AMBER: COLOR_SWITCH_COMBINED_AMBER,
+    ColorComponent.CYAN: COLOR_SWITCH_COMBINED_CYAN,
+    ColorComponent.PURPLE: COLOR_SWITCH_COMBINED_PURPLE,
 }
-
-TRANSITION_DURATION = "transitionDuration"
 
 
 async def async_setup_entry(
@@ -100,12 +114,12 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         self._min_mireds = 153  # 6500K as a safe default
         self._max_mireds = 370  # 2700K as a safe default
         self._warm_white = self.get_zwave_value(
-            "targetColor",
+            TARGET_COLOR_PROPERTY,
             CommandClass.SWITCH_COLOR,
             value_property_key=ColorComponent.WARM_WHITE,
         )
         self._cold_white = self.get_zwave_value(
-            "targetColor",
+            TARGET_COLOR_PROPERTY,
             CommandClass.SWITCH_COLOR,
             value_property_key=ColorComponent.COLD_WHITE,
         )
@@ -113,10 +127,12 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
 
         # get additional (optional) values and set features
         self._target_brightness = self.get_zwave_value(
-            "targetValue", add_to_watched_value_ids=False
+            TARGET_VALUE_PROPERTY, add_to_watched_value_ids=False
         )
         self._target_color = self.get_zwave_value(
-            "targetColor", CommandClass.SWITCH_COLOR, add_to_watched_value_ids=False
+            TARGET_COLOR_PROPERTY,
+            CommandClass.SWITCH_COLOR,
+            add_to_watched_value_ids=False,
         )
 
         self._calculate_color_values()
@@ -133,12 +149,13 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         self._attr_supported_features = 0
         self.supports_brightness_transition = bool(
             self._target_brightness is not None
-            and TRANSITION_DURATION
+            and TRANSITION_DURATION_OPTION
             in self._target_brightness.metadata.value_change_options
         )
         self.supports_color_transition = bool(
             self._target_color is not None
-            and TRANSITION_DURATION in self._target_color.metadata.value_change_options
+            and TRANSITION_DURATION_OPTION
+            in self._target_color.metadata.value_change_options
         )
 
         if self.supports_brightness_transition or self.supports_color_transition:
@@ -284,9 +301,9 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
 
         if self.supports_color_transition:
             if transition is not None:
-                zwave_transition = {TRANSITION_DURATION: f"{int(transition)}s"}
+                zwave_transition = {TRANSITION_DURATION_OPTION: f"{int(transition)}s"}
             else:
-                zwave_transition = {TRANSITION_DURATION: "default"}
+                zwave_transition = {TRANSITION_DURATION_OPTION: "default"}
 
         colors_dict = {}
         for color, value in colors.items():
@@ -312,9 +329,9 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         zwave_transition = None
         if self.supports_brightness_transition:
             if transition is not None:
-                zwave_transition = {TRANSITION_DURATION: f"{int(transition)}s"}
+                zwave_transition = {TRANSITION_DURATION_OPTION: f"{int(transition)}s"}
             else:
-                zwave_transition = {TRANSITION_DURATION: "default"}
+                zwave_transition = {TRANSITION_DURATION_OPTION: "default"}
 
         # setting a value requires setting targetValue
         await self.info.node.async_set_value(
@@ -328,34 +345,34 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         # to find out what colors are supported
         # as this is a simple lookup by key, this not heavy
         red_val = self.get_zwave_value(
-            "currentColor",
+            CURRENT_COLOR_PROPERTY,
             CommandClass.SWITCH_COLOR,
             value_property_key=ColorComponent.RED.value,
         )
         green_val = self.get_zwave_value(
-            "currentColor",
+            CURRENT_COLOR_PROPERTY,
             CommandClass.SWITCH_COLOR,
             value_property_key=ColorComponent.GREEN.value,
         )
         blue_val = self.get_zwave_value(
-            "currentColor",
+            CURRENT_COLOR_PROPERTY,
             CommandClass.SWITCH_COLOR,
             value_property_key=ColorComponent.BLUE.value,
         )
         ww_val = self.get_zwave_value(
-            "currentColor",
+            CURRENT_COLOR_PROPERTY,
             CommandClass.SWITCH_COLOR,
             value_property_key=ColorComponent.WARM_WHITE.value,
         )
         cw_val = self.get_zwave_value(
-            "currentColor",
+            CURRENT_COLOR_PROPERTY,
             CommandClass.SWITCH_COLOR,
             value_property_key=ColorComponent.COLD_WHITE.value,
         )
         # prefer the (new) combined color property
         # https://github.com/zwave-js/node-zwave-js/pull/1782
         combined_color_val = self.get_zwave_value(
-            "currentColor",
+            CURRENT_COLOR_PROPERTY,
             CommandClass.SWITCH_COLOR,
             value_property_key=None,
         )
@@ -370,9 +387,9 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         # RGB support
         if red_val and green_val and blue_val:
             # prefer values from the multicolor property
-            red = multi_color.get("red", red_val.value)
-            green = multi_color.get("green", green_val.value)
-            blue = multi_color.get("blue", blue_val.value)
+            red = multi_color.get(COLOR_SWITCH_COMBINED_RED, red_val.value)
+            green = multi_color.get(COLOR_SWITCH_COMBINED_GREEN, green_val.value)
+            blue = multi_color.get(COLOR_SWITCH_COMBINED_BLUE, blue_val.value)
             self._supports_color = True
             if None not in (red, green, blue):
                 # convert to HS
@@ -383,8 +400,8 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         # color temperature support
         if ww_val and cw_val:
             self._supports_color_temp = True
-            warm_white = multi_color.get("warmWhite", ww_val.value)
-            cold_white = multi_color.get("coldWhite", cw_val.value)
+            warm_white = multi_color.get(COLOR_SWITCH_COMBINED_WARM_WHITE, ww_val.value)
+            cold_white = multi_color.get(COLOR_SWITCH_COMBINED_COLD_WHITE, cw_val.value)
             # Calculate color temps based on whites
             if cold_white or warm_white:
                 self._color_temp = round(
@@ -398,14 +415,14 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         # only one white channel (warm white) = rgbw support
         elif red_val and green_val and blue_val and ww_val:
             self._supports_rgbw = True
-            white = multi_color.get("warmWhite", ww_val.value)
+            white = multi_color.get(COLOR_SWITCH_COMBINED_WARM_WHITE, ww_val.value)
             self._rgbw_color = (red, green, blue, white)
             # Light supports rgbw, set color mode to rgbw
             self._color_mode = COLOR_MODE_RGBW
         # only one white channel (cool white) = rgbw support
         elif cw_val:
             self._supports_rgbw = True
-            white = multi_color.get("coldWhite", cw_val.value)
+            white = multi_color.get(COLOR_SWITCH_COMBINED_COLD_WHITE, cw_val.value)
             self._rgbw_color = (red, green, blue, white)
             # Light supports rgbw, set color mode to rgbw
             self._color_mode = COLOR_MODE_RGBW

--- a/homeassistant/components/zwave_js/number.py
+++ b/homeassistant/components/zwave_js/number.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from zwave_js_server.client import Client as ZwaveClient
+from zwave_js_server.const import TARGET_VALUE_PROPERTY
 
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, NumberEntity
 from homeassistant.config_entries import ConfigEntry
@@ -52,7 +53,7 @@ class ZwaveNumberEntity(ZWaveBaseEntity, NumberEntity):
         if self.info.primary_value.metadata.writeable:
             self._target_value = self.info.primary_value
         else:
-            self._target_value = self.get_zwave_value("targetValue")
+            self._target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
 
         # Entity class attributes
         self._attr_name = self.generate_name(

--- a/homeassistant/components/zwave_js/select.py
+++ b/homeassistant/components/zwave_js/select.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Dict, cast
 
 from zwave_js_server.client import Client as ZwaveClient
-from zwave_js_server.const import CommandClass
+from zwave_js_server.const import TARGET_VALUE_PROPERTY, CommandClass
 from zwave_js_server.const.command_class.sound_switch import ToneID
 
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN, SelectEntity
@@ -142,7 +142,7 @@ class ZwaveMultilevelSwitchSelectEntity(ZWaveBaseEntity, SelectEntity):
     ) -> None:
         """Initialize a ZwaveSelectEntity entity."""
         super().__init__(config_entry, client, info)
-        self._target_value = self.get_zwave_value("targetValue")
+        self._target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
         assert self.info.platform_data_template
         self._lookup_map = cast(
             Dict[int, str], self.info.platform_data_template.static_data

--- a/homeassistant/components/zwave_js/switch.py
+++ b/homeassistant/components/zwave_js/switch.py
@@ -56,6 +56,14 @@ async def async_setup_entry(
 class ZWaveSwitch(ZWaveBaseEntity, SwitchEntity):
     """Representation of a Z-Wave switch."""
 
+    def __init__(
+        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(config_entry, client, info)
+
+        self._target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
+
     @property
     def is_on(self) -> bool | None:  # type: ignore
         """Return a boolean for the state of the switch."""
@@ -66,15 +74,13 @@ class ZWaveSwitch(ZWaveBaseEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
-        if target_value is not None:
-            await self.info.node.async_set_value(target_value, True)
+        if self._target_value is not None:
+            await self.info.node.async_set_value(self._target_value, True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
-        if target_value is not None:
-            await self.info.node.async_set_value(target_value, False)
+        if self._target_value is not None:
+            await self.info.node.async_set_value(self._target_value, False)
 
 
 class ZWaveBarrierEventSignalingSwitch(ZWaveBaseEntity, SwitchEntity):

--- a/homeassistant/components/zwave_js/switch.py
+++ b/homeassistant/components/zwave_js/switch.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from zwave_js_server.client import Client as ZwaveClient
+from zwave_js_server.const import TARGET_VALUE_PROPERTY
 from zwave_js_server.const.command_class.barrier_operator import (
     BarrierEventSignalingSubsystemState,
 )
@@ -65,13 +66,13 @@ class ZWaveSwitch(ZWaveBaseEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        target_value = self.get_zwave_value("targetValue")
+        target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
         if target_value is not None:
             await self.info.node.async_set_value(target_value, True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        target_value = self.get_zwave_value("targetValue")
+        target_value = self.get_zwave_value(TARGET_VALUE_PROPERTY)
         if target_value is not None:
             await self.info.node.async_set_value(target_value, False)
 


### PR DESCRIPTION
## Proposed change
There were a lot of places where we were using strings for values that should be in the library constants. This PR switches to using constants wherever possible.

~~This PR is dependent on an upstream release after https://github.com/home-assistant-libs/zwave-js-server-python/pull/300 is merged~~

This PR is dependent on https://github.com/home-assistant/core/pull/56517


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
