### PR TITLE
Move Kostal Plenticore writable settings from sensor to switch

### DIFF
--- a/homeassistant/components/kostal_plenticore/__init__.py
+++ b/homeassistant/components/kostal_plenticore/__init__.py
@@ -11,7 +11,7 @@ from .helper import Plenticore
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "switch"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/kostal_plenticore/const.py
+++ b/homeassistant/components/kostal_plenticore/const.py
@@ -626,3 +626,19 @@ SENSOR_SETTINGS_DATA = [
         "format_round",
     ),
 ]
+SWITCH_SETTINGS_DATA = [
+    (
+        "devices:local",
+        "Battery:SmartBatteryControl:Enable",
+        "Battery SmartBatteryControl Enable",
+        {},
+        "format_round",
+    ),
+    (
+        "devices:local",
+        "Battery:TimeControl:Enable",
+        "Battery TimeControl Enable",
+        {},
+        "format_round",
+    ),
+]

--- a/homeassistant/components/kostal_plenticore/helper.py
+++ b/homeassistant/components/kostal_plenticore/helper.py
@@ -185,6 +185,19 @@ class SettingDataUpdateCoordinator(PlenticoreUpdateCoordinator):
 
         return fetched_data
 
+    async def _async_write_data(self, module_id: str, value: Dict[str, str]) -> bool:
+        client = self._plenticore.client
+
+        if not self._fetch or client is None:
+            return False
+
+        try:
+            await client.set_setting_values(module_id, value)
+        except:
+            return False
+        else:
+            return True
+
 
 class PlenticoreDataFormatter:
     """Provides method to format values of process or settings data."""

--- a/homeassistant/components/kostal_plenticore/switch.py
+++ b/homeassistant/components/kostal_plenticore/switch.py
@@ -1,0 +1,173 @@
+﻿"""Platform for Kostal Plenticore switches."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any, Callable
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ICON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DOMAIN,
+    SWITCH_SETTINGS_DATA,
+)
+from .helper import (
+    PlenticoreDataFormatter,
+    SettingDataUpdateCoordinator,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+        hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+):
+    """Add kostal plenticore Sensors."""
+    plenticore = hass.data[DOMAIN][entry.entry_id]
+
+    entities = []
+
+    available_settings_data = await plenticore.client.get_settings()
+    settings_data_update_coordinator = SettingDataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        "Settings Data",
+        timedelta(seconds=30),
+        plenticore,
+    )
+    for module_id, data_id, name, sensor_data, fmt in SWITCH_SETTINGS_DATA:
+        if module_id not in available_settings_data or data_id not in (
+                setting.id for setting in available_settings_data[module_id]
+        ):
+            _LOGGER.debug(
+                "Skipping non existing setting data %s/%s", module_id, data_id
+            )
+            continue
+
+        entities.append(
+            PlenticoreDataSwitch(
+                settings_data_update_coordinator,
+                entry.entry_id,
+                entry.title,
+                module_id,
+                data_id,
+                name,
+                sensor_data,
+                PlenticoreDataFormatter.get_method(fmt),
+                plenticore.device_info,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class PlenticoreDataSwitch(CoordinatorEntity, SwitchEntity):
+    def __init__(
+            self,
+            coordinator,
+            entry_id: str,
+            platform_name: str,
+            module_id: str,
+            data_id: str,
+            switch_name: str,
+            switch_data: dict[str, Any],
+            formatter: Callable[[str], Any],
+            device_info: DeviceInfo,
+    ):
+        """Create a new switch Entity for Plenticore process data."""
+        super().__init__(coordinator)
+        self.entry_id = entry_id
+        self.platform_name = platform_name
+        self.module_id = module_id
+        self.data_id = data_id
+        self._state: bool | None = None
+        self._last_run_success: bool | None = None
+        self._switch_name = switch_name
+        self._switch_data = switch_data
+        self._formatter = formatter
+
+        self._device_info = device_info
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+                super().available
+                and self.coordinator.data is not None
+                and self.module_id in self.coordinator.data
+                and self.data_id in self.coordinator.data[self.module_id]
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Register this entity on the Update Coordinator."""
+        await super().async_added_to_hass()
+        self.coordinator.start_fetch_data(self.module_id, self.data_id)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister this entity from the Update Coordinator."""
+        self.coordinator.stop_fetch_data(self.module_id, self.data_id)
+        await super().async_will_remove_from_hass()
+
+    async def async_turn_on(self) -> None:
+        """Turn device on."""
+        if await self.coordinator._async_write_data(self.module_id, {self.data_id: '1'}):
+            self._state = True
+            self._last_run_success = True
+            await self.coordinator.async_request_refresh()
+        else:
+            self._last_run_success = False
+
+    async def async_turn_off(self) -> None:
+        """Turn device off."""
+        if await self.coordinator._async_write_data(self.module_id, {self.data_id: '0'}):
+            self._state = False
+            self._last_run_success = True
+            await self.coordinator.async_request_refresh()
+        else:
+            self._last_run_success = False
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return self._device_info
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return true if unable to access real state of entity."""
+        if self.coordinator.data is None:
+            raw_value = True
+            _LOGGER.debug("NO assumed_state ")
+        else:
+            raw_value = int(self.coordinator.data[self.module_id][self.data_id])
+
+        return bool(raw_value)
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is on."""
+        return bool(self._state)
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique id of this switch Entity."""
+        return f"{self.entry_id}_{self.module_id}_{self.data_id}"
+
+    @property
+    def name(self) -> str:
+        """Return the name of this switch Entity."""
+        return f"{self.platform_name} {self._switch_name}"
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon name of this switch Entity or None."""
+        return self._switch_data.get(ATTR_ICON)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes."""
+        return {"last_run_success": self._last_run_success}

--- a/homeassistant/components/kostal_plenticore/switch.py
+++ b/homeassistant/components/kostal_plenticore/switch.py
@@ -1,4 +1,4 @@
-﻿"""Platform for Kostal Plenticore sensors."""
+﻿"""Platform for Kostal Plenticore switches."""
 from __future__ import annotations
 
 from datetime import timedelta

--- a/homeassistant/components/kostal_plenticore/switch.py
+++ b/homeassistant/components/kostal_plenticore/switch.py
@@ -1,0 +1,173 @@
+﻿"""Platform for Kostal Plenticore sensors."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any, Callable
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ICON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DOMAIN,
+    SWITCH_SETTINGS_DATA,
+)
+from .helper import (
+    PlenticoreDataFormatter,
+    SettingDataUpdateCoordinator,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+        hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+):
+    """Add kostal plenticore Sensors."""
+    plenticore = hass.data[DOMAIN][entry.entry_id]
+
+    entities = []
+
+    available_settings_data = await plenticore.client.get_settings()
+    settings_data_update_coordinator = SettingDataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        "Settings Data",
+        timedelta(seconds=30),
+        plenticore,
+    )
+    for module_id, data_id, name, sensor_data, fmt in SWITCH_SETTINGS_DATA:
+        if module_id not in available_settings_data or data_id not in (
+                setting.id for setting in available_settings_data[module_id]
+        ):
+            _LOGGER.debug(
+                "Skipping non existing setting data %s/%s", module_id, data_id
+            )
+            continue
+
+        entities.append(
+            PlenticoreDataSwitch(
+                settings_data_update_coordinator,
+                entry.entry_id,
+                entry.title,
+                module_id,
+                data_id,
+                name,
+                sensor_data,
+                PlenticoreDataFormatter.get_method(fmt),
+                plenticore.device_info,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class PlenticoreDataSwitch(CoordinatorEntity, SwitchEntity):
+    def __init__(
+            self,
+            coordinator,
+            entry_id: str,
+            platform_name: str,
+            module_id: str,
+            data_id: str,
+            switch_name: str,
+            switch_data: dict[str, Any],
+            formatter: Callable[[str], Any],
+            device_info: DeviceInfo,
+    ):
+        """Create a new switch Entity for Plenticore process data."""
+        super().__init__(coordinator)
+        self.entry_id = entry_id
+        self.platform_name = platform_name
+        self.module_id = module_id
+        self.data_id = data_id
+        self._state: bool | None = None
+        self._last_run_success: bool | None = None
+        self._switch_name = switch_name
+        self._switch_data = switch_data
+        self._formatter = formatter
+
+        self._device_info = device_info
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+                super().available
+                and self.coordinator.data is not None
+                and self.module_id in self.coordinator.data
+                and self.data_id in self.coordinator.data[self.module_id]
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Register this entity on the Update Coordinator."""
+        await super().async_added_to_hass()
+        self.coordinator.start_fetch_data(self.module_id, self.data_id)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister this entity from the Update Coordinator."""
+        self.coordinator.stop_fetch_data(self.module_id, self.data_id)
+        await super().async_will_remove_from_hass()
+
+    async def async_turn_on(self) -> None:
+        """Turn device on."""
+        if await self.coordinator._async_write_data(self.module_id, {self.data_id: '1'}):
+            self._state = True
+            self._last_run_success = True
+            await self.coordinator.async_request_refresh()
+        else:
+            self._last_run_success = False
+
+    async def async_turn_off(self) -> None:
+        """Turn device off."""
+        if await self.coordinator._async_write_data(self.module_id, {self.data_id: '0'}):
+            self._state = False
+            self._last_run_success = True
+            await self.coordinator.async_request_refresh()
+        else:
+            self._last_run_success = False
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return self._device_info
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return true if unable to access real state of entity."""
+        if self.coordinator.data is None:
+            raw_value = True
+            _LOGGER.debug("NO assumed_state ")
+        else:
+            raw_value = int(self.coordinator.data[self.module_id][self.data_id])
+
+        return bool(raw_value)
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is on."""
+        return bool(self._state)
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique id of this switch Entity."""
+        return f"{self.entry_id}_{self.module_id}_{self.data_id}"
+
+    @property
+    def name(self) -> str:
+        """Return the name of this switch Entity."""
+        return f"{self.platform_name} {self._switch_name}"
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon name of this switch Entity or None."""
+        return self._switch_data.get(ATTR_ICON)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes."""
+        return {"last_run_success": self._last_run_success}


### PR DESCRIPTION
Move "Battery:SmartBatteryControl:Enable" from a simple sensor to a switch
Add "Battery:TimeControl:Enable" as a switch

If you want to change charging behavior you need to turn off both switches, before you can enable the function you want. (Same as on Plenticore UI)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
