### PR TITLE
 Use HTTPStatus instead of HTTP_* constants in various test mocks

### DIFF
--- a/tests/components/buienradar/test_camera.py
+++ b/tests/components/buienradar/test_camera.py
@@ -2,15 +2,12 @@
 import asyncio
 from contextlib import suppress
 import copy
+from http import HTTPStatus
 
 from aiohttp.client_exceptions import ClientResponseError
 
 from homeassistant.components.buienradar.const import CONF_COUNTRY, CONF_DELTA, DOMAIN
-from homeassistant.const import (
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    HTTP_INTERNAL_SERVER_ERROR,
-)
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.helpers.entity_registry import async_get
 from homeassistant.util import dt as dt_util
 
@@ -216,7 +213,9 @@ async def test_retries_after_error(aioclient_mock, hass, hass_client):
 
     client = await hass_client()
 
-    aioclient_mock.get(radar_map_url(), text=None, status=HTTP_INTERNAL_SERVER_ERROR)
+    aioclient_mock.get(
+        radar_map_url(), text=None, status=HTTPStatus.INTERNAL_SERVER_ERROR
+    )
 
     # A 404 should not return data and throw:
     with suppress(ClientResponseError):

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -1,5 +1,6 @@
 """Tests for the HTTP API for the cloud component."""
 import asyncio
+from http import HTTPStatus
 from ipaddress import ip_network
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -412,7 +413,7 @@ async def test_websocket_subscription_fail(
     hass, hass_ws_client, aioclient_mock, mock_auth, mock_cloud_login
 ):
     """Test querying the status."""
-    aioclient_mock.get(SUBSCRIPTION_INFO_URL, status=HTTP_INTERNAL_SERVER_ERROR)
+    aioclient_mock.get(SUBSCRIPTION_INFO_URL, status=HTTPStatus.INTERNAL_SERVER_ERROR)
     client = await hass_ws_client(hass)
     await client.send_json({"id": 5, "type": "cloud/subscription"})
     response = await client.receive_json()

--- a/tests/components/directv/__init__.py
+++ b/tests/components/directv/__init__.py
@@ -1,12 +1,9 @@
 """Tests for the DirecTV component."""
+from http import HTTPStatus
+
 from homeassistant.components.directv.const import CONF_RECEIVER_ID, DOMAIN
 from homeassistant.components.ssdp import ATTR_SSDP_LOCATION
-from homeassistant.const import (
-    CONF_HOST,
-    CONTENT_TYPE_JSON,
-    HTTP_FORBIDDEN,
-    HTTP_INTERNAL_SERVER_ERROR,
-)
+from homeassistant.const import CONF_HOST, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
@@ -46,7 +43,7 @@ def mock_connection(aioclient_mock: AiohttpClientMocker) -> None:
     aioclient_mock.get(
         f"http://{HOST}:8080/info/mode",
         params={"clientAddr": "9XXXXXXXXXX9"},
-        status=HTTP_INTERNAL_SERVER_ERROR,
+        status=HTTPStatus.INTERNAL_SERVER_ERROR,
         text=load_fixture("directv/info-mode-error.json"),
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
@@ -86,7 +83,7 @@ def mock_connection(aioclient_mock: AiohttpClientMocker) -> None:
     aioclient_mock.get(
         f"http://{HOST}:8080/tv/getTuned",
         params={"clientAddr": "C01234567890"},
-        status=HTTP_FORBIDDEN,
+        status=HTTPStatus.FORBIDDEN,
         text=load_fixture("directv/tv-get-tuned-restricted.json"),
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
@@ -107,7 +104,8 @@ async def setup_integration(
     """Set up the DirecTV integration in Home Assistant."""
     if setup_error:
         aioclient_mock.get(
-            f"http://{HOST}:8080/info/getVersion", status=HTTP_INTERNAL_SERVER_ERROR
+            f"http://{HOST}:8080/info/getVersion",
+            status=HTTPStatus.INTERNAL_SERVER_ERROR,
         )
     else:
         mock_connection(aioclient_mock)

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -1,5 +1,6 @@
 """The tests for the REST switch platform."""
 import asyncio
+from http import HTTPStatus
 
 import aiohttp
 
@@ -13,9 +14,6 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_RESOURCE,
     CONTENT_TYPE_JSON,
-    HTTP_INTERNAL_SERVER_ERROR,
-    HTTP_NOT_FOUND,
-    HTTP_OK,
 )
 from homeassistant.helpers.template import Template
 from homeassistant.setup import async_setup_component
@@ -69,7 +67,7 @@ async def test_setup_timeout(hass, aioclient_mock):
 
 async def test_setup_minimum(hass, aioclient_mock):
     """Test setup with minimum configuration."""
-    aioclient_mock.get("http://localhost", status=HTTP_OK)
+    aioclient_mock.get("http://localhost", status=HTTPStatus.OK)
     with assert_setup_component(1, SWITCH_DOMAIN):
         assert await async_setup_component(
             hass,
@@ -87,7 +85,7 @@ async def test_setup_minimum(hass, aioclient_mock):
 
 async def test_setup_query_params(hass, aioclient_mock):
     """Test setup with query params."""
-    aioclient_mock.get("http://localhost/?search=something", status=HTTP_OK)
+    aioclient_mock.get("http://localhost/?search=something", status=HTTPStatus.OK)
     with assert_setup_component(1, SWITCH_DOMAIN):
         assert await async_setup_component(
             hass,
@@ -108,7 +106,7 @@ async def test_setup_query_params(hass, aioclient_mock):
 
 async def test_setup(hass, aioclient_mock):
     """Test setup with valid configuration."""
-    aioclient_mock.get("http://localhost", status=HTTP_OK)
+    aioclient_mock.get("http://localhost", status=HTTPStatus.OK)
     assert await async_setup_component(
         hass,
         SWITCH_DOMAIN,
@@ -130,8 +128,8 @@ async def test_setup(hass, aioclient_mock):
 
 async def test_setup_with_state_resource(hass, aioclient_mock):
     """Test setup with valid configuration."""
-    aioclient_mock.get("http://localhost", status=HTTP_NOT_FOUND)
-    aioclient_mock.get("http://localhost/state", status=HTTP_OK)
+    aioclient_mock.get("http://localhost", status=HTTPStatus.NOT_FOUND)
+    aioclient_mock.get("http://localhost/state", status=HTTPStatus.OK)
     assert await async_setup_component(
         hass,
         SWITCH_DOMAIN,
@@ -190,7 +188,7 @@ def test_is_on_before_update(hass):
 
 async def test_turn_on_success(hass, aioclient_mock):
     """Test turn_on."""
-    aioclient_mock.post(RESOURCE, status=HTTP_OK)
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_on()
 
@@ -200,7 +198,7 @@ async def test_turn_on_success(hass, aioclient_mock):
 
 async def test_turn_on_status_not_ok(hass, aioclient_mock):
     """Test turn_on when error status returned."""
-    aioclient_mock.post(RESOURCE, status=HTTP_INTERNAL_SERVER_ERROR)
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_on()
 
@@ -210,7 +208,7 @@ async def test_turn_on_status_not_ok(hass, aioclient_mock):
 
 async def test_turn_on_timeout(hass, aioclient_mock):
     """Test turn_on when timeout occurs."""
-    aioclient_mock.post(RESOURCE, status=HTTP_INTERNAL_SERVER_ERROR)
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_on()
 
@@ -219,7 +217,7 @@ async def test_turn_on_timeout(hass, aioclient_mock):
 
 async def test_turn_off_success(hass, aioclient_mock):
     """Test turn_off."""
-    aioclient_mock.post(RESOURCE, status=HTTP_OK)
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.OK)
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_off()
 
@@ -229,7 +227,7 @@ async def test_turn_off_success(hass, aioclient_mock):
 
 async def test_turn_off_status_not_ok(hass, aioclient_mock):
     """Test turn_off when error status returned."""
-    aioclient_mock.post(RESOURCE, status=HTTP_INTERNAL_SERVER_ERROR)
+    aioclient_mock.post(RESOURCE, status=HTTPStatus.INTERNAL_SERVER_ERROR)
     switch, body_on, body_off = _setup_test_switch(hass)
     await switch.async_turn_off()
 

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the SmartThings config flow module."""
+from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
@@ -15,14 +16,7 @@ from homeassistant.components.smartthings.const import (
     DOMAIN,
 )
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.const import (
-    CONF_ACCESS_TOKEN,
-    CONF_CLIENT_ID,
-    CONF_CLIENT_SECRET,
-    HTTP_FORBIDDEN,
-    HTTP_NOT_FOUND,
-    HTTP_UNAUTHORIZED,
-)
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_CLIENT_ID, CONF_CLIENT_SECRET
 
 from tests.common import MockConfigEntry
 
@@ -482,7 +476,7 @@ async def test_unauthorized_token_shows_error(hass, smartthings_mock):
     token = str(uuid4())
     request_info = Mock(real_url="http://example.com")
     smartthings_mock.apps.side_effect = ClientResponseError(
-        request_info=request_info, history=None, status=HTTP_UNAUTHORIZED
+        request_info=request_info, history=None, status=HTTPStatus.UNAUTHORIZED
     )
 
     # Webhook confirmation shown
@@ -519,7 +513,7 @@ async def test_forbidden_token_shows_error(hass, smartthings_mock):
     token = str(uuid4())
     request_info = Mock(real_url="http://example.com")
     smartthings_mock.apps.side_effect = ClientResponseError(
-        request_info=request_info, history=None, status=HTTP_FORBIDDEN
+        request_info=request_info, history=None, status=HTTPStatus.FORBIDDEN
     )
 
     # Webhook confirmation shown
@@ -635,7 +629,7 @@ async def test_unknown_response_error_shows_error(hass, smartthings_mock):
     token = str(uuid4())
     request_info = Mock(real_url="http://example.com")
     error = ClientResponseError(
-        request_info=request_info, history=None, status=HTTP_NOT_FOUND
+        request_info=request_info, history=None, status=HTTPStatus.NOT_FOUND
     )
     smartthings_mock.apps.side_effect = error
 

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the SmartThings component init module."""
+from http import HTTPStatus
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
@@ -19,7 +20,6 @@ from homeassistant.components.smartthings.const import (
     SIGNAL_SMARTTHINGS_UPDATE,
 )
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.const import HTTP_FORBIDDEN, HTTP_INTERNAL_SERVER_ERROR
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.setup import async_setup_component
@@ -83,7 +83,9 @@ async def test_recoverable_api_errors_raise_not_ready(
     config_entry.add_to_hass(hass)
     request_info = Mock(real_url="http://example.com")
     smartthings_mock.app.side_effect = ClientResponseError(
-        request_info=request_info, history=None, status=HTTP_INTERNAL_SERVER_ERROR
+        request_info=request_info,
+        history=None,
+        status=HTTPStatus.INTERNAL_SERVER_ERROR,
     )
 
     with pytest.raises(ConfigEntryNotReady):
@@ -99,7 +101,9 @@ async def test_scenes_api_errors_raise_not_ready(
     smartthings_mock.app.return_value = app
     smartthings_mock.installed_app.return_value = installed_app
     smartthings_mock.scenes.side_effect = ClientResponseError(
-        request_info=request_info, history=None, status=HTTP_INTERNAL_SERVER_ERROR
+        request_info=request_info,
+        history=None,
+        status=HTTPStatus.INTERNAL_SERVER_ERROR,
     )
     with pytest.raises(ConfigEntryNotReady):
         await smartthings.async_setup_entry(hass, config_entry)
@@ -160,7 +164,7 @@ async def test_scenes_unauthorized_loads_platforms(
     smartthings_mock.installed_app.return_value = installed_app
     smartthings_mock.devices.return_value = [device]
     smartthings_mock.scenes.side_effect = ClientResponseError(
-        request_info=request_info, history=None, status=HTTP_FORBIDDEN
+        request_info=request_info, history=None, status=HTTPStatus.FORBIDDEN
     )
     mock_token = Mock()
     mock_token.access_token = str(uuid4())
@@ -311,10 +315,10 @@ async def test_remove_entry_already_deleted(hass, config_entry, smartthings_mock
     request_info = Mock(real_url="http://example.com")
     # Arrange
     smartthings_mock.delete_installed_app.side_effect = ClientResponseError(
-        request_info=request_info, history=None, status=HTTP_FORBIDDEN
+        request_info=request_info, history=None, status=HTTPStatus.FORBIDDEN
     )
     smartthings_mock.delete_app.side_effect = ClientResponseError(
-        request_info=request_info, history=None, status=HTTP_FORBIDDEN
+        request_info=request_info, history=None, status=HTTPStatus.FORBIDDEN
     )
     # Act
     await smartthings.async_remove_entry(hass, config_entry)
@@ -330,7 +334,9 @@ async def test_remove_entry_installedapp_api_error(
     request_info = Mock(real_url="http://example.com")
     # Arrange
     smartthings_mock.delete_installed_app.side_effect = ClientResponseError(
-        request_info=request_info, history=None, status=HTTP_INTERNAL_SERVER_ERROR
+        request_info=request_info,
+        history=None,
+        status=HTTPStatus.INTERNAL_SERVER_ERROR,
     )
     # Act
     with pytest.raises(ClientResponseError):
@@ -359,7 +365,9 @@ async def test_remove_entry_app_api_error(hass, config_entry, smartthings_mock):
     # Arrange
     request_info = Mock(real_url="http://example.com")
     smartthings_mock.delete_app.side_effect = ClientResponseError(
-        request_info=request_info, history=None, status=HTTP_INTERNAL_SERVER_ERROR
+        request_info=request_info,
+        history=None,
+        status=HTTPStatus.INTERNAL_SERVER_ERROR,
     )
     # Act
     with pytest.raises(ClientResponseError):

--- a/tests/components/startca/test_sensor.py
+++ b/tests/components/startca/test_sensor.py
@@ -1,12 +1,9 @@
 """Tests for the Start.ca sensor platform."""
+from http import HTTPStatus
+
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components.startca.sensor import StartcaData
-from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT,
-    DATA_GIGABYTES,
-    HTTP_NOT_FOUND,
-    PERCENTAGE,
-)
+from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, DATA_GIGABYTES, PERCENTAGE
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 
@@ -205,7 +202,8 @@ async def test_unlimited_setup(hass, aioclient_mock):
 async def test_bad_return_code(hass, aioclient_mock):
     """Test handling a return code that isn't HTTP OK."""
     aioclient_mock.get(
-        "https://www.start.ca/support/usage/api?key=NOTAKEY", status=HTTP_NOT_FOUND
+        "https://www.start.ca/support/usage/api?key=NOTAKEY",
+        status=HTTPStatus.NOT_FOUND,
     )
 
     scd = StartcaData(hass.loop, async_get_clientsession(hass), "NOTAKEY", 400)

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -1,5 +1,6 @@
 """The tests for the Yandex SpeechKit speech platform."""
 import asyncio
+from http import HTTPStatus
 import os
 import shutil
 
@@ -9,7 +10,6 @@ from homeassistant.components.media_player.const import (
 )
 import homeassistant.components.tts as tts
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.const import HTTP_FORBIDDEN
 from homeassistant.setup import setup_component
 
 from tests.common import assert_setup_component, get_test_home_assistant, mock_service
@@ -207,7 +207,10 @@ class TestTTSYandexPlatform:
             "speed": 1,
         }
         aioclient_mock.get(
-            self._base_url, status=HTTP_FORBIDDEN, content=b"test", params=url_param
+            self._base_url,
+            status=HTTPStatus.FORBIDDEN,
+            content=b"test",
+            params=url_param,
         )
 
         config = {tts.DOMAIN: {"platform": "yandextts", "api_key": "1234567xx"}}

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -1,6 +1,7 @@
 """Aiohttp test utils."""
 import asyncio
 from contextlib import contextmanager
+from http import HTTPStatus
 import json as _json
 import re
 from unittest import mock
@@ -41,7 +42,7 @@ class AiohttpClientMocker:
         url,
         *,
         auth=None,
-        status=200,
+        status=HTTPStatus.OK,
         text=None,
         data=None,
         content=None,
@@ -157,7 +158,7 @@ class AiohttpClientMockResponse:
         self,
         method,
         url,
-        status=200,
+        status=HTTPStatus.OK,
         response=None,
         json=None,
         text=None,


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

More work towards moving to use stdlib HTTPStatus enum instead of int constants of our own.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/548
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
