### PR TITLE
Fix an issue where core process crashes when an SMS is received

### DIFF
--- a/homeassistant/components/sms/gateway.py
+++ b/homeassistant/components/sms/gateway.py
@@ -24,16 +24,6 @@ class Gateway:
     async def init_async(self):
         """Initialize the sms gateway asynchronously."""
         await self._worker.init_async()
-        try:
-            await self._worker.set_incoming_sms_async()
-        except gammu.ERR_NOTSUPPORTED:
-            _LOGGER.warning("Falling back to pulling method for SMS notifications")
-        except gammu.GSMError:
-            _LOGGER.warning(
-                "GSM error, falling back to pulling method for SMS notifications"
-            )
-        else:
-            await self._worker.set_incoming_callback_async(self.sms_callback)
 
     def sms_pull(self, state_machine):
         """Pull device.
@@ -46,21 +36,6 @@ class Gateway:
         _LOGGER.debug("Pulling modem")
         self.sms_read_messages(state_machine, self._first_pull)
         self._first_pull = False
-
-    def sms_callback(self, state_machine, callback_type, callback_data):
-        """Receive notification about incoming event.
-
-        @param state_machine: state machine which invoked action
-        @type state_machine: gammu.StateMachine
-        @param callback_type: type of action, one of Call, SMS, CB, USSD
-        @type callback_type: string
-        @param data: event data
-        @type data: hash
-        """
-        _LOGGER.debug(
-            "Received incoming event type:%s,data:%s", callback_type, callback_data
-        )
-        self.sms_read_messages(state_machine)
 
     def sms_read_messages(self, state_machine, force=False):
         """Read all received SMS messages.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After recent changes to the OS, the callback functionality of the SMS integration started to fail. We changed SMS to [bypass the callback](https://github.com/home-assistant/core/pull/54114) and [implemented polling](https://github.com/home-assistant/core/pull/54237).
However, the code that installs the callback was still being executed (and the following is an hypotheses) this leave [certain GSM modems](https://www.amazon.com/SIM800C-Wireless-Quad-Band-Communication-Transmission/dp/B087Z6F953/ref=pd_ybh_a_1?_encoding=UTF8&psc=1&refRID=PMR9ZDS9VW0PXJ117DSB) in a bad state.
The crash happened when there was an incoming SMS and ReadDevice() was called. ReadDevice will execute the callback, but for some unknown reason this generates a segment fault.

The fix is very simple, just bypass completely the callback mechanism ([as it is not working for this modem](https://github.com/gammu/python-gammu/issues/53)) and only read incoming SMS via polling. Which is in essence the same thing that ReadDevice does (but without crashing) :)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54876
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation [added/updated](https://github.com/home-assistant/home-assistant.io/pull/19438) for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
