### PR TITLE
Warn if total_increasing sensor has negative states

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -734,7 +734,10 @@ class Entity(ABC):
         Not to be extended by integrations.
         """
         if self.platform:
-            info = {"domain": self.platform.platform_name}
+            info = {
+                "domain": self.platform.platform_name,
+                "custom_component": "custom_components" in type(self).__module__,
+            }
 
             if self.platform.config_entry:
                 info["source"] = SOURCE_CONFIG_ENTRY

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from pytest import approx
 
+from homeassistant import loader
 from homeassistant.components.recorder import history
 from homeassistant.components.recorder.const import DATA_INSTANCE
 from homeassistant.components.recorder.models import process_timestamp_to_utc_isoformat
@@ -609,6 +610,26 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
     assert "Error while processing event StatisticsTask" not in caplog.text
 
 
+@pytest.mark.parametrize(
+    "entity_id,warning_1,warning_2",
+    [
+        (
+            "sensor.test1",
+            "",
+            "bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue",
+        ),
+        (
+            "sensor.today_energy",
+            "from integration demo ",
+            "bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+demo%22",
+        ),
+        (
+            "sensor.custom_sensor",
+            "from integration test ",
+            "report it to the custom component author",
+        ),
+    ],
+)
 @pytest.mark.parametrize("state_class", ["total_increasing"])
 @pytest.mark.parametrize(
     "device_class,unit,native_unit,factor",
@@ -617,28 +638,48 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
     ],
 )
 def test_compile_hourly_sum_statistics_negative_state(
-    hass_recorder, caplog, state_class, device_class, unit, native_unit, factor
+    hass_recorder,
+    caplog,
+    entity_id,
+    warning_1,
+    warning_2,
+    state_class,
+    device_class,
+    unit,
+    native_unit,
+    factor,
 ):
     """Test compiling hourly statistics with negative states."""
     zero = dt_util.utcnow()
     hass = hass_recorder()
+    hass.data.pop(loader.DATA_CUSTOM_COMPONENTS)
     recorder = hass.data[DATA_INSTANCE]
-    setup_component(hass, "sensor", {})
+
+    platform = getattr(hass.components, "test.sensor")
+    platform.init(empty=True)
+    mocksensor = platform.MockSensor(name="custom_sensor")
+    mocksensor._attr_should_poll = False
+    platform.ENTITIES["custom_sensor"] = mocksensor
+
+    setup_component(
+        hass, "sensor", {"sensor": [{"platform": "demo"}, {"platform": "test"}]}
+    )
+    hass.block_till_done()
     attributes = {
         "device_class": device_class,
         "state_class": state_class,
         "unit_of_measurement": unit,
     }
-    seq = [10, 11, 15, 16, 20, -20, 20, 10]
+    seq = [15, 16, 15, 16, 20, -20, 20, 10]
 
-    states = {"sensor.test1": []}
+    states = {entity_id: []}
+    if state := hass.states.get(entity_id):
+        states[entity_id].append(state)
     one = zero
     for i in range(len(seq)):
         one = one + timedelta(seconds=5)
-        _states = record_meter_state(
-            hass, one, "sensor.test1", attributes, seq[i : i + 1]
-        )
-        states["sensor.test1"].extend(_states["sensor.test1"])
+        _states = record_meter_state(hass, one, entity_id, attributes, seq[i : i + 1])
+        states[entity_id].extend(_states[entity_id])
 
     hist = history.get_significant_states(
         hass,
@@ -646,35 +687,35 @@ def test_compile_hourly_sum_statistics_negative_state(
         one + timedelta.resolution,
         significant_changes_only=False,
     )
-    assert dict(states)["sensor.test1"] == dict(hist)["sensor.test1"]
+    assert dict(states)[entity_id] == dict(hist)[entity_id]
 
     recorder.do_adhoc_statistics(start=zero)
     wait_recording_done(hass)
     statistic_ids = list_statistic_ids(hass)
-    assert statistic_ids == [
-        {"statistic_id": "sensor.test1", "unit_of_measurement": native_unit}
-    ]
+    assert {
+        "statistic_id": entity_id,
+        "unit_of_measurement": native_unit,
+    } in statistic_ids
     stats = statistics_during_period(hass, zero, period="5minute")
-    assert stats == {
-        "sensor.test1": [
-            {
-                "statistic_id": "sensor.test1",
-                "start": process_timestamp_to_utc_isoformat(zero),
-                "end": process_timestamp_to_utc_isoformat(zero + timedelta(minutes=5)),
-                "max": None,
-                "mean": None,
-                "min": None,
-                "last_reset": None,
-                "state": approx(factor * seq[7]),
-                "sum": approx(factor * 20),  # (20 - 10) + (10 - 0)
-            },
-        ]
-    }
+    assert stats[entity_id] == [
+        {
+            "statistic_id": entity_id,
+            "start": process_timestamp_to_utc_isoformat(zero),
+            "end": process_timestamp_to_utc_isoformat(zero + timedelta(minutes=5)),
+            "max": None,
+            "mean": None,
+            "min": None,
+            "last_reset": None,
+            "state": approx(factor * seq[7]),
+            "sum": approx(factor * 15),  # (15 - 10) + (10 - 0)
+        },
+    ]
     assert "Error while processing event StatisticsTask" not in caplog.text
     assert (
-        "Entity sensor.test1 has state class total_increasing, but its state is negative"
+        f"Entity {entity_id} {warning_1}has state class total_increasing, but its state is negative"
         in caplog.text
     )
+    assert warning_2 in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -666,9 +666,7 @@ def test_compile_hourly_sum_statistics_negative_state(
                 "min": None,
                 "last_reset": None,
                 "state": approx(factor * seq[7]),
-                "sum": approx(factor * 40),  # (20 - 10) + (10 - (-20))
-                "sum_decrease": approx(factor * 20.0),
-                "sum_increase": approx(factor * 60),
+                "sum": approx(factor * 20),  # (20 - 10) + (10 - 0)
             },
         ]
     }

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -891,16 +891,14 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
     assert (
         "Entity sensor.test1 has state class total_increasing, but its state is not "
         "strictly increasing. Please create a bug report at https://github.com/"
-        "home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A"
-        "+recorder%22"
+        "home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
     ) not in caplog.text
     recorder.do_adhoc_statistics(start=period2)
     wait_recording_done(hass)
     assert (
         "Entity sensor.test1 has state class total_increasing, but its state is not "
         "strictly increasing. Please create a bug report at https://github.com/"
-        "home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A"
-        "+recorder%22"
+        "home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
     ) in caplog.text
     statistic_ids = list_statistic_ids(hass)
     assert statistic_ids == [

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -922,12 +922,14 @@ async def test_entity_source_admin(hass, websocket_client, hass_admin_user):
     assert msg["success"]
     assert msg["result"] == {
         "test_domain.entity_1": {
-            "source": entity.SOURCE_PLATFORM_CONFIG,
+            "custom_component": False,
             "domain": "test_platform",
+            "source": entity.SOURCE_PLATFORM_CONFIG,
         },
         "test_domain.entity_2": {
-            "source": entity.SOURCE_PLATFORM_CONFIG,
+            "custom_component": False,
             "domain": "test_platform",
+            "source": entity.SOURCE_PLATFORM_CONFIG,
         },
     }
 
@@ -942,8 +944,9 @@ async def test_entity_source_admin(hass, websocket_client, hass_admin_user):
     assert msg["success"]
     assert msg["result"] == {
         "test_domain.entity_2": {
-            "source": entity.SOURCE_PLATFORM_CONFIG,
+            "custom_component": False,
             "domain": "test_platform",
+            "source": entity.SOURCE_PLATFORM_CONFIG,
         },
     }
 
@@ -962,12 +965,14 @@ async def test_entity_source_admin(hass, websocket_client, hass_admin_user):
     assert msg["success"]
     assert msg["result"] == {
         "test_domain.entity_1": {
-            "source": entity.SOURCE_PLATFORM_CONFIG,
+            "custom_component": False,
             "domain": "test_platform",
+            "source": entity.SOURCE_PLATFORM_CONFIG,
         },
         "test_domain.entity_2": {
-            "source": entity.SOURCE_PLATFORM_CONFIG,
+            "custom_component": False,
             "domain": "test_platform",
+            "source": entity.SOURCE_PLATFORM_CONFIG,
         },
     }
 
@@ -1001,8 +1006,9 @@ async def test_entity_source_admin(hass, websocket_client, hass_admin_user):
     assert msg["success"]
     assert msg["result"] == {
         "test_domain.entity_2": {
-            "source": entity.SOURCE_PLATFORM_CONFIG,
+            "custom_component": False,
             "domain": "test_platform",
+            "source": entity.SOURCE_PLATFORM_CONFIG,
         },
     }
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -707,13 +707,15 @@ async def test_setup_source(hass):
 
     assert entity.entity_sources(hass) == {
         "test_domain.platform_config_source": {
-            "source": entity.SOURCE_PLATFORM_CONFIG,
+            "custom_component": False,
             "domain": "test_platform",
+            "source": entity.SOURCE_PLATFORM_CONFIG,
         },
         "test_domain.config_entry_source": {
-            "source": entity.SOURCE_CONFIG_ENTRY,
             "config_entry": platform.config_entry.entry_id,
+            "custom_component": False,
             "domain": "test_platform",
+            "source": entity.SOURCE_CONFIG_ENTRY,
         },
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Warn if `total_increasing` sensor has negative states; negative states will not give correct sum statistics.
If negative states are possible for a meter type sensor, state class `total` should be used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
