### PR TITLE
Avoid enabling ipv6 dual stack for zeroconf on unsupported platforms

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -8,6 +8,7 @@ import fnmatch
 from ipaddress import IPv6Address, ip_address
 import logging
 import socket
+import sys
 from typing import Any, TypedDict, cast
 
 import voluptuous as vol
@@ -131,18 +132,31 @@ async def _async_get_instance(hass: HomeAssistant, **zcargs: Any) -> HaAsyncZero
     return aio_zc
 
 
+@callback
+def _async_zc_has_functional_dual_stack() -> bool:
+    """Return true for platforms that not support IP_ADD_MEMBERSHIP on an AF_INET6 socket.
+
+    Zeroconf only supports a single listen socket at this time.
+    """
+    return not sys.platform.startswith("freebsd") and not sys.platform.startswith(
+        "darwin"
+    )
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Zeroconf and make Home Assistant discoverable."""
-    zc_args: dict = {}
+    zc_args: dict = {"ip_version": IPVersion.V4Only}
 
     adapters = await network.async_get_adapters(hass)
 
-    ipv6 = True
-    if not any(adapter["enabled"] and adapter["ipv6"] for adapter in adapters):
-        ipv6 = False
-        zc_args["ip_version"] = IPVersion.V4Only
-    else:
-        zc_args["ip_version"] = IPVersion.All
+    ipv6 = False
+    if _async_zc_has_functional_dual_stack():
+        if any(adapter["enabled"] and adapter["ipv6"] for adapter in adapters):
+            ipv6 = True
+            zc_args["ip_version"] = IPVersion.All
+    elif not any(adapter["enabled"] and adapter["ipv4"] for adapter in adapters):
+        zc_args["ip_version"] = IPVersion.V6Only
+        ipv6 = True
 
     if not ipv6 and network.async_only_default_interface_enabled(adapters):
         zc_args["interfaces"] = InterfaceChoice.Default

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -5,7 +5,7 @@ import asyncio
 from collections.abc import Coroutine
 from contextlib import suppress
 import fnmatch
-from ipaddress import IPv6Address, ip_address
+from ipaddress import IPv4Address, IPv6Address, ip_address
 import logging
 import socket
 import sys
@@ -166,6 +166,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             for source_ip in await network.async_get_enabled_source_ips(hass)
             if not source_ip.is_loopback
             and not (isinstance(source_ip, IPv6Address) and source_ip.is_global)
+            and not (
+                isinstance(source_ip, IPv6Address)
+                and zc_args["ip_version"] == IPVersion.V4Only
+            )
+            and not (
+                isinstance(source_ip, IPv4Address)
+                and zc_args["ip_version"] == IPVersion.V6Only
+            )
         ]
 
     aio_zc = await _async_get_instance(hass, **zc_args)

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -779,11 +779,13 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
 ]
 
 
-async def test_async_detect_interfaces_setting_empty_route(hass, mock_async_zeroconf):
-    """Test without default interface config and the route returns nothing."""
-    with patch("homeassistant.components.zeroconf.HaZeroconf") as mock_zc, patch.object(
-        hass.config_entries.flow, "async_init"
-    ), patch.object(
+async def test_async_detect_interfaces_setting_empty_route_linux(
+    hass, mock_async_zeroconf
+):
+    """Test without default interface config and the route returns nothing on linux."""
+    with patch("homeassistant.components.zeroconf.sys.platform", "linux"), patch(
+        "homeassistant.components.zeroconf.HaZeroconf"
+    ) as mock_zc, patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
     ), patch(
         "homeassistant.components.zeroconf.network.async_get_adapters",
@@ -804,6 +806,33 @@ async def test_async_detect_interfaces_setting_empty_route(hass, mock_async_zero
             "fe80::dead:beef:dead:beef",
         ],
         ip_version=IPVersion.All,
+    )
+
+
+async def test_async_detect_interfaces_setting_empty_route_freebsd(
+    hass, mock_async_zeroconf
+):
+    """Test without default interface config and the route returns nothing on freebsd."""
+    with patch("homeassistant.components.zeroconf.sys.platform", "freebsd"), patch(
+        "homeassistant.components.zeroconf.HaZeroconf"
+    ) as mock_zc, patch.object(hass.config_entries.flow, "async_init"), patch.object(
+        zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.network.async_get_adapters",
+        return_value=_ADAPTERS_WITH_MANUAL_CONFIG,
+    ), patch(
+        "homeassistant.components.zeroconf.AsyncServiceInfo",
+        side_effect=get_service_info_mock,
+    ):
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+    assert mock_zc.mock_calls[0] == call(
+        interfaces=[
+            "192.168.1.5",
+            "172.16.1.5",
+        ],
+        ip_version=IPVersion.V4Only,
     )
 
 
@@ -848,11 +877,13 @@ _ADAPTER_WITH_DEFAULT_ENABLED_AND_IPV6 = [
 ]
 
 
-async def test_async_detect_interfaces_explicitly_set_ipv6(hass, mock_async_zeroconf):
-    """Test interfaces are explicitly set when IPv6 is present."""
-    with patch("homeassistant.components.zeroconf.HaZeroconf") as mock_zc, patch.object(
-        hass.config_entries.flow, "async_init"
-    ), patch.object(
+async def test_async_detect_interfaces_explicitly_set_ipv6_linux(
+    hass, mock_async_zeroconf
+):
+    """Test interfaces are explicitly set when IPv6 is present on linux."""
+    with patch("homeassistant.components.zeroconf.sys.platform", "linux"), patch(
+        "homeassistant.components.zeroconf.HaZeroconf"
+    ) as mock_zc, patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
     ), patch(
         "homeassistant.components.zeroconf.network.async_get_adapters",
@@ -868,6 +899,31 @@ async def test_async_detect_interfaces_explicitly_set_ipv6(hass, mock_async_zero
     assert mock_zc.mock_calls[0] == call(
         interfaces=["192.168.1.5", "fe80::dead:beef:dead:beef"],
         ip_version=IPVersion.All,
+    )
+
+
+async def test_async_detect_interfaces_explicitly_set_ipv6_freebsd(
+    hass, mock_async_zeroconf
+):
+    """Test interfaces are explicitly set when IPv6 is present on freebsd."""
+    with patch("homeassistant.components.zeroconf.sys.platform", "freebsd"), patch(
+        "homeassistant.components.zeroconf.HaZeroconf"
+    ) as mock_zc, patch.object(hass.config_entries.flow, "async_init"), patch.object(
+        zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.network.async_get_adapters",
+        return_value=_ADAPTER_WITH_DEFAULT_ENABLED_AND_IPV6,
+    ), patch(
+        "homeassistant.components.zeroconf.AsyncServiceInfo",
+        side_effect=get_service_info_mock,
+    ):
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    assert mock_zc.mock_calls[0] == call(
+        interfaces=InterfaceChoice.Default,
+        ip_version=IPVersion.V4Only,
     )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- BSD and MacOS cannot see IPv4 traffic on an IPv6 multicast socket (`AF_INET6`)
  even if `IPV6_V6ONLY` is `False`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
