### PR TITLE
Fix state_class for deCONZ power sensors

### DIFF
--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_VIBRATION,
     DOMAIN,
     BinarySensorEntity,
+    BinarySensorEntityDescription,
 )
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import callback
@@ -24,13 +25,31 @@ ATTR_ORIENTATION = "orientation"
 ATTR_TILTANGLE = "tiltangle"
 ATTR_VIBRATIONSTRENGTH = "vibrationstrength"
 
-DEVICE_CLASS = {
-    CarbonMonoxide: DEVICE_CLASS_GAS,
-    Fire: DEVICE_CLASS_SMOKE,
-    OpenClose: DEVICE_CLASS_OPENING,
-    Presence: DEVICE_CLASS_MOTION,
-    Vibration: DEVICE_CLASS_VIBRATION,
-    Water: DEVICE_CLASS_MOISTURE,
+ENTITY_DESCRIPTIONS = {
+    CarbonMonoxide: BinarySensorEntityDescription(
+        key="carbonmonoxide",
+        device_class=DEVICE_CLASS_GAS,
+    ),
+    Fire: BinarySensorEntityDescription(
+        key="fire",
+        device_class=DEVICE_CLASS_SMOKE,
+    ),
+    OpenClose: BinarySensorEntityDescription(
+        key="openclose",
+        device_class=DEVICE_CLASS_OPENING,
+    ),
+    Presence: BinarySensorEntityDescription(
+        key="presence",
+        device_class=DEVICE_CLASS_MOTION,
+    ),
+    Vibration: BinarySensorEntityDescription(
+        key="vibration",
+        device_class=DEVICE_CLASS_VIBRATION,
+    ),
+    Water: BinarySensorEntityDescription(
+        key="water",
+        device_class=DEVICE_CLASS_MOISTURE,
+    ),
 }
 
 
@@ -84,7 +103,9 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     def __init__(self, device, gateway):
         """Initialize deCONZ binary sensor."""
         super().__init__(device, gateway)
-        self._attr_device_class = DEVICE_CLASS.get(type(self._device))
+
+        if entity_description := ENTITY_DESCRIPTIONS.get(type(device)):
+            self.entity_description = entity_description
 
     @callback
     def async_update_callback(self, force_update=False):

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -59,14 +59,6 @@ class DeconzDevice(DeconzBase, Entity):
 
         self._attr_name = self._device.name
 
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry.
-
-        Daylight is a virtual sensor from deCONZ that should never be enabled by default.
-        """
-        return self._device.type != "Daylight"
-
     async def async_added_to_hass(self):
         """Subscribe to device events."""
         self._device.register_callback(self.async_update_callback)

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -91,14 +91,12 @@ ENTITY_DESCRIPTIONS = {
     Pressure: SensorEntityDescription(
         key="pressure",
         device_class=DEVICE_CLASS_PRESSURE,
-        icon="mdi:gauge",
         state_class=STATE_CLASS_MEASUREMENT,
         unit_of_measurement=PRESSURE_HPA,
     ),
     Temperature: SensorEntityDescription(
         key="temperature",
         device_class=DEVICE_CLASS_TEMPERATURE,
-        icon="mdi:thermometer",
         state_class=STATE_CLASS_MEASUREMENT,
         unit_of_measurement=TEMP_CELSIUS,
     ),

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
+    SensorEntityDescription,
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
@@ -52,35 +53,55 @@ ATTR_POWER = "power"
 ATTR_DAYLIGHT = "daylight"
 ATTR_EVENT_ID = "event_id"
 
-DEVICE_CLASS = {
-    Consumption: DEVICE_CLASS_ENERGY,
-    Humidity: DEVICE_CLASS_HUMIDITY,
-    LightLevel: DEVICE_CLASS_ILLUMINANCE,
-    Power: DEVICE_CLASS_POWER,
-    Pressure: DEVICE_CLASS_PRESSURE,
-    Temperature: DEVICE_CLASS_TEMPERATURE,
-}
-
-ICON = {
-    Daylight: "mdi:white-balance-sunny",
-    Pressure: "mdi:gauge",
-    Temperature: "mdi:thermometer",
-}
-
-STATE_CLASS = {
-    Consumption: STATE_CLASS_TOTAL_INCREASING,
-    Humidity: STATE_CLASS_MEASUREMENT,
-    Pressure: STATE_CLASS_MEASUREMENT,
-    Temperature: STATE_CLASS_MEASUREMENT,
-}
-
-UNIT_OF_MEASUREMENT = {
-    Consumption: ENERGY_KILO_WATT_HOUR,
-    Humidity: PERCENTAGE,
-    LightLevel: LIGHT_LUX,
-    Power: POWER_WATT,
-    Pressure: PRESSURE_HPA,
-    Temperature: TEMP_CELSIUS,
+ENTITY_DESCRIPTIONS = {
+    Battery: SensorEntityDescription(
+        key="battery",
+        device_class=DEVICE_CLASS_BATTERY,
+        state_class=STATE_CLASS_MEASUREMENT,
+        unit_of_measurement=PERCENTAGE,
+    ),
+    Consumption: SensorEntityDescription(
+        key="consumption",
+        device_class=DEVICE_CLASS_ENERGY,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+    ),
+    Daylight: SensorEntityDescription(
+        key="daylight",
+        icon="mdi:white-balance-sunny",
+        entity_registry_enabled_default=False,
+    ),
+    Humidity: SensorEntityDescription(
+        key="humidity",
+        device_class=DEVICE_CLASS_HUMIDITY,
+        state_class=STATE_CLASS_MEASUREMENT,
+        unit_of_measurement=PERCENTAGE,
+    ),
+    LightLevel: SensorEntityDescription(
+        key="lightlevel",
+        device_class=DEVICE_CLASS_ILLUMINANCE,
+        unit_of_measurement=LIGHT_LUX,
+    ),
+    Power: SensorEntityDescription(
+        key="power",
+        device_class=DEVICE_CLASS_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
+        unit_of_measurement=POWER_WATT,
+    ),
+    Pressure: SensorEntityDescription(
+        key="pressure",
+        device_class=DEVICE_CLASS_PRESSURE,
+        icon="mdi:gauge",
+        state_class=STATE_CLASS_MEASUREMENT,
+        unit_of_measurement=PRESSURE_HPA,
+    ),
+    Temperature: SensorEntityDescription(
+        key="temperature",
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        icon="mdi:thermometer",
+        state_class=STATE_CLASS_MEASUREMENT,
+        unit_of_measurement=TEMP_CELSIUS,
+    ),
 }
 
 
@@ -157,12 +178,8 @@ class DeconzSensor(DeconzDevice, SensorEntity):
         """Initialize deCONZ binary sensor."""
         super().__init__(device, gateway)
 
-        self._attr_device_class = DEVICE_CLASS.get(type(self._device))
-        self._attr_icon = ICON.get(type(self._device))
-        self._attr_state_class = STATE_CLASS.get(type(self._device))
-        self._attr_native_unit_of_measurement = UNIT_OF_MEASUREMENT.get(
-            type(self._device)
-        )
+        if entity_description := ENTITY_DESCRIPTIONS.get(type(device)):
+            self.entity_description = entity_description
 
     @callback
     def async_update_callback(self, force_update=False):
@@ -214,16 +231,13 @@ class DeconzTemperature(DeconzDevice, SensorEntity):
     Extra temperature sensor on certain Xiaomi devices.
     """
 
-    _attr_device_class = DEVICE_CLASS_TEMPERATURE
-    _attr_state_class = STATE_CLASS_MEASUREMENT
-    _attr_native_unit_of_measurement = TEMP_CELSIUS
-
     TYPE = DOMAIN
 
     def __init__(self, device, gateway):
         """Initialize deCONZ temperature sensor."""
         super().__init__(device, gateway)
 
+        self.entity_description = ENTITY_DESCRIPTIONS[Temperature]
         self._attr_name = f"{self._device.name} Temperature"
 
     @property
@@ -247,16 +261,13 @@ class DeconzTemperature(DeconzDevice, SensorEntity):
 class DeconzBattery(DeconzDevice, SensorEntity):
     """Battery class for when a device is only represented as an event."""
 
-    _attr_device_class = DEVICE_CLASS_BATTERY
-    _attr_state_class = STATE_CLASS_MEASUREMENT
-    _attr_native_unit_of_measurement = PERCENTAGE
-
     TYPE = DOMAIN
 
     def __init__(self, device, gateway):
         """Initialize deCONZ battery level sensor."""
         super().__init__(device, gateway)
 
+        self.entity_description = ENTITY_DESCRIPTIONS[Battery]
         self._attr_name = f"{self._device.name} Battery Level"
 
     @callback


### PR DESCRIPTION
Rewrite entity descriptions for binary sensor and sensor platforms

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix state_class for power sensors
Rewrite entity descriptions for binary sensor and sensor platforms
Move daylight sensor enabled_by_default to SensorEntityDescription

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
