### PR TITLE
Reuse zwave_js device when replacing removed node with same node

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -318,7 +318,7 @@ async def async_setup_entry(  # noqa: C901
     def async_on_node_removed(event: dict) -> None:
         """Handle node removed event."""
         node: ZwaveNode = event["node"]
-        replaced: bool = event["replaced"]
+        replaced: bool = event.get("replaced", False)
         # grab device in device registry attached to this node
         dev_id = get_device_id(client, node)
         device = dev_reg.async_get_device({dev_id})

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -322,13 +322,17 @@ async def async_setup_entry(  # noqa: C901
         # grab device in device registry attached to this node
         dev_id = get_device_id(client, node)
         device = dev_reg.async_get_device({dev_id})
+        # We assert because we know the device exists
+        assert device
         if not replaced:
-            remove_device(device)  # type: ignore
+            remove_device(device)
 
     @callback
     def async_on_value_notification(notification: ValueNotification) -> None:
         """Relay stateless value notification events from Z-Wave nodes to hass."""
         device = dev_reg.async_get_device({get_device_id(client, notification.node)})
+        # We assert because we know the device exists
+        assert device
         raw_value = value = notification.value
         if notification.metadata.states:
             value = notification.metadata.states.get(str(value), value)
@@ -339,7 +343,7 @@ async def async_setup_entry(  # noqa: C901
                 ATTR_NODE_ID: notification.node.node_id,
                 ATTR_HOME_ID: client.driver.controller.home_id,
                 ATTR_ENDPOINT: notification.endpoint,
-                ATTR_DEVICE_ID: device.id,  # type: ignore
+                ATTR_DEVICE_ID: device.id,
                 ATTR_COMMAND_CLASS: notification.command_class,
                 ATTR_COMMAND_CLASS_NAME: notification.command_class_name,
                 ATTR_LABEL: notification.metadata.label,
@@ -358,11 +362,13 @@ async def async_setup_entry(  # noqa: C901
     ) -> None:
         """Relay stateless notification events from Z-Wave nodes to hass."""
         device = dev_reg.async_get_device({get_device_id(client, notification.node)})
+        # We assert because we know the device exists
+        assert device
         event_data = {
             ATTR_DOMAIN: DOMAIN,
             ATTR_NODE_ID: notification.node.node_id,
             ATTR_HOME_ID: client.driver.controller.home_id,
-            ATTR_DEVICE_ID: device.id,  # type: ignore
+            ATTR_DEVICE_ID: device.id,
             ATTR_COMMAND_CLASS: notification.command_class,
         }
 
@@ -401,6 +407,8 @@ async def async_setup_entry(  # noqa: C901
         disc_info = value_updates_disc_info[value.value_id]
 
         device = dev_reg.async_get_device({get_device_id(client, value.node)})
+        # We assert because we know the device exists
+        assert device
 
         unique_id = get_unique_id(
             client.driver.controller.home_id, disc_info.primary_value.value_id
@@ -416,7 +424,7 @@ async def async_setup_entry(  # noqa: C901
             {
                 ATTR_NODE_ID: value.node.node_id,
                 ATTR_HOME_ID: client.driver.controller.home_id,
-                ATTR_DEVICE_ID: device.id,  # type: ignore
+                ATTR_DEVICE_ID: device.id,
                 ATTR_ENTITY_ID: entity_id,
                 ATTR_COMMAND_CLASS: value.command_class,
                 ATTR_COMMAND_CLASS_NAME: value.command_class_name,

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -522,9 +522,7 @@ async def async_setup_entry(  # noqa: C901
         # listen for nodes being removed from the mesh
         # NOTE: This will not remove nodes that were removed when HA was not running
         entry.async_on_unload(
-            client.driver.controller.on(
-                "node removed", lambda event: async_on_node_removed(event)
-            )
+            client.driver.controller.on("node removed", async_on_node_removed)
         )
 
     platform_task = hass.async_create_task(start_platforms())

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from typing import Callable
 
 from async_timeout import timeout
 from zwave_js_server.client import Client as ZwaveClient
@@ -97,11 +98,22 @@ def register_node_in_dev_reg(
     dev_reg: device_registry.DeviceRegistry,
     client: ZwaveClient,
     node: ZwaveNode,
+    remove_device_func: Callable[[device_registry.DeviceEntry], None],
 ) -> device_registry.DeviceEntry:
     """Register node in dev reg."""
+    device_id = get_device_id(client, node)
+    # If a device already exists but it doesn't match the new node, it means the node
+    # was replaced with a different device and the device needs to be removeed so the
+    # new device can be created. Otherwise if the device exists and the node is the same,
+    # the node was replaced with the same device model and we can reuse the device.
+    if (device := dev_reg.async_get_device({device_id})) and (
+        device.model != node.device_config.label
+        or device.manufacturer != node.device_config.manufacturer
+    ):
+        remove_device_func(device)
     params = {
         "config_entry_id": entry.entry_id,
-        "identifiers": {get_device_id(client, node)},
+        "identifiers": {device_id},
         "sw_version": node.firmware_version,
         "name": node.name or node.device_config.description or f"Node {node.node_id}",
         "model": node.device_config.label,
@@ -134,6 +146,14 @@ async def async_setup_entry(  # noqa: C901
 
     registered_unique_ids: dict[str, dict[str, set[str]]] = defaultdict(dict)
     discovered_value_ids: dict[str, set[str]] = defaultdict(set)
+
+    @callback
+    def remove_device(device: device_registry.DeviceEntry) -> None:
+        """Remove device from registry."""
+        # note: removal of entity registry entry is handled by core
+        dev_reg.async_remove_device(device.id)
+        registered_unique_ids.pop(device.id, None)
+        discovered_value_ids.pop(device.id, None)
 
     async def async_handle_discovery_info(
         device: device_registry.DeviceEntry,
@@ -188,7 +208,9 @@ async def async_setup_entry(  # noqa: C901
         """Handle node ready event."""
         LOGGER.debug("Processing node %s", node)
         # register (or update) node in device registry
-        device = register_node_in_dev_reg(hass, entry, dev_reg, client, node)
+        device = register_node_in_dev_reg(
+            hass, entry, dev_reg, client, node, remove_device
+        )
         # We only want to create the defaultdict once, even on reinterviews
         if device.id not in registered_unique_ids:
             registered_unique_ids[device.id] = defaultdict(set)
@@ -265,7 +287,7 @@ async def async_setup_entry(  # noqa: C901
         )
         # we do submit the node to device registry so user has
         # some visual feedback that something is (in the process of) being added
-        register_node_in_dev_reg(hass, entry, dev_reg, client, node)
+        register_node_in_dev_reg(hass, entry, dev_reg, client, node, remove_device)
 
     async def async_on_value_added(
         value_updates_disc_info: dict[str, ZwaveDiscoveryInfo], value: Value
@@ -293,15 +315,15 @@ async def async_setup_entry(  # noqa: C901
         )
 
     @callback
-    def async_on_node_removed(node: ZwaveNode) -> None:
+    def async_on_node_removed(event: dict) -> None:
         """Handle node removed event."""
+        node: ZwaveNode = event["node"]
+        replaced: bool = event["replaced"]
         # grab device in device registry attached to this node
         dev_id = get_device_id(client, node)
         device = dev_reg.async_get_device({dev_id})
-        # note: removal of entity registry entry is handled by core
-        dev_reg.async_remove_device(device.id)  # type: ignore
-        registered_unique_ids.pop(device.id, None)  # type: ignore
-        discovered_value_ids.pop(device.id, None)  # type: ignore
+        if not replaced:
+            remove_device(device)  # type: ignore
 
     @callback
     def async_on_value_notification(notification: ValueNotification) -> None:
@@ -501,7 +523,7 @@ async def async_setup_entry(  # noqa: C901
         # NOTE: This will not remove nodes that were removed when HA was not running
         entry.async_on_unload(
             client.driver.controller.on(
-                "node removed", lambda event: async_on_node_removed(event["node"])
+                "node removed", lambda event: async_on_node_removed(event)
             )
         )
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -161,7 +161,7 @@ async def test_new_entity_on_value_added(hass, multisensor_6, client, integratio
 async def test_on_node_added_ready(hass, multisensor_6_state, client, integration):
     """Test we handle a ready node added event."""
     dev_reg = dr.async_get(hass)
-    node = Node(client, multisensor_6_state)
+    node = Node(client, deepcopy(multisensor_6_state))
     event = {"node": node}
     air_temperature_device_id = f"{client.driver.controller.home_id}-{node.node_id}"
 
@@ -661,7 +661,7 @@ async def test_suggested_area(hass, client, eaton_rf9640_dimmer):
 async def test_node_removed(hass, multisensor_6_state, client, integration):
     """Test that device gets removed when node gets removed."""
     dev_reg = dr.async_get(hass)
-    node = Node(client, multisensor_6_state)
+    node = Node(client, deepcopy(multisensor_6_state))
     device_id = f"{client.driver.controller.home_id}-{node.node_id}"
     event = {"node": node}
 
@@ -681,7 +681,7 @@ async def test_node_removed(hass, multisensor_6_state, client, integration):
 async def test_replace_same_node(hass, multisensor_6_state, client, integration):
     """Test when a node is replaced with itself that the device remains."""
     dev_reg = dr.async_get(hass)
-    node = Node(client, multisensor_6_state)
+    node = Node(client, deepcopy(multisensor_6_state))
     device_id = f"{client.driver.controller.home_id}-{node.node_id}"
     event = {"node": node}
 
@@ -709,6 +709,8 @@ async def test_replace_different_node(
     hass, multisensor_6_state, hank_binary_switch_state, client, integration
 ):
     """Test when a node is replaced with a different node."""
+    hank_binary_switch_state = deepcopy(hank_binary_switch_state)
+    multisensor_6_state = deepcopy(multisensor_6_state)
     hank_binary_switch_state["nodeId"] = multisensor_6_state["nodeId"]
     dev_reg = dr.async_get(hass)
     old_node = Node(client, multisensor_6_state)

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -725,6 +725,8 @@ async def test_replace_different_node(
 
     client.driver.controller.emit("node removed", event)
     await hass.async_block_till_done()
+    # Device should still be there after the node was removed
+    assert device
 
     event = {"node": new_node}
 

--- a/tests/components/zwave_js/test_migrate.py
+++ b/tests/components/zwave_js/test_migrate.py
@@ -1,4 +1,6 @@
 """Test the Z-Wave JS migration module."""
+import copy
+
 import pytest
 from zwave_js_server.model.node import Node
 
@@ -48,7 +50,7 @@ async def test_unique_id_migration_dupes(
     assert entity_entry.unique_id == old_unique_id_2
 
     # Add a ready node, unique ID should be migrated
-    node = Node(client, multisensor_6_state)
+    node = Node(client, copy.deepcopy(multisensor_6_state))
     event = {"node": node}
 
     client.driver.controller.emit("node added", event)
@@ -91,7 +93,7 @@ async def test_unique_id_migration(hass, multisensor_6_state, client, integratio
     assert entity_entry.unique_id == old_unique_id
 
     # Add a ready node, unique ID should be migrated
-    node = Node(client, multisensor_6_state)
+    node = Node(client, copy.deepcopy(multisensor_6_state))
     event = {"node": node}
 
     client.driver.controller.emit("node added", event)
@@ -135,7 +137,7 @@ async def test_unique_id_migration_property_key(
     assert entity_entry.unique_id == old_unique_id
 
     # Add a ready node, unique ID should be migrated
-    node = Node(client, hank_binary_switch_state)
+    node = Node(client, copy.deepcopy(hank_binary_switch_state))
     event = {"node": node}
 
     client.driver.controller.emit("node added", event)
@@ -170,7 +172,7 @@ async def test_unique_id_migration_notification_binary_sensor(
     assert entity_entry.unique_id == old_unique_id
 
     # Add a ready node, unique ID should be migrated
-    node = Node(client, multisensor_6_state)
+    node = Node(client, copy.deepcopy(multisensor_6_state))
     event = {"node": node}
 
     client.driver.controller.emit("node added", event)
@@ -187,12 +189,15 @@ async def test_old_entity_migration(
     hass, hank_binary_switch_state, client, integration
 ):
     """Test old entity on a different endpoint is migrated to a new one."""
-    node = Node(client, hank_binary_switch_state)
+    node = Node(client, copy.deepcopy(hank_binary_switch_state))
 
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_or_create(
-        config_entry_id=integration.entry_id, identifiers={get_device_id(client, node)}
+        config_entry_id=integration.entry_id,
+        identifiers={get_device_id(client, node)},
+        manufacturer=hank_binary_switch_state["deviceConfig"]["manufacturer"],
+        model=hank_binary_switch_state["deviceConfig"]["label"],
     )
 
     SENSOR_NAME = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed"
@@ -230,12 +235,15 @@ async def test_different_endpoint_migration_status_sensor(
     hass, hank_binary_switch_state, client, integration
 ):
     """Test that the different endpoint migration logic skips over the status sensor."""
-    node = Node(client, hank_binary_switch_state)
+    node = Node(client, copy.deepcopy(hank_binary_switch_state))
 
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_or_create(
-        config_entry_id=integration.entry_id, identifiers={get_device_id(client, node)}
+        config_entry_id=integration.entry_id,
+        identifiers={get_device_id(client, node)},
+        manufacturer=hank_binary_switch_state["deviceConfig"]["manufacturer"],
+        model=hank_binary_switch_state["deviceConfig"]["label"],
     )
 
     SENSOR_NAME = "sensor.smart_plug_with_two_usb_ports_status_sensor"
@@ -271,12 +279,15 @@ async def test_skip_old_entity_migration_for_multiple(
     hass, hank_binary_switch_state, client, integration
 ):
     """Test that multiple entities of the same value but on a different endpoint get skipped."""
-    node = Node(client, hank_binary_switch_state)
+    node = Node(client, copy.deepcopy(hank_binary_switch_state))
 
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_or_create(
-        config_entry_id=integration.entry_id, identifiers={get_device_id(client, node)}
+        config_entry_id=integration.entry_id,
+        identifiers={get_device_id(client, node)},
+        manufacturer=hank_binary_switch_state["deviceConfig"]["manufacturer"],
+        model=hank_binary_switch_state["deviceConfig"]["label"],
     )
 
     SENSOR_NAME = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed"
@@ -328,12 +339,15 @@ async def test_old_entity_migration_notification_binary_sensor(
     hass, multisensor_6_state, client, integration
 ):
     """Test old entity on a different endpoint is migrated to a new one for a notification binary sensor."""
-    node = Node(client, multisensor_6_state)
+    node = Node(client, copy.deepcopy(multisensor_6_state))
 
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_or_create(
-        config_entry_id=integration.entry_id, identifiers={get_device_id(client, node)}
+        config_entry_id=integration.entry_id,
+        identifiers={get_device_id(client, node)},
+        manufacturer=multisensor_6_state["deviceConfig"]["manufacturer"],
+        model=multisensor_6_state["deviceConfig"]["label"],
     )
 
     entity_name = NOTIFICATION_MOTION_BINARY_SENSOR.split(".")[1]


### PR DESCRIPTION
## Proposed change
When a failed node is replaced, we would previously remove the HA device when we received the `node removed` event and then create a new HA device when we saw the `node added` event. The end result was that any device customizations would be lost if you replaced a failed node with the same zwave device.

In this PR, we allow the HA device to remain when the `node removed` event has a `replaced` of `True`. When a zwave device gets added with that same node ID, we check if the device entry matches the node, and if not we remove the node before moving forward. This eliminates the problem above while also ensuring that replacing a failed node with a completely new zwave device will result in a new device.

@kpine discovered that we were missing the `replaced` parameter in the event callback in the server, so this feature only works with servers that include that parameter. For servers that don't have the fix, this code will fall back to the old logic, so users who haven't updated the addon just won't see the change until they do.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
