### PR TITLE
Use SurePetcareEntity for surepetcare binary sensor

### DIFF
--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -1,8 +1,6 @@
 """Support for Sure PetCare Flaps/Pets binary sensors."""
 from __future__ import annotations
 
-from abc import abstractmethod
-import logging
 from typing import cast
 
 from surepy.entities import SurepyEntity
@@ -17,14 +15,10 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
 
+from . import SurePetcareDataCoordinator
 from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
+from .entity import SurePetcareEntity
 
 
 async def async_setup_entry(
@@ -34,7 +28,7 @@ async def async_setup_entry(
 
     entities: list[SurePetcareBinarySensor] = []
 
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: SurePetcareDataCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     for surepy_entity in coordinator.data.values():
 
@@ -54,41 +48,19 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SurePetcareBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class SurePetcareBinarySensor(SurePetcareEntity, BinarySensorEntity):
     """A binary sensor implementation for Sure Petcare Entities."""
 
     def __init__(
         self,
-        _id: int,
-        coordinator: DataUpdateCoordinator,
+        surepetcare_id: int,
+        coordinator: SurePetcareDataCoordinator,
     ) -> None:
         """Initialize a Sure Petcare binary sensor."""
-        super().__init__(coordinator)
+        super().__init__(surepetcare_id, coordinator)
 
-        self._id = _id
-
-        surepy_entity: SurepyEntity = coordinator.data[_id]
-
-        # cover special case where a device has no name set
-        if surepy_entity.name:
-            name = surepy_entity.name
-        else:
-            name = f"Unnamed {surepy_entity.type.name.capitalize()}"
-
-        self._attr_name = f"{surepy_entity.type.name.capitalize()} {name.capitalize()}"
-        self._attr_unique_id = f"{surepy_entity.household_id}-{_id}"
-        self._update_attr(coordinator.data[_id])
-
-    @abstractmethod
-    @callback
-    def _update_attr(self, surepy_entity: SurepyEntity) -> None:
-        """Update the state and attributes."""
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Get the latest data and update the state."""
-        self._update_attr(self.coordinator.data[self._id])
-        self.async_write_ha_state()
+        self._attr_name = self._device_name
+        self._attr_unique_id = self._device_id
 
 
 class Hub(SurePetcareBinarySensor):
@@ -115,7 +87,6 @@ class Hub(SurePetcareBinarySensor):
             }
         else:
             self._attr_extra_state_attributes = {}
-        _LOGGER.debug("%s -> state: %s", self.name, state)
 
 
 class Pet(SurePetcareBinarySensor):
@@ -139,7 +110,6 @@ class Pet(SurePetcareBinarySensor):
             }
         else:
             self._attr_extra_state_attributes = {}
-        _LOGGER.debug("%s -> state: %s", self.name, state)
 
 
 class DeviceConnectivity(SurePetcareBinarySensor):
@@ -149,15 +119,13 @@ class DeviceConnectivity(SurePetcareBinarySensor):
 
     def __init__(
         self,
-        _id: int,
-        coordinator: DataUpdateCoordinator,
+        surepetcare_id: int,
+        coordinator: SurePetcareDataCoordinator,
     ) -> None:
         """Initialize a Sure Petcare Device."""
-        super().__init__(_id, coordinator)
-        self._attr_name = f"{self.name}_connectivity"
-        self._attr_unique_id = (
-            f"{self.coordinator.data[self._id].household_id}-{self._id}-connectivity"
-        )
+        super().__init__(surepetcare_id, coordinator)
+        self._attr_name = f"{self._device_name} Connectivity"
+        self._attr_unique_id = f"{self._device_id}-connectivity"
 
     @callback
     def _update_attr(self, surepy_entity: SurepyEntity) -> None:
@@ -170,4 +138,3 @@ class DeviceConnectivity(SurePetcareBinarySensor):
             }
         else:
             self._attr_extra_state_attributes = {}
-        _LOGGER.debug("%s -> state: %s", self.name, state)

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -7,11 +7,11 @@ from homeassistant.setup import async_setup_component
 from . import HOUSEHOLD_ID, HUB_ID, MOCK_CONFIG
 
 EXPECTED_ENTITY_IDS = {
-    "binary_sensor.pet_flap_pet_flap_connectivity": f"{HOUSEHOLD_ID}-13576-connectivity",
-    "binary_sensor.cat_flap_cat_flap_connectivity": f"{HOUSEHOLD_ID}-13579-connectivity",
-    "binary_sensor.feeder_feeder_connectivity": f"{HOUSEHOLD_ID}-12345-connectivity",
-    "binary_sensor.pet_pet": f"{HOUSEHOLD_ID}-24680",
-    "binary_sensor.hub_hub": f"{HOUSEHOLD_ID}-{HUB_ID}",
+    "binary_sensor.pet_flap_connectivity": f"{HOUSEHOLD_ID}-13576-connectivity",
+    "binary_sensor.cat_flap_connectivity": f"{HOUSEHOLD_ID}-13579-connectivity",
+    "binary_sensor.feeder_connectivity": f"{HOUSEHOLD_ID}-12345-connectivity",
+    "binary_sensor.pet": f"{HOUSEHOLD_ID}-24680",
+    "binary_sensor.hub": f"{HOUSEHOLD_ID}-{HUB_ID}",
 }
 
 


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use SurePetcareEntity for surepetcare binary sensor.
Simplify the names

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
