### PR TITLE
Add device_info to `Speedtestdotnet` and some code cleanup

### DIFF
--- a/homeassistant/components/speedtestdotnet/__init__.py
+++ b/homeassistant/components/speedtestdotnet/__init__.py
@@ -83,6 +83,11 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator):
             update_method=self.async_update,
         )
 
+    def initialize(self) -> None:
+        """Initialize speedtest api."""
+        self.api = speedtest.Speedtest()
+        self.update_servers()
+
     def update_servers(self):
         """Update list of test servers."""
         test_servers = self.api.get_servers()
@@ -131,8 +136,7 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator):
     async def async_setup(self) -> None:
         """Set up SpeedTest."""
         try:
-            self.api = await self.hass.async_add_executor_job(speedtest.Speedtest)
-            await self.hass.async_add_executor_job(self.update_servers)
+            await self.hass.async_add_executor_job(self.initialize)
         except speedtest.SpeedtestException as err:
             raise ConfigEntryNotReady from err
 

--- a/homeassistant/components/speedtestdotnet/const.py
+++ b/homeassistant/components/speedtestdotnet/const.py
@@ -28,7 +28,7 @@ SENSOR_TYPES: Final[tuple[SpeedtestSensorEntityDescription, ...]] = (
         name="Ping",
         native_unit_of_measurement=TIME_MILLISECONDS,
         state_class=STATE_CLASS_MEASUREMENT,
-        value=lambda value: round(value, 2),
+        value=lambda value: round(value),
     ),
     SpeedtestSensorEntityDescription(
         key="download",

--- a/homeassistant/components/speedtestdotnet/const.py
+++ b/homeassistant/components/speedtestdotnet/const.py
@@ -28,7 +28,6 @@ SENSOR_TYPES: Final[tuple[SpeedtestSensorEntityDescription, ...]] = (
         name="Ping",
         native_unit_of_measurement=TIME_MILLISECONDS,
         state_class=STATE_CLASS_MEASUREMENT,
-        value=lambda value: round(value),
     ),
     SpeedtestSensorEntityDescription(
         key="download",

--- a/homeassistant/components/speedtestdotnet/const.py
+++ b/homeassistant/components/speedtestdotnet/const.py
@@ -1,7 +1,8 @@
-"""Consts used by Speedtest.net."""
+"""Constants used by Speedtest.net."""
 from __future__ import annotations
 
-from typing import Final
+from dataclasses import dataclass
+from typing import Callable, Final
 
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
@@ -13,24 +14,35 @@ DOMAIN: Final = "speedtestdotnet"
 
 SPEED_TEST_SERVICE: Final = "speedtest"
 
-SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
-    SensorEntityDescription(
+
+@dataclass
+class SpeedtestSensorEntityDescription(SensorEntityDescription):
+    """Class describing Speedtest sensor entities."""
+
+    value: Callable = round
+
+
+SENSOR_TYPES: Final[tuple[SpeedtestSensorEntityDescription, ...]] = (
+    SpeedtestSensorEntityDescription(
         key="ping",
         name="Ping",
         native_unit_of_measurement=TIME_MILLISECONDS,
         state_class=STATE_CLASS_MEASUREMENT,
+        value=lambda value: round(value, 2),
     ),
-    SensorEntityDescription(
+    SpeedtestSensorEntityDescription(
         key="download",
         name="Download",
         native_unit_of_measurement=DATA_RATE_MEGABITS_PER_SECOND,
         state_class=STATE_CLASS_MEASUREMENT,
+        value=lambda value: round(value / 10 ** 6, 2),
     ),
-    SensorEntityDescription(
+    SpeedtestSensorEntityDescription(
         key="upload",
         name="Upload",
         native_unit_of_measurement=DATA_RATE_MEGABITS_PER_SECOND,
         state_class=STATE_CLASS_MEASUREMENT,
+        value=lambda value: round(value / 10 ** 6, 2),
     ),
 )
 

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -61,7 +61,7 @@ class SpeedtestSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         self._state: StateType = None
         self._attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, "Speed Test")},
+            "identifiers": {(DOMAIN, self.coordinator.config_entry.entry_id)},
             "name": DEFAULT_NAME,
             "entry_type": "service",
         }

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -1,15 +1,16 @@
 """Support for Speedtest.net internet speed testing sensor."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.speedtestdotnet import SpeedTestDataCoordinator
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
@@ -23,6 +24,7 @@ from .const import (
     DOMAIN,
     ICON,
     SENSOR_TYPES,
+    SpeedtestSensorEntityDescription,
 )
 
 
@@ -43,12 +45,13 @@ class SpeedtestSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
     """Implementation of a speedtest.net sensor."""
 
     coordinator: SpeedTestDataCoordinator
+    entity_description: SpeedtestSensorEntityDescription
     _attr_icon = ICON
 
     def __init__(
         self,
         coordinator: SpeedTestDataCoordinator,
-        description: SensorEntityDescription,
+        description: SpeedtestSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -56,6 +59,17 @@ class SpeedtestSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         self._attr_name = f"{DEFAULT_NAME} {description.name}"
         self._attr_unique_id = description.key
         self._attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, "Speed Test")},
+            "name": DEFAULT_NAME,
+            "entry_type": "service",
+        }
+
+    @property
+    def native_value(self) -> StateType:
+        """Return native value for entity."""
+        state = self.coordinator.data[self.entity_description.key]
+        return cast(StateType, self.entity_description.value(state))
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -84,26 +98,3 @@ class SpeedtestSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         state = await self.async_get_last_state()
         if state:
             self._attr_native_value = state.state
-
-        @callback
-        def update() -> None:
-            """Update state."""
-            self._update_state()
-            self.async_write_ha_state()
-
-        self.async_on_remove(self.coordinator.async_add_listener(update))
-        self._update_state()
-
-    def _update_state(self):
-        """Update sensors state."""
-        if self.coordinator.data:
-            if self.entity_description.key == "ping":
-                self._attr_native_value = self.coordinator.data["ping"]
-            elif self.entity_description.key == "download":
-                self._attr_native_value = round(
-                    self.coordinator.data["download"] / 10 ** 6, 2
-                )
-            elif self.entity_description.key == "upload":
-                self._attr_native_value = round(
-                    self.coordinator.data["upload"] / 10 ** 6, 2
-                )

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -68,8 +68,12 @@ class SpeedtestSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return native value for entity."""
-        state = self.coordinator.data[self.entity_description.key]
-        return cast(StateType, self.entity_description.value(state))
+        if self.coordinator.data:
+            state = self.coordinator.data[self.entity_description.key]
+            self._attr_native_value = cast(
+                StateType, self.entity_description.value(state)
+            )
+        return self._attr_native_value
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -58,6 +58,7 @@ class SpeedtestSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         self.entity_description = description
         self._attr_name = f"{DEFAULT_NAME} {description.name}"
         self._attr_unique_id = description.key
+        self._state: StateType = None
         self._attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
         self._attr_device_info = {
             "identifiers": {(DOMAIN, "Speed Test")},
@@ -70,10 +71,8 @@ class SpeedtestSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         """Return native value for entity."""
         if self.coordinator.data:
             state = self.coordinator.data[self.entity_description.key]
-            self._attr_native_value = cast(
-                StateType, self.entity_description.value(state)
-            )
-        return self._attr_native_value
+            self._state = cast(StateType, self.entity_description.value(state))
+        return self._state
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -101,4 +100,4 @@ class SpeedtestSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         await super().async_added_to_hass()
         state = await self.async_get_last_state()
         if state:
-            self._attr_native_value = state.state
+            self._state = state.state

--- a/tests/components/speedtestdotnet/__init__.py
+++ b/tests/components/speedtestdotnet/__init__.py
@@ -52,4 +52,4 @@ MOCK_RESULTS = {
     "share": None,
 }
 
-MOCK_STATES = {"ping": "18.46", "download": "1.02", "upload": "1.02"}
+MOCK_STATES = {"ping": "18", "download": "1.02", "upload": "1.02"}

--- a/tests/components/speedtestdotnet/__init__.py
+++ b/tests/components/speedtestdotnet/__init__.py
@@ -52,4 +52,4 @@ MOCK_RESULTS = {
     "share": None,
 }
 
-MOCK_STATES = {"ping": "18.465", "download": "1.02", "upload": "1.02"}
+MOCK_STATES = {"ping": "18.46", "download": "1.02", "upload": "1.02"}

--- a/tests/components/speedtestdotnet/test_config_flow.py
+++ b/tests/components/speedtestdotnet/test_config_flow.py
@@ -65,6 +65,28 @@ async def test_options(hass: HomeAssistant, mock_api: MagicMock) -> None:
 
     assert hass.data[DOMAIN].update_interval is None
 
+    # test setting server name to "*Auto Detect"
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SERVER_NAME: "*Auto Detect",
+            CONF_SCAN_INTERVAL: 30,
+            CONF_MANUAL: True,
+        },
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == {
+        CONF_SERVER_NAME: "*Auto Detect",
+        CONF_SERVER_ID: None,
+        CONF_SCAN_INTERVAL: 30,
+        CONF_MANUAL: True,
+    }
+
     # test setting the option to update periodically
     result2 = await hass.config_entries.options.async_init(entry.entry_id)
     assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/components/speedtestdotnet/test_sensor.py
+++ b/tests/components/speedtestdotnet/test_sensor.py
@@ -3,12 +3,16 @@ from unittest.mock import MagicMock
 
 from homeassistant.components import speedtestdotnet
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.components.speedtestdotnet.const import DEFAULT_NAME, SENSOR_TYPES
-from homeassistant.core import HomeAssistant
+from homeassistant.components.speedtestdotnet.const import (
+    CONF_MANUAL,
+    DEFAULT_NAME,
+    SENSOR_TYPES,
+)
+from homeassistant.core import HomeAssistant, State
 
 from . import MOCK_RESULTS, MOCK_SERVERS, MOCK_STATES
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, mock_restore_cache
 
 
 async def test_speedtestdotnet_sensors(
@@ -28,5 +32,30 @@ async def test_speedtestdotnet_sensors(
 
     for description in SENSOR_TYPES:
         sensor = hass.states.get(f"sensor.{DEFAULT_NAME}_{description.name}")
+        assert sensor
+        assert sensor.state == MOCK_STATES[description.key]
+
+
+async def test_restore_last_state(hass: HomeAssistant, mock_api: MagicMock) -> None:
+    """Test restoring last state for sensors."""
+    mock_restore_cache(
+        hass,
+        [
+            State(f"sensor.speedtest_{sensor}", state)
+            for sensor, state in MOCK_STATES.items()
+        ],
+    )
+    entry = MockConfigEntry(
+        domain=speedtestdotnet.DOMAIN, data={}, options={CONF_MANUAL: True}
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
+
+    for description in SENSOR_TYPES:
+        sensor = hass.states.get(f"sensor.speedtest_{description.name}")
         assert sensor
         assert sensor.state == MOCK_STATES[description.key]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Add `device_info` as service entry.
- Code cleanup based on suggestions from previous PRs

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
