### PR TITLE
Migrate TP-Link devices to their own config entry - part 2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1096,11 +1096,8 @@ omit =
     homeassistant/components/totalconnect/binary_sensor.py
     homeassistant/components/totalconnect/const.py
     homeassistant/components/touchline/climate.py
-    homeassistant/components/tplink/__init__.py
     homeassistant/components/tplink/coordinator.py
-    homeassistant/components/tplink/entity.py
     homeassistant/components/tplink/light.py
-    homeassistant/components/tplink/sensor.py
     homeassistant/components/tplink/switch.py
     homeassistant/components/tplink_lte/*
     homeassistant/components/traccar/device_tracker.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1100,7 +1100,6 @@ omit =
     homeassistant/components/tplink/coordinator.py
     homeassistant/components/tplink/entity.py
     homeassistant/components/tplink/light.py
-    homeassistant/components/tplink/migration.py
     homeassistant/components/tplink/sensor.py
     homeassistant/components/tplink/switch.py
     homeassistant/components/tplink_lte/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1096,9 +1096,6 @@ omit =
     homeassistant/components/totalconnect/binary_sensor.py
     homeassistant/components/totalconnect/const.py
     homeassistant/components/touchline/climate.py
-    homeassistant/components/tplink/coordinator.py
-    homeassistant/components/tplink/light.py
-    homeassistant/components/tplink/switch.py
     homeassistant/components/tplink_lte/*
     homeassistant/components/traccar/device_tracker.py
     homeassistant/components/traccar/const.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1097,8 +1097,10 @@ omit =
     homeassistant/components/totalconnect/const.py
     homeassistant/components/touchline/climate.py
     homeassistant/components/tplink/__init__.py
-    homeassistant/components/tplink/common.py
+    homeassistant/components/tplink/coordinator.py
+    homeassistant/components/tplink/entity.py
     homeassistant/components/tplink/light.py
+    homeassistant/components/tplink/migration.py
     homeassistant/components/tplink/sensor.py
     homeassistant/components/tplink/switch.py
     homeassistant/components/tplink_lte/*

--- a/.strict-typing
+++ b/.strict-typing
@@ -107,6 +107,7 @@ homeassistant.components.tag.*
 homeassistant.components.tautulli.*
 homeassistant.components.tcp.*
 homeassistant.components.tile.*
+homeassistant.components.tplink.*
 homeassistant.components.tradfri.*
 homeassistant.components.tts.*
 homeassistant.components.upcloud.*

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -11,8 +11,7 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigEntryNotReady
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -36,25 +35,28 @@ from .utils import async_entry_is_legacy
 TPLINK_HOST_SCHEMA = vol.Schema({vol.Required(CONF_HOST): cv.string})
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Optional(CONF_LIGHT, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_SWITCH, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_STRIP, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_DIMMER, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
-            }
-        )
-    },
+    vol.All(
+        cv.deprecated(DOMAIN),
+        {
+            DOMAIN: vol.Schema(
+                {
+                    vol.Optional(CONF_LIGHT, default=[]): vol.All(
+                        cv.ensure_list, [TPLINK_HOST_SCHEMA]
+                    ),
+                    vol.Optional(CONF_SWITCH, default=[]): vol.All(
+                        cv.ensure_list, [TPLINK_HOST_SCHEMA]
+                    ),
+                    vol.Optional(CONF_STRIP, default=[]): vol.All(
+                        cv.ensure_list, [TPLINK_HOST_SCHEMA]
+                    ),
+                    vol.Optional(CONF_DIMMER, default=[]): vol.All(
+                        cv.ensure_list, [TPLINK_HOST_SCHEMA]
+                    ),
+                    vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
+                }
+            )
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
 

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -32,6 +32,7 @@ from .migration import (
     async_migrate_legacy_entries,
     async_migrate_yaml_entries,
 )
+from .utils import async_entry_is_legacy
 
 TPLINK_HOST_SCHEMA = vol.Schema({vol.Required(CONF_HOST): cv.string})
 
@@ -87,7 +88,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     legacy_entry = None
     config_entries_by_mac = {}
     for entry in hass.config_entries.async_entries(DOMAIN):
-        if entry.unique_id is None or entry.unique_id == DOMAIN:
+        if async_entry_is_legacy(entry):
             legacy_entry = entry
         else:
             config_entries_by_mac[entry.unique_id] = entry
@@ -112,7 +113,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up TPLink from a config entry."""
-    if not entry.unique_id or entry.unique_id == DOMAIN:
+    if async_entry_is_legacy(entry):
         return True
 
     if legacy_entry_id := entry.data.get(CONF_LEGACY_ENTRY_ID):

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -1,8 +1,6 @@
 """Component to embed TP-Link smart home devices."""
 from __future__ import annotations
 
-from datetime import timedelta
-import logging
 from typing import Any
 
 from kasa import SmartDevice, SmartDeviceException
@@ -12,21 +10,15 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigEntryNotReady
-from homeassistant.const import ATTR_VOLTAGE, CONF_HOST, CONF_MAC, CONF_NAME
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
-    ATTR_CURRENT_A,
-    ATTR_CURRENT_POWER_W,
-    ATTR_TODAY_ENERGY_KWH,
-    ATTR_TOTAL_ENERGY_KWH,
     CONF_DIMMER,
     CONF_DISCOVERY,
-    CONF_EMETER_PARAMS,
     CONF_LEGACY_ENTRY_ID,
     CONF_LIGHT,
     CONF_STRIP,
@@ -35,13 +27,12 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
+from .coordinator import TPLinkDataUpdateCoordinator
 from .migration import (
     async_migrate_entities_devices,
     async_migrate_legacy_entries,
     async_migrate_yaml_entries,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 TPLINK_HOST_SCHEMA = vol.Schema({vol.Required(CONF_HOST): cv.string})
 
@@ -152,56 +143,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if entry.entry_id in hass_data:
             hass_data.pop(entry.entry_id)
     return unload_ok
-
-
-class TPLinkDataUpdateCoordinator(DataUpdateCoordinator):
-    """DataUpdateCoordinator to gather data for specific SmartPlug."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        device: SmartDevice,
-    ) -> None:
-        """Initialize DataUpdateCoordinator to gather data for specific SmartPlug."""
-        self.device = device
-        self.update_children = True
-        update_interval = timedelta(seconds=10)
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=device.host,
-            update_interval=update_interval,
-        )
-
-    async def _async_update_data(self) -> dict:
-        """Fetch all device and sensor data from api."""
-        try:
-            await self.device.update(update_children=self.update_children)
-        except SmartDeviceException as ex:
-            raise UpdateFailed(ex) from ex
-        else:
-            self.update_children = True
-
-        self.name = self.device.alias
-
-        # Check if the device has emeter
-        if not self.device.has_emeter:
-            return {}
-
-        if (emeter_today := self.device.emeter_today) is not None:
-            consumption_today = emeter_today
-        else:
-            # today's consumption not available, when device was off all the day
-            # bulb's do not report this information, so filter it out
-            consumption_today = None if self.device.is_bulb else 0.0
-
-        emeter_readings = self.device.emeter_realtime
-        return {
-            CONF_EMETER_PARAMS: {
-                ATTR_CURRENT_POWER_W: emeter_readings.power,
-                ATTR_TOTAL_ENERGY_KWH: emeter_readings.total,
-                ATTR_VOLTAGE: emeter_readings.voltage,
-                ATTR_CURRENT_A: emeter_readings.current,
-                ATTR_TODAY_ENERGY_KWH: consumption_today,
-            }
-        }

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -83,7 +83,7 @@ def async_trigger_discovery(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the TP-Link component."""
     conf = config.get(DOMAIN)
-    hass.data[DOMAIN] = {}
+    domain_data = hass.data[DOMAIN] = {}
 
     legacy_entry = None
     config_entries_by_mac = {}
@@ -93,11 +93,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         else:
             config_entries_by_mac[entry.unique_id] = entry
 
-    discovered_devices = {
+    domain_data[DISCOVERED_DEVICES] = {
         dr.format_mac(device.mac): device
         for device in (await Discover.discover()).values()
     }
-    hass.data[DOMAIN][DISCOVERED_DEVICES] = discovered_devices
 
     if legacy_entry:
         async_migrate_legacy_entries(hass, config_entries_by_mac, legacy_entry)
@@ -105,8 +104,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if conf is not None:
         async_migrate_yaml_entries(hass, conf)
 
-    if discovered_devices:
-        async_trigger_discovery(hass, discovered_devices)
+    if domain_data[DISCOVERED_DEVICES]:
+        async_trigger_discovery(hass, domain_data[DISCOVERED_DEVICES])
 
     return True
 

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -139,7 +139,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     hass_data: dict[str, Any] = hass.data[DOMAIN]
+    if entry.entry_id not in hass_data:
+        return True
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        if entry.entry_id in hass_data:
-            hass_data.pop(entry.entry_id)
+        hass_data.pop(entry.entry_id)
     return unload_ok

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -90,7 +90,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     for entry in hass.config_entries.async_entries(DOMAIN):
         if async_entry_is_legacy(entry):
             legacy_entry = entry
-        else:
+        elif entry.unique_id:
             config_entries_by_mac[entry.unique_id] = entry
 
     domain_data[DISCOVERED_DEVICES] = {

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -18,7 +18,6 @@ from homeassistant.helpers.typing import ConfigType
 from .const import (
     CONF_DIMMER,
     CONF_DISCOVERY,
-    CONF_LEGACY_ENTRY_ID,
     CONF_LIGHT,
     CONF_STRIP,
     CONF_SWITCH,
@@ -115,8 +114,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if async_entry_is_legacy(entry):
         return True
 
-    if legacy_entry_id := entry.data.get(CONF_LEGACY_ENTRY_ID):
-        await async_migrate_entities_devices(hass, legacy_entry_id, entry)
+    legacy_entry: ConfigEntry | None = None
+    for config_entry in hass.config_entries.async_entries(DOMAIN):
+        if async_entry_is_legacy(config_entry):
+            legacy_entry = config_entry
+            break
+
+    if legacy_entry is not None:
+        await async_migrate_entities_devices(hass, legacy_entry.entry_id, entry)
 
     try:
         device: SmartDevice = await Discover.discover_single(entry.data[CONF_HOST])

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -1,133 +1,16 @@
 """Common code for tplink."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
-from kasa import Discover, SmartDevice, SmartDeviceException
+from kasa import SmartDevice
 
-from homeassistant.core import HomeAssistant
-import homeassistant.helpers.device_registry as dr
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
-
-from .const import (
-    CONF_DIMMER,
-    CONF_LIGHT,
-    CONF_STRIP,
-    CONF_SWITCH,
-    MAX_DISCOVERY_RETRIES,
-)
-
-_LOGGER = logging.getLogger(__name__)
-
-
-class SmartDevices:
-    """Hold different kinds of devices."""
-
-    def __init__(
-        self, lights: list[SmartDevice] = None, switches: list[SmartDevice] = None
-    ) -> None:
-        """Initialize device holder."""
-        self._lights = lights or []
-        self._switches = switches or []
-
-    @property
-    def lights(self) -> list[SmartDevice]:
-        """Get the lights."""
-        return self._lights
-
-    @property
-    def switches(self) -> list[SmartDevice]:
-        """Get the switches."""
-        return self._switches
-
-    def has_device_with_host(self, host: str) -> bool:
-        """Check if a devices exists with a specific host."""
-        return any(device.host == host for device in self.lights + self.switches)
-
-
-async def async_get_discoverable_devices(hass: HomeAssistant) -> dict[str, SmartDevice]:
-    """Return if there are devices that can be discovered."""
-    return await Discover.discover()
-
-
-async def async_discover_devices(
-    hass: HomeAssistant, existing_devices: SmartDevices, target_device_count: int
-) -> SmartDevices:
-    """Get devices through discovery."""
-
-    lights = []
-    switches = []
-
-    # We do retries since UDP packets over wifi can get lost
-    devices: dict[str, SmartDevice] = {}
-    for attempt in range(1, MAX_DISCOVERY_RETRIES + 1):
-        _LOGGER.debug(
-            "Discovering tplink devices, attempt %s of %s",
-            attempt,
-            MAX_DISCOVERY_RETRIES,
-        )
-        discovered_devices = await async_get_discoverable_devices(hass)
-        _LOGGER.debug(
-            "Discovered %s TP-Link of expected %s smart home device(s)",
-            len(discovered_devices),
-            target_device_count,
-        )
-        for device_ip in discovered_devices:
-            devices[device_ip] = discovered_devices[device_ip]
-
-        if len(discovered_devices) >= target_device_count:
-            _LOGGER.debug(
-                "Discovered at least as many devices on the network as exist in our device registry, no need to retry"
-            )
-            break
-
-    _LOGGER.debug(
-        "Found %s unique TP-Link smart home device(s) after %s discovery attempts",
-        len(devices),
-        attempt,
-    )
-
-    for device in devices.values():
-        # If this device already exists, ignore dynamic setup.
-        if existing_devices.has_device_with_host(device.host):
-            continue
-
-        if device.is_strip or device.is_plug:
-            switches.append(device)
-        elif device.is_bulb or device.is_light_strip or device.is_dimmer:
-            lights.append(device)
-        else:
-            _LOGGER.error("Unknown smart device type: %s", type(device))
-
-    return SmartDevices(lights, switches)
-
-
-async def get_static_devices(config_data) -> SmartDevices:
-    """Get statically defined devices in the config."""
-    lights = []
-    switches = []
-
-    for type_ in (CONF_LIGHT, CONF_SWITCH, CONF_STRIP, CONF_DIMMER):
-        for entry in config_data[type_]:
-            host = entry["host"]
-            try:
-                device: SmartDevice = await Discover.discover_single(host)
-                if device.is_bulb or device.is_light_strip or device.is_dimmer:
-                    _LOGGER.debug("Found static light: %s", device)
-                    lights.append(device)
-                elif device.is_plug or device.is_strip:
-                    _LOGGER.debug("Found static switch: %s", device)
-                    switches.append(device)
-            except SmartDeviceException as sde:
-                _LOGGER.error(
-                    "Failed to setup device %s due to %s; not retrying", host, sde
-                )
-    return SmartDevices(lights, switches)
 
 
 class CoordinatedTPLinkEntity(CoordinatorEntity):

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -173,7 +173,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             device = await self._async_try_connect(host, raise_on_progress=False)
         except SmartDeviceException:
-            _LOGGER.error("Failed to import %s: cannot connect", host)
+            _LOGGER.exception("Failed to import %s: cannot connect", host)
             return self.async_abort(reason="cannot_connect")
         return self._async_create_entry_from_device(device)
 

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -159,7 +159,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def _async_create_entry_from_device(self, device: SmartDevice) -> FlowResult:
         """Create a config entry from a smart device."""
-        self._abort_if_unique_id_configured()
+        self._abort_if_unique_id_configured(updates={CONF_HOST: device.host})
         return self.async_create_entry(
             title=f"{device.alias} {device.model}",
             data={

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import CONF_LEGACY_ENTRY_ID, DISCOVERED_DEVICES, DOMAIN
+from .utils import async_entry_is_legacy
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,7 +129,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         configured_devices = {
             entry.unique_id
             for entry in self._async_current_entries()
-            if entry.unique_id
+            if not async_entry_is_legacy(entry)
         }
         self._discovered_devices = {
             dr.format_mac(device.mac): device

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -1,11 +1,191 @@
 """Config flow for TP-Link."""
-from homeassistant.helpers import config_entry_flow
+from __future__ import annotations
 
-from .common import async_get_discoverable_devices
-from .const import DOMAIN
+import logging
 
-config_entry_flow.register_discovery_flow(
-    DOMAIN,
-    "TP-Link Smart Home",
-    async_get_discoverable_devices,
-)
+from kasa import SmartDevice, SmartDeviceException
+from kasa.discover import Discover
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components.dhcp import IP_ADDRESS, MAC_ADDRESS
+from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_MAC, CONF_NAME
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.typing import DiscoveryInfoType
+
+from .const import CONF_LEGACY_ENTRY_ID, DISCOVERED_DEVICES, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for tplink."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovered_devices: dict[str, SmartDevice] = {}
+        self._discovered_device: SmartDevice | None = None
+        self._discovered_ip: str | None = None
+
+    async def async_step_dhcp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
+        """Handle discovery via dhcp."""
+        self.context[CONF_HOST] = self._discovered_ip = discovery_info[IP_ADDRESS]
+        await self.async_set_unique_id(dr.format_mac(discovery_info[MAC_ADDRESS]))
+        return await self._async_handle_discovery()
+
+    async def async_step_discovery(self, discovery_info) -> FlowResult:
+        """Handle discovery."""
+        self.context[CONF_HOST] = self._discovered_ip = discovery_info[CONF_HOST]
+        await self.async_set_unique_id(dr.format_mac(discovery_info[CONF_MAC]))
+        return await self._async_handle_discovery()
+
+    async def _async_handle_discovery(self) -> FlowResult:
+        """Handle any discovery."""
+        self._abort_if_unique_id_configured(updates={CONF_HOST: self._discovered_ip})
+        self._async_abort_entries_match({CONF_HOST: self._discovered_ip})
+        for progress in self._async_in_progress():
+            if progress.get("context", {}).get(CONF_HOST) == self._discovered_ip:
+                return self.async_abort(reason="already_in_progress")
+
+        try:
+            self._discovered_device = await self._async_try_connect(
+                self._discovered_ip, raise_on_progress=True
+            )
+        except SmartDeviceException:
+            return self.async_abort(reason="cannot_connect")
+        return await self.async_step_discovery_confirm()
+
+    async def async_step_discovery_confirm(self, user_input=None) -> FlowResult:
+        """Confirm discovery."""
+        assert self._discovered_device is not None
+        if user_input is not None:
+            return self.async_create_entry(
+                title=f"{self._discovered_device.alias} {self._discovered_device.model}",
+                data={
+                    CONF_HOST: self._discovered_ip,
+                },
+            )
+
+        self._set_confirm_only()
+        placeholders = {
+            "name": self._discovered_device.alias,
+            "model": self._discovered_device.model,
+            "host": self._discovered_ip,
+        }
+        self.context["title_placeholders"] = placeholders
+        return self.async_show_form(
+            step_id="discovery_confirm", description_placeholders=placeholders
+        )
+
+    async def async_step_user(self, user_input=None) -> FlowResult:
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            if not user_input.get(CONF_HOST):
+                return await self.async_step_pick_device()
+            try:
+                device = await self._async_try_connect(
+                    user_input[CONF_HOST], raise_on_progress=False
+                )
+            except SmartDeviceException:
+                errors["base"] = "cannot_connect"
+            else:
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=f"{device.alias} {device.model}",
+                    data={
+                        CONF_HOST: user_input[CONF_HOST],
+                    },
+                )
+
+        user_input = user_input or {}
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {vol.Optional(CONF_HOST, default=user_input.get(CONF_HOST, "")): str}
+            ),
+            errors=errors,
+        )
+
+    async def async_step_pick_device(self, user_input=None) -> FlowResult:
+        """Handle the step to pick discovered device."""
+        if user_input is not None:
+            device_id: str = user_input[CONF_DEVICE]
+            mac = device_id.split(" ")[-1]
+            device: SmartDevice = self._discovered_devices[mac]
+            await self.async_set_unique_id(mac, raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=f"{device.alias} {device.model}",
+                data={
+                    CONF_HOST: device.host,
+                },
+            )
+
+        configured_devices = {
+            entry.unique_id
+            for entry in self._async_current_entries()
+            if entry.unique_id
+        }
+        self._discovered_devices = {
+            dr.format_mac(device.mac): device
+            for device in (await Discover.discover()).values()
+        }
+        devices_name = {
+            f"{device.alias} {device.model} ({device.host}) {formatted_mac}"
+            for formatted_mac, device in self._discovered_devices.items()
+            if formatted_mac not in configured_devices
+        }
+        # Check if there is at least one device
+        if not devices_name:
+            return self.async_abort(reason="no_devices_found")
+        return self.async_show_form(
+            step_id="pick_device",
+            data_schema=vol.Schema({vol.Required(CONF_DEVICE): vol.In(devices_name)}),
+        )
+
+    async def async_step_migration(self, migration_input=None) -> FlowResult:
+        """Handle migration from legacy config entry to per device config entry."""
+        mac = migration_input[CONF_MAC]
+        name = migration_input[CONF_NAME]
+        discovered_devices = self.hass.data[DOMAIN][DISCOVERED_DEVICES]
+        host = None
+        if device := discovered_devices.get(mac):
+            host = device.host
+        await self.async_set_unique_id(dr.format_mac(mac), raise_on_progress=True)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=name,
+            data={
+                CONF_HOST: host,
+                CONF_LEGACY_ENTRY_ID: migration_input[CONF_LEGACY_ENTRY_ID],
+            },
+        )
+
+    async def async_step_import(self, user_input=None) -> FlowResult:
+        """Handle import step."""
+        host = user_input[CONF_HOST]
+        try:
+            device = await self._async_try_connect(host, raise_on_progress=False)
+        except SmartDeviceException:
+            _LOGGER.error("Failed to import %s: cannot connect", host)
+            return self.async_abort(reason="cannot_connect")
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=f"{device.alias} {device.model}",
+            data={
+                CONF_HOST: device.host,
+            },
+        )
+
+    async def _async_try_connect(self, host, raise_on_progress=True) -> SmartDevice:
+        """Try to connect."""
+        self._async_abort_entries_match({CONF_HOST: host})
+        device: SmartDevice = await Discover.discover_single(host)
+        await self.async_set_unique_id(
+            dr.format_mac(device.mac), raise_on_progress=raise_on_progress
+        )
+        return device

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -99,7 +99,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             except SmartDeviceException:
                 errors["base"] = "cannot_connect"
-            return self._async_create_entry_from_device(device)
+            else:
+                return self._async_create_entry_from_device(device)
 
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -147,7 +147,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         host = None
         if device := discovered_devices.get(mac):
             host = device.host
-        await self.async_set_unique_id(dr.format_mac(mac), raise_on_progress=True)
+        await self.async_set_unique_id(dr.format_mac(mac), raise_on_progress=False)
         self._abort_if_unique_id_configured()
         return self.async_create_entry(
             title=name,

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import CONF_LEGACY_ENTRY_ID, DISCOVERED_DEVICES, DOMAIN
+from .const import DISCOVERED_DEVICES, DOMAIN
 from .utils import async_entry_is_legacy
 
 _LOGGER = logging.getLogger(__name__)
@@ -153,7 +153,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             title=name,
             data={
                 CONF_HOST: host,
-                CONF_LEGACY_ENTRY_ID: migration_input[CONF_LEGACY_ENTRY_ID],
             },
         )
 

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -1,23 +1,24 @@
 """Const for TP-Link."""
 from __future__ import annotations
 
+from typing import Final
+
 DOMAIN = "tplink"
 
-ATTR_CURRENT_A = "current_a"
-ATTR_CURRENT_POWER_W = "current_power_w"
-ATTR_TODAY_ENERGY_KWH = "today_energy_kwh"
-ATTR_TOTAL_ENERGY_KWH = "total_energy_kwh"
+ATTR_CURRENT_A: Final = "current_a"
+ATTR_CURRENT_POWER_W: Final = "current_power_w"
+ATTR_TODAY_ENERGY_KWH: Final = "today_energy_kwh"
+ATTR_TOTAL_ENERGY_KWH: Final = "total_energy_kwh"
 
-MAC_ADDRESS_LEN = 17
-CONF_LEGACY_ENTRY_ID = "legacy_entry_id"
-DISCOVERED_DEVICES = "discovered_devices"
+CONF_LEGACY_ENTRY_ID: Final = "legacy_entry_id"
+DISCOVERED_DEVICES: Final = "discovered_devices"
 
-CONF_EMETER_PARAMS = "emeter_params"
-CONF_DIMMER = "dimmer"
-CONF_DISCOVERY = "discovery"
-CONF_LIGHT = "light"
-CONF_STRIP = "strip"
-CONF_SWITCH = "switch"
-CONF_SENSOR = "sensor"
+CONF_EMETER_PARAMS: Final = "emeter_params"
+CONF_DIMMER: Final = "dimmer"
+CONF_DISCOVERY: Final = "discovery"
+CONF_LIGHT: Final = "light"
+CONF_STRIP: Final = "strip"
+CONF_SWITCH: Final = "switch"
+CONF_SENSOR: Final = "sensor"
 
-PLATFORMS = [CONF_LIGHT, CONF_SENSOR, CONF_SWITCH]
+PLATFORMS: Final = [CONF_LIGHT, CONF_SENSOR, CONF_SWITCH]

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -10,7 +10,6 @@ ATTR_CURRENT_POWER_W: Final = "current_power_w"
 ATTR_TODAY_ENERGY_KWH: Final = "today_energy_kwh"
 ATTR_TOTAL_ENERGY_KWH: Final = "total_energy_kwh"
 
-CONF_LEGACY_ENTRY_ID: Final = "legacy_entry_id"
 DISCOVERED_DEVICES: Final = "discovered_devices"
 
 CONF_EMETER_PARAMS: Final = "emeter_params"

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -1,22 +1,17 @@
 """Const for TP-Link."""
 from __future__ import annotations
 
-import datetime
-
 DOMAIN = "tplink"
-COORDINATORS = "coordinators"
-UNAVAILABLE_DEVICES = "unavailable_devices"
-UNAVAILABLE_RETRY_DELAY = datetime.timedelta(seconds=300)
 
-MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=8)
-MAX_DISCOVERY_RETRIES = 4
-
-ATTR_CONFIG = "config"
-ATTR_TOTAL_ENERGY_KWH = "total_energy_kwh"
 ATTR_CURRENT_A = "current_a"
+ATTR_CURRENT_POWER_W = "current_power_w"
+ATTR_TODAY_ENERGY_KWH = "today_energy_kwh"
+ATTR_TOTAL_ENERGY_KWH = "total_energy_kwh"
 
-CONF_MODEL = "model"
-CONF_SW_VERSION = "sw_ver"
+MAC_ADDRESS_LEN = 17
+CONF_LEGACY_ENTRY_ID = "legacy_entry_id"
+DISCOVERED_DEVICES = "discovered_devices"
+
 CONF_EMETER_PARAMS = "emeter_params"
 CONF_DIMMER = "dimmer"
 CONF_DISCOVERY = "discovery"

--- a/homeassistant/components/tplink/coordinator.py
+++ b/homeassistant/components/tplink/coordinator.py
@@ -25,7 +25,7 @@ REQUEST_REFRESH_DELAY = 0.35
 
 
 class TPLinkDataUpdateCoordinator(DataUpdateCoordinator):
-    """DataUpdateCoordinator to gather data for specific SmartPlug."""
+    """DataUpdateCoordinator to gather data for a specific TPLink device."""
 
     def __init__(
         self,

--- a/homeassistant/components/tplink/coordinator.py
+++ b/homeassistant/components/tplink/coordinator.py
@@ -8,6 +8,7 @@ from kasa import SmartDevice, SmartDeviceException
 
 from homeassistant.const import ATTR_VOLTAGE
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -19,6 +20,8 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+REQUEST_REFRESH_DELAY = 0.35
 
 
 class TPLinkDataUpdateCoordinator(DataUpdateCoordinator):
@@ -38,6 +41,11 @@ class TPLinkDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER,
             name=device.host,
             update_interval=update_interval,
+            # We don't want an immediate refresh since the device and
+            # take a moment to reflect the state change
+            request_refresh_debouncer=Debouncer(
+                hass, _LOGGER, cooldown=REQUEST_REFRESH_DELAY, immediate=False
+            ),
         )
 
     @callback

--- a/homeassistant/components/tplink/coordinator.py
+++ b/homeassistant/components/tplink/coordinator.py
@@ -1,0 +1,74 @@
+"""Component to embed TP-Link smart home devices."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from kasa import SmartDevice, SmartDeviceException
+
+from homeassistant.const import ATTR_VOLTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import (
+    ATTR_CURRENT_A,
+    ATTR_CURRENT_POWER_W,
+    ATTR_TODAY_ENERGY_KWH,
+    ATTR_TOTAL_ENERGY_KWH,
+    CONF_EMETER_PARAMS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TPLinkDataUpdateCoordinator(DataUpdateCoordinator):
+    """DataUpdateCoordinator to gather data for specific SmartPlug."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        device: SmartDevice,
+    ) -> None:
+        """Initialize DataUpdateCoordinator to gather data for specific SmartPlug."""
+        self.device = device
+        self.update_children = True
+        update_interval = timedelta(seconds=10)
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=device.host,
+            update_interval=update_interval,
+        )
+
+    async def _async_update_data(self) -> dict:
+        """Fetch all device and sensor data from api."""
+        try:
+            await self.device.update(update_children=self.update_children)
+        except SmartDeviceException as ex:
+            raise UpdateFailed(ex) from ex
+        else:
+            self.update_children = True
+
+        self.name = self.device.alias
+
+        # Check if the device has emeter
+        if not self.device.has_emeter:
+            return {}
+
+        if (emeter_today := self.device.emeter_today) is not None:
+            consumption_today = emeter_today
+        else:
+            # today's consumption not available, when device was off all the day
+            # bulb's do not report this information, so filter it out
+            consumption_today = None if self.device.is_bulb else 0.0
+
+        emeter_readings = self.device.emeter_realtime
+        return {
+            CONF_EMETER_PARAMS: {
+                ATTR_CURRENT_POWER_W: emeter_readings.power,
+                ATTR_TOTAL_ENERGY_KWH: emeter_readings.total,
+                ATTR_VOLTAGE: emeter_readings.voltage,
+                ATTR_CURRENT_A: emeter_readings.current,
+                ATTR_TODAY_ENERGY_KWH: consumption_today,
+            }
+        }

--- a/homeassistant/components/tplink/coordinator.py
+++ b/homeassistant/components/tplink/coordinator.py
@@ -48,6 +48,14 @@ class TPLinkDataUpdateCoordinator(DataUpdateCoordinator):
             ),
         )
 
+    async def async_request_refresh_without_children(self) -> None:
+        """Request a refresh without the children."""
+        # If the children do get updated this is ok as this is an
+        # optimization to reduce the number of requests on the device
+        # when we do not need it.
+        self.update_children = False
+        await self.async_request_refresh()
+
     @callback
     def async_data_from_device(self) -> dict:
         """Build the coordinator data from the device."""

--- a/homeassistant/components/tplink/coordinator.py
+++ b/homeassistant/components/tplink/coordinator.py
@@ -89,6 +89,6 @@ class TPLinkDataUpdateCoordinator(DataUpdateCoordinator):
             await self.device.update(update_children=self.update_children)
         except SmartDeviceException as ex:
             raise UpdateFailed(ex) from ex
-        else:
+        finally:
             self.update_children = True
         return self.async_data_from_device()

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
 
 
@@ -55,7 +56,7 @@ class CoordinatedTPLinkEntity(CoordinatorEntity):
             "name": self.device.alias,
             "model": self.device.model,
             "manufacturer": "TP-Link",
-            # Note: mac instead of device_id here to connect subdevices to the main device
+            "identifiers": {(DOMAIN, str(self.device.device_id))},
             "connections": {(dr.CONNECTION_NETWORK_MAC, self.device.mac)},
             "sw_version": self.device.hw_info["sw_ver"],
         }

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -35,17 +35,13 @@ class CoordinatedTPLinkEntity(CoordinatorEntity):
         """Initialize the switch."""
         super().__init__(coordinator)
         self.device: SmartDevice = device
+        self._attr_unique_id = self.device.device_id
 
     @property
     def data(self) -> dict[str, Any]:
         """Return data from DataUpdateCoordinator."""
         data: dict[str, Any] = self.coordinator.data
         return data
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        return cast(str, self.device.device_id)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -7,16 +7,17 @@ from kasa import SmartDevice
 
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import TPLinkDataUpdateCoordinator
 
 
 class CoordinatedTPLinkEntity(CoordinatorEntity):
     """Common base class for all coordinated tplink entities."""
 
-    def __init__(self, device: SmartDevice, coordinator: DataUpdateCoordinator) -> None:
+    def __init__(
+        self, device: SmartDevice, coordinator: TPLinkDataUpdateCoordinator
+    ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator)
         self.device = device

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -1,7 +1,7 @@
 """Common code for tplink."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from kasa import SmartDevice
 
@@ -20,22 +20,22 @@ class CoordinatedTPLinkEntity(CoordinatorEntity):
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator)
-        self.device = device
+        self.device: SmartDevice = device
 
     @property
     def data(self) -> dict[str, Any]:
         """Return data from DataUpdateCoordinator."""
-        return self.coordinator.data
+        return cast(dict[str, Any], self.coordinator.data)
 
     @property
-    def unique_id(self) -> str | None:
+    def unique_id(self) -> str:
         """Return a unique ID."""
-        return self.device.device_id
+        return cast(str, self.device.device_id)
 
     @property
-    def name(self) -> str | None:
+    def name(self) -> str:
         """Return the name of the Smart Plug."""
-        return self.device.alias
+        return cast(str, self.device.alias)
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -50,6 +50,6 @@ class CoordinatedTPLinkEntity(CoordinatorEntity):
         }
 
     @property
-    def is_on(self) -> bool | None:
+    def is_on(self) -> bool:
         """Return true if switch is on."""
-        return self.device.is_on
+        return bool(self.device.is_on)

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -40,7 +40,7 @@ class CoordinatedTPLinkEntity(CoordinatorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return information about the device."""
-        data = {
+        return {
             "name": self.device.alias,
             "model": self.device.model,
             "manufacturer": "TP-Link",
@@ -48,10 +48,6 @@ class CoordinatedTPLinkEntity(CoordinatorEntity):
             "connections": {(dr.CONNECTION_NETWORK_MAC, self.device.mac)},
             "sw_version": self.device.hw_info["sw_ver"],
         }
-        if self.device.is_strip_socket:
-            data["via_device"] = self.device.parent.device_id
-
-        return data
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -1,7 +1,7 @@
 """Common code for tplink."""
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 from kasa import SmartDevice
 
@@ -12,8 +12,22 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import TPLinkDataUpdateCoordinator
 
 
+def async_refresh_after(func: Callable) -> Callable:
+    """Define a wrapper to refresh after."""
+
+    async def _async_wrap(
+        self: CoordinatedTPLinkEntity, *args: Any, **kwargs: Any
+    ) -> None:
+        await func(self, *args, **kwargs)
+        await self.coordinator.async_request_refresh_without_children()
+
+    return _async_wrap
+
+
 class CoordinatedTPLinkEntity(CoordinatorEntity):
     """Common base class for all coordinated tplink entities."""
+
+    coordinator: TPLinkDataUpdateCoordinator
 
     def __init__(
         self, device: SmartDevice, coordinator: TPLinkDataUpdateCoordinator

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -39,7 +39,8 @@ class CoordinatedTPLinkEntity(CoordinatorEntity):
     @property
     def data(self) -> dict[str, Any]:
         """Return data from DataUpdateCoordinator."""
-        return cast(dict[str, Any], self.coordinator.data)
+        data: dict[str, Any] = self.coordinator.data
+        return data
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -1,7 +1,6 @@
 """Support for TPLink lights."""
 from __future__ import annotations
 
-from datetime import timedelta
 import logging
 from typing import Any
 
@@ -30,18 +29,11 @@ from homeassistant.util.color import (
 )
 
 from .common import CoordinatedTPLinkEntity
-from .const import CONF_LIGHT, COORDINATORS, DOMAIN as TPLINK_DOMAIN
+from .const import DOMAIN
 
 PARALLEL_UPDATES = 0
-SCAN_INTERVAL = timedelta(seconds=5)
-CURRENT_POWER_UPDATE_INTERVAL = timedelta(seconds=60)
-HISTORICAL_POWER_UPDATE_INTERVAL = timedelta(minutes=60)
 
 _LOGGER = logging.getLogger(__name__)
-
-ATTR_CURRENT_POWER_W = "current_power_w"
-ATTR_DAILY_ENERGY_KWH = "daily_energy_kwh"
-ATTR_MONTHLY_ENERGY_KWH = "monthly_energy_kwh"
 
 
 async def async_setup_entry(
@@ -50,15 +42,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up switches."""
-    coordinators: dict[str, TPLinkDataUpdateCoordinator] = hass.data[TPLINK_DOMAIN][
-        COORDINATORS
-    ]
-    async_add_entities(
-        [
-            TPLinkSmartBulb(device, coordinators[device.device_id])
-            for device in hass.data[TPLINK_DOMAIN][CONF_LIGHT]
-        ]
-    )
+    coordinator: TPLinkDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    device = coordinator.device
+    if not device.is_bulb and not device.is_light_strip and not device.is_dimmer:
+        return
+    async_add_entities([TPLinkSmartBulb(device, coordinator)])
 
 
 def brightness_to_percentage(byt):

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -54,8 +54,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         transition = kwargs.get(ATTR_TRANSITION)
-        brightness = kwargs.get(ATTR_BRIGHTNESS)
-        if brightness is not None:
+        if (brightness := kwargs.get(ATTR_BRIGHTNESS)) is not None:
             brightness = round((brightness * 100.0) / 255.0)
 
         # Handle turning to temp mode

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from kasa import SmartBulb
-
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
@@ -52,13 +50,6 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     """Representation of a TPLink Smart Bulb."""
 
     coordinator: TPLinkDataUpdateCoordinator
-
-    def __init__(
-        self, smartbulb: SmartBulb, coordinator: TPLinkDataUpdateCoordinator
-    ) -> None:
-        """Initialize the bulb."""
-        super().__init__(smartbulb, coordinator)
-        self.device = smartbulb
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -49,16 +49,6 @@ async def async_setup_entry(
     async_add_entities([TPLinkSmartBulb(device, coordinator)])
 
 
-def brightness_to_percentage(byt):
-    """Convert brightness from absolute 0..255 to percentage."""
-    return round((byt * 100.0) / 255.0)
-
-
-def brightness_from_percentage(percent):
-    """Convert percentage to absolute value 0..255."""
-    return round((percent * 255.0) / 100.0)
-
-
 class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     """Representation of a TPLink Smart Bulb."""
 
@@ -80,7 +70,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         transition = kwargs.get(ATTR_TRANSITION)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         if brightness is not None:
-            brightness = int(brightness_to_percentage(brightness))
+            brightness = round((brightness * 100.0) / 255.0)
 
         # Handle turning to temp mode
         if ATTR_COLOR_TEMP in kwargs:
@@ -127,7 +117,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     @property
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
-        return brightness_from_percentage(self.device.brightness)
+        return round((self.device.brightness * 255.0) / 100.0)
 
     @property
     def hs_color(self) -> tuple[int, int] | None:

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -21,7 +21,6 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.color import (
     color_temperature_kelvin_to_mired as kelvin_to_mired,
     color_temperature_mired_to_kelvin as mired_to_kelvin,
@@ -52,8 +51,10 @@ async def async_setup_entry(
 class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     """Representation of a TPLink Smart Bulb."""
 
+    coordinator: TPLinkDataUpdateCoordinator
+
     def __init__(
-        self, smartbulb: SmartBulb, coordinator: DataUpdateCoordinator
+        self, smartbulb: SmartBulb, coordinator: TPLinkDataUpdateCoordinator
     ) -> None:
         """Initialize the bulb."""
         super().__init__(smartbulb, coordinator)

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -41,9 +41,8 @@ async def async_setup_entry(
     """Set up switches."""
     coordinator: TPLinkDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     device = coordinator.device
-    if not device.is_bulb and not device.is_light_strip and not device.is_dimmer:
-        return
-    async_add_entities([TPLinkSmartBulb(device, coordinator)])
+    if device.is_bulb or device.is_light_strip or device.is_dimmer:
+        async_add_entities([TPLinkSmartBulb(device, coordinator)])
 
 
 class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -18,7 +18,6 @@ from homeassistant.components.light import (
     SUPPORT_TRANSITION,
     LightEntity,
 )
-from homeassistant.components.tplink import TPLinkDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -28,8 +27,9 @@ from homeassistant.util.color import (
     color_temperature_mired_to_kelvin as mired_to_kelvin,
 )
 
-from .common import CoordinatedTPLinkEntity
 from .const import DOMAIN
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import CoordinatedTPLinkEntity
 
 PARALLEL_UPDATES = 0
 

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -26,7 +26,7 @@ from homeassistant.util.color import (
 
 from .const import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
-from .entity import CoordinatedTPLinkEntity
+from .entity import CoordinatedTPLinkEntity, async_refresh_after
 
 PARALLEL_UPDATES = 0
 
@@ -51,14 +51,9 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
 
     coordinator: TPLinkDataUpdateCoordinator
 
+    @async_refresh_after
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
-        await self._async_turn_on(**kwargs)
-        await self.coordinator.async_request_refresh()
-
-    async def _async_turn_on(self, **kwargs: Any) -> None:
-        _LOGGER.debug("Turning on %s", kwargs)
-
         transition = kwargs.get(ATTR_TRANSITION)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         if brightness is not None:
@@ -86,10 +81,10 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         else:
             await self.device.turn_on(transition=transition)
 
+    @async_refresh_after
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self.device.turn_off(transition=kwargs.get(ATTR_TRANSITION))
-        await self.coordinator.async_request_refresh()
 
     @property
     def min_mireds(self) -> int:

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -72,7 +72,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         await self._async_turn_on(**kwargs)
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()
 
     async def _async_turn_on(self, **kwargs: Any) -> None:
         _LOGGER.debug("Turning on %s", kwargs)
@@ -107,7 +107,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self.device.turn_off(transition=kwargs.get(ATTR_TRANSITION))
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()
 
     @property
     def min_mireds(self) -> int:

--- a/homeassistant/components/tplink/migration.py
+++ b/homeassistant/components/tplink/migration.py
@@ -18,8 +18,9 @@ from .const import (
     CONF_STRIP,
     CONF_SWITCH,
     DOMAIN,
-    MAC_ADDRESS_LEN,
 )
+
+MAC_ADDRESS_LEN = 17
 
 
 async def async_cleanup_legacy_entry(

--- a/homeassistant/components/tplink/migration.py
+++ b/homeassistant/components/tplink/migration.py
@@ -71,9 +71,7 @@ def async_migrate_legacy_entries(
 def async_migrate_yaml_entries(hass: HomeAssistant, conf: ConfigType) -> None:
     """Migrate yaml to config entries."""
     for device_type in (CONF_LIGHT, CONF_SWITCH, CONF_STRIP, CONF_DIMMER):
-        if device_type not in conf:
-            continue
-        for device in conf[device_type]:
+        for device in conf.get(device_type, []):
             hass.async_create_task(
                 hass.config_entries.flow.async_init(
                     DOMAIN,

--- a/homeassistant/components/tplink/migration.py
+++ b/homeassistant/components/tplink/migration.py
@@ -1,68 +1,24 @@
 """Component to embed TP-Link smart home devices."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-import logging
-from typing import Any
-
-from kasa import SmartDevice, SmartDeviceException
-from kasa.discover import Discover
-from kasa.protocol import TPLinkSmartHomeProtocol
-import voluptuous as vol
+from datetime import datetime
 
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigEntry, ConfigEntryNotReady
-from homeassistant.const import ATTR_VOLTAGE, CONF_HOST, CONF_MAC, CONF_NAME
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant, callback, split_entity_id
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
-    ATTR_CURRENT_A,
-    ATTR_CURRENT_POWER_W,
-    ATTR_TODAY_ENERGY_KWH,
-    ATTR_TOTAL_ENERGY_KWH,
     CONF_DIMMER,
-    CONF_DISCOVERY,
-    CONF_EMETER_PARAMS,
     CONF_LEGACY_ENTRY_ID,
     CONF_LIGHT,
     CONF_STRIP,
     CONF_SWITCH,
-    DISCOVERED_DEVICES,
     DOMAIN,
     MAC_ADDRESS_LEN,
-    PLATFORMS,
-)
-
-_LOGGER = logging.getLogger(__name__)
-
-TPLINK_HOST_SCHEMA = vol.Schema({vol.Required(CONF_HOST): cv.string})
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Optional(CONF_LIGHT, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_SWITCH, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_STRIP, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_DIMMER, default=[]): vol.All(
-                    cv.ensure_list, [TPLINK_HOST_SCHEMA]
-                ),
-                vol.Optional(CONF_DISCOVERY, default=True): cv.boolean,
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
 )
 
 
@@ -137,57 +93,6 @@ def async_migrate_yaml_entries(hass: HomeAssistant, conf: ConfigType) -> None:
             )
 
 
-@callback
-def async_trigger_discovery(
-    hass: HomeAssistant,
-    discovered_devices: dict[str, SmartDevice],
-) -> None:
-    """Trigger config flows for discovered devices."""
-    for formatted_mac, device in discovered_devices.items():
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": config_entries.SOURCE_DISCOVERY},
-                data={
-                    CONF_NAME: device.alias,
-                    CONF_HOST: device.host,
-                    CONF_MAC: formatted_mac,
-                },
-            )
-        )
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the TP-Link component."""
-    conf = config.get(DOMAIN)
-    hass.data[DOMAIN] = {}
-
-    legacy_entry = None
-    config_entries_by_mac = {}
-    for entry in hass.config_entries.async_entries(DOMAIN):
-        if entry.unique_id is None or entry.unique_id == DOMAIN:
-            legacy_entry = entry
-        else:
-            config_entries_by_mac[entry.unique_id] = entry
-
-    discovered_devices = {
-        dr.format_mac(device.mac): device
-        for device in (await Discover.discover()).values()
-    }
-    hass.data[DOMAIN][DISCOVERED_DEVICES] = discovered_devices
-
-    if legacy_entry:
-        async_migrate_legacy_entries(hass, config_entries_by_mac, legacy_entry)
-
-    if conf is not None:
-        async_migrate_yaml_entries(hass, conf)
-
-    if discovered_devices:
-        async_trigger_discovery(hass, discovered_devices)
-
-    return True
-
-
 async def async_migrate_entities_devices(
     hass: HomeAssistant, legacy_entry_id: str, new_entry: ConfigEntry
 ) -> None:
@@ -224,90 +129,3 @@ async def async_migrate_entities_devices(
         new_entry,
         data={k: v for k, v in new_entry.data.items() if k != CONF_LEGACY_ENTRY_ID},
     )
-
-
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up TPLink from a config entry."""
-    if not entry.unique_id or entry.unique_id == DOMAIN:
-        return True
-
-    if legacy_entry_id := entry.data.get(CONF_LEGACY_ENTRY_ID):
-        await async_migrate_entities_devices(hass, legacy_entry_id, entry)
-
-    protocol = TPLinkSmartHomeProtocol(entry.data[CONF_HOST])
-    try:
-        info = await protocol.query(Discover.DISCOVERY_QUERY)
-    except SmartDeviceException as ex:
-        raise ConfigEntryNotReady from ex
-
-    device_class = Discover._get_device_class(info)  # pylint: disable=protected-access
-    device = device_class(entry.data[CONF_HOST])
-    coordinator = TPLinkDataUpdateCoordinator(hass, device)
-    await coordinator.async_config_entry_first_refresh()
-
-    hass.data[DOMAIN][entry.entry_id] = coordinator
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-
-    return True
-
-
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
-    hass_data: dict[str, Any] = hass.data[DOMAIN]
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        if entry.entry_id in hass_data:
-            hass_data.pop(entry.entry_id)
-    return unload_ok
-
-
-class TPLinkDataUpdateCoordinator(DataUpdateCoordinator):
-    """DataUpdateCoordinator to gather data for specific SmartPlug."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        device: SmartDevice,
-    ) -> None:
-        """Initialize DataUpdateCoordinator to gather data for specific SmartPlug."""
-        self.device = device
-        self.update_children = True
-        update_interval = timedelta(seconds=10)
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=device.host,
-            update_interval=update_interval,
-        )
-
-    async def _async_update_data(self) -> dict:
-        """Fetch all device and sensor data from api."""
-        try:
-            await self.device.update(update_children=self.update_children)
-        except SmartDeviceException as ex:
-            raise UpdateFailed(ex) from ex
-        else:
-            self.update_children = True
-
-        self.name = self.device.alias
-
-        # Check if the device has emeter
-        if not self.device.has_emeter:
-            return {}
-
-        if (emeter_today := self.device.emeter_today) is not None:
-            consumption_today = emeter_today
-        else:
-            # today's consumption not available, when device was off all the day
-            # bulb's do not report this information, so filter it out
-            consumption_today = None if self.device.is_bulb else 0.0
-
-        emeter_readings = self.device.emeter_realtime
-        return {
-            CONF_EMETER_PARAMS: {
-                ATTR_CURRENT_POWER_W: emeter_readings.power,
-                ATTR_TOTAL_ENERGY_KWH: emeter_readings.total,
-                ATTR_VOLTAGE: emeter_readings.voltage,
-                ATTR_CURRENT_A: emeter_readings.current,
-                ATTR_TODAY_ENERGY_KWH: consumption_today,
-            }
-        }

--- a/homeassistant/components/tplink/migration.py
+++ b/homeassistant/components/tplink/migration.py
@@ -1,7 +1,7 @@
 """Component to embed TP-Link smart home devices."""
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 from typing import Any
 
@@ -13,9 +13,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigEntryNotReady
 from homeassistant.const import ATTR_VOLTAGE, CONF_HOST, CONF_MAC, CONF_NAME
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import HomeAssistant, callback, split_entity_id
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -33,12 +34,8 @@ from .const import (
     CONF_SWITCH,
     DISCOVERED_DEVICES,
     DOMAIN,
+    MAC_ADDRESS_LEN,
     PLATFORMS,
-)
-from .migration import (
-    async_migrate_entities_devices,
-    async_migrate_legacy_entries,
-    async_migrate_yaml_entries,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,6 +64,77 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
+
+
+async def async_cleanup_legacy_entry(
+    hass: HomeAssistant,
+    legacy_entry_id: str,
+) -> None:
+    """Cleanup the legacy entry if the migration is successful."""
+    entity_registry = er.async_get(hass)
+    if not er.async_entries_for_config_entry(entity_registry, legacy_entry_id):
+        await hass.config_entries.async_remove(legacy_entry_id)
+
+
+@callback
+def async_migrate_legacy_entries(
+    hass: HomeAssistant,
+    config_entries_by_mac: dict[str, ConfigEntry],
+    legacy_entry: ConfigEntry,
+) -> None:
+    """Migrate the legacy config entries to have an entry per device."""
+    entity_registry = er.async_get(hass)
+    tplink_reg_entities = er.async_entries_for_config_entry(
+        entity_registry, legacy_entry.entry_id
+    )
+
+    for reg_entity in tplink_reg_entities:
+        # Only migrate entities with a mac address only
+        if len(reg_entity.unique_id) != MAC_ADDRESS_LEN:
+            continue
+        mac = dr.format_mac(reg_entity.unique_id)
+        if mac in config_entries_by_mac:
+            continue
+
+        domain = (split_entity_id(reg_entity.entity_id))[0]
+        if domain not in ("switch", "light"):
+            continue
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": "migration"},
+                data={
+                    CONF_LEGACY_ENTRY_ID: reg_entity.config_entry_id,
+                    CONF_MAC: mac,
+                    CONF_NAME: reg_entity.name
+                    or reg_entity.original_name
+                    or f"TP-Link device {mac}",
+                },
+            )
+        )
+
+    async def _async_cleanup_legacy_entry(_now: datetime) -> None:
+        await async_cleanup_legacy_entry(hass, legacy_entry.entry_id)
+
+    async_call_later(hass, 60, _async_cleanup_legacy_entry)
+
+
+@callback
+def async_migrate_yaml_entries(hass: HomeAssistant, conf: ConfigType) -> None:
+    """Migrate yaml to config entries."""
+    for device_type in (CONF_LIGHT, CONF_SWITCH, CONF_STRIP, CONF_DIMMER):
+        if device_type not in conf:
+            continue
+        for device in conf[device_type]:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": config_entries.SOURCE_IMPORT},
+                    data={
+                        CONF_HOST: device[CONF_HOST],
+                    },
+                )
+            )
 
 
 @callback
@@ -118,6 +186,44 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         async_trigger_discovery(hass, discovered_devices)
 
     return True
+
+
+async def async_migrate_entities_devices(
+    hass: HomeAssistant, legacy_entry_id: str, new_entry: ConfigEntry
+) -> None:
+    """Move entities and devices to the new config entry."""
+    entity_registry = er.async_get(hass)
+    tplink_reg_entities = er.async_entries_for_config_entry(
+        entity_registry, legacy_entry_id
+    )
+
+    for reg_entity in tplink_reg_entities:
+        # Only migrate entities with a mac address only
+        if len(reg_entity.unique_id) < MAC_ADDRESS_LEN:
+            continue
+        if dr.format_mac(reg_entity.unique_id[:MAC_ADDRESS_LEN]) == new_entry.unique_id:
+            entity_registry._async_update_entity(  # pylint: disable=protected-access
+                reg_entity.entity_id, config_entry_id=new_entry.entry_id
+            )
+
+    device_registry = dr.async_get(hass)
+    tplink_dev_entities = dr.async_entries_for_config_entry(
+        device_registry, legacy_entry_id
+    )
+    for dev_entry in tplink_dev_entities:
+        for connection_type, value in dev_entry.connections:
+            if (
+                connection_type == dr.CONNECTION_NETWORK_MAC
+                and value == new_entry.unique_id
+            ):
+                device_registry._async_update_device(  # pylint: disable=protected-access
+                    dev_entry.id, add_config_entry_id=new_entry.entry_id
+                )
+
+    hass.config_entries.async_update_entry(
+        new_entry,
+        data={k: v for k, v in new_entry.data.items() if k != CONF_LEGACY_ENTRY_ID},
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/tplink/migration.py
+++ b/homeassistant/components/tplink/migration.py
@@ -97,7 +97,7 @@ async def async_migrate_entities_devices(
         if len(reg_entity.unique_id) < MAC_ADDRESS_LEN:
             continue
         if dr.format_mac(reg_entity.unique_id[:MAC_ADDRESS_LEN]) == new_entry.unique_id:
-            entity_registry._async_update_entity(  # pylint: disable=protected-access
+            entity_registry.async_update_entity(
                 reg_entity.entity_id, config_entry_id=new_entry.entry_id
             )
 
@@ -111,6 +111,6 @@ async def async_migrate_entities_devices(
                 connection_type == dr.CONNECTION_NETWORK_MAC
                 and value == new_entry.unique_id
             ):
-                device_registry._async_update_device(  # pylint: disable=protected-access
+                device_registry.async_update_device(
                     dev_entry.id, add_config_entry_id=new_entry.entry_id
                 )

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -108,6 +108,7 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
         """Initialize the switch."""
         super().__init__(device, coordinator)
         self.entity_description = description
+        self._attr_unique_id = f"{self.device.device_id}_{self.entity_description.key}"
 
     @property
     def name(self) -> str:
@@ -121,8 +122,3 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
     def native_value(self) -> float:
         """Return the sensors state."""
         return cast(float, self.data[CONF_EMETER_PARAMS][self.entity_description.key])
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        return f"{self.device.device_id}_{self.entity_description.key}"

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -1,7 +1,7 @@
 """Support for TPLink HS100/HS110/HS200 smart switch energy sensors."""
 from __future__ import annotations
 
-from typing import Any, Final
+from typing import Final
 
 from kasa import SmartDevice
 
@@ -116,11 +116,6 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
         Overridden to include the description.
         """
         return f"{self.device.alias} {self.entity_description.name}"
-
-    @property
-    def data(self) -> dict[str, Any]:
-        """Return data from DataUpdateCoordinator."""
-        return self.coordinator.data
 
     @property
     def native_value(self) -> float | None:

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -107,7 +107,6 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
     ) -> None:
         """Initialize the switch."""
         super().__init__(device, coordinator)
-        self.device = device
         self.entity_description = description
 
     @property

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.components.tplink import TPLinkDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_VOLTAGE,
@@ -28,7 +27,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .common import CoordinatedTPLinkEntity
 from .const import (
     ATTR_CURRENT_A,
     ATTR_CURRENT_POWER_W,
@@ -37,6 +35,8 @@ from .const import (
     CONF_EMETER_PARAMS,
     DOMAIN,
 )
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import CoordinatedTPLinkEntity
 
 ENERGY_SENSORS: Final[list[SensorEntityDescription]] = [
     SensorEntityDescription(

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -84,14 +84,14 @@ async def async_setup_entry(
     """Set up sensors."""
     coordinator: TPLinkDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     device = coordinator.device
-    if not device.has_emeter:
-        return
-
-    entities = []
-    for description in ENERGY_SENSORS:
-        if coordinator.data[CONF_EMETER_PARAMS].get(description.key) is not None:
-            entities.append(SmartPlugSensor(device, coordinator, description))
-    async_add_entities(entities)
+    async_add_entities(
+        [
+            SmartPlugSensor(device, coordinator, description)
+            for description in ENERGY_SENSORS
+            if device.has_emeter
+            and coordinator.data[CONF_EMETER_PARAMS].get(description.key) is not None
+        ]
+    )
 
 
 class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     ATTR_CURRENT_A,
@@ -98,10 +97,12 @@ async def async_setup_entry(
 class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
     """Representation of a TPLink Smart Plug energy sensor."""
 
+    coordinator: TPLinkDataUpdateCoordinator
+
     def __init__(
         self,
         device: SmartDevice,
-        coordinator: DataUpdateCoordinator,
+        coordinator: TPLinkDataUpdateCoordinator,
         description: SensorEntityDescription,
     ) -> None:
         """Initialize the switch."""
@@ -110,7 +111,7 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
         self.entity_description = description
 
     @property
-    def name(self) -> str | None:
+    def name(self) -> str:
         """Return the name of the Smart Plug.
 
         Overridden to include the description.
@@ -118,11 +119,12 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
         return f"{self.device.alias} {self.entity_description.name}"
 
     @property
-    def native_value(self) -> float | None:
+    def native_value(self) -> float:
         """Return the sensors state."""
-        return self.data[CONF_EMETER_PARAMS][self.entity_description.key]
+        value: float = self.data[CONF_EMETER_PARAMS][self.entity_description.key]
+        return value
 
     @property
-    def unique_id(self) -> str | None:
+    def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self.device.device_id}_{self.entity_description.key}"

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -1,7 +1,7 @@
 """Support for TPLink HS100/HS110/HS200 smart switch energy sensors."""
 from __future__ import annotations
 
-from typing import Final
+from typing import Final, cast
 
 from kasa import SmartDevice
 
@@ -120,8 +120,7 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
     @property
     def native_value(self) -> float:
         """Return the sensors state."""
-        value: float = self.data[CONF_EMETER_PARAMS][self.entity_description.key]
-        return value
+        return cast(float, self.data[CONF_EMETER_PARAMS][self.entity_description.key])
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -1,12 +1,27 @@
 {
   "config": {
+    "flow_title": "{name} {model} ({host})",
     "step": {
-      "confirm": {
-        "description": "Do you want to setup TP-Link smart devices?"
+      "user": {
+        "description": "If you leave the host empty, discovery will be used to find devices.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      },
+      "pick_device": {
+        "data": {
+          "device": "Device"
+        }
+      },
+      "discovery_confirm": {
+        "description": "Do you want to setup {name} {model} ({host})?"
       }
     },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     }
   }

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -6,13 +6,13 @@ import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.components.tplink import TPLinkDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .common import CoordinatedTPLinkEntity
 from .const import DOMAIN
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import CoordinatedTPLinkEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -39,6 +39,8 @@ async def async_setup_entry(
 class SmartPlugSwitch(CoordinatedTPLinkEntity, SwitchEntity):
     """Representation of a TPLink Smart Plug switch."""
 
+    coordinator: TPLinkDataUpdateCoordinator
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.device.turn_on()

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -59,4 +59,4 @@ class SmartPlugSwitch(CoordinatedTPLinkEntity, SwitchEntity):
 
     async def _async_refresh_with_children(self) -> None:
         self.coordinator.update_children = False
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
-from .entity import CoordinatedTPLinkEntity
+from .entity import CoordinatedTPLinkEntity, async_refresh_after
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,12 +41,12 @@ class SmartPlugSwitch(CoordinatedTPLinkEntity, SwitchEntity):
 
     coordinator: TPLinkDataUpdateCoordinator
 
+    @async_refresh_after
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.device.turn_on()
-        await self.coordinator.async_request_refresh_without_children()
 
+    @async_refresh_after
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.device.turn_off()
-        await self.coordinator.async_request_refresh_without_children()

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -1,7 +1,6 @@
 """Support for TPLink HS100/HS110/HS200 smart switch."""
 from __future__ import annotations
 
-from asyncio import sleep
 import logging
 from typing import Any
 
@@ -43,20 +42,13 @@ class SmartPlugSwitch(CoordinatedTPLinkEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.device.turn_on()
-        await self._async_device_workarounds()
-        await self._async_refresh_with_children()
+        await self._async_refresh_without_children()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.device.turn_off()
-        await self._async_device_workarounds()
-        await self._async_refresh_with_children()
+        await self._async_refresh_without_children()
 
-    async def _async_device_workarounds(self) -> None:
-        # Workaround for delayed device state update on HS210: #55190
-        if "HS210" in self.device.model:
-            await sleep(0.5)
-
-    async def _async_refresh_with_children(self) -> None:
+    async def _async_refresh_without_children(self) -> None:
         self.coordinator.update_children = False
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -42,13 +42,9 @@ class SmartPlugSwitch(CoordinatedTPLinkEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.device.turn_on()
-        await self._async_refresh_without_children()
+        await self.coordinator.async_request_refresh_without_children()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.device.turn_off()
-        await self._async_refresh_without_children()
-
-    async def _async_refresh_without_children(self) -> None:
-        self.coordinator.update_children = False
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh_without_children()

--- a/homeassistant/components/tplink/translations/en.json
+++ b/homeassistant/components/tplink/translations/en.json
@@ -1,12 +1,27 @@
 {
     "config": {
         "abort": {
-            "no_devices_found": "No devices found on the network",
-            "single_instance_allowed": "Already configured. Only a single configuration possible."
+            "already_configured": "Device is already configured",
+            "no_devices_found": "No devices found on the network"
         },
+        "error": {
+            "cannot_connect": "Failed to connect"
+        },
+        "flow_title": "{name} {model} ({host})",
         "step": {
-            "confirm": {
-                "description": "Do you want to setup TP-Link smart devices?"
+            "discovery_confirm": {
+                "description": "Do you want to setup {name} {model} ({host})?"
+            },
+            "pick_device": {
+                "data": {
+                    "device": "Device"
+                }
+            },
+            "user": {
+                "data": {
+                    "host": "Host"
+                },
+                "description": "If you leave the host empty, discovery will be used to find devices."
             }
         }
     }

--- a/homeassistant/components/tplink/utils.py
+++ b/homeassistant/components/tplink/utils.py
@@ -1,0 +1,13 @@
+"""Common code for tplink."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
+
+from .const import DOMAIN
+
+
+@callback
+def async_entry_is_legacy(entry: ConfigEntry) -> bool:
+    """Check if a config entry is the legacy shared one."""
+    return entry.unique_id is None or entry.unique_id == DOMAIN

--- a/mypy.ini
+++ b/mypy.ini
@@ -1188,6 +1188,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.tplink.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.tradfri.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -1687,9 +1698,6 @@ ignore_errors = true
 ignore_errors = true
 
 [mypy-homeassistant.components.toon.*]
-ignore_errors = true
-
-[mypy-homeassistant.components.tplink.*]
 ignore_errors = true
 
 [mypy-homeassistant.components.unifi.*]

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -126,7 +126,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.telegram_bot.*",
     "homeassistant.components.template.*",
     "homeassistant.components.toon.*",
-    "homeassistant.components.tplink.*",
     "homeassistant.components.unifi.*",
     "homeassistant.components.upnp.*",
     "homeassistant.components.vera.*",

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -21,7 +21,12 @@ def _mocked_bulb() -> SmartBulb:
     bulb.alias = ALIAS
     bulb.model = MODEL
     bulb.host = IP_ADDRESS
-    bulb.hw_info = {"sw_version": "1.0.0"}
+    bulb.brightness = 255
+    bulb.color_temp = 4000
+    bulb.device_id = MAC_ADDRESS
+    bulb.valid_temperature_range.min = 9000
+    bulb.valid_temperature_range.max = 4000
+    bulb.hw_info = {"sw_ver": "1.0.0"}
     return bulb
 
 

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -1,1 +1,45 @@
 """Tests for the TP-Link component."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from kasa import SmartBulb
+from kasa.exceptions import SmartDeviceException
+
+MODULE = "homeassistant.components.tplink"
+MODULE_CONFIG_FLOW = "homeassistant.components.tplink.config_flow"
+IP_ADDRESS = "127.0.0.1"
+ALIAS = "My Bulb"
+MODEL = "HS100"
+MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
+DEFAULT_ENTRY_TITLE = f"{ALIAS} {MODEL}"
+
+
+def _mocked_bulb() -> SmartBulb:
+    bulb = MagicMock(auto_spec=SmartBulb)
+    bulb.update = AsyncMock()
+    bulb.mac = MAC_ADDRESS
+    bulb.alias = ALIAS
+    bulb.model = MODEL
+    bulb.host = IP_ADDRESS
+    bulb.hw_info = {"sw_version": "1.0.0"}
+    return bulb
+
+
+def _patch_discovery(no_device=False):
+    async def _discovery(*_):
+        if no_device:
+            return {}
+        return {IP_ADDRESS: _mocked_bulb()}
+
+    return patch("homeassistant.components.tplink.Discover.discover", new=_discovery)
+
+
+def _patch_single_discovery(no_device=False):
+    async def _discover_single(*_):
+        if no_device:
+            raise SmartDeviceException
+        return _mocked_bulb()
+
+    return patch(
+        "homeassistant.components.tplink.Discover.discover_single", new=_discover_single
+    )

--- a/tests/components/tplink/conftest.py
+++ b/tests/components/tplink/conftest.py
@@ -1,14 +1,13 @@
 """tplink conftest."""
-from unittest.mock import patch
 
 import pytest
 
-from tests.components.light.conftest import mock_light_profiles  # noqa: F401
+from . import _patch_discovery
 
 
 @pytest.fixture
 def mock_discovery():
     """Mock python-kasa discovery."""
-    with patch("homeassistant.components.tplink.Discover.discover") as mock_discover:
+    with _patch_discovery() as mock_discover:
         mock_discover.return_value = {}
         yield mock_discover

--- a/tests/components/tplink/conftest.py
+++ b/tests/components/tplink/conftest.py
@@ -1,2 +1,14 @@
 """tplink conftest."""
+from unittest.mock import patch
+
+import pytest
+
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
+
+
+@pytest.fixture
+def mock_discovery():
+    """Mock python-kasa discovery."""
+    with patch("homeassistant.components.tplink.Discover.discover") as mock_discover:
+        mock_discover.return_value = {}
+        yield mock_discover

--- a/tests/components/tplink/conftest.py
+++ b/tests/components/tplink/conftest.py
@@ -4,6 +4,8 @@ import pytest
 
 from . import _patch_discovery
 
+from tests.common import mock_device_registry, mock_registry
+
 
 @pytest.fixture
 def mock_discovery():
@@ -11,3 +13,15 @@ def mock_discovery():
     with _patch_discovery() as mock_discover:
         mock_discover.return_value = {}
         yield mock_discover
+
+
+@pytest.fixture(name="device_reg")
+def device_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture(name="entity_reg")
+def entity_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -1,0 +1,380 @@
+"""Test the tplink config flow."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant import config_entries, setup
+from homeassistant.components.tplink import DOMAIN
+from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_MAC, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
+
+from . import (
+    ALIAS,
+    DEFAULT_ENTRY_TITLE,
+    IP_ADDRESS,
+    MAC_ADDRESS,
+    MODEL,
+    MODULE,
+    _patch_discovery,
+    _patch_single_discovery,
+)
+
+from tests.common import MockConfigEntry
+
+DEVICE_ID = f"{ALIAS} {MODEL} ({IP_ADDRESS}) {MAC_ADDRESS}"
+
+
+async def test_discovery(hass: HomeAssistant):
+    """Test setting up discovery."""
+    with _patch_discovery(), _patch_single_discovery():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert not result["errors"]
+
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        assert result2["type"] == "form"
+        assert result2["step_id"] == "pick_device"
+        assert not result2["errors"]
+
+        # test we can try again
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert not result["errors"]
+
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        assert result2["type"] == "form"
+        assert result2["step_id"] == "pick_device"
+        assert not result2["errors"]
+
+    with _patch_discovery(), _patch_single_discovery(), patch(
+        f"{MODULE}.async_setup", return_value=True
+    ) as mock_setup, patch(
+        f"{MODULE}.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_DEVICE: DEVICE_ID},
+        )
+    assert result3["type"] == "create_entry"
+    assert result3["title"] == DEFAULT_ENTRY_TITLE
+    assert result3["data"] == {CONF_HOST: IP_ADDRESS}
+    await hass.async_block_till_done()
+    mock_setup.assert_called_once()
+    mock_setup_entry.assert_called_once()
+
+    # ignore configured devices
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert not result["errors"]
+
+    with _patch_discovery(), _patch_single_discovery():
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "no_devices_found"
+
+
+async def test_discovery_with_existing_device_present(hass: HomeAssistant):
+    """Test setting up discovery."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.2"}, unique_id="dd:dd:dd:dd:dd:dd"
+    )
+    config_entry.add_to_hass(hass)
+
+    with _patch_discovery():
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert not result["errors"]
+
+    with _patch_discovery(), _patch_single_discovery():
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "pick_device"
+    assert not result2["errors"]
+
+    # Now abort and make sure we can start over
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert not result["errors"]
+
+    with _patch_discovery(), _patch_single_discovery():
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "pick_device"
+    assert not result2["errors"]
+
+    with _patch_discovery(), _patch_single_discovery():
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DEVICE: DEVICE_ID}
+        )
+        assert result3["type"] == "create_entry"
+        assert result3["title"] == DEFAULT_ENTRY_TITLE
+        assert result3["data"] == {
+            CONF_HOST: IP_ADDRESS,
+        }
+        await hass.async_block_till_done()
+
+    # ignore configured devices
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert not result["errors"]
+
+    with _patch_discovery(), _patch_single_discovery():
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "no_devices_found"
+
+
+async def test_discovery_no_device(hass: HomeAssistant):
+    """Test discovery without device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with _patch_discovery(no_device=True), _patch_single_discovery():
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "no_devices_found"
+
+
+async def test_import(hass: HomeAssistant):
+    """Test import from yaml."""
+    config = {
+        CONF_HOST: IP_ADDRESS,
+    }
+
+    # Cannot connect
+    with _patch_discovery(no_device=True), _patch_single_discovery(no_device=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config
+        )
+    assert result["type"] == "abort"
+    assert result["reason"] == "cannot_connect"
+
+    # Success
+    with _patch_discovery(), _patch_single_discovery(), patch(
+        f"{MODULE}.async_setup", return_value=True
+    ) as mock_setup, patch(
+        f"{MODULE}.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config
+        )
+    assert result["type"] == "create_entry"
+    assert result["title"] == DEFAULT_ENTRY_TITLE
+    assert result["data"] == {
+        CONF_HOST: IP_ADDRESS,
+    }
+    await hass.async_block_till_done()
+    mock_setup.assert_called_once()
+    mock_setup_entry.assert_called_once()
+
+    # Duplicate
+    with _patch_discovery(), _patch_single_discovery():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=config
+        )
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+async def test_manual(hass: HomeAssistant):
+    """Test manually setup."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert not result["errors"]
+
+    # Cannot connect (timeout)
+    with _patch_discovery(no_device=True), _patch_single_discovery(no_device=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: IP_ADDRESS}
+        )
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+    # Success
+    with _patch_discovery(), _patch_single_discovery(), patch(
+        f"{MODULE}.async_setup", return_value=True
+    ), patch(f"{MODULE}.async_setup_entry", return_value=True):
+        result4 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: IP_ADDRESS}
+        )
+        await hass.async_block_till_done()
+    assert result4["type"] == "create_entry"
+    assert result4["title"] == DEFAULT_ENTRY_TITLE
+    assert result4["data"] == {
+        CONF_HOST: IP_ADDRESS,
+    }
+
+    # Duplicate
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with _patch_discovery(no_device=True), _patch_single_discovery(no_device=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: IP_ADDRESS}
+        )
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "already_configured"
+
+
+async def test_manual_no_capabilities(hass: HomeAssistant):
+    """Test manually setup without successful get_capabilities."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert not result["errors"]
+
+    with _patch_discovery(no_device=True), _patch_single_discovery(), patch(
+        f"{MODULE}.async_setup", return_value=True
+    ), patch(f"{MODULE}.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: IP_ADDRESS}
+        )
+    assert result["type"] == "create_entry"
+    assert result["data"] == {
+        CONF_HOST: IP_ADDRESS,
+    }
+
+
+async def test_discovered_by_discovery_and_dhcp(hass):
+    """Test we get the form with discovery and abort for dhcp source when we get both."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with _patch_discovery(), _patch_single_discovery():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DISCOVERY},
+            data={CONF_HOST: IP_ADDRESS, CONF_MAC: MAC_ADDRESS, CONF_NAME: ALIAS},
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    with _patch_discovery(), _patch_single_discovery():
+        result2 = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data={"ip": IP_ADDRESS, "macaddress": MAC_ADDRESS, "hostname": ALIAS},
+        )
+        await hass.async_block_till_done()
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "already_in_progress"
+
+    with _patch_discovery(), _patch_single_discovery():
+        result3 = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data={"ip": IP_ADDRESS, "macaddress": "00:00:00:00:00:00"},
+        )
+        await hass.async_block_till_done()
+    assert result3["type"] == RESULT_TYPE_ABORT
+    assert result3["reason"] == "already_in_progress"
+
+    with _patch_discovery(no_device=True), _patch_single_discovery(no_device=True):
+        result3 = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data={"ip": "1.2.3.5", "macaddress": "00:00:00:00:00:01"},
+        )
+        await hass.async_block_till_done()
+    assert result3["type"] == RESULT_TYPE_ABORT
+    assert result3["reason"] == "cannot_connect"
+
+
+@pytest.mark.parametrize(
+    "source, data",
+    [
+        (
+            config_entries.SOURCE_DHCP,
+            {"ip": IP_ADDRESS, "macaddress": MAC_ADDRESS, "hostname": ALIAS},
+        ),
+        (
+            config_entries.SOURCE_DISCOVERY,
+            {CONF_HOST: IP_ADDRESS, CONF_MAC: MAC_ADDRESS, CONF_NAME: ALIAS},
+        ),
+    ],
+)
+async def test_discovered_by_dhcp_or_discovery(hass, source, data):
+    """Test we can setup when discovered from dhcp or discovery."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with _patch_discovery(), _patch_single_discovery():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": source}, data=data
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    with _patch_discovery(), _patch_single_discovery(), patch(
+        f"{MODULE}.async_setup", return_value=True
+    ) as mock_async_setup, patch(
+        f"{MODULE}.async_setup_entry", return_value=True
+    ) as mock_async_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["data"] == {
+        CONF_HOST: IP_ADDRESS,
+    }
+    assert mock_async_setup.called
+    assert mock_async_setup_entry.called
+
+
+@pytest.mark.parametrize(
+    "source, data",
+    [
+        (
+            config_entries.SOURCE_DHCP,
+            {"ip": IP_ADDRESS, "macaddress": MAC_ADDRESS, "hostname": ALIAS},
+        ),
+        (
+            config_entries.SOURCE_DISCOVERY,
+            {CONF_HOST: IP_ADDRESS, CONF_MAC: MAC_ADDRESS, CONF_NAME: ALIAS},
+        ),
+    ],
+)
+async def test_discovered_by_dhcp_or_discovery_failed_to_get_device(hass, source, data):
+    """Test we abort if we cannot get the unique id when discovered from dhcp."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with _patch_discovery(no_device=True), _patch_single_discovery(no_device=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": source}, data=data
+        )
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "cannot_connect"

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -5,7 +5,6 @@ import pytest
 
 from homeassistant import config_entries, setup
 from homeassistant.components.tplink import DOMAIN
-from homeassistant.components.tplink.const import CONF_LEGACY_ENTRY_ID
 from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
@@ -415,7 +414,6 @@ async def test_migration_device_online(hass: HomeAssistant):
     config = {
         CONF_MAC: MAC_ADDRESS,
         CONF_NAME: ALIAS,
-        CONF_LEGACY_ENTRY_ID: config_entry.entry_id,
     }
 
     with _patch_discovery(), _patch_single_discovery(), patch(
@@ -432,7 +430,6 @@ async def test_migration_device_online(hass: HomeAssistant):
     assert result["title"] == ALIAS
     assert result["data"] == {
         CONF_HOST: IP_ADDRESS,
-        CONF_LEGACY_ENTRY_ID: config_entry.entry_id,
     }
     assert len(mock_setup_entry.mock_calls) == 2
 
@@ -456,7 +453,6 @@ async def test_migration_device_offline(hass: HomeAssistant):
     config = {
         CONF_MAC: MAC_ADDRESS,
         CONF_NAME: ALIAS,
-        CONF_LEGACY_ENTRY_ID: config_entry.entry_id,
     }
 
     with _patch_discovery(no_device=True), _patch_single_discovery(
@@ -473,6 +469,5 @@ async def test_migration_device_offline(hass: HomeAssistant):
     assert result["title"] == ALIAS
     assert result["data"] == {
         CONF_HOST: None,
-        CONF_LEGACY_ENTRY_ID: config_entry.entry_id,
     }
     assert len(mock_setup_entry.mock_calls) == 2

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -1,98 +1,17 @@
 """Tests for the TP-Link component."""
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import patch
 
-from kasa import SmartDevice
-
-from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import tplink
 from homeassistant.setup import async_setup_component
-
-from tests.common import mock_coro
-
-
-async def test_creating_entry_tries_discover(hass):
-    """Test setting up does discovery."""
-    with patch(
-        "homeassistant.components.tplink.async_setup_entry",
-        return_value=mock_coro(True),
-    ) as mock_setup, patch(
-        "homeassistant.components.tplink.common.Discover.discover",
-        return_value={"host": 1234},
-    ):
-        result = await hass.config_entries.flow.async_init(
-            tplink.DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
-
-        # Confirmation form
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-
-        await hass.async_block_till_done()
-
-    assert len(mock_setup.mock_calls) == 1
 
 
 async def test_configuring_tplink_causes_discovery(hass):
     """Test that specifying empty config does discovery."""
-    with patch("homeassistant.components.tplink.common.Discover.discover") as discover:
+    with patch("homeassistant.components.tplink.Discover.discover") as discover:
         discover.return_value = {"host": 1234}
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
 
     assert len(discover.mock_calls) == 1
-
-
-class UnknownSmartDevice(SmartDevice):
-    """Dummy class for testing."""
-
-    @property
-    def has_emeter(self) -> bool:
-        """Do nothing."""
-
-    def turn_off(self) -> None:
-        """Do nothing."""
-
-    def turn_on(self) -> None:
-        """Do nothing."""
-
-    @property
-    def is_on(self) -> bool:
-        """Do nothing."""
-
-    @property
-    def state_information(self) -> dict[str, Any]:
-        """Do nothing."""
-
-
-async def test_configuring_discovery_disabled(hass):
-    """Test that discover does not get called when disabled."""
-    with patch(
-        "homeassistant.components.tplink.async_setup_entry",
-        return_value=mock_coro(True),
-    ) as mock_setup, patch(
-        "homeassistant.components.tplink.common.Discover.discover", return_value=[]
-    ) as discover:
-        await async_setup_component(
-            hass, tplink.DOMAIN, {tplink.DOMAIN: {tplink.CONF_DISCOVERY: False}}
-        )
-        await hass.async_block_till_done()
-
-    assert discover.call_count == 0
-    assert mock_setup.call_count == 1
-
-
-async def test_no_config_creates_no_entry(hass):
-    """Test for when there is no tplink in config."""
-    with patch(
-        "homeassistant.components.tplink.async_setup_entry",
-        return_value=mock_coro(True),
-    ) as mock_setup:
-        await async_setup_component(hass, tplink.DOMAIN, {})
-        await hass.async_block_till_done()
-
-    assert mock_setup.call_count == 0

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from homeassistant.components import tplink
+from homeassistant.components.tplink.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST
 from homeassistant.setup import async_setup_component
+
+from . import IP_ADDRESS, MAC_ADDRESS, _patch_discovery, _patch_single_discovery
+
+from tests.common import MockConfigEntry
 
 
 async def test_configuring_tplink_causes_discovery(hass):
@@ -15,3 +22,30 @@ async def test_configuring_tplink_causes_discovery(hass):
         await hass.async_block_till_done()
 
     assert len(discover.mock_calls) == 1
+
+
+async def test_config_entry_reload(hass):
+    """Test that a config entry can be reloaded."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    with _patch_discovery(), _patch_single_discovery():
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        assert already_migrated_config_entry.state == ConfigEntryState.LOADED
+        await hass.config_entries.async_unload(already_migrated_config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert already_migrated_config_entry.state == ConfigEntryState.NOT_LOADED
+
+
+async def test_config_entry_retry(hass):
+    """Test that a config entry can be retried."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    with _patch_discovery(no_device=True), _patch_single_discovery(no_device=True):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -372,7 +372,7 @@ async def update_entity(hass: HomeAssistant, entity_id: str) -> None:
 
 
 async def test_unknown_light(
-    hass: HomeAssistant, unknown_light_mock_data: LightMockData
+    hass: HomeAssistant, unknown_light_mock_data: LightMockData, mock_discovery: Mock
 ) -> None:
     """Test function."""
     await async_setup_component(hass, HA_DOMAIN, {})
@@ -397,7 +397,7 @@ async def test_unknown_light(
 
 
 async def test_update_failure(
-    hass: HomeAssistant, light_mock_data: LightMockData, caplog
+    hass: HomeAssistant, light_mock_data: LightMockData, mock_discovery: Mock, caplog
 ):
     """Test that update failures are logged."""
 

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -1,394 +1,271 @@
 """Tests for light platform."""
-from datetime import timedelta
-from typing import Callable, NamedTuple
-from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
 
 from homeassistant.components import tplink
-from homeassistant.components.homeassistant import DOMAIN as HA_DOMAIN
-from homeassistant.components.tplink.const import CONF_DISCOVERY, CONF_LIGHT
-from homeassistant.const import CONF_HOST
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_MODE,
+    ATTR_COLOR_TEMP,
+    ATTR_HS_COLOR,
+    ATTR_MAX_MIREDS,
+    ATTR_MIN_MIREDS,
+    ATTR_RGB_COLOR,
+    ATTR_SUPPORTED_COLOR_MODES,
+    ATTR_XY_COLOR,
+    DOMAIN as LIGHT_DOMAIN,
+)
+from homeassistant.components.tplink.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util.dt import utcnow
 
-from tests.common import async_fire_time_changed
+from . import MAC_ADDRESS, _mocked_bulb, _patch_discovery, _patch_single_discovery
 
-MOCK_ENERGY_DATA = {
-    "smartlife.iot.common.emeter": {
-        "get_daystat": {
-            "day_list": [
-                {"day": 23, "energy_wh": 2, "month": 9, "year": 2021},
-                {"day": 24, "energy_wh": 66, "month": 9, "year": 2021},
-            ],
-            "err_code": 0,
-        },
-        "get_monthstat": {
-            "err_code": 0,
-            "month_list": [{"energy_wh": 68, "month": 9, "year": 2021}],
-        },
-        "get_realtime": {"err_code": 0, "power_mw": 10800},
-    }
-}
+from tests.common import MockConfigEntry
 
 
-class LightMockData(NamedTuple):
-    """Mock light data."""
-
-    query_mock: AsyncMock
-    sys_info: dict
-    light_state: dict
-    set_light_state: Callable[[dict], None]
-    set_light_state_mock: Mock
-    get_light_state_mock: Mock
-    current_consumption_mock: Mock
-    sys_info_mock: Mock
-    get_emeter_daily_mock: Mock
-    get_emeter_monthly_mock: Mock
-
-
-class SmartSwitchMockData(NamedTuple):
-    """Mock smart switch data."""
-
-    query_mock: AsyncMock
-    sys_info: dict
-    is_on_mock: Mock
-    brightness_mock: Mock
-    sys_info_mock: Mock
-
-
-@pytest.fixture(name="unknown_light_mock_data")
-def unknown_light_mock_data_fixture() -> None:
-    """Create light mock data."""
-    light_state = {
-        "on_off": True,
-        "dft_on_state": {
-            "brightness": 12,
-            "color_temp": 3200,
-            "hue": 110,
-            "saturation": 90,
-        },
-        "brightness": 13,
-        "color_temp": 3300,
-        "hue": 110,
-        "saturation": 90,
-    }
-    sys_info = {
-        "sw_ver": "1.2.3",
-        "type": "smartbulb",
-        "hw_ver": "2.3.4",
-        "mac": "aa:bb:cc:dd:ee:ff",
-        "mic_mac": "00:11:22:33:44",
-        "hwId": "1234",
-        "fwId": "4567",
-        "oemId": "891011",
-        "dev_name": "light1",
-        "rssi": 11,
-        "latitude": "0",
-        "longitude": "0",
-        "is_color": True,
-        "is_dimmable": True,
-        "is_variable_color_temp": True,
-        "model": "Foo",
-        "alias": "light1",
-        "light_state": light_state,
-    }
-
-    def set_light_state(state) -> None:
-        nonlocal light_state
-        drt_on_state = light_state["dft_on_state"]
-        drt_on_state.update(state.get("dft_on_state", {}))
-
-        light_state.update(state)
-        light_state["dft_on_state"] = drt_on_state
-        return light_state
-
-    set_light_state_patch = patch(
-        "kasa.smartbulb.SmartBulb.set_light_state",
-        side_effect=set_light_state,
+async def test_color_light(hass: HomeAssistant) -> None:
+    """Test a light."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
     )
-    get_light_state_patch = patch(
-        "kasa.smartbulb.SmartBulb.get_light_state",
-        return_value=light_state,
-    )
-    current_consumption_patch = patch(
-        "kasa.smartdevice.SmartDevice.current_consumption",
-        return_value=3.23,
-    )
-    sys_info_patch = patch(
-        "kasa.smartdevice.SmartDevice.sys_info",
-        sys_info,
-    )
-    get_emeter_daily_patch = patch(
-        "kasa.smartdevice.SmartDevice.get_emeter_daily",
-        return_value={
-            1: 1.01,
-            2: 1.02,
-            3: 1.03,
-            4: 1.04,
-            5: 1.05,
-            6: 1.06,
-            7: 1.07,
-            8: 1.08,
-            9: 1.09,
-            10: 1.10,
-            11: 1.11,
-            12: 1.12,
-        },
-    )
-    get_emeter_monthly_patch = patch(
-        "kasa.smartdevice.SmartDevice.get_emeter_monthly",
-        return_value={
-            1: 2.01,
-            2: 2.02,
-            3: 2.03,
-            4: 2.04,
-            5: 2.05,
-            6: 2.06,
-            7: 2.07,
-            8: 2.08,
-            9: 2.09,
-            10: 2.10,
-            11: 2.11,
-            12: 2.12,
-        },
-    )
-    query_patch = patch(
-        "kasa.smartdevice.TPLinkSmartHomeProtocol.query",
-        return_value={"system": {"get_sysinfo": sys_info}, **MOCK_ENERGY_DATA},
-    )
-    with query_patch as query_mock, set_light_state_patch as set_light_state_mock, get_light_state_patch as get_light_state_mock, current_consumption_patch as current_consumption_mock, sys_info_patch as sys_info_mock, get_emeter_daily_patch as get_emeter_daily_mock, get_emeter_monthly_patch as get_emeter_monthly_mock:
-        yield LightMockData(
-            query_mock=query_mock,
-            sys_info=sys_info,
-            light_state=light_state,
-            set_light_state=set_light_state,
-            set_light_state_mock=set_light_state_mock,
-            get_light_state_mock=get_light_state_mock,
-            current_consumption_mock=current_consumption_mock,
-            sys_info_mock=sys_info_mock,
-            get_emeter_daily_mock=get_emeter_daily_mock,
-            get_emeter_monthly_mock=get_emeter_monthly_mock,
-        )
+    already_migrated_config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.color_temp = None
+    with _patch_discovery(device=bulb), _patch_single_discovery(device=bulb):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
+    entity_id = "light.my_bulb"
 
-@pytest.fixture(name="light_mock_data")
-def light_mock_data_fixture() -> None:
-    """Create light mock data."""
-    light_state = {
-        "on_off": True,
-        "dft_on_state": {
-            "brightness": 12,
-            "color_temp": 3200,
-            "hue": 110,
-            "saturation": 90,
-        },
-        "brightness": 13,
-        "color_temp": 3300,
-        "hue": 110,
-        "saturation": 90,
-    }
-    sys_info = {
-        "sw_ver": "1.2.3",
-        "hw_ver": "2.3.4",
-        "mac": "aa:bb:cc:dd:ee:ff",
-        "mic_mac": "00:11:22:33:44",
-        "type": "smartbulb",
-        "hwId": "1234",
-        "fwId": "4567",
-        "oemId": "891011",
-        "dev_name": "light1",
-        "rssi": 11,
-        "latitude": "0",
-        "longitude": "0",
-        "is_color": True,
-        "is_dimmable": True,
-        "is_variable_color_temp": True,
-        "model": "LB120",
-        "alias": "light1",
-        "light_state": light_state,
-    }
-
-    def set_light_state(state) -> None:
-        nonlocal light_state
-        drt_on_state = light_state["dft_on_state"]
-        drt_on_state.update(state.get("dft_on_state", {}))
-
-        light_state.update(state)
-        light_state["dft_on_state"] = drt_on_state
-        return light_state
-
-    set_light_state_patch = patch(
-        "kasa.smartbulb.SmartBulb.set_light_state",
-        side_effect=set_light_state,
-    )
-    get_light_state_patch = patch(
-        "kasa.smartbulb.SmartBulb.get_light_state",
-        return_value=light_state,
-    )
-    current_consumption_patch = patch(
-        "kasa.smartdevice.SmartDevice.current_consumption",
-        return_value=3.23,
-    )
-    sys_info_patch = patch(
-        "kasa.smartdevice.SmartDevice.sys_info",
-        sys_info,
-    )
-    get_emeter_daily_patch = patch(
-        "kasa.smartdevice.SmartDevice.get_emeter_daily",
-        return_value={
-            1: 1.01,
-            2: 1.02,
-            3: 1.03,
-            4: 1.04,
-            5: 1.05,
-            6: 1.06,
-            7: 1.07,
-            8: 1.08,
-            9: 1.09,
-            10: 1.10,
-            11: 1.11,
-            12: 1.12,
-        },
-    )
-    get_emeter_monthly_patch = patch(
-        "kasa.smartdevice.SmartDevice.get_emeter_monthly",
-        return_value={
-            1: 2.01,
-            2: 2.02,
-            3: 2.03,
-            4: 2.04,
-            5: 2.05,
-            6: 2.06,
-            7: 2.07,
-            8: 2.08,
-            9: 2.09,
-            10: 2.10,
-            11: 2.11,
-            12: 2.12,
-        },
-    )
-    query_patch = patch(
-        "kasa.smartdevice.TPLinkSmartHomeProtocol.query",
-        return_value={"system": {"get_sysinfo": sys_info}, **MOCK_ENERGY_DATA},
-    )
-    with query_patch as query_mock, set_light_state_patch as set_light_state_mock, get_light_state_patch as get_light_state_mock, current_consumption_patch as current_consumption_mock, sys_info_patch as sys_info_mock, get_emeter_daily_patch as get_emeter_daily_mock, get_emeter_monthly_patch as get_emeter_monthly_mock:
-        yield LightMockData(
-            query_mock=query_mock,
-            sys_info=sys_info,
-            light_state=light_state,
-            set_light_state=set_light_state,
-            set_light_state_mock=set_light_state_mock,
-            get_light_state_mock=get_light_state_mock,
-            current_consumption_mock=current_consumption_mock,
-            sys_info_mock=sys_info_mock,
-            get_emeter_daily_mock=get_emeter_daily_mock,
-            get_emeter_monthly_mock=get_emeter_monthly_mock,
-        )
-
-
-@pytest.fixture(name="dimmer_switch_mock_data")
-def dimmer_switch_mock_data_fixture() -> None:
-    """Create dimmer switch mock data."""
-    sys_info = {
-        "sw_ver": "1.2.3",
-        "hw_ver": "2.3.4",
-        "mac": "aa:bb:cc:dd:ee:ff",
-        "mic_mac": "00:11:22:33:44",
-        "type": "smartplug",
-        "hwId": "1234",
-        "fwId": "4567",
-        "oemId": "891011",
-        "dev_name": "dimmer1",
-        "led_off": 1,
-        "rssi": 11,
-        "latitude": "0",
-        "longitude": "0",
-        "is_color": False,
-        "is_dimmable": True,
-        "is_variable_color_temp": False,
-        "model": "HS220",
-        "alias": "dimmer1",
-        "feature": ":",
-        "relay_state": 1,
-        "brightness": 13,
-    }
-
-    def is_on(*args, **kwargs):
-        nonlocal sys_info
-        if len(args) == 0:
-            return sys_info["relay_state"]
-        if args[0] == "ON":
-            sys_info["relay_state"] = 1
-        else:
-            sys_info["relay_state"] = 0
-
-    def brightness(*args, **kwargs):
-        nonlocal sys_info
-        if len(args) == 0:
-            return sys_info["brightness"]
-        if sys_info["brightness"] == 0:
-            sys_info["relay_state"] = 0
-        else:
-            sys_info["relay_state"] = 1
-            sys_info["brightness"] = args[0]
-
-    sys_info_patch = patch(
-        "kasa.smartdevice.SmartDevice.sys_info",
-        sys_info,
-    )
-    is_on_patch = patch(
-        "kasa.smartdimmer.SmartDimmer.is_on",
-        new_callable=PropertyMock,
-        side_effect=is_on,
-    )
-    brightness_patch = patch(
-        "kasa.smartdimmer.SmartDimmer.brightness",
-        new_callable=PropertyMock,
-        side_effect=brightness,
-    )
-    query_patch = patch(
-        "kasa.smartdevice.TPLinkSmartHomeProtocol.query",
-        return_value={"system": {"get_sysinfo": sys_info}, **MOCK_ENERGY_DATA},
-    )
-    with query_patch as query_mock, brightness_patch as brightness_mock, is_on_patch as is_on_mock, sys_info_patch as sys_info_mock:
-        yield SmartSwitchMockData(
-            query=query_mock,
-            sys_info=sys_info,
-            brightness_mock=brightness_mock,
-            is_on_mock=is_on_mock,
-            sys_info_mock=sys_info_mock,
-        )
-
-
-async def update_entity(hass: HomeAssistant, entity_id: str) -> None:
-    """Run an update action for an entity."""
-    future = utcnow() + timedelta(seconds=30)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
-
-
-async def test_unknown_light(
-    hass: HomeAssistant, unknown_light_mock_data: LightMockData, mock_discovery: Mock
-) -> None:
-    """Test function."""
-    await async_setup_component(hass, HA_DOMAIN, {})
-    await hass.async_block_till_done()
-
-    await async_setup_component(
-        hass,
-        tplink.DOMAIN,
-        {
-            tplink.DOMAIN: {
-                CONF_DISCOVERY: False,
-                CONF_LIGHT: [{CONF_HOST: "123.123.123.123"}],
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("light.light1")
+    state = hass.states.get(entity_id)
     assert state.state == "on"
-    assert state.attributes["min_mireds"] == 200
-    assert state.attributes["max_mireds"] == 370
+    attributes = state.attributes
+    assert attributes[ATTR_BRIGHTNESS] == 128
+    assert attributes[ATTR_COLOR_MODE] == "hs"
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["brightness", "color_temp", "hs"]
+    assert attributes[ATTR_MIN_MIREDS] == 111
+    assert attributes[ATTR_MAX_MIREDS] == 250
+    assert attributes[ATTR_HS_COLOR] == (10, 30)
+    assert attributes[ATTR_RGB_COLOR] == (255, 191, 178)
+    assert attributes[ATTR_XY_COLOR] == (0.42, 0.336)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.turn_off.assert_called_once()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.turn_on.assert_called_once()
+    bulb.turn_on.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
+        blocking=True,
+    )
+    bulb.set_brightness.assert_called_with(39, transition=None)
+    bulb.set_brightness.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 150},
+        blocking=True,
+    )
+    bulb.set_color_temp.assert_called_with(6666, brightness=None, transition=None)
+    bulb.set_color_temp.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 150},
+        blocking=True,
+    )
+    bulb.set_color_temp.assert_called_with(6666, brightness=None, transition=None)
+    bulb.set_color_temp.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_HS_COLOR: (10, 30)},
+        blocking=True,
+    )
+    bulb.set_hsv.assert_called_with(10, 30, None, transition=None)
+    bulb.set_hsv.reset_mock()
+
+
+@pytest.mark.parametrize("is_color", [True, False])
+async def test_color_temp_light(hass: HomeAssistant, is_color: bool) -> None:
+    """Test a light."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.is_color = is_color
+    bulb.color_temp = 4000
+    bulb.is_variable_color_temp = True
+
+    with _patch_discovery(device=bulb), _patch_single_discovery(device=bulb):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_bulb"
+
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+    attributes = state.attributes
+    assert attributes[ATTR_BRIGHTNESS] == 128
+    assert attributes[ATTR_COLOR_MODE] == "color_temp"
+    if bulb.is_color:
+        assert attributes[ATTR_SUPPORTED_COLOR_MODES] == [
+            "brightness",
+            "color_temp",
+            "hs",
+        ]
+    else:
+        assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["brightness", "color_temp"]
+    assert attributes[ATTR_MIN_MIREDS] == 111
+    assert attributes[ATTR_MAX_MIREDS] == 250
+    assert attributes[ATTR_COLOR_TEMP] == 250
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.turn_off.assert_called_once()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.turn_on.assert_called_once()
+    bulb.turn_on.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
+        blocking=True,
+    )
+    bulb.set_brightness.assert_called_with(39, transition=None)
+    bulb.set_brightness.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 150},
+        blocking=True,
+    )
+    bulb.set_color_temp.assert_called_with(6666, brightness=None, transition=None)
+    bulb.set_color_temp.reset_mock()
+
+
+async def test_brightness_only_light(hass: HomeAssistant) -> None:
+    """Test a light."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.is_color = False
+    bulb.is_variable_color_temp = False
+
+    with _patch_discovery(device=bulb), _patch_single_discovery(device=bulb):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_bulb"
+
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+    attributes = state.attributes
+    assert attributes[ATTR_BRIGHTNESS] == 128
+    assert attributes[ATTR_COLOR_MODE] == "brightness"
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["brightness"]
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.turn_off.assert_called_once()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.turn_on.assert_called_once()
+    bulb.turn_on.reset_mock()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
+        blocking=True,
+    )
+    bulb.set_brightness.assert_called_with(39, transition=None)
+    bulb.set_brightness.reset_mock()
+
+
+async def test_on_off_light(hass: HomeAssistant) -> None:
+    """Test a light."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.is_color = False
+    bulb.is_variable_color_temp = False
+    bulb.is_dimmable = False
+
+    with _patch_discovery(device=bulb), _patch_single_discovery(device=bulb):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_bulb"
+
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+    attributes = state.attributes
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["onoff"]
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.turn_off.assert_called_once()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    bulb.turn_on.assert_called_once()
+    bulb.turn_on.reset_mock()
+
+
+async def test_off_at_start_light(hass: HomeAssistant) -> None:
+    """Test a light."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.is_color = False
+    bulb.is_variable_color_temp = False
+    bulb.is_dimmable = False
+    bulb.is_on = False
+
+    with _patch_discovery(device=bulb), _patch_single_discovery(device=bulb):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_bulb"
+
+    state = hass.states.get(entity_id)
+    assert state.state == "off"
+    attributes = state.attributes
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["onoff"]

--- a/tests/components/tplink/test_migration.py
+++ b/tests/components/tplink/test_migration.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from homeassistant import setup
 from homeassistant.components.tplink import DOMAIN
 from homeassistant.components.tplink.migration import CLEANUP_DELAY
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceRegistry
@@ -91,7 +92,7 @@ async def test_migration_device_online_end_to_end_after_downgrade(
     config_entry.add_to_hass(hass)
 
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     device = device_reg.async_get_or_create(

--- a/tests/components/tplink/test_migration.py
+++ b/tests/components/tplink/test_migration.py
@@ -1,0 +1,217 @@
+"""Test the tplink config flow."""
+from datetime import timedelta
+
+from homeassistant import setup
+from homeassistant.components.tplink import DOMAIN
+from homeassistant.components.tplink.migration import CLEANUP_DELAY
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.device_registry import DeviceRegistry
+from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.util import dt as dt_util
+
+from . import (
+    ALIAS,
+    IP_ADDRESS,
+    MAC_ADDRESS,
+    MODEL,
+    _patch_discovery,
+    _patch_single_discovery,
+)
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+DEVICE_ID = f"{ALIAS} {MODEL} ({IP_ADDRESS}) {MAC_ADDRESS}"
+
+
+async def test_migration_device_online_end_to_end(
+    hass: HomeAssistant, device_reg: DeviceRegistry, entity_reg: EntityRegistry
+):
+    """Test migration from single config entry."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+    device = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS)},
+        name=ALIAS,
+    )
+    light_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=MAC_ADDRESS,
+        original_name=ALIAS,
+        device_id=device.id,
+    )
+    power_sensor_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="sensor",
+        unique_id=f"{MAC_ADDRESS}_sensor",
+        original_name=ALIAS,
+        device_id=device.id,
+    )
+
+    with _patch_discovery(), _patch_single_discovery():
+        await setup.async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+        migrated_entry = None
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if entry.unique_id == DOMAIN:
+                migrated_entry = entry
+                break
+
+        assert migrated_entry is not None
+
+        assert device.config_entries == {migrated_entry.entry_id}
+        assert light_entity_reg.config_entry_id == migrated_entry.entry_id
+        assert power_sensor_entity_reg.config_entry_id == migrated_entry.entry_id
+        assert er.async_entries_for_config_entry(entity_reg, config_entry) == []
+
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=CLEANUP_DELAY + 5)
+        )
+        await hass.async_block_till_done()
+
+        legacy_entry = None
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if entry.unique_id == DOMAIN:
+                legacy_entry = entry
+                break
+
+        assert legacy_entry is None
+
+
+async def test_migration_device_online_end_to_end_after_downgrade(
+    hass: HomeAssistant, device_reg: DeviceRegistry, entity_reg: EntityRegistry
+):
+    """Test migration from single config entry can happen again after a downgrade."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    device = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS)},
+        name=ALIAS,
+    )
+    light_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=MAC_ADDRESS,
+        original_name=ALIAS,
+        device_id=device.id,
+    )
+    power_sensor_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="sensor",
+        unique_id=f"{MAC_ADDRESS}_sensor",
+        original_name=ALIAS,
+        device_id=device.id,
+    )
+
+    with _patch_discovery(), _patch_single_discovery():
+        await setup.async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+        assert device.config_entries == {config_entry.entry_id}
+        assert light_entity_reg.config_entry_id == config_entry.entry_id
+        assert power_sensor_entity_reg.config_entry_id == config_entry.entry_id
+        assert er.async_entries_for_config_entry(entity_reg, config_entry) == []
+
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=CLEANUP_DELAY + 5)
+        )
+        await hass.async_block_till_done()
+
+        legacy_entry = None
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if entry.unique_id == DOMAIN:
+                legacy_entry = entry
+                break
+
+        assert legacy_entry is None
+
+
+async def test_migration_device_online_end_to_end_ignores_other_devices(
+    hass: HomeAssistant, device_reg: DeviceRegistry, entity_reg: EntityRegistry
+):
+    """Test migration from single config entry."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+    device = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS)},
+        name=ALIAS,
+    )
+    light_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=MAC_ADDRESS,
+        original_name=ALIAS,
+        device_id=device.id,
+    )
+    power_sensor_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="sensor",
+        unique_id=f"{MAC_ADDRESS}_sensor",
+        original_name=ALIAS,
+        device_id=device.id,
+    )
+    ignored_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="sensor",
+        unique_id="00:00:00:00:00:00_sensor",
+        original_name=ALIAS,
+        device_id=device.id,
+    )
+    garbage_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="sensor",
+        unique_id="garbage",
+        original_name=ALIAS,
+        device_id=device.id,
+    )
+
+    with _patch_discovery(), _patch_single_discovery():
+        await setup.async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+        migrated_entry = None
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if entry.unique_id == DOMAIN:
+                migrated_entry = entry
+                break
+
+        assert migrated_entry is not None
+
+        assert device.config_entries == {migrated_entry.entry_id}
+        assert light_entity_reg.config_entry_id == migrated_entry.entry_id
+        assert power_sensor_entity_reg.config_entry_id == migrated_entry.entry_id
+        assert ignored_entity_reg.config_entry_id == config_entry.entry_id
+        assert garbage_entity_reg.config_entry_id == config_entry.entry_id
+
+        assert er.async_entries_for_config_entry(entity_reg, config_entry) == []
+
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=CLEANUP_DELAY + 5)
+        )
+        await hass.async_block_till_done()
+
+        legacy_entry = None
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if entry.unique_id == DOMAIN:
+                legacy_entry = entry
+                break
+
+        assert legacy_entry is not None

--- a/tests/components/tplink/test_sensor.py
+++ b/tests/components/tplink/test_sensor.py
@@ -1,0 +1,117 @@
+"""Tests for light platform."""
+
+from unittest.mock import Mock
+
+from homeassistant.components import tplink
+from homeassistant.components.tplink.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import (
+    MAC_ADDRESS,
+    _mocked_bulb,
+    _mocked_plug,
+    _patch_discovery,
+    _patch_single_discovery,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_color_light_with_an_emeter(hass: HomeAssistant) -> None:
+    """Test a light with an emeter."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.color_temp = None
+    bulb.has_emeter = True
+    bulb.emeter_realtime = Mock(
+        power=100,
+        total=30,
+        voltage=121,
+        current=5,
+    )
+    bulb.emeter_today = 5000
+    with _patch_discovery(device=bulb), _patch_single_discovery(device=bulb):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    expected = {
+        "sensor.my_bulb_current_consumption": 100,
+        "sensor.my_bulb_total_consumption": 30,
+        "sensor.my_bulb_today_s_consumption": 5000,
+        "sensor.my_bulb_voltage": 121,
+        "sensor.my_bulb_current": 5,
+    }
+    entity_id = "light.my_bulb"
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+    for sensor_entity_id, value in expected.items():
+        assert hass.states.get(sensor_entity_id).state == str(value)
+
+
+async def test_plug_with_an_emeter(hass: HomeAssistant) -> None:
+    """Test a plug with an emeter."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    plug = _mocked_plug()
+    plug.color_temp = None
+    plug.has_emeter = True
+    plug.emeter_realtime = Mock(
+        power=100,
+        total=30,
+        voltage=121,
+        current=5,
+    )
+    plug.emeter_today = None
+    with _patch_discovery(device=plug), _patch_single_discovery(device=plug):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    expected = {
+        "sensor.my_plug_current_consumption": 100,
+        "sensor.my_plug_total_consumption": 30,
+        "sensor.my_plug_today_s_consumption": 0.0,
+        "sensor.my_plug_voltage": 121,
+        "sensor.my_plug_current": 5,
+    }
+    entity_id = "switch.my_plug"
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+    for sensor_entity_id, value in expected.items():
+        assert hass.states.get(sensor_entity_id).state == str(value)
+
+
+async def test_color_light_no_emeter(hass: HomeAssistant) -> None:
+    """Test a light without an emeter."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.color_temp = None
+    bulb.has_emeter = False
+    with _patch_discovery(device=bulb), _patch_single_discovery(device=bulb):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_bulb"
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+
+    not_expected = [
+        "sensor.my_bulb_current_consumption"
+        "sensor.my_bulb_total_consumption"
+        "sensor.my_bulb_today_s_consumption"
+        "sensor.my_bulb_voltage"
+        "sensor.my_bulb_current"
+    ]
+    for sensor_entity_id in not_expected:
+        assert hass.states.get(sensor_entity_id) is None

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -34,7 +34,6 @@ async def test_plug(hass: HomeAssistant) -> None:
     with _patch_discovery(device=plug), _patch_single_discovery(device=plug):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
-        await hass.async_block_till_done()
 
     entity_id = "switch.my_plug"
     state = hass.states.get(entity_id)
@@ -63,7 +62,6 @@ async def test_plug_update_fails(hass: HomeAssistant) -> None:
     with _patch_discovery(device=plug), _patch_single_discovery(device=plug):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
-        await hass.async_block_till_done()
 
     entity_id = "switch.my_plug"
     state = hass.states.get(entity_id)
@@ -85,7 +83,6 @@ async def test_strip(hass: HomeAssistant) -> None:
     plug = _mocked_strip()
     with _patch_discovery(device=plug), _patch_single_discovery(device=plug):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
-        await hass.async_block_till_done()
         await hass.async_block_till_done()
 
     entity_id = "switch.my_strip"

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -1,0 +1,105 @@
+"""Tests for switch platform."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from kasa import SmartDeviceException
+
+from homeassistant.components import tplink
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.tplink.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from . import (
+    MAC_ADDRESS,
+    _mocked_plug,
+    _mocked_strip,
+    _patch_discovery,
+    _patch_single_discovery,
+)
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_plug(hass: HomeAssistant) -> None:
+    """Test a smart plug."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    plug = _mocked_plug()
+    with _patch_discovery(device=plug), _patch_single_discovery(device=plug):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    entity_id = "switch.my_plug"
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    plug.turn_off.assert_called_once()
+    plug.turn_off.reset_mock()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    plug.turn_on.assert_called_once()
+    plug.turn_on.reset_mock()
+
+
+async def test_plug_update_fails(hass: HomeAssistant) -> None:
+    """Test a smart plug update failure."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    plug = _mocked_plug()
+    with _patch_discovery(device=plug), _patch_single_discovery(device=plug):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    entity_id = "switch.my_plug"
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    plug.update = AsyncMock(side_effect=SmartDeviceException)
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_strip(hass: HomeAssistant) -> None:
+    """Test a smart strip."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    plug = _mocked_strip()
+    with _patch_discovery(device=plug), _patch_single_discovery(device=plug):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    entity_id = "switch.my_strip"
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    plug.turn_off.assert_called_once()
+    plug.turn_off.reset_mock()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    plug.turn_on.assert_called_once()
+    plug.turn_on.reset_mock()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Part 2 of https://github.com/home-assistant/core/pull/56512

Setup retries are now handled by config entry retries instead of additional complex retry logic.

Even with the config flow and the migration code, the integration shrunk from 477 lines to 441 lines. When we remove migration/yaml import code in the future, we should be around ~295 lines.

```
---------- coverage: platform darwin, python 3.9.6-final-0 -----------
Name                                             Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------
homeassistant/components/tplink/__init__.py         65      0   100%
homeassistant/components/tplink/config_flow.py      97      0   100%
homeassistant/components/tplink/const.py            16      0   100%
homeassistant/components/tplink/coordinator.py      37      0   100%
homeassistant/components/tplink/entity.py           32      0   100%
homeassistant/components/tplink/light.py            80      0   100%
homeassistant/components/tplink/migration.py        48      0   100%
homeassistant/components/tplink/sensor.py           28      0   100%
homeassistant/components/tplink/switch.py           31      0   100%
homeassistant/components/tplink/utils.py             7      0   100%
------------------------------------------------------------------------------
TOTAL                                              441      0   100%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
