### PR TITLE
Add binary sensor platform to Tractive integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1102,6 +1102,7 @@ omit =
     homeassistant/components/traccar/device_tracker.py
     homeassistant/components/traccar/const.py
     homeassistant/components/tractive/__init__.py
+    homeassistant/components/tractive/binary_sensor.py
     homeassistant/components/tractive/device_tracker.py
     homeassistant/components/tractive/entity.py
     homeassistant/components/tractive/sensor.py

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -9,6 +9,7 @@ import aiotractive
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_BATTERY_CHARGING,
     ATTR_BATTERY_LEVEL,
     CONF_EMAIL,
     CONF_PASSWORD,
@@ -32,7 +33,7 @@ from .const import (
     TRACKER_POSITION_UPDATED,
 )
 
-PLATFORMS = ["device_tracker", "sensor"]
+PLATFORMS = ["binary_sensor", "device_tracker", "sensor"]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -187,7 +188,10 @@ class TractiveClient:
                 continue
 
     def _send_hardware_update(self, event):
-        payload = {ATTR_BATTERY_LEVEL: event["hardware"]["battery_level"]}
+        payload = {
+            ATTR_BATTERY_LEVEL: event["hardware"]["battery_level"],
+            ATTR_BATTERY_CHARGING: event["charging_state"] == "CHARGING",
+        }
         self._dispatch_tracker_event(
             TRACKER_HARDWARE_STATUS_UPDATED, event["tracker_id"], payload
         )

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -1,0 +1,95 @@
+"""Support for Tractive binary sensors."""
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_BATTERY_CHARGING,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import ATTR_BATTERY_CHARGING
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import (
+    CLIENT,
+    DOMAIN,
+    SERVER_UNAVAILABLE,
+    TRACKABLES,
+    TRACKER_HARDWARE_STATUS_UPDATED,
+)
+from .entity import TractiveEntity
+
+
+class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
+    """Tractive sensor."""
+
+    def __init__(self, user_id, trackable, tracker_details, unique_id, description):
+        """Initialize sensor entity."""
+        super().__init__(user_id, trackable, tracker_details)
+
+        self._attr_name = f"{trackable['details']['name']} {description.name}"
+        self._attr_unique_id = unique_id
+        self.entity_description = description
+
+    @callback
+    def handle_server_unavailable(self):
+        """Handle server unavailable."""
+        self._attr_available = False
+        self.async_write_ha_state()
+
+    @callback
+    def handle_hardware_status_update(self, event):
+        """Handle hardware status update."""
+        self._attr_is_on = event[self.entity_description.key]
+        self._attr_available = True
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{TRACKER_HARDWARE_STATUS_UPDATED}-{self._tracker_id}",
+                self.handle_hardware_status_update,
+            )
+        )
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SERVER_UNAVAILABLE}-{self._user_id}",
+                self.handle_server_unavailable,
+            )
+        )
+
+
+SENSOR_TYPES = (
+    BinarySensorEntityDescription(
+        key=ATTR_BATTERY_CHARGING,
+        name="Battery Charging",
+        device_class=DEVICE_CLASS_BATTERY_CHARGING,
+    ),
+)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Tractive device trackers."""
+    client = hass.data[DOMAIN][entry.entry_id][CLIENT]
+    trackables = hass.data[DOMAIN][entry.entry_id][TRACKABLES]
+
+    entities = []
+
+    for item in trackables:
+        for description in SENSOR_TYPES:
+            entities.append(
+                TractiveBinarySensor(
+                    client.user_id,
+                    item.trackable,
+                    item.tracker_details,
+                    f"{item.trackable['_id']}_{description.key}",
+                    description,
+                )
+            )
+
+    async_add_entities(entities)

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -82,14 +82,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     for item in trackables:
         for description in SENSOR_TYPES:
-            entities.append(
-                TractiveBinarySensor(
-                    client.user_id,
-                    item.trackable,
-                    item.tracker_details,
-                    f"{item.trackable['_id']}_{description.key}",
-                    description,
+            if item.tracker_details["model_number"] == "TRNJA4":
+                entities.append(
+                    TractiveBinarySensor(
+                        client.user_id,
+                        item.trackable,
+                        item.tracker_details,
+                        f"{item.trackable['_id']}_{description.key}",
+                        description,
+                    )
                 )
-            )
 
     async_add_entities(entities)

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -19,6 +19,8 @@ from .const import (
 )
 from .entity import TractiveEntity
 
+TRACKERS_WITH_BUILTIN_BATTERY = ("TRNJA4", "TRAXL1")
+
 
 class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
     """Tractive sensor."""
@@ -79,8 +81,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
 
     for item in trackables:
-        # Currently, we only know one model that supports the battery charging sensor.
-        if item.tracker_details["model_number"] != "TRNJA4":
+        if item.tracker_details["model_number"] not in TRACKERS_WITH_BUILTIN_BATTERY:
             continue
         entities.append(
             TractiveBinarySensor(

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -64,12 +64,10 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
         )
 
 
-SENSOR_TYPES = (
-    BinarySensorEntityDescription(
-        key=ATTR_BATTERY_CHARGING,
-        name="Battery Charging",
-        device_class=DEVICE_CLASS_BATTERY_CHARGING,
-    ),
+SENSOR_TYPE = BinarySensorEntityDescription(
+    key=ATTR_BATTERY_CHARGING,
+    name="Battery Charging",
+    device_class=DEVICE_CLASS_BATTERY_CHARGING,
 )
 
 
@@ -81,16 +79,17 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities = []
 
     for item in trackables:
-        for description in SENSOR_TYPES:
-            if item.tracker_details["model_number"] == "TRNJA4":
-                entities.append(
-                    TractiveBinarySensor(
-                        client.user_id,
-                        item.trackable,
-                        item.tracker_details,
-                        f"{item.trackable['_id']}_{description.key}",
-                        description,
-                    )
-                )
+        # Currently, we only know one model that supports the battery charging sensor.
+        if item.tracker_details["model_number"] != "TRNJA4":
+            continue
+        entities.append(
+            TractiveBinarySensor(
+                client.user_id,
+                item.trackable,
+                item.tracker_details,
+                f"{item.trackable['_id']}_{SENSOR_TYPE.key}",
+                SENSOR_TYPE,
+            )
+        )
 
     async_add_entities(entities)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds `binary_sensor` platform to Tractive integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19466

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
