### PR TITLE
Add code_format to template alarm

### DIFF
--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -62,9 +62,9 @@ CONF_CODE_FORMAT = "code_format"
 class CodeFormat(Enum):
     """Class to represent different code formats."""
 
-    text = FORMAT_TEXT
+    no_code = None
     number = FORMAT_NUMBER
-    none = None
+    text = FORMAT_TEXT
 
 
 ALARM_CONTROL_PANEL_SCHEMA = vol.Schema(

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -101,8 +101,8 @@ async def _async_create_entities(hass, config):
         arm_away_action = device_config.get(CONF_ARM_AWAY_ACTION)
         arm_home_action = device_config.get(CONF_ARM_HOME_ACTION)
         arm_night_action = device_config.get(CONF_ARM_NIGHT_ACTION)
-        code_arm_required = device_config.get(CONF_CODE_ARM_REQUIRED)
-        code_format = device_config.get(CONF_CODE_FORMAT)
+        code_arm_required = device_config[CONF_CODE_ARM_REQUIRED]
+        code_format = device_config[CONF_CODE_FORMAT]
         unique_id = device_config.get(CONF_UNIQUE_ID)
 
         alarm_control_panels.append(

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -1,4 +1,5 @@
 """Support for Template alarm control panels."""
+from enum import Enum
 import logging
 
 import voluptuous as vol
@@ -6,6 +7,7 @@ import voluptuous as vol
 from homeassistant.components.alarm_control_panel import (
     ENTITY_ID_FORMAT,
     FORMAT_NUMBER,
+    FORMAT_TEXT,
     PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
     AlarmControlPanelEntity,
 )
@@ -54,6 +56,16 @@ CONF_ARM_NIGHT_ACTION = "arm_night"
 CONF_DISARM_ACTION = "disarm"
 CONF_ALARM_CONTROL_PANELS = "panels"
 CONF_CODE_ARM_REQUIRED = "code_arm_required"
+CONF_CODE_FORMAT = "code_format"
+
+
+class CodeFormat(Enum):
+    """Class to represent different code formats."""
+
+    text = FORMAT_TEXT
+    number = FORMAT_NUMBER
+    none = None
+
 
 ALARM_CONTROL_PANEL_SCHEMA = vol.Schema(
     {
@@ -63,6 +75,7 @@ ALARM_CONTROL_PANEL_SCHEMA = vol.Schema(
         vol.Optional(CONF_ARM_HOME_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_ARM_NIGHT_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
+        vol.Optional(CONF_CODE_FORMAT, default="number"): cv.enum(CodeFormat),
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
@@ -88,7 +101,8 @@ async def _async_create_entities(hass, config):
         arm_away_action = device_config.get(CONF_ARM_AWAY_ACTION)
         arm_home_action = device_config.get(CONF_ARM_HOME_ACTION)
         arm_night_action = device_config.get(CONF_ARM_NIGHT_ACTION)
-        code_arm_required = device_config[CONF_CODE_ARM_REQUIRED]
+        code_arm_required = device_config.get(CONF_CODE_ARM_REQUIRED)
+        code_format = device_config.get(CONF_CODE_FORMAT)
         unique_id = device_config.get(CONF_UNIQUE_ID)
 
         alarm_control_panels.append(
@@ -102,6 +116,7 @@ async def _async_create_entities(hass, config):
                 arm_home_action,
                 arm_night_action,
                 code_arm_required,
+                code_format,
                 unique_id,
             )
         )
@@ -128,6 +143,7 @@ class AlarmControlPanelTemplate(TemplateEntity, AlarmControlPanelEntity):
         arm_home_action,
         arm_night_action,
         code_arm_required,
+        code_format,
         unique_id,
     ):
         """Initialize the panel."""
@@ -139,6 +155,7 @@ class AlarmControlPanelTemplate(TemplateEntity, AlarmControlPanelEntity):
         self._template = state_template
         self._disarm_script = None
         self._code_arm_required = code_arm_required
+        self._code_format = code_format
         domain = __name__.split(".")[-2]
         if disarm_action is not None:
             self._disarm_script = Script(hass, disarm_action, name, domain)
@@ -187,8 +204,8 @@ class AlarmControlPanelTemplate(TemplateEntity, AlarmControlPanelEntity):
 
     @property
     def code_format(self):
-        """Return one or more digits/characters."""
-        return FORMAT_NUMBER
+        """Regex for code format or None if no code is required."""
+        return self._code_format.value
 
     @property
     def code_arm_required(self):

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -71,7 +71,7 @@ ALARM_CONTROL_PANEL_SCHEMA = vol.Schema(
         vol.Optional(CONF_ARM_HOME_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_ARM_NIGHT_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
-        vol.Optional(CONF_CODE_FORMAT, default="number"): vol.In(
+        vol.Optional(CONF_CODE_FORMAT, default=FORMAT_NUMBER): vol.In(
             SUPPORTED_CODE_FORMATS
         ),
         vol.Optional(CONF_NAME): cv.string,

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -1,5 +1,4 @@
 """Support for Template alarm control panels."""
-from enum import Enum
 import logging
 
 import voluptuous as vol
@@ -59,12 +58,9 @@ CONF_CODE_ARM_REQUIRED = "code_arm_required"
 CONF_CODE_FORMAT = "code_format"
 
 
-class CodeFormat(Enum):
-    """Class to represent different code formats."""
+FORMAT_NONE = "none"
 
-    text = FORMAT_TEXT
-    number = FORMAT_NUMBER
-    none = None
+SUPPORTED_CODE_FORMATS = (FORMAT_TEXT, FORMAT_NUMBER, FORMAT_NONE)
 
 
 ALARM_CONTROL_PANEL_SCHEMA = vol.Schema(
@@ -75,7 +71,9 @@ ALARM_CONTROL_PANEL_SCHEMA = vol.Schema(
         vol.Optional(CONF_ARM_HOME_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_ARM_NIGHT_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
-        vol.Optional(CONF_CODE_FORMAT, default="number"): cv.enum(CodeFormat),
+        vol.Optional(CONF_CODE_FORMAT, default="number"): vol.In(
+            SUPPORTED_CODE_FORMATS
+        ),
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
@@ -205,7 +203,7 @@ class AlarmControlPanelTemplate(TemplateEntity, AlarmControlPanelEntity):
     @property
     def code_format(self):
         """Regex for code format or None if no code is required."""
-        return self._code_format.value
+        return None if self._code_format == FORMAT_NONE else self._code_format
 
     @property
     def code_arm_required(self):

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -1,4 +1,5 @@
 """Support for Template alarm control panels."""
+from enum import Enum
 import logging
 
 import voluptuous as vol
@@ -58,9 +59,12 @@ CONF_CODE_ARM_REQUIRED = "code_arm_required"
 CONF_CODE_FORMAT = "code_format"
 
 
-FORMAT_NONE = "none"
+class CodeFormat(Enum):
+    """Class to represent different code formats."""
 
-SUPPORTED_CODE_FORMATS = (FORMAT_TEXT, FORMAT_NUMBER, FORMAT_NONE)
+    text = FORMAT_TEXT
+    number = FORMAT_NUMBER
+    none = None
 
 
 ALARM_CONTROL_PANEL_SCHEMA = vol.Schema(
@@ -71,8 +75,8 @@ ALARM_CONTROL_PANEL_SCHEMA = vol.Schema(
         vol.Optional(CONF_ARM_HOME_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_ARM_NIGHT_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
-        vol.Optional(CONF_CODE_FORMAT, default=FORMAT_NUMBER): vol.In(
-            SUPPORTED_CODE_FORMATS
+        vol.Optional(CONF_CODE_FORMAT, default=CodeFormat.number.name): cv.enum(
+            CodeFormat
         ),
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
@@ -203,7 +207,7 @@ class AlarmControlPanelTemplate(TemplateEntity, AlarmControlPanelEntity):
     @property
     def code_format(self):
         """Regex for code format or None if no code is required."""
-        return None if self._code_format == FORMAT_NONE else self._code_format
+        return self._code_format.value
 
     @property
     def code_arm_required(self):

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -278,7 +278,7 @@ async def test_no_action_scripts(hass, start_ha):
                     },
                 }
             },
-            "value must be one of ['none', 'number', 'text']",
+            "value must be one of ['no_code', 'number', 'text']",
         ),
     ],
 )
@@ -527,7 +527,7 @@ async def test_unique_id(hass, start_ha):
                     "panels": {
                         "test_template_panel": {
                             "value_template": "disarmed",
-                            "code_format": "none",
+                            "code_format": "no_code",
                             "code_arm_required": False,
                         }
                     },

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -204,7 +204,7 @@ async def test_no_action_scripts(hass, start_ha):
                     "platform": "template",
                     "panels": {
                         "bad name here": {
-                            "value_template": "{{ disarmed }}",
+                            "value_template": "disarmed",
                             "arm_away": {
                                 "service": "alarm_control_panel.alarm_arm_away",
                                 "entity_id": "alarm_control_panel.test",
@@ -246,6 +246,40 @@ async def test_no_action_scripts(hass, start_ha):
             },
             "required key not provided @ data['panels']",
         ),
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "test_template_panel": {
+                            "value_template": "disarmed",
+                            "arm_away": {
+                                "service": "alarm_control_panel.alarm_arm_away",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "arm_home": {
+                                "service": "alarm_control_panel.alarm_arm_home",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "arm_night": {
+                                "service": "alarm_control_panel.alarm_arm_night",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "disarm": {
+                                "service": "alarm_control_panel.alarm_disarm",
+                                "entity_id": "alarm_control_panel.test",
+                                "data": {"code": "1234"},
+                            },
+                            "code_format": "bad_format",
+                        }
+                    },
+                }
+            },
+            "value must be one of ['none', 'number', 'text']",
+        ),
     ],
 )
 async def test_template_syntax_error(hass, msg, start_ha, caplog_setup_text):
@@ -264,7 +298,7 @@ async def test_template_syntax_error(hass, msg, start_ha, caplog_setup_text):
                 "panels": {
                     "test_template_panel": {
                         "name": "Template Alarm Panel",
-                        "value_template": "{{ disarmed }}",
+                        "value_template": "disarmed",
                         "arm_away": {
                             "service": "alarm_control_panel.alarm_arm_away",
                             "entity_id": "alarm_control_panel.test",
@@ -451,3 +485,77 @@ async def test_arm_home_action(hass, func, start_ha, calls):
 async def test_unique_id(hass, start_ha):
     """Test unique_id option only creates one alarm control panel per id."""
     assert len(hass.states.async_all()) == 1
+
+
+@pytest.mark.parametrize("count,domain", [(1, "alarm_control_panel")])
+@pytest.mark.parametrize(
+    "config,code_format,code_arm_required",
+    [
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "test_template_panel": {
+                            "value_template": "disarmed",
+                        }
+                    },
+                }
+            },
+            "number",
+            True,
+        ),
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "test_template_panel": {
+                            "value_template": "disarmed",
+                            "code_format": "text",
+                        }
+                    },
+                }
+            },
+            "text",
+            True,
+        ),
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "test_template_panel": {
+                            "value_template": "disarmed",
+                            "code_format": "none",
+                            "code_arm_required": False,
+                        }
+                    },
+                }
+            },
+            None,
+            False,
+        ),
+        (
+            {
+                "alarm_control_panel": {
+                    "platform": "template",
+                    "panels": {
+                        "test_template_panel": {
+                            "value_template": "disarmed",
+                            "code_format": "text",
+                            "code_arm_required": False,
+                        }
+                    },
+                }
+            },
+            "text",
+            False,
+        ),
+    ],
+)
+async def test_code_config(hass, code_format, code_arm_required, start_ha):
+    """Test configuration options related to alarm code."""
+    state = hass.states.get(TEMPLATE_NAME)
+    assert state.attributes.get("code_format") == code_format
+    assert state.attributes.get("code_arm_required") == code_arm_required


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding an option to specify code format for template alarms. It defaults to "number" to reflect the current behaviour and not introduce breaking changes.

Without this PR, the format is hardcoded to "number" which makes it impossible to disarm alarm from UI without entering some code even if it's completely unnecessary.

Screenshots of UI when having "none", "text" and "number" selected:

<img width="498" alt="Screenshot 2021-09-26 at 23 53 02" src="https://user-images.githubusercontent.com/6134677/134827028-74a9caae-f9f3-4ff3-b255-d09f8600157e.png">
<img width="499" alt="Screenshot 2021-09-26 at 23 53 26" src="https://user-images.githubusercontent.com/6134677/134827032-9866f62d-a751-4c30-abdb-3af3d8fd8d01.png">
<img width="503" alt="Screenshot 2021-09-26 at 23 53 51" src="https://user-images.githubusercontent.com/6134677/134827037-21fedf3a-5a6d-4225-95dc-4c16252222e0.png">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19482

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
