### PR TITLE
Add is_number template filter and function

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1370,7 +1370,7 @@ def forgiving_float(value):
         return value
 
 
-def is_numeric(value):
+def is_number(value):
     """Try to convert value to a float."""
     try:
         fvalue = float(value)
@@ -1586,7 +1586,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["bitwise_and"] = bitwise_and
         self.filters["bitwise_or"] = bitwise_or
         self.filters["ord"] = ord
-        self.filters["isnumeric"] = is_numeric
+        self.filters["is_number"] = is_number
         self.globals["log"] = logarithm
         self.globals["sin"] = sine
         self.globals["cos"] = cosine
@@ -1609,7 +1609,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["urlencode"] = urlencode
         self.globals["max"] = max
         self.globals["min"] = min
-        self.globals["isnumeric"] = is_numeric
+        self.globals["is_number"] = is_number
         self.tests["match"] = regex_match
         self.tests["search"] = regex_search
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1370,6 +1370,17 @@ def forgiving_float(value):
         return value
 
 
+def is_numeric(value):
+    """Try to convert value to a float."""
+    try:
+        fvalue = float(value)
+    except (ValueError, TypeError):
+        return False
+    if math.isnan(fvalue) or math.isinf(fvalue):
+        return False
+    return True
+
+
 def regex_match(value, find="", ignorecase=False):
     """Match value using regex."""
     if not isinstance(value, str):
@@ -1575,6 +1586,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["bitwise_and"] = bitwise_and
         self.filters["bitwise_or"] = bitwise_or
         self.filters["ord"] = ord
+        self.filters["isnumeric"] = is_numeric
         self.globals["log"] = logarithm
         self.globals["sin"] = sine
         self.globals["cos"] = cosine
@@ -1597,6 +1609,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["urlencode"] = urlencode
         self.globals["max"] = max
         self.globals["min"] = min
+        self.globals["isnumeric"] = is_numeric
         self.tests["match"] = regex_match
         self.tests["search"] = regex_search
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -227,6 +227,12 @@ def test_float(hass):
         (0.0, True),
         ("0", True),
         ("0.0", True),
+        (True, True),
+        (False, True),
+        ("True", False),
+        ("False", False),
+        (None, False),
+        ("None", False),
         ("horse", False),
         (math.pi, True),
         (math.nan, False),
@@ -235,19 +241,16 @@ def test_float(hass):
         ("inf", False),
     ],
 )
-def test_isnumeric(hass, value, expected):
-    """Test isnumeric."""
-    hass.states.async_set("sensor.temperature", value)
+def test_isnumber(hass, value, expected):
+    """Test is_number."""
     assert (
-        template.Template(
-            "{{ isnumeric(states('sensor.temperature')) }}", hass
-        ).async_render()
+        template.Template("{{ is_number(value) }}", hass).async_render({"value": value})
         == expected
     )
     assert (
-        template.Template(
-            "{{ states('sensor.temperature') | isnumeric }}", hass
-        ).async_render()
+        template.Template("{{ value | is_number }}", hass).async_render(
+            {"value": value}
+        )
         == expected
     )
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -220,6 +220,38 @@ def test_float(hass):
     )
 
 
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, True),
+        (0.0, True),
+        ("0", True),
+        ("0.0", True),
+        ("horse", False),
+        (math.pi, True),
+        (math.nan, False),
+        (math.inf, False),
+        ("nan", False),
+        ("inf", False),
+    ],
+)
+def test_isnumeric(hass, value, expected):
+    """Test isnumeric."""
+    hass.states.async_set("sensor.temperature", value)
+    assert (
+        template.Template(
+            "{{ isnumeric(states('sensor.temperature')) }}", hass
+        ).async_render()
+        == expected
+    )
+    assert (
+        template.Template(
+            "{{ states('sensor.temperature') | isnumeric }}", hass
+        ).async_render()
+        == expected
+    )
+
+
 def test_rounding_value(hass):
     """Test rounding value."""
     hass.states.async_set("sensor.temperature", 12.78)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `is_number` template filter and function
The `is_number` function and filter returns `True` if the input can be parsed by Python's `float` function and the parsed input is not `inf` or `nan`. Note that a Python `bool` will return `True` but the strings `"True"` and `"False"` will both return `False`.
Examples:
`{{ "" | is_number}}` - will render as `False`
`{{ "1" | is_number}}` - will render as `True`
`{{ "1.1" | is_number}}` - will render as `True`
`{{ "nan" | is_number}}` - will render as `False`
`{{ "inf" | is_number}}` - will render as `False`
`{{ "½" | is_number}}` - will render as `False`
`{{ True | is_number }}` - will render as `True`
`{{ False | is_number }}` - will render as `True`
`{{ "True" | is_number}}` - will render as `False`
`{{ "False" | is_number}}` - will render as `False`

Note: This differs from Python's `string.isnumeric`:
```
>>> "".isnumeric()
False
>>> "1".isnumeric()
True
>>> "1.1".isnumeric()
False
>>> "½".isnumeric()
True
```

The driver is to make it possible to check that the input to functions and filters expecting a numeric value is valid:
`{% set state= states('sensor.temperature') %}{{ ((state | float * 10) | round(2)) if isnumeric(state) }}`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19487

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
