### PR TITLE
Add config_flow for Fronius integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -368,6 +368,7 @@ omit =
     homeassistant/components/fritzbox_callmonitor/const.py
     homeassistant/components/fritzbox_callmonitor/base.py
     homeassistant/components/fritzbox_callmonitor/sensor.py
+    homeassistant/components/fronius/__init__.py
     homeassistant/components/fronius/sensor.py
     homeassistant/components/frontier_silicon/media_player.py
     homeassistant/components/futurenow/light.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -180,7 +180,7 @@ homeassistant/components/freebox/* @hacf-fr @Quentame
 homeassistant/components/freedompro/* @stefano055415
 homeassistant/components/fritz/* @mammuth @AaronDavidSchneider @chemelli74
 homeassistant/components/fritzbox/* @mib1185
-homeassistant/components/fronius/* @nielstron
+homeassistant/components/fronius/* @nielstron @farmio
 homeassistant/components/frontend/* @home-assistant/frontend
 homeassistant/components/garages_amsterdam/* @klaasnicolaas
 homeassistant/components/gdacs/* @exxamalte

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -1,1 +1,46 @@
-"""The Fronius component."""
+"""The Fronius integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+PLATFORMS: list[str] = ["sensor"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up fronius from a config entry."""
+    fronius = FroniusSolarNet(hass, entry)
+    await fronius.init_devices()
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = fronius
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
+
+
+class FroniusSolarNet:
+    """The FroniusSolarNet class manages update coordinators."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize FroniusSolarNet class."""
+        self.hass = hass
+        self.host: str = entry.data[CONF_HOST]
+
+    async def init_devices(self) -> None:
+        """Initialize DataUpdateCoordinators for SolarNet devices."""
+        raise NotImplementedError

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -1,0 +1,114 @@
+"""Config flow for Fronius integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pyfronius import Fronius, FroniusError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_RESOURCE
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN, FroniusConfigEntryData
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+    }
+)
+
+
+async def validate_input(
+    hass: HomeAssistant, data: dict[str, Any]
+) -> tuple[str, FroniusConfigEntryData]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+    host = data[CONF_HOST]
+    fronius = Fronius(async_get_clientsession(hass), host)
+
+    try:
+        logger_info: dict[str, Any]
+        logger_info = await fronius.current_logger_info()
+    except FroniusError as err:
+        _LOGGER.debug(err)
+    else:
+        logger_uid: str = logger_info["unique_identifier"]["value"]
+        return logger_uid, FroniusConfigEntryData(
+            host=host,
+            is_logger=True,
+        )
+    # Gen24 devices don't provide GetLoggerInfo
+    try:
+        inverter_info = await fronius.inverter_info()
+    except FroniusError as err:
+        _LOGGER.debug(err)
+        raise CannotConnect from err
+    for inverter in inverter_info["inverters"]:
+        first_inverter_uid: str = inverter["unique_id"]["value"]
+        return first_inverter_uid, FroniusConfigEntryData(
+            host=host,
+            is_logger=False,
+        )
+    raise CannotConnect("No supported Fronius SolarNet device found.")
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Fronius."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+
+        errors = {}
+
+        try:
+            unique_id, info = await validate_input(self.hass, user_input)
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            title = (
+                f"SolarNet {'Datalogger' if info['is_logger'] else 'Inverter'}"
+                f" at {info['host']}"
+            )
+            entry = await self.async_set_unique_id(unique_id, raise_on_progress=False)
+            if entry is not None:
+                if info.items() <= entry.data.items():
+                    return self.async_abort(reason="already_configured")
+                self.hass.config_entries.async_update_entry(
+                    entry, title=title, data=info  # type: ignore[arg-type]
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="entry_update_successful")
+
+            return self.async_create_entry(title=title, data=info)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, conf: dict) -> FlowResult:
+        """Import a configuration from config.yaml."""
+        return await self.async_step_user(user_input={CONF_HOST: conf[CONF_RESOURCE]})
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -1,0 +1,27 @@
+"""Constants for the Fronius integration."""
+from typing import Final, NamedTuple, TypedDict
+
+from homeassistant.helpers.entity import DeviceInfo
+
+DEFAULT_UPDATE_INTERVAL = 60
+DEFAULT_UPDATE_INTERVAL_LOGGER = 60 * 60
+DOMAIN: Final = "fronius"
+
+SolarNetId = str
+SOLAR_NET_ID_POWER_FLOW: SolarNetId = "power_flow"
+SOLAR_NET_ID_SYSTEM: SolarNetId = "system"
+
+
+class FroniusConfigEntryData(TypedDict):
+    """ConfigEntry for the Fronius integration."""
+
+    host: str
+    is_logger: bool
+
+
+class FroniusDeviceInfo(NamedTuple):
+    """Information about a Fronius inverter device."""
+
+    device_info: DeviceInfo
+    solar_net_id: SolarNetId
+    unique_id: str

--- a/homeassistant/components/fronius/manifest.json
+++ b/homeassistant/components/fronius/manifest.json
@@ -1,8 +1,13 @@
 {
   "domain": "fronius",
   "name": "Fronius",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/fronius",
-  "requirements": ["pyfronius==0.6.0"],
-  "codeowners": ["@nielstron"],
+  "requirements": ["pyfronius==0.7.0"],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": ["@nielstron", "@farmio"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -1,354 +1,51 @@
 """Support for Fronius devices."""
 from __future__ import annotations
 
-import copy
-from datetime import timedelta
 import logging
-from typing import Any
 
-from pyfronius import Fronius
 import voluptuous as vol
 
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA,
-    STATE_CLASS_MEASUREMENT,
-    STATE_CLASS_TOTAL_INCREASING,
-    SensorEntity,
-)
-from homeassistant.const import (
-    CONF_DEVICE,
-    CONF_MONITORED_CONDITIONS,
-    CONF_RESOURCE,
-    CONF_SCAN_INTERVAL,
-    CONF_SENSOR_TYPE,
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_CURRENT,
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_POWER_FACTOR,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_TIMESTAMP,
-    DEVICE_CLASS_VOLTAGE,
-)
-from homeassistant.core import callback
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import CONF_RESOURCE
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_SCOPE = "scope"
-
-TYPE_INVERTER = "inverter"
-TYPE_STORAGE = "storage"
-TYPE_METER = "meter"
-TYPE_POWER_FLOW = "power_flow"
-TYPE_LOGGER_INFO = "logger_info"
-SCOPE_DEVICE = "device"
-SCOPE_SYSTEM = "system"
-
-DEFAULT_SCOPE = SCOPE_DEVICE
-DEFAULT_DEVICE = 0
-DEFAULT_INVERTER = 1
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
-
-SENSOR_TYPES = [
-    TYPE_INVERTER,
-    TYPE_STORAGE,
-    TYPE_METER,
-    TYPE_POWER_FLOW,
-    TYPE_LOGGER_INFO,
-]
-SCOPE_TYPES = [SCOPE_DEVICE, SCOPE_SYSTEM]
-
-PREFIX_DEVICE_CLASS_MAPPING = [
-    ("state_of_charge", DEVICE_CLASS_BATTERY),
-    ("temperature", DEVICE_CLASS_TEMPERATURE),
-    ("power_factor", DEVICE_CLASS_POWER_FACTOR),
-    ("power", DEVICE_CLASS_POWER),
-    ("energy", DEVICE_CLASS_ENERGY),
-    ("current", DEVICE_CLASS_CURRENT),
-    ("timestamp", DEVICE_CLASS_TIMESTAMP),
-    ("voltage", DEVICE_CLASS_VOLTAGE),
-]
-
-PREFIX_STATE_CLASS_MAPPING = [
-    ("state_of_charge", STATE_CLASS_MEASUREMENT),
-    ("temperature", STATE_CLASS_MEASUREMENT),
-    ("power_factor", STATE_CLASS_MEASUREMENT),
-    ("power", STATE_CLASS_MEASUREMENT),
-    ("energy", STATE_CLASS_TOTAL_INCREASING),
-    ("current", STATE_CLASS_MEASUREMENT),
-    ("timestamp", STATE_CLASS_MEASUREMENT),
-    ("voltage", STATE_CLASS_MEASUREMENT),
-]
-
-
-def _device_id_validator(config):
-    """Ensure that inverters have default id 1 and other devices 0."""
-    config = copy.deepcopy(config)
-    for cond in config[CONF_MONITORED_CONDITIONS]:
-        if CONF_DEVICE not in cond:
-            if cond[CONF_SENSOR_TYPE] == TYPE_INVERTER:
-                cond[CONF_DEVICE] = DEFAULT_INVERTER
-            else:
-                cond[CONF_DEVICE] = DEFAULT_DEVICE
-    return config
-
-
-PLATFORM_SCHEMA = vol.Schema(
-    vol.All(
-        PLATFORM_SCHEMA.extend(
-            {
-                vol.Required(CONF_RESOURCE): cv.url,
-                vol.Required(CONF_MONITORED_CONDITIONS): vol.All(
-                    cv.ensure_list,
-                    [
-                        {
-                            vol.Required(CONF_SENSOR_TYPE): vol.In(SENSOR_TYPES),
-                            vol.Optional(CONF_SCOPE, default=DEFAULT_SCOPE): vol.In(
-                                SCOPE_TYPES
-                            ),
-                            vol.Optional(CONF_DEVICE): cv.positive_int,
-                        }
-                    ],
-                ),
-            }
-        ),
-        _device_id_validator,
-    )
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {vol.Required(CONF_RESOURCE): cv.url},
+    extra=vol.ALLOW_EXTRA,
 )
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up of Fronius platform."""
-    session = async_get_clientsession(hass)
-    fronius = Fronius(session, config[CONF_RESOURCE])
-
-    scan_interval = config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-    adapters = []
-    # Creates all adapters for monitored conditions
-    for condition in config[CONF_MONITORED_CONDITIONS]:
-
-        device = condition[CONF_DEVICE]
-        sensor_type = condition[CONF_SENSOR_TYPE]
-        scope = condition[CONF_SCOPE]
-        name = f"Fronius {condition[CONF_SENSOR_TYPE].replace('_', ' ').capitalize()} {device if scope == SCOPE_DEVICE else SCOPE_SYSTEM} {config[CONF_RESOURCE]}"
-        if sensor_type == TYPE_INVERTER:
-            if scope == SCOPE_SYSTEM:
-                adapter_cls = FroniusInverterSystem
-            else:
-                adapter_cls = FroniusInverterDevice
-        elif sensor_type == TYPE_METER:
-            if scope == SCOPE_SYSTEM:
-                adapter_cls = FroniusMeterSystem
-            else:
-                adapter_cls = FroniusMeterDevice
-        elif sensor_type == TYPE_POWER_FLOW:
-            adapter_cls = FroniusPowerFlow
-        elif sensor_type == TYPE_LOGGER_INFO:
-            adapter_cls = FroniusLoggerInfo
-        else:
-            adapter_cls = FroniusStorage
-
-        adapters.append(adapter_cls(fronius, name, device, async_add_entities))
-
-    # Creates a lamdba that fetches an update when called
-    def adapter_data_fetcher(data_adapter):
-        async def fetch_data(*_):
-            await data_adapter.async_update()
-
-        return fetch_data
-
-    # Set up the fetching in a fixed interval for each adapter
-    for adapter in adapters:
-        fetch = adapter_data_fetcher(adapter)
-        # fetch data once at set-up
-        await fetch()
-        async_track_time_interval(hass, fetch, scan_interval)
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: None = None,
+) -> None:
+    """Import Fronius configuration from yaml."""
+    _LOGGER.warning(
+        "Loading Fronius via platform setup is deprecated. Please remove it from your configuration"
+    )
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data=config,
+        )
+    )
 
 
-class FroniusAdapter:
-    """The Fronius sensor fetching component."""
-
-    def __init__(
-        self, bridge: Fronius, name: str, device: int, add_entities: AddEntitiesCallback
-    ) -> None:
-        """Initialize the sensor."""
-        self.bridge = bridge
-        self._name = name
-        self._device = device
-        self._fetched: dict[str, Any] = {}
-        self._available = True
-
-        self.sensors: set[str] = set()
-        self._registered_sensors: set[SensorEntity] = set()
-        self._add_entities = add_entities
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def data(self):
-        """Return the state attributes."""
-        return self._fetched
-
-    @property
-    def available(self):
-        """Whether the fronius device is active."""
-        return self._available
-
-    async def async_update(self):
-        """Retrieve and update latest state."""
-        try:
-            values = await self._update()
-        except ConnectionError:
-            # fronius devices are often powered by self-produced solar energy
-            # and henced turned off at night.
-            # Therefore we will not print multiple errors when connection fails
-            if self._available:
-                self._available = False
-                _LOGGER.error("Failed to update: connection error")
-            return
-        except ValueError:
-            _LOGGER.error(
-                "Failed to update: invalid response returned."
-                "Maybe the configured device is not supported"
-            )
-            return
-
-        self._available = True  # reset connection failure
-
-        attributes = self._fetched
-        # Copy data of current fronius device
-        for key, entry in values.items():
-            # If the data is directly a sensor
-            if "value" in entry:
-                attributes[key] = entry
-        self._fetched = attributes
-
-        # Add discovered value fields as sensors
-        # because some fields are only sent temporarily
-        new_sensors = []
-        for key in attributes:
-            if key not in self.sensors:
-                self.sensors.add(key)
-                _LOGGER.info("Discovered %s, adding as sensor", key)
-                new_sensors.append(FroniusTemplateSensor(self, key))
-        self._add_entities(new_sensors, True)
-
-        # Schedule an update for all included sensors
-        for sensor in self._registered_sensors:
-            sensor.async_schedule_update_ha_state(True)
-
-    async def _update(self) -> dict:
-        """Return values of interest."""
-
-    @callback
-    def register(self, sensor):
-        """Register child sensor for update subscriptions."""
-        self._registered_sensors.add(sensor)
-        return lambda: self._registered_sensors.remove(sensor)
-
-
-class FroniusInverterSystem(FroniusAdapter):
-    """Adapter for the fronius inverter with system scope."""
-
-    async def _update(self):
-        """Get the values for the current state."""
-        return await self.bridge.current_system_inverter_data()
-
-
-class FroniusInverterDevice(FroniusAdapter):
-    """Adapter for the fronius inverter with device scope."""
-
-    async def _update(self):
-        """Get the values for the current state."""
-        return await self.bridge.current_inverter_data(self._device)
-
-
-class FroniusStorage(FroniusAdapter):
-    """Adapter for the fronius battery storage."""
-
-    async def _update(self):
-        """Get the values for the current state."""
-        return await self.bridge.current_storage_data(self._device)
-
-
-class FroniusMeterSystem(FroniusAdapter):
-    """Adapter for the fronius meter with system scope."""
-
-    async def _update(self):
-        """Get the values for the current state."""
-        return await self.bridge.current_system_meter_data()
-
-
-class FroniusMeterDevice(FroniusAdapter):
-    """Adapter for the fronius meter with device scope."""
-
-    async def _update(self):
-        """Get the values for the current state."""
-        return await self.bridge.current_meter_data(self._device)
-
-
-class FroniusPowerFlow(FroniusAdapter):
-    """Adapter for the fronius power flow."""
-
-    async def _update(self):
-        """Get the values for the current state."""
-        return await self.bridge.current_power_flow()
-
-
-class FroniusLoggerInfo(FroniusAdapter):
-    """Adapter for the fronius power flow."""
-
-    async def _update(self):
-        """Get the values for the current state."""
-        return await self.bridge.current_logger_info()
-
-
-class FroniusTemplateSensor(SensorEntity):
-    """Sensor for the single values (e.g. pv power, ac power)."""
-
-    def __init__(self, parent: FroniusAdapter, key: str) -> None:
-        """Initialize a singular value sensor."""
-        self._key = key
-        self._attr_name = f"{key.replace('_', ' ').capitalize()} {parent.name}"
-        self._parent = parent
-        for prefix, device_class in PREFIX_DEVICE_CLASS_MAPPING:
-            if self._key.startswith(prefix):
-                self._attr_device_class = device_class
-                break
-        for prefix, state_class in PREFIX_STATE_CLASS_MAPPING:
-            if self._key.startswith(prefix):
-                self._attr_state_class = state_class
-                break
-
-    @property
-    def should_poll(self):
-        """Device should not be polled, returns False."""
-        return False
-
-    @property
-    def available(self):
-        """Whether the fronius device is active."""
-        return self._parent.available
-
-    async def async_update(self):
-        """Update the internal state."""
-        state = self._parent.data.get(self._key)
-        self._attr_native_value = state.get("value")
-        if isinstance(self._attr_native_value, float):
-            self._attr_native_value = round(self._attr_native_value, 2)
-        self._attr_native_unit_of_measurement = state.get("unit")
-
-    async def async_added_to_hass(self):
-        """Register at parent component for updates."""
-        self.async_on_remove(self._parent.register(self))
-
-    def __hash__(self):
-        """Hash sensor by hashing its name."""
-        return hash(self.name)
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Fronius sensor entities based on a config entry."""
+    raise NotImplementedError

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Fronius SolarNet",
+        "description": "Configure the IP address or local hostname of your Fronius device.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "entry_update_successful": "Config entry updated"
+    }
+  }
+}

--- a/homeassistant/components/fronius/translations/en.json
+++ b/homeassistant/components/fronius/translations/en.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured",
+            "entry_update_successful": "Config entry updated"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host"
+                },
+                "description": "Configure the IP address or local hostname of your Fronius device.",
+                "title": "Fronius SolarNet"
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -93,6 +93,7 @@ FLOWS = [
     "fritz",
     "fritzbox",
     "fritzbox_callmonitor",
+    "fronius",
     "garages_amsterdam",
     "gdacs",
     "geofency",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1495,7 +1495,7 @@ pyfreedompro==1.1.0
 pyfritzhome==0.6.2
 
 # homeassistant.components.fronius
-pyfronius==0.6.0
+pyfronius==0.7.0
 
 # homeassistant.components.ifttt
 pyfttt==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -864,6 +864,9 @@ pyfreedompro==1.1.0
 # homeassistant.components.fritzbox
 pyfritzhome==0.6.2
 
+# homeassistant.components.fronius
+pyfronius==0.7.0
+
 # homeassistant.components.ifttt
 pyfttt==0.3
 

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the fronius integration."""

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -1,0 +1,206 @@
+"""Test the fronius config flow."""
+from unittest.mock import patch
+
+from pyfronius import FroniusError
+
+from homeassistant import config_entries, setup
+from homeassistant.components.fronius.const import DOMAIN
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+from tests.common import MockConfigEntry
+
+INVERTER_INFO_RETURN_VALUE = {"inverters": [{"unique_id": {"value": "1234567"}}]}
+LOGGER_INFO_RETURN_VALUE = {"unique_identifier": {"value": "123.4567"}}
+
+
+async def test_form_with_logger(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    with patch(
+        "pyfronius.Fronius.current_logger_info",
+        return_value=LOGGER_INFO_RETURN_VALUE,
+    ), patch(
+        "homeassistant.components.fronius.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "10.9.8.1",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "SolarNet Datalogger at 10.9.8.1"
+    assert result2["data"] == {
+        "host": "10.9.8.1",
+        "is_logger": True,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_with_inverter(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    with patch(
+        "pyfronius.Fronius.current_logger_info",
+        side_effect=FroniusError,
+    ), patch(
+        "pyfronius.Fronius.inverter_info",
+        return_value=INVERTER_INFO_RETURN_VALUE,
+    ), patch(
+        "homeassistant.components.fronius.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "10.9.1.1",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "SolarNet Inverter at 10.9.1.1"
+    assert result2["data"] == {
+        "host": "10.9.1.1",
+        "is_logger": False,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "pyfronius.Fronius.current_logger_info",
+        side_effect=FroniusError,
+    ), patch(
+        "pyfronius.Fronius.inverter_info",
+        side_effect=FroniusError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+            },
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_unexpected(hass: HomeAssistant) -> None:
+    """Test we handle unexpected error."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.fronius.config_flow.validate_input",
+        side_effect=KeyError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+            },
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "unknown"}
+
+
+async def test_form_already_existing(hass):
+    """Test existing entry."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="123.4567",
+        data={CONF_HOST: "10.9.8.1", "is_logger": True},
+    ).add_to_hass(hass)
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch(
+        "pyfronius.Fronius.current_logger_info",
+        return_value=LOGGER_INFO_RETURN_VALUE,
+    ), patch(
+        "homeassistant.components.fronius.async_setup_entry",
+        return_value=True,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "10.9.8.1",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "already_configured"
+
+
+async def test_form_updates_host(hass):
+    """Test existing entry gets updated."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    MockConfigEntry(
+        domain=DOMAIN, unique_id="123.4567", data={CONF_HOST: "different host"}
+    ).add_to_hass(hass)
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch(
+        "pyfronius.Fronius.current_logger_info",
+        return_value=LOGGER_INFO_RETURN_VALUE,
+    ), patch(
+        "homeassistant.components.fronius.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "10.9.8.1",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "entry_update_successful"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].title == "SolarNet Datalogger at 10.9.8.1"
+    assert entries[0].data == {
+        "host": "10.9.8.1",
+        "is_logger": True,
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
**Please create a feature branch for this PR.**
- YAML configuration will be imported to a ConfigEntry

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is part 1 of the breakup of #56166.

- remove old integration logic in sensor.py
- require `pyfronius 0.7.0` since the new integration heavily relies on that and config_flow does too
- add a ConfigFlow
- provide an import for the now deprecated yaml config

`pyfronius 0.7.0` ([changelog](https://github.com/nielstron/pyfronius/compare/release-0.6.3...release-0.7.0)) was developed alongside this integration refactoring (so it is not fully compatible with the previous version of the Fronius integration). The changes to the previously used `pyfronius` version are
- different error handling
- add system wide storage request
- add inverter info request
- decode device_type "DT" in `inverter_info"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #56166
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
