### PR TITLE
Provide most media metadata in DlnaDmrEntity

### DIFF
--- a/homeassistant/components/dlna_dmr/const.py
+++ b/homeassistant/components/dlna_dmr/const.py
@@ -1,7 +1,11 @@
 """Constants for the DLNA DMR component."""
+from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Final
+
+from homeassistant.components.media_player import const as _mp_const
 
 LOGGER = logging.getLogger(__package__)
 
@@ -14,3 +18,43 @@ CONF_POLL_AVAILABILITY: Final = "poll_availability"
 DEFAULT_NAME: Final = "DLNA Digital Media Renderer"
 
 CONNECT_TIMEOUT: Final = 10
+
+# Map UPnP class to media_player media_content_type
+MEDIA_TYPE_MAP: Mapping[str, str] = {
+    "object": _mp_const.MEDIA_TYPE_URL,
+    "object.item": _mp_const.MEDIA_TYPE_URL,
+    "object.item.imageItem": _mp_const.MEDIA_TYPE_IMAGE,
+    "object.item.imageItem.photo": _mp_const.MEDIA_TYPE_IMAGE,
+    "object.item.audioItem": _mp_const.MEDIA_TYPE_MUSIC,
+    "object.item.audioItem.musicTrack": _mp_const.MEDIA_TYPE_MUSIC,
+    "object.item.audioItem.audioBroadcast": _mp_const.MEDIA_TYPE_MUSIC,
+    "object.item.audioItem.audioBook": _mp_const.MEDIA_TYPE_PODCAST,
+    "object.item.videoItem": _mp_const.MEDIA_TYPE_VIDEO,
+    "object.item.videoItem.movie": _mp_const.MEDIA_TYPE_MOVIE,
+    "object.item.videoItem.videoBroadcast": _mp_const.MEDIA_TYPE_TVSHOW,
+    "object.item.videoItem.musicVideoClip": _mp_const.MEDIA_TYPE_VIDEO,
+    "object.item.playlistItem": _mp_const.MEDIA_TYPE_PLAYLIST,
+    "object.item.textItem": _mp_const.MEDIA_TYPE_URL,
+    "object.item.bookmarkItem": _mp_const.MEDIA_TYPE_URL,
+    "object.item.epgItem": _mp_const.MEDIA_TYPE_EPISODE,
+    "object.item.epgItem.audioProgram": _mp_const.MEDIA_TYPE_EPISODE,
+    "object.item.epgItem.videoProgram": _mp_const.MEDIA_TYPE_EPISODE,
+    "object.container": _mp_const.MEDIA_TYPE_PLAYLIST,
+    "object.container.person": _mp_const.MEDIA_TYPE_ARTIST,
+    "object.container.person.musicArtist": _mp_const.MEDIA_TYPE_ARTIST,
+    "object.container.playlistContainer": _mp_const.MEDIA_TYPE_PLAYLIST,
+    "object.container.album": _mp_const.MEDIA_TYPE_ALBUM,
+    "object.container.album.musicAlbum": _mp_const.MEDIA_TYPE_ALBUM,
+    "object.container.album.photoAlbum": _mp_const.MEDIA_TYPE_ALBUM,
+    "object.container.genre": _mp_const.MEDIA_TYPE_GENRE,
+    "object.container.genre.musicGenre": _mp_const.MEDIA_TYPE_GENRE,
+    "object.container.genre.movieGenre": _mp_const.MEDIA_TYPE_GENRE,
+    "object.container.channelGroup": _mp_const.MEDIA_TYPE_CHANNELS,
+    "object.container.channelGroup.audioChannelGroup": _mp_const.MEDIA_TYPE_CHANNELS,
+    "object.container.channelGroup.videoChannelGroup": _mp_const.MEDIA_TYPE_CHANNELS,
+    "object.container.epgContainer": _mp_const.MEDIA_TYPE_TVSHOW,
+    "object.container.storageSystem": _mp_const.MEDIA_TYPE_PLAYLIST,
+    "object.container.storageVolume": _mp_const.MEDIA_TYPE_PLAYLIST,
+    "object.container.storageFolder": _mp_const.MEDIA_TYPE_PLAYLIST,
+    "object.container.bookmarkFolder": _mp_const.MEDIA_TYPE_PLAYLIST,
+}

--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -3,7 +3,7 @@
   "name": "DLNA Digital Media Renderer",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/dlna_dmr",
-  "requirements": ["async-upnp-client==0.22.3"],
+  "requirements": ["async-upnp-client==0.22.4"],
   "dependencies": ["network", "ssdp"],
   "ssdp": [
     {

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -37,7 +37,6 @@ from homeassistant.const import (
     STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
-    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry, entity_registry
@@ -438,7 +437,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
         return f"{self.udn}::{self.device_type}"
 
     @property
-    def state(self) -> str:
+    def state(self) -> str | None:
         """State of the player."""
         if not self._device or not self.available:
             return STATE_OFF
@@ -455,7 +454,8 @@ class DlnaDmrEntity(MediaPlayerEntity):
         ):
             return STATE_PAUSED
         if self._device.transport_state == TransportState.VENDOR_DEFINED:
-            return STATE_UNKNOWN
+            # Unable to map this state to anything reasonable, so it's "Unknown"
+            return None
 
         return STATE_IDLE
 

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ssdp",
   "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "requirements": ["async-upnp-client==0.22.3"],
+  "requirements": ["async-upnp-client==0.22.4"],
   "dependencies": ["network"],
   "after_dependencies": ["zeroconf"],
   "codeowners": [],

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -3,7 +3,7 @@
   "name": "UPnP/IGD",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upnp",
-  "requirements": ["async-upnp-client==0.22.3"],
+  "requirements": ["async-upnp-client==0.22.4"],
   "dependencies": ["network", "ssdp"],
   "codeowners": ["@StevenLooman","@ehendrix23"],
   "ssdp": [

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -2,7 +2,7 @@
   "domain": "yeelight",
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
-  "requirements": ["yeelight==0.7.5", "async-upnp-client==0.22.3"],
+  "requirements": ["yeelight==0.7.5", "async-upnp-client==0.22.4"],
   "codeowners": ["@rytilahti", "@zewelor", "@shenxn", "@starkillerOG"],
   "config_flow": true,
   "dependencies": ["network"],

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,7 +4,7 @@ aiodiscover==1.4.2
 aiohttp==3.7.4.post0
 aiohttp_cors==0.7.0
 astral==2.2
-async-upnp-client==0.22.3
+async-upnp-client==0.22.4
 async_timeout==3.0.1
 attrs==21.2.0
 awesomeversion==21.8.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -327,7 +327,7 @@ asterisk_mbox==0.5.0
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.22.3
+async-upnp-client==0.22.4
 
 # homeassistant.components.supla
 asyncpysupla==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -221,7 +221,7 @@ arcam-fmj==0.7.0
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.22.3
+async-upnp-client==0.22.4
 
 # homeassistant.components.aurora
 auroranoaa==0.0.2

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -74,6 +74,8 @@ async def mock_entity_id(
     """
     entity_id = await setup_mock_component(hass, config_entry_mock)
 
+    assert dmr_device_mock.async_subscribe_services.await_count == 1
+
     yield entity_id
 
     # Unload config entry to clean up
@@ -97,6 +99,8 @@ async def mock_disconnected_entity_id(
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
 
     entity_id = await setup_mock_component(hass, config_entry_mock)
+
+    assert dmr_device_mock.async_subscribe_services.await_count == 0
 
     yield entity_id
 
@@ -240,7 +244,6 @@ async def test_setup_entry_with_options(
 
 async def test_event_subscribe_failure(
     hass: HomeAssistant,
-    domain_data_mock: Mock,
     config_entry_mock: MockConfigEntry,
     dmr_device_mock: Mock,
 ) -> None:
@@ -727,7 +730,6 @@ async def test_multiple_ssdp_alive(
     domain_data_mock: Mock,
     ssdp_scanner_mock: Mock,
     mock_disconnected_entity_id: str,
-    dmr_device_mock: Mock,
 ) -> None:
     """Test multiple SSDP alive notifications is ok, only connects to device once."""
     domain_data_mock.upnp_factory.async_create_device.reset_mock()
@@ -1067,7 +1069,6 @@ async def test_ssdp_bootid(
 
 async def test_become_unavailable(
     hass: HomeAssistant,
-    domain_data_mock: Mock,
     mock_entity_id: str,
     dmr_device_mock: Mock,
 ) -> None:
@@ -1265,7 +1266,6 @@ async def test_config_update_connect_failure(
     hass: HomeAssistant,
     domain_data_mock: Mock,
     config_entry_mock: MockConfigEntry,
-    dmr_device_mock: Mock,
     mock_entity_id: str,
 ) -> None:
     """Test DlnaDmrEntity gracefully handles connect failure after config change."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds media metadata properties to the `dlna_dmr.media_player.DlnaDmrEntity` class. E.g. artist, album, season, series, etc.

I've also done some minor cleanup of the code so the metadata methods are in the one spot of the file.

It depends on https://github.com/StevenLooman/async_upnp_client/pull/94 being merged and released first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
