### PR TITLE
Optimize _get_states_with_session

### DIFF
--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -251,14 +251,13 @@ def _get_states_with_session(
             session.query(
                 func.max(States.state_id).label("max_state_id"),
             )
-            .filter(States.last_updated < utc_point_in_time)
+            .filter(
+                (States.last_updated >= run.start)
+                & (States.last_updated < utc_point_in_time)
+            )
             .filter(States.entity_id.in_(entity_ids))
         )
         most_recent_state_ids = most_recent_state_ids.group_by(States.entity_id)
-        # Filtering out too old states after grouping improves the query time by 3-4x
-        most_recent_state_ids = most_recent_state_ids.filter(
-            States.last_updated >= run.start
-        )
         most_recent_state_ids = most_recent_state_ids.subquery()
         query = query.join(
             most_recent_state_ids,

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -80,6 +80,11 @@ def _get_significant_states(
     """
     Return states changes during UTC period start_time - end_time.
 
+    entity_ids is an optional iterable of entities to include in the results.
+
+    filters is an optional SQLAlchemy filter which will be applied to the database
+    queries unless entity_ids is given, in which case its ignored.
+
     Significant states are all states where there is a state change,
     as well as all states from certain domains (for instance
     thermostat so that we get current temperature in our graphs).
@@ -298,9 +303,8 @@ def _get_states_with_session(
             States.state_id == most_recent_state_ids.c.max_state_id,
         )
         query = query.filter(~States.domain.in_(IGNORE_DOMAINS))
-
-    if filters:
-        query = filters.apply(query)
+        if filters:
+            query = filters.apply(query)
 
     return [LazyState(row) for row in execute(query)]
 

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -253,7 +253,13 @@ def _get_states_with_session(
     )
 
     if entity_ids:
-        most_recent_states_by_date.filter(States.entity_id.in_(entity_ids))
+        most_recent_states_by_date = most_recent_states_by_date.filter(
+            States.entity_id.in_(entity_ids)
+        )
+    else:
+        most_recent_states_by_date = most_recent_states_by_date.filter(
+            ~States.domain.in_(IGNORE_DOMAINS)
+        )
 
     most_recent_states_by_date = most_recent_states_by_date.group_by(States.entity_id)
 
@@ -278,12 +284,8 @@ def _get_states_with_session(
         States.state_id == most_recent_state_ids.c.max_state_id,
     )
 
-    if entity_ids is not None:
-        query = query.filter(States.entity_id.in_(entity_ids))
-    else:
-        query = query.filter(~States.domain.in_(IGNORE_DOMAINS))
-        if filters:
-            query = filters.apply(query)
+    if entity_ids is None and filters:
+        query = filters.apply(query)
 
     return [LazyState(row) for row in execute(query)]
 

--- a/homeassistant/components/recorder/history.py
+++ b/homeassistant/components/recorder/history.py
@@ -6,7 +6,7 @@ from itertools import groupby
 import logging
 import time
 
-from sqlalchemy import bindparam, func
+from sqlalchemy import and_, bindparam, func
 from sqlalchemy.ext import baked
 
 from homeassistant.components import recorder
@@ -245,34 +245,58 @@ def _get_states_with_session(
     # last recorder run started.
     query = session.query(*QUERY_STATES)
 
-    most_recent_state_ids = session.query(
-        func.max(States.state_id).label("max_state_id"),
-    ).filter(States.last_updated < utc_point_in_time)
-
-    # Apply entity filters to the derived table
     if entity_ids:
+        most_recent_state_ids = (
+            session.query(
+                func.max(States.state_id).label("max_state_id"),
+            )
+            .filter(States.last_updated < utc_point_in_time)
+            .filter(States.entity_id.in_(entity_ids))
+        )
+        most_recent_state_ids = most_recent_state_ids.group_by(States.entity_id)
+        # Filtering out too old states after grouping improves the query time by 3-4x
         most_recent_state_ids = most_recent_state_ids.filter(
-            States.entity_id.in_(entity_ids)
+            States.last_updated >= run.start
+        )
+        most_recent_state_ids = most_recent_state_ids.subquery()
+        query = query.join(
+            most_recent_state_ids,
+            States.state_id == most_recent_state_ids.c.max_state_id,
         )
     else:
-        most_recent_state_ids = most_recent_state_ids.filter(
-            ~States.domain.in_(IGNORE_DOMAINS)
+        most_recent_states_by_date = (
+            session.query(
+                States.entity_id.label("max_entity_id"),
+                func.max(States.last_updated).label("max_last_updated"),
+            )
+            .filter(
+                (States.last_updated >= run.start)
+                & (States.last_updated < utc_point_in_time)
+            )
+            .group_by(States.entity_id)
+            .subquery()
         )
-        if filters:
-            most_recent_state_ids = filters.apply(most_recent_state_ids)
+        most_recent_state_ids = (
+            session.query(func.max(States.state_id).label("max_state_id"))
+            .join(
+                most_recent_states_by_date,
+                and_(
+                    States.entity_id == most_recent_states_by_date.c.max_entity_id,
+                    States.last_updated
+                    == most_recent_states_by_date.c.max_last_updated,
+                ),
+            )
+            .group_by(States.entity_id)
+            .subquery()
+        )
+        query = query.join(
+            most_recent_state_ids,
+            States.state_id == most_recent_state_ids.c.max_state_id,
+        )
+        query = query.filter(~States.domain.in_(IGNORE_DOMAINS))
 
-    most_recent_state_ids = most_recent_state_ids.group_by(States.entity_id)
-    # Filtering out too old states after grouping improves the query time by 3-4x
-    most_recent_state_ids = most_recent_state_ids.filter(
-        States.last_updated >= run.start
-    )
-
-    most_recent_state_ids = most_recent_state_ids.subquery()
-
-    query = query.join(
-        most_recent_state_ids,
-        States.state_id == most_recent_state_ids.c.max_state_id,
-    )
+    if filters:
+        query = filters.apply(query)
 
     return [LazyState(row) for row in execute(query)]
 

--- a/tests/components/recorder/test_history.py
+++ b/tests/components/recorder/test_history.py
@@ -48,10 +48,21 @@ def test_get_states(hass_recorder):
 
         wait_recording_done(hass)
 
-    # Get states returns everything before POINT
+    # Get states returns everything before POINT for all entities
     for state1, state2 in zip(
         states,
         sorted(history.get_states(hass, future), key=lambda state: state.entity_id),
+    ):
+        assert state1 == state2
+
+    # Get states returns everything before POINT for tested entities
+    entities = [f"test.point_in_time_{i % 5}" for i in range(5)]
+    for state1, state2 in zip(
+        states,
+        sorted(
+            history.get_states(hass, future, entities),
+            key=lambda state: state.entity_id,
+        ),
     ):
         assert state1 == state2
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Optimize _get_states_with_session in case an include-list of entities is provided to:
  - Ensure we filter on entity_id or domain already in the inner derived table.
    In local testing witha  15GB SQLite database, this gives a 100x speedup when getting the last known state for only a handful of entities.
  - Skip a 2nd layer of derived tables, just a single one is enough. This doesn't affect the query time by a lot
  - ~~Filter state updates to those within the current recorder after finding the newest update
    In local testing witha  15GB SQLite database, this gives a 3-4x speedup when getting the last known state for all entities~~
    No longer included in the PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
