### PR TITLE
Fix cover group to handle unknown state properly

### DIFF
--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -37,6 +37,7 @@ from homeassistant.const import (
     CONF_ENTITIES,
     CONF_NAME,
     CONF_UNIQUE_ID,
+    STATE_CLOSED,
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING,
@@ -85,7 +86,7 @@ async def async_setup_platform(
 class CoverGroup(GroupEntity, CoverEntity):
     """Representation of a CoverGroup."""
 
-    _attr_is_closed: bool | None = False
+    _attr_is_closed: bool | None = None
     _attr_is_opening: bool | None = False
     _attr_is_closing: bool | None = False
     _attr_current_cover_position: int | None = 100
@@ -258,7 +259,7 @@ class CoverGroup(GroupEntity, CoverEntity):
         """Update state and attributes."""
         self._attr_assumed_state = False
 
-        self._attr_is_closed = True
+        self._attr_is_closed = None
         self._attr_is_closing = False
         self._attr_is_opening = False
         for entity_id in self._entities:
@@ -267,6 +268,9 @@ class CoverGroup(GroupEntity, CoverEntity):
                 continue
             if state.state == STATE_OPEN:
                 self._attr_is_closed = False
+                continue
+            if state.state == STATE_CLOSED:
+                self._attr_is_closed = True
                 continue
             if state.state == STATE_CLOSING:
                 self._attr_is_closing = True

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -87,8 +87,8 @@ class CoverGroup(GroupEntity, CoverEntity):
     """Representation of a CoverGroup."""
 
     _attr_is_closed: bool | None = None
-    _attr_is_opening: bool | None = False
-    _attr_is_closing: bool | None = False
+    _attr_is_opening: bool | None = None
+    _attr_is_closing: bool | None = None
     _attr_current_cover_position: int | None = 100
     _attr_assumed_state: bool = True
 
@@ -260,8 +260,8 @@ class CoverGroup(GroupEntity, CoverEntity):
         self._attr_assumed_state = False
 
         self._attr_is_closed = None
-        self._attr_is_closing = False
-        self._attr_is_opening = False
+        self._attr_is_closing = None
+        self._attr_is_opening = None
         for entity_id in self._entities:
             state = self.hass.states.get(entity_id)
             if not state:

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -87,8 +87,8 @@ class CoverGroup(GroupEntity, CoverEntity):
     """Representation of a CoverGroup."""
 
     _attr_is_closed: bool | None = None
-    _attr_is_opening: bool | None = None
-    _attr_is_closing: bool | None = None
+    _attr_is_opening: bool | None = False
+    _attr_is_closing: bool | None = False
     _attr_current_cover_position: int | None = 100
     _attr_assumed_state: bool = True
 
@@ -260,8 +260,8 @@ class CoverGroup(GroupEntity, CoverEntity):
         self._attr_assumed_state = False
 
         self._attr_is_closed = None
-        self._attr_is_closing = None
-        self._attr_is_opening = None
+        self._attr_is_closing = False
+        self._attr_is_opening = False
         for entity_id in self._entities:
             state = self.hass.states.get(entity_id)
             if not state:

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING,
+    STATE_UNKNOWN,
 )
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -99,7 +100,7 @@ async def setup_comp(hass, config_count):
 async def test_attributes(hass, setup_comp):
     """Test handling of state attributes."""
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_CLOSED
+    assert state.state == STATE_UNKNOWN
     assert state.attributes[ATTR_FRIENDLY_NAME] == DEFAULT_NAME
     assert state.attributes[ATTR_ENTITY_ID] == [
         DEMO_COVER,
@@ -111,6 +112,34 @@ async def test_attributes(hass, setup_comp):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert ATTR_CURRENT_TILT_POSITION not in state.attributes
+
+    # Set entity as closed
+    hass.states.async_set(DEMO_COVER, STATE_CLOSED, {})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_CLOSED
+
+    # Set entity as opening
+    hass.states.async_set(DEMO_COVER, STATE_OPENING, {})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_OPENING
+
+    # Set entity as closing
+    hass.states.async_set(DEMO_COVER, STATE_CLOSING, {})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_CLOSING
+
+    # Set entity as unknown again
+    hass.states.async_set(DEMO_COVER, STATE_UNKNOWN, {})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_UNKNOWN
 
     # Add Entity that supports open / close / stop
     hass.states.async_set(DEMO_COVER, STATE_OPEN, {ATTR_SUPPORTED_FEATURES: 11})


### PR DESCRIPTION
## Proposed change
Some covers don't support the open and closed state. I'm guessing that happens when the cover integration doesn't know the position. In those covers, when the cover is static, it just reports an `unknown` state.
When using a cover group with such covers, the state is wrongly stuck on `closed` and doesn't allow you in the lovelace UI to perform an open operation.
The fix is to properly handle the cover group state as described [here](https://developers.home-assistant.io/docs/core/entity/cover)

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
none

## Checklist
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
