### PR TITLE
Fix energy validation when not tracking costs

### DIFF
--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -272,12 +272,15 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
 
                 if flow.get("stat_cost") is not None:
                     _async_validate_cost_stat(hass, flow["stat_cost"], source_result)
+                elif flow.get("entity_energy_price") is not None:
+                    _async_validate_price_entity(
+                        hass, flow["entity_energy_price"], source_result
+                    )
 
-                else:
-                    if flow.get("entity_energy_price") is not None:
-                        _async_validate_price_entity(
-                            hass, flow["entity_energy_price"], source_result
-                        )
+                if (
+                    flow.get("entity_energy_price") is not None
+                    or flow.get("number_energy_price") is not None
+                ):
                     _async_validate_auto_generated_cost_entity(
                         hass,
                         hass.data[DOMAIN]["cost_sensors"][flow["stat_energy_from"]],
@@ -298,12 +301,15 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
                     _async_validate_cost_stat(
                         hass, flow["stat_compensation"], source_result
                     )
+                elif flow.get("entity_energy_price") is not None:
+                    _async_validate_price_entity(
+                        hass, flow["entity_energy_price"], source_result
+                    )
 
-                else:
-                    if flow.get("entity_energy_price") is not None:
-                        _async_validate_price_entity(
-                            hass, flow["entity_energy_price"], source_result
-                        )
+                if (
+                    flow.get("entity_energy_price") is not None
+                    or flow.get("number_energy_price") is not None
+                ):
                     _async_validate_auto_generated_cost_entity(
                         hass,
                         hass.data[DOMAIN]["cost_sensors"][flow["stat_energy_to"]],
@@ -322,12 +328,15 @@ async def async_validate(hass: HomeAssistant) -> EnergyPreferencesValidation:
 
             if source.get("stat_cost") is not None:
                 _async_validate_cost_stat(hass, source["stat_cost"], source_result)
+            elif source.get("entity_energy_price") is not None:
+                _async_validate_price_entity(
+                    hass, source["entity_energy_price"], source_result
+                )
 
-            else:
-                if source.get("entity_energy_price") is not None:
-                    _async_validate_price_entity(
-                        hass, source["entity_energy_price"], source_result
-                    )
+            if (
+                source.get("entity_energy_price") is not None
+                or source.get("number_energy_price") is not None
+            ):
                 _async_validate_auto_generated_cost_entity(
                     hass,
                     hass.data[DOMAIN]["cost_sensors"][source["stat_energy_from"]],

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -625,3 +625,85 @@ async def test_validation_gas(hass, mock_energy_manager, mock_is_entity_recorded
         ],
         "device_consumption": [],
     }
+
+
+async def test_validation_gas_no_costs_tracking(
+    hass, mock_energy_manager, mock_is_entity_recorded
+):
+    """Test validating gas with sensors without cost tracking."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "gas",
+                    "stat_energy_from": "sensor.gas_consumption_1",
+                    "stat_cost": None,
+                    "entity_energy_from": None,
+                    "entity_energy_price": None,
+                    "number_energy_price": None,
+                },
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.gas_consumption_1",
+        "10.10",
+        {
+            "device_class": "gas",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+
+    assert (await validate.async_validate(hass)).as_dict() == {
+        "energy_sources": [[]],
+        "device_consumption": [],
+    }
+
+
+async def test_validation_grid_no_costs_tracking(
+    hass, mock_energy_manager, mock_is_entity_recorded
+):
+    """Test validating grid with sensors for energy without cost tracking."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "grid",
+                    "flow_from": [
+                        {
+                            "stat_energy_from": "sensor.grid_energy",
+                            "stat_cost": None,
+                            "entity_energy_from": "sensor.grid_energy",
+                            "entity_energy_price": None,
+                            "number_energy_price": None,
+                        },
+                    ],
+                    "flow_to": [
+                        {
+                            "stat_energy_to": "sensor.grid_energy",
+                            "stat_cost": None,
+                            "entity_energy_to": "sensor.grid_energy",
+                            "entity_energy_price": None,
+                            "number_energy_price": None,
+                        },
+                    ],
+                    "cost_adjustment_day": 0.0,
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.grid_energy",
+        "10.10",
+        {
+            "device_class": "energy",
+            "unit_of_measurement": "kWh",
+            "state_class": "total_increasing",
+        },
+    )
+
+    assert (await validate.async_validate(hass)).as_dict() == {
+        "energy_sources": [[]],
+        "device_consumption": [],
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The current energy validation will crash when grid or gas is set up without costs tracking.
This PR adjusts the validation to handle that case.

Example stack trace of the current issue at hand:

```
Logger: homeassistant.components.websocket_api.http.connection
Source: components/energy/validate.py:283
Integration: Home Assistant WebSocket API (documentation, issues)
First occurred: 12:01:13 AM (1 occurrences)
Last logged: 12:01:13 AM

[281473065293904] Error handling message: Unknown error
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 25, in _handle_async_response
    await func(hass, connection, msg)
  File "/usr/src/homeassistant/homeassistant/components/energy/websocket_api.py", line 167, in ws_validate
    connection.send_result(msg["id"], (await async_validate(hass)).as_dict())
  File "/usr/src/homeassistant/homeassistant/components/energy/validate.py", line 283, in async_validate
    hass.data[DOMAIN]["cost_sensors"][flow["stat_energy_from"]],
KeyError: 'sensor.total_meter_energy_delivered'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
