### PR TITLE
Remove automatic splitting of net meters from statistics

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -502,15 +502,6 @@ def _apply_update(instance, session, new_version, old_version):  # noqa: C901
                 ],
             )
     elif new_version == 21:
-        if engine.dialect.name in ["mysql", "oracle", "postgresql"]:
-            data_type = "DOUBLE PRECISION"
-        else:
-            data_type = "FLOAT"
-        _add_columns(
-            connection,
-            "statistics",
-            [f"sum_increase {data_type}"],
-        )
         # Try to change the character set of the statistic_meta table
         if engine.dialect.name == "mysql":
             for table in ("events", "states", "statistics_meta"):
@@ -591,7 +582,6 @@ def _apply_update(instance, session, new_version, old_version):  # noqa: C901
                         last_reset=last_statistic.last_reset,
                         state=last_statistic.state,
                         sum=last_statistic.sum,
-                        sum_increase=last_statistic.sum_increase,
                     )
                 )
     else:

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -249,7 +249,6 @@ class StatisticData(StatisticDataBase, total=False):
     last_reset: datetime | None
     state: float
     sum: float
-    sum_increase: float
 
 
 class StatisticsBase:
@@ -274,7 +273,6 @@ class StatisticsBase:
     last_reset = Column(DATETIME_TYPE)
     state = Column(DOUBLE_TYPE)
     sum = Column(DOUBLE_TYPE)
-    sum_increase = Column(DOUBLE_TYPE)
 
     @classmethod
     def from_stats(cls, metadata_id: str, stats: StatisticData):

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -54,7 +54,6 @@ QUERY_STATISTICS = [
     Statistics.last_reset,
     Statistics.state,
     Statistics.sum,
-    Statistics.sum_increase,
 ]
 
 QUERY_STATISTICS_SHORT_TERM = [
@@ -66,7 +65,6 @@ QUERY_STATISTICS_SHORT_TERM = [
     StatisticsShortTerm.last_reset,
     StatisticsShortTerm.state,
     StatisticsShortTerm.sum,
-    StatisticsShortTerm.sum_increase,
 ]
 
 QUERY_STATISTICS_SUMMARY_MEAN = [
@@ -82,7 +80,6 @@ QUERY_STATISTICS_SUMMARY_SUM = [
     StatisticsShortTerm.last_reset,
     StatisticsShortTerm.state,
     StatisticsShortTerm.sum,
-    StatisticsShortTerm.sum_increase,
     func.row_number()
     .over(
         partition_by=StatisticsShortTerm.metadata_id,
@@ -308,14 +305,13 @@ def compile_hourly_statistics(
 
     if stats:
         for stat in stats:
-            metadata_id, start, last_reset, state, _sum, sum_increase, _ = stat
+            metadata_id, start, last_reset, state, _sum, _ = stat
             if metadata_id in summary:
                 summary[metadata_id].update(
                     {
                         "last_reset": process_timestamp(last_reset),
                         "state": state,
                         "sum": _sum,
-                        "sum_increase": sum_increase,
                     }
                 )
             else:
@@ -324,7 +320,6 @@ def compile_hourly_statistics(
                     "last_reset": process_timestamp(last_reset),
                     "state": state,
                     "sum": _sum,
-                    "sum_increase": sum_increase,
                 }
 
     # Insert compiled hourly statistics in the database
@@ -693,9 +688,7 @@ def _sorted_statistics_to_dict(
                         db_state.last_reset
                     ),
                     "state": convert(db_state.state, units),
-                    "sum": (_sum := convert(db_state.sum, units)),
-                    "sum_increase": (inc := convert(db_state.sum_increase, units)),
-                    "sum_decrease": None if _sum is None or inc is None else inc - _sum,
+                    "sum": convert(db_state.sum, units),
                 }
             )
 

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -419,15 +419,12 @@ def compile_statistics(  # noqa: C901
             last_reset = old_last_reset = None
             new_state = old_state = None
             _sum = 0.0
-            sum_increase = 0.0
-            sum_increase_tmp = 0.0
             last_stats = statistics.get_last_statistics(hass, 1, entity_id, False)
             if entity_id in last_stats:
                 # We have compiled history for this sensor before, use that as a starting point
                 last_reset = old_last_reset = last_stats[entity_id][0]["last_reset"]
                 new_state = old_state = last_stats[entity_id][0]["state"]
                 _sum = last_stats[entity_id][0]["sum"] or 0.0
-                sum_increase = last_stats[entity_id][0]["sum_increase"] or 0.0
 
             for fstate, state in fstates:
 
@@ -486,10 +483,6 @@ def compile_statistics(  # noqa: C901
                     # The sensor has been reset, update the sum
                     if old_state is not None:
                         _sum += new_state - old_state
-                        sum_increase += sum_increase_tmp
-                        sum_increase_tmp = 0.0
-                        if fstate > 0:
-                            sum_increase_tmp += fstate
                     # ..and update the starting point
                     new_state = fstate
                     old_last_reset = last_reset
@@ -499,8 +492,6 @@ def compile_statistics(  # noqa: C901
                     else:
                         old_state = new_state
                 else:
-                    if new_state is not None and fstate > new_state:
-                        sum_increase_tmp += fstate - new_state
                     new_state = fstate
 
             # Deprecated, will be removed in Home Assistant 2021.11
@@ -514,11 +505,9 @@ def compile_statistics(  # noqa: C901
 
             # Update the sum with the last state
             _sum += new_state - old_state
-            sum_increase += sum_increase_tmp
             if last_reset is not None:
                 stat["last_reset"] = dt_util.parse_datetime(last_reset)
             stat["sum"] = _sum
-            stat["sum_increase"] = sum_increase
             stat["state"] = new_state
 
         result.append({"meta": meta, "stat": (stat,)})

--- a/tests/components/history/test_init.py
+++ b/tests/components/history/test_init.py
@@ -916,8 +916,6 @@ async def test_statistics_during_period(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ]
     }

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -52,8 +52,6 @@ def test_compile_hourly_statistics(hass_recorder):
         "last_reset": None,
         "state": None,
         "sum": None,
-        "sum_decrease": None,
-        "sum_increase": None,
     }
     expected_2 = {
         "statistic_id": "sensor.test1",
@@ -65,8 +63,6 @@ def test_compile_hourly_statistics(hass_recorder):
         "last_reset": None,
         "state": None,
         "sum": None,
-        "sum_decrease": None,
-        "sum_increase": None,
     }
     expected_stats1 = [
         {**expected_1, "statistic_id": "sensor.test1"},
@@ -182,8 +178,6 @@ def test_compile_periodic_statistics_exception(
         "last_reset": None,
         "state": None,
         "sum": None,
-        "sum_decrease": None,
-        "sum_increase": None,
     }
     expected_2 = {
         "statistic_id": "sensor.test1",
@@ -195,8 +189,6 @@ def test_compile_periodic_statistics_exception(
         "last_reset": None,
         "state": None,
         "sum": None,
-        "sum_decrease": None,
-        "sum_increase": None,
     }
     expected_stats1 = [
         {**expected_1, "statistic_id": "sensor.test1"},
@@ -255,8 +247,6 @@ def test_rename_entity(hass_recorder):
         "last_reset": None,
         "state": None,
         "sum": None,
-        "sum_decrease": None,
-        "sum_increase": None,
     }
     expected_stats1 = [
         {**expected_1, "statistic_id": "sensor.test1"},

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -293,8 +293,6 @@ async def test_clear_statistics(hass, hass_ws_client):
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ],
         "sensor.test2": [
@@ -308,8 +306,6 @@ async def test_clear_statistics(hass, hass_ws_client):
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ],
         "sensor.test3": [
@@ -323,8 +319,6 @@ async def test_clear_statistics(hass, hass_ws_client):
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ],
     }

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -113,8 +113,6 @@ def test_compile_hourly_statistics(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ]
     }
@@ -178,8 +176,6 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ],
         "sensor.test6": [
@@ -193,8 +189,6 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ],
         "sensor.test7": [
@@ -208,8 +202,6 @@ def test_compile_hourly_statistics_unsupported(hass_recorder, caplog, attributes
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ],
     }
@@ -285,8 +277,6 @@ def test_compile_hourly_sum_statistics_amount(
                 "last_reset": process_timestamp_to_utc_isoformat(period0),
                 "state": approx(factor * seq[2]),
                 "sum": approx(factor * 10.0),
-                "sum_decrease": approx(factor * 0.0),
-                "sum_increase": approx(factor * 10.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -298,8 +288,6 @@ def test_compile_hourly_sum_statistics_amount(
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(factor * seq[5]),
                 "sum": approx(factor * 40.0),
-                "sum_decrease": approx(factor * 10.0),
-                "sum_increase": approx(factor * 50.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -311,8 +299,6 @@ def test_compile_hourly_sum_statistics_amount(
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(factor * seq[8]),
                 "sum": approx(factor * 70.0),
-                "sum_decrease": approx(factor * 10.0),
-                "sum_increase": approx(factor * 80.0),
             },
         ]
     }
@@ -407,8 +393,6 @@ def test_compile_hourly_sum_statistics_amount_reset_every_state_change(
                 "last_reset": process_timestamp_to_utc_isoformat(dt_util.as_local(one)),
                 "state": approx(factor * seq[7]),
                 "sum": approx(factor * (sum(seq) - seq[0])),
-                "sum_decrease": approx(factor * 0.0),
-                "sum_increase": approx(factor * (sum(seq) - seq[0])),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -422,8 +406,6 @@ def test_compile_hourly_sum_statistics_amount_reset_every_state_change(
                 "last_reset": process_timestamp_to_utc_isoformat(dt_util.as_local(two)),
                 "state": approx(factor * seq[7]),
                 "sum": approx(factor * (2 * sum(seq) - seq[0])),
-                "sum_decrease": approx(factor * 0.0),
-                "sum_increase": approx(factor * (2 * sum(seq) - seq[0])),
             },
         ]
     }
@@ -495,8 +477,6 @@ def test_compile_hourly_sum_statistics_amount_invalid_last_reset(
                 "last_reset": process_timestamp_to_utc_isoformat(dt_util.as_local(one)),
                 "state": approx(factor * seq[7]),
                 "sum": approx(factor * (sum(seq) - seq[0] - seq[3])),
-                "sum_decrease": approx(factor * 0.0),
-                "sum_increase": approx(factor * (sum(seq) - seq[0] - seq[3])),
             },
         ]
     }
@@ -565,10 +545,6 @@ def test_compile_hourly_sum_statistics_nan_inf_state(
                 "last_reset": process_timestamp_to_utc_isoformat(one),
                 "state": approx(factor * seq[7]),
                 "sum": approx(factor * (seq[2] + seq[3] + seq[4] + seq[6] + seq[7])),
-                "sum_decrease": approx(factor * 0.0),
-                "sum_increase": approx(
-                    factor * (seq[2] + seq[3] + seq[4] + seq[6] + seq[7])
-                ),
             },
         ]
     }
@@ -635,8 +611,6 @@ def test_compile_hourly_sum_statistics_total_no_reset(
                 "last_reset": None,
                 "state": approx(factor * seq[2]),
                 "sum": approx(factor * 10.0),
-                "sum_decrease": approx(factor * 0.0),
-                "sum_increase": approx(factor * 10.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -648,8 +622,6 @@ def test_compile_hourly_sum_statistics_total_no_reset(
                 "last_reset": None,
                 "state": approx(factor * seq[5]),
                 "sum": approx(factor * 30.0),
-                "sum_decrease": approx(factor * 10.0),
-                "sum_increase": approx(factor * 40.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -661,8 +633,6 @@ def test_compile_hourly_sum_statistics_total_no_reset(
                 "last_reset": None,
                 "state": approx(factor * seq[8]),
                 "sum": approx(factor * 60.0),
-                "sum_decrease": approx(factor * 10.0),
-                "sum_increase": approx(factor * 70.0),
             },
         ]
     }
@@ -727,8 +697,6 @@ def test_compile_hourly_sum_statistics_total_increasing(
                 "last_reset": None,
                 "state": approx(factor * seq[2]),
                 "sum": approx(factor * 10.0),
-                "sum_decrease": approx(factor * 0.0),
-                "sum_increase": approx(factor * 10.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -740,8 +708,6 @@ def test_compile_hourly_sum_statistics_total_increasing(
                 "last_reset": None,
                 "state": approx(factor * seq[5]),
                 "sum": approx(factor * 50.0),
-                "sum_decrease": approx(factor * 0.0),
-                "sum_increase": approx(factor * 50.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -753,8 +719,6 @@ def test_compile_hourly_sum_statistics_total_increasing(
                 "last_reset": None,
                 "state": approx(factor * seq[8]),
                 "sum": approx(factor * 80.0),
-                "sum_decrease": approx(factor * 0.0),
-                "sum_increase": approx(factor * 80.0),
             },
         ]
     }
@@ -829,8 +793,6 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
                 "min": None,
                 "state": approx(factor * seq[2]),
                 "sum": approx(factor * 10.0),
-                "sum_decrease": approx(factor * 0.0),
-                "sum_increase": approx(factor * 10.0),
             },
             {
                 "last_reset": None,
@@ -842,8 +804,6 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
                 "min": None,
                 "state": approx(factor * seq[5]),
                 "sum": approx(factor * 30.0),
-                "sum_decrease": approx(factor * 1.0),
-                "sum_increase": approx(factor * 31.0),
             },
             {
                 "last_reset": None,
@@ -855,8 +815,6 @@ def test_compile_hourly_sum_statistics_total_increasing_small_dip(
                 "min": None,
                 "state": approx(factor * seq[8]),
                 "sum": approx(factor * 60.0),
-                "sum_decrease": approx(factor * 2.0),
-                "sum_increase": approx(factor * 62.0),
             },
         ]
     }
@@ -928,8 +886,6 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(period0),
                 "state": approx(20.0),
                 "sum": approx(10.0),
-                "sum_decrease": approx(0.0),
-                "sum_increase": approx(10.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -941,8 +897,6 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(40.0),
                 "sum": approx(40.0),
-                "sum_decrease": approx(10.0),
-                "sum_increase": approx(50.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -954,8 +908,6 @@ def test_compile_hourly_energy_statistics_unsupported(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(70.0),
                 "sum": approx(70.0),
-                "sum_decrease": approx(10.0),
-                "sum_increase": approx(80.0),
             },
         ]
     }
@@ -1023,8 +975,6 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(period0),
                 "state": approx(20.0),
                 "sum": approx(10.0),
-                "sum_decrease": approx(0.0),
-                "sum_increase": approx(10.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -1036,8 +986,6 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(40.0),
                 "sum": approx(40.0),
-                "sum_decrease": approx(10.0),
-                "sum_increase": approx(50.0),
             },
             {
                 "statistic_id": "sensor.test1",
@@ -1049,8 +997,6 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(70.0),
                 "sum": approx(70.0),
-                "sum_decrease": approx(10.0),
-                "sum_increase": approx(80.0),
             },
         ],
         "sensor.test2": [
@@ -1064,8 +1010,6 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(period0),
                 "state": approx(130.0),
                 "sum": approx(20.0),
-                "sum_decrease": approx(0.0),
-                "sum_increase": approx(20.0),
             },
             {
                 "statistic_id": "sensor.test2",
@@ -1077,8 +1021,6 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(45.0),
                 "sum": approx(-65.0),
-                "sum_decrease": approx(130.0),
-                "sum_increase": approx(65.0),
             },
             {
                 "statistic_id": "sensor.test2",
@@ -1090,8 +1032,6 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(75.0),
                 "sum": approx(-35.0),
-                "sum_decrease": approx(130.0),
-                "sum_increase": approx(95.0),
             },
         ],
         "sensor.test3": [
@@ -1105,8 +1045,6 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(period0),
                 "state": approx(5.0 / 1000),
                 "sum": approx(5.0 / 1000),
-                "sum_decrease": approx(0.0 / 1000),
-                "sum_increase": approx(5.0 / 1000),
             },
             {
                 "statistic_id": "sensor.test3",
@@ -1118,8 +1056,6 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(50.0 / 1000),
                 "sum": approx(60.0 / 1000),
-                "sum_decrease": approx(0.0 / 1000),
-                "sum_increase": approx(60.0 / 1000),
             },
             {
                 "statistic_id": "sensor.test3",
@@ -1131,8 +1067,6 @@ def test_compile_hourly_energy_statistics_multiple(hass_recorder, caplog):
                 "last_reset": process_timestamp_to_utc_isoformat(four),
                 "state": approx(90.0 / 1000),
                 "sum": approx(100.0 / 1000),
-                "sum_decrease": approx(0.0 / 1000),
-                "sum_increase": approx(100.0 / 1000),
             },
         ],
     }
@@ -1187,8 +1121,6 @@ def test_compile_hourly_statistics_unchanged(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ]
     }
@@ -1222,8 +1154,6 @@ def test_compile_hourly_statistics_partially_unavailable(hass_recorder, caplog):
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ]
     }
@@ -1282,8 +1212,6 @@ def test_compile_hourly_statistics_unavailable(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ]
     }
@@ -1435,8 +1363,6 @@ def test_compile_hourly_statistics_changing_units_1(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ]
     }
@@ -1464,8 +1390,6 @@ def test_compile_hourly_statistics_changing_units_1(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ]
     }
@@ -1572,8 +1496,6 @@ def test_compile_hourly_statistics_changing_units_3(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ]
     }
@@ -1599,8 +1521,6 @@ def test_compile_hourly_statistics_changing_units_3(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             }
         ]
     }
@@ -1680,8 +1600,6 @@ def test_compile_hourly_statistics_changing_statistics(
                 "last_reset": None,
                 "state": None,
                 "sum": None,
-                "sum_decrease": None,
-                "sum_increase": None,
             },
             {
                 "statistic_id": "sensor.test1",
@@ -1693,8 +1611,6 @@ def test_compile_hourly_statistics_changing_statistics(
                 "last_reset": None,
                 "state": approx(30.0),
                 "sum": approx(30.0),
-                "sum_decrease": approx(10.0),
-                "sum_increase": approx(40.0),
             },
         ]
     }
@@ -1763,8 +1679,6 @@ def test_compile_statistics_hourly_summary(hass_recorder, caplog):
     expected_averages = {"sensor.test1": [], "sensor.test2": [], "sensor.test3": []}
     expected_states = {"sensor.test4": []}
     expected_sums = {"sensor.test4": []}
-    expected_decreases = {"sensor.test4": []}
-    expected_increases = {"sensor.test4": []}
     last_states = {
         "sensor.test1": None,
         "sensor.test2": None,
@@ -1817,10 +1731,6 @@ def test_compile_statistics_hourly_summary(hass_recorder, caplog):
         expected_states["sensor.test4"].append(seq[-1])
         expected_sums["sensor.test4"].append(
             _sum(seq, last_state, expected_sums["sensor.test4"])
-        )
-        expected_decreases["sensor.test4"].append(0)
-        expected_increases["sensor.test4"].append(
-            _sum(seq, last_state, expected_increases["sensor.test4"])
         )
         last_states["sensor.test4"] = seq[-1]
 
@@ -1879,16 +1789,6 @@ def test_compile_statistics_hourly_summary(hass_recorder, caplog):
             expected_sum = (
                 expected_sums[entity_id][i] if entity_id in expected_sums else None
             )
-            expected_decrease = (
-                expected_decreases[entity_id][i]
-                if entity_id in expected_decreases
-                else None
-            )
-            expected_increase = (
-                expected_increases[entity_id][i]
-                if entity_id in expected_increases
-                else None
-            )
             expected_stats[entity_id].append(
                 {
                     "statistic_id": entity_id,
@@ -1900,8 +1800,6 @@ def test_compile_statistics_hourly_summary(hass_recorder, caplog):
                     "last_reset": None,
                     "state": expected_state,
                     "sum": expected_sum,
-                    "sum_decrease": expected_decrease,
-                    "sum_increase": expected_increase,
                 }
             )
         start += timedelta(minutes=5)
@@ -1949,16 +1847,6 @@ def test_compile_statistics_hourly_summary(hass_recorder, caplog):
                 if entity_id in expected_sums
                 else None
             )
-            expected_decrease = (
-                expected_decreases[entity_id][(i + 1) * 12 - 1]
-                if entity_id in expected_decreases
-                else None
-            )
-            expected_increase = (
-                expected_increases[entity_id][(i + 1) * 12 - 1]
-                if entity_id in expected_increases
-                else None
-            )
             expected_stats[entity_id].append(
                 {
                     "statistic_id": entity_id,
@@ -1970,8 +1858,6 @@ def test_compile_statistics_hourly_summary(hass_recorder, caplog):
                     "last_reset": None,
                     "state": expected_state,
                     "sum": expected_sum,
-                    "sum_decrease": expected_decrease,
-                    "sum_increase": expected_increase,
                 }
             )
         start += timedelta(hours=1)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove automatic splitting of net meters to import and export from statistics

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
