### PR TITLE
Import Callable from collections.abc (1)

### DIFF
--- a/homeassistant/auth/permissions/__init__.py
+++ b/homeassistant/auth/permissions/__init__.py
@@ -1,8 +1,9 @@
 """Permissions for Home Assistant."""
 from __future__ import annotations
 
+from collections.abc import Callable
 import logging
-from typing import Any, Callable
+from typing import Any
 
 import voluptuous as vol
 

--- a/homeassistant/auth/permissions/entities.py
+++ b/homeassistant/auth/permissions/entities.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Callable
+from collections.abc import Callable
 
 import voluptuous as vol
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -2,14 +2,14 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 import logging
 import os
 from pathlib import Path
 import re
 import shutil
 from types import ModuleType
-from typing import Any, Callable
+from typing import Any
 from urllib.parse import urlparse
 
 from awesomeversion import AwesomeVersion

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from ssl import SSLContext
 import sys
 from types import MappingProxyType
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import aiohttp
 from aiohttp import web

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 
 from abc import ABC, ABCMeta, abstractmethod
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 import logging
 import secrets
 import time
-from typing import Any, Callable, Dict, cast
+from typing import Any, Dict, cast
 
 from aiohttp import client, web
 import async_timeout

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,7 +1,7 @@
 """Helpers for config validation using voluptuous."""
 from __future__ import annotations
 
-from collections.abc import Hashable
+from collections.abc import Callable, Hashable
 from datetime import (
     date as date_sys,
     datetime as datetime_sys,
@@ -15,7 +15,7 @@ from numbers import Number
 import os
 import re
 from socket import _GLOBAL_DEFAULT_TIMEOUT  # type: ignore # private, not in typeshed
-from typing import Any, Callable, Dict, TypeVar, cast
+from typing import Any, Dict, TypeVar, cast
 from urllib.parse import urlparse
 from uuid import UUID
 

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from logging import Logger
-from typing import Any, Callable
+from typing import Any
 
 from homeassistant.core import HassJob, HomeAssistant, callback
 

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -1,10 +1,11 @@
 """Deprecation helpers for Home Assistant."""
 from __future__ import annotations
 
+from collections.abc import Callable
 import functools
 import inspect
 import logging
-from typing import Any, Callable
+from typing import Any
 
 from ..helpers.frame import MissingIntegrationFrame, get_integration_frame
 

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -7,7 +7,8 @@ There are two different types of discoveries that can be fired/listened for.
 """
 from __future__ import annotations
 
-from typing import Any, Callable, TypedDict
+from collections.abc import Callable
+from typing import Any, TypedDict
 
 from homeassistant import core, setup
 from homeassistant.core import CALLBACK_TYPE

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -1,6 +1,9 @@
 """Helpers for Home Assistant dispatcher & internal component/platform."""
+from __future__ import annotations
+
+from collections.abc import Callable
 import logging
-from typing import Any, Callable
+from typing import Any
 
 from homeassistant.core import HassJob, HomeAssistant, callback
 from homeassistant.loader import bind_hass

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from datetime import timedelta
 from itertools import chain
 import logging
 from types import ModuleType
-from typing import Any, Callable
+from typing import Any
 
 import voluptuous as vol
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -2,13 +2,13 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Coroutine, Iterable
+from collections.abc import Callable, Coroutine, Iterable
 from contextvars import ContextVar
 from datetime import datetime, timedelta
 import logging
 from logging import Logger
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Callable, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import voluptuous as vol
 

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -10,9 +10,9 @@ timer.
 from __future__ import annotations
 
 from collections import OrderedDict
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 import logging
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import attr
 

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -1,9 +1,9 @@
 """Helper class to implement include/exclude of entities and domains."""
 from __future__ import annotations
 
+from collections.abc import Callable
 import fnmatch
 import re
-from typing import Callable
 
 import voluptuous as vol
 

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import functools
 import logging
 from traceback import FrameSummary, extract_stack
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from homeassistant.exceptions import HomeAssistantError
 

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -1,8 +1,9 @@
 """Helper for httpx."""
 from __future__ import annotations
 
+from collections.abc import Callable
 import sys
-from typing import Any, Callable
+from typing import Any
 
 import httpx
 

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 import logging
-from typing import Any, Callable
+from typing import Any
 
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.loader import async_get_integration, bind_hass

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -1,10 +1,10 @@
 """Module to coordinate user intentions."""
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 import logging
 import re
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
 import voluptuous as vol
 

--- a/homeassistant/helpers/ratelimit.py
+++ b/homeassistant/helpers/ratelimit.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Hashable
+from collections.abc import Callable, Hashable
 from datetime import datetime, timedelta
 import logging
-from typing import Any, Callable
+from typing import Any
 
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.util.dt as dt_util

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -2,14 +2,14 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timedelta
 from functools import partial
 import itertools
 import logging
 from types import MappingProxyType
-from typing import Any, Callable, Dict, TypedDict, Union, cast
+from typing import Any, Dict, TypedDict, Union, cast
 
 import async_timeout
 import voluptuous as vol

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1,7 +1,8 @@
 """Selectors for Home Assistant."""
 from __future__ import annotations
 
-from typing import Any, Callable, cast
+from collections.abc import Callable
+from typing import Any, cast
 
 import voluptuous as vol
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 import dataclasses
 from functools import partial, wraps
 import logging
-from typing import TYPE_CHECKING, Any, Callable, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import voluptuous as vol
 

--- a/homeassistant/helpers/start.py
+++ b/homeassistant/helpers/start.py
@@ -1,6 +1,7 @@
 """Helpers to help during startup."""
-from collections.abc import Awaitable
-from typing import Callable
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import Event, HomeAssistant, callback

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from contextlib import suppress
 from json import JSONEncoder
 import logging
 import os
-from typing import Any, Callable
+from typing import Any
 
 from homeassistant.const import EVENT_HOMEASSISTANT_FINAL_WRITE
 from homeassistant.core import CALLBACK_TYPE, CoreState, Event, HomeAssistant, callback

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -5,7 +5,7 @@ from ast import literal_eval
 import asyncio
 import base64
 import collections.abc
-from collections.abc import Generator, Iterable
+from collections.abc import Callable, Generator, Iterable
 from contextlib import suppress
 from contextvars import ContextVar
 from datetime import datetime, timedelta
@@ -17,7 +17,7 @@ from operator import attrgetter
 import random
 import re
 import sys
-from typing import Any, Callable, cast
+from typing import Any, cast
 from urllib.parse import urlencode as urllib_urlencode
 import weakref
 

--- a/homeassistant/helpers/trace.py
+++ b/homeassistant/helpers/trace.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import wraps
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 from homeassistant.helpers.typing import TemplateVarsType
 import homeassistant.util.dt as dt_util

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import logging
-from typing import Any, Callable
+from typing import Any
 
 import voluptuous as vol
 

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 import logging
 from time import monotonic
-from typing import Callable, Generic, TypeVar
+from typing import Generic, TypeVar
 import urllib.error
 
 import aiohttp

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 import collections
+from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime
 import json
 import logging
 from timeit import default_timer as timer
-from typing import Callable, TypeVar
+from typing import TypeVar
 
 from homeassistant import core
 from homeassistant.components.websocket_api.const import JSON_DUMP

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 import argparse
 import asyncio
 from collections import OrderedDict
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from glob import glob
 import logging
 import os
-from typing import Any, Callable
+from typing import Any
 from unittest.mock import patch
 
 from homeassistant import core

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -2,12 +2,11 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Generator, Iterable
+from collections.abc import Awaitable, Callable, Generator, Iterable
 import contextlib
 import logging.handlers
 from timeit import default_timer as timer
 from types import ModuleType
-from typing import Callable
 
 from homeassistant import config as conf_util, core, loader, requirements
 from homeassistant.config import async_notify_setup_error

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Coroutine, Iterable, KeysView
+from collections.abc import Callable, Coroutine, Iterable, KeysView
 from datetime import datetime, timedelta
 import enum
 from functools import lru_cache, wraps
@@ -12,7 +12,7 @@ import socket
 import string
 import threading
 from types import MappingProxyType
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
 
 import slugify as unicode_slug
 

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 from asyncio import Semaphore, coroutines, ensure_future, gather, get_running_loop
 from asyncio.events import AbstractEventLoop
-from collections.abc import Awaitable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 import concurrent.futures
 import functools
 import logging
 import threading
 from traceback import extract_stack
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/util/decorator.py
+++ b/homeassistant/util/decorator.py
@@ -1,6 +1,8 @@
 """Decorator utility functions."""
-from collections.abc import Hashable
-from typing import Callable, TypeVar
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable
+from typing import TypeVar
 
 CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)  # pylint: disable=invalid-name
 

--- a/homeassistant/util/distance.py
+++ b/homeassistant/util/distance.py
@@ -1,8 +1,8 @@
 """Distance util functions."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from numbers import Number
-from typing import Callable
 
 from homeassistant.const import (
     LENGTH,

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Callable
 import json
 import logging
 import os
 import tempfile
-from typing import Any, Callable
+from typing import Any
 
 from homeassistant.core import Event, State
 from homeassistant.exceptions import HomeAssistantError


### PR DESCRIPTION
## Proposed change
In most cases `Callable` can already be imported from `collections.abc` instead of `typing`.
The next version of `pylint` will emit a warning if that's the case. Similar to the one for the remaining typing aliases.

For reference: #49480


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
