### PR TITLE
Use isinstance to verify class in deCONZ integration

### DIFF
--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -76,7 +76,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
         for sensor in sensors:
 
             if (
-                sensor.type in AncillaryControl.ZHATYPE
+                isinstance(sensor, AncillaryControl)
                 and sensor.unique_id not in gateway.entities[DOMAIN]
                 and get_alarm_system_for_unique_id(gateway, sensor.unique_id)
             ):

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -1,5 +1,15 @@
 """Support for deCONZ binary sensors."""
-from pydeconz.sensor import CarbonMonoxide, Fire, OpenClose, Presence, Vibration, Water
+from pydeconz.sensor import (
+    Alarm,
+    CarbonMonoxide,
+    Fire,
+    GenericFlag,
+    GenericStatus,
+    OpenClose,
+    Presence,
+    Vibration,
+    Water,
+)
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_GAS,
@@ -20,6 +30,18 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from .const import ATTR_DARK, ATTR_ON, NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
+
+DECONZ_BINARY_SENSORS = (
+    Alarm,
+    CarbonMonoxide,
+    Fire,
+    GenericFlag,
+    GenericStatus,
+    OpenClose,
+    Presence,
+    Vibration,
+    Water,
+)
 
 ATTR_ORIENTATION = "orientation"
 ATTR_TILTANGLE = "tiltangle"
@@ -65,13 +87,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         for sensor in sensors:
 
+            if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
+                continue
+
             if (
-                sensor.BINARY
+                isinstance(sensor, DECONZ_BINARY_SENSORS)
                 and sensor.unique_id not in gateway.entities[DOMAIN]
-                and (
-                    gateway.option_allow_clip_sensor
-                    or not sensor.type.startswith("CLIP")
-                )
             ):
                 entities.append(DeconzBinarySensor(sensor, gateway))
 

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -84,13 +84,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         for sensor in sensors:
 
+            if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
+                continue
+
             if (
-                sensor.type in Thermostat.ZHATYPE
+                isinstance(sensor, Thermostat)
                 and sensor.unique_id not in gateway.entities[DOMAIN]
-                and (
-                    gateway.option_allow_clip_sensor
-                    or not sensor.type.startswith("CLIP")
-                )
             ):
                 entities.append(DeconzThermostat(sensor, gateway))
 

--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -57,23 +57,6 @@ ATTR_OFFSET = "offset"
 ATTR_ON = "on"
 ATTR_VALVE = "valve"
 
-# Covers
-LEVEL_CONTROLLABLE_OUTPUT = "Level controllable output"
-DAMPERS = [LEVEL_CONTROLLABLE_OUTPUT]
-WINDOW_COVERING_CONTROLLER = "Window covering controller"
-WINDOW_COVERING_DEVICE = "Window covering device"
-WINDOW_COVERS = [WINDOW_COVERING_CONTROLLER, WINDOW_COVERING_DEVICE]
-COVER_TYPES = DAMPERS + WINDOW_COVERS
-
-# Fans
-FANS = ["Fan"]
-
-# Locks
-LOCK_TYPES = ["Door Lock", "ZHADoorLock"]
-
-# Sirens
-SIRENS = ["Warning device"]
-
 # Switches
 POWER_PLUGS = ["On/Off light", "On/Off plug-in unit", "Smart plug"]
 

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -1,4 +1,7 @@
 """Support for deCONZ covers."""
+
+from pydeconz.light import Cover
+
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
@@ -18,20 +21,14 @@ from homeassistant.components.cover import (
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import (
-    COVER_TYPES,
-    LEVEL_CONTROLLABLE_OUTPUT,
-    NEW_LIGHT,
-    WINDOW_COVERING_CONTROLLER,
-    WINDOW_COVERING_DEVICE,
-)
+from .const import NEW_LIGHT
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
 DEVICE_CLASS = {
-    LEVEL_CONTROLLABLE_OUTPUT: DEVICE_CLASS_DAMPER,
-    WINDOW_COVERING_CONTROLLER: DEVICE_CLASS_SHADE,
-    WINDOW_COVERING_DEVICE: DEVICE_CLASS_SHADE,
+    "Level controllable output": DEVICE_CLASS_DAMPER,
+    "Window covering controller": DEVICE_CLASS_SHADE,
+    "Window covering device": DEVICE_CLASS_SHADE,
 }
 
 
@@ -47,7 +44,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         for light in lights:
             if (
-                light.type in COVER_TYPES
+                isinstance(light, Cover)
                 and light.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzCover(light, gateway))

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -1,4 +1,5 @@
 """Base class for deCONZ devices."""
+
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -40,23 +40,24 @@ async def async_setup_events(gateway) -> None:
     @callback
     def async_add_sensor(sensors=gateway.api.sensors.values()):
         """Create DeconzEvent."""
+        new_events = []
+        known_events = {event.unique_id for event in gateway.events}
+
         for sensor in sensors:
 
             if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
                 continue
 
-            if (
-                sensor.type not in Switch.ZHATYPE + AncillaryControl.ZHATYPE
-                or sensor.unique_id in {event.unique_id for event in gateway.events}
-            ):
+            if sensor.unique_id in known_events:
                 continue
 
-            if sensor.type in Switch.ZHATYPE:
-                new_event = DeconzEvent(sensor, gateway)
+            if isinstance(sensor, Switch):
+                new_events.append(DeconzEvent(sensor, gateway))
 
-            elif sensor.type in AncillaryControl.ZHATYPE:
-                new_event = DeconzAlarmEvent(sensor, gateway)
+            elif isinstance(sensor, AncillaryControl):
+                new_events.append(DeconzAlarmEvent(sensor, gateway))
 
+        for new_event in new_events:
             gateway.hass.async_create_task(new_event.async_update_device_registry())
             gateway.events.append(new_event)
 

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -1,6 +1,8 @@
 """Support for deCONZ fans."""
 from __future__ import annotations
 
+from pydeconz.light import Fan
+
 from homeassistant.components.fan import (
     DOMAIN,
     SPEED_HIGH,
@@ -17,7 +19,7 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
-from .const import FANS, NEW_LIGHT
+from .const import NEW_LIGHT
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -39,7 +41,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
 
         for light in lights:
 
-            if light.type in FANS and light.unique_id not in gateway.entities[DOMAIN]:
+            if (
+                isinstance(light, Fan)
+                and light.unique_id not in gateway.entities[DOMAIN]
+            ):
                 entities.append(DeconzFan(light, gateway))
 
         if entities:

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pydeconz.light import Light
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
@@ -28,24 +30,11 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.color import color_hs_to_xy
 
-from .const import (
-    COVER_TYPES,
-    DOMAIN as DECONZ_DOMAIN,
-    LOCK_TYPES,
-    NEW_GROUP,
-    NEW_LIGHT,
-    POWER_PLUGS,
-    SIRENS,
-)
+from .const import DOMAIN as DECONZ_DOMAIN, NEW_GROUP, NEW_LIGHT, POWER_PLUGS
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
-CONTROLLER = ["Configuration tool"]
 DECONZ_GROUP = "is_deconz_group"
-
-OTHER_LIGHT_RESOURCE_TYPES = (
-    CONTROLLER + COVER_TYPES + LOCK_TYPES + POWER_PLUGS + SIRENS
-)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -60,7 +49,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         for light in lights:
             if (
-                light.type not in OTHER_LIGHT_RESOURCE_TYPES
+                isinstance(light, Light)
+                and light.type not in POWER_PLUGS
                 and light.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzLight(light, gateway))

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -1,9 +1,13 @@
 """Support for deCONZ locks."""
+
+from pydeconz.light import Lock
+from pydeconz.sensor import DoorLock
+
 from homeassistant.components.lock import DOMAIN, LockEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import LOCK_TYPES, NEW_LIGHT, NEW_SENSOR
+from .const import NEW_LIGHT, NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -21,7 +25,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for light in lights:
 
             if (
-                light.type in LOCK_TYPES
+                isinstance(light, Lock)
                 and light.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzLock(light, gateway))
@@ -43,7 +47,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for sensor in sensors:
 
             if (
-                sensor.type in LOCK_TYPES
+                isinstance(sensor, DoorLock)
                 and sensor.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzLock(sensor, gateway))

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -1,6 +1,7 @@
 """Support for deCONZ sensors."""
 from pydeconz.sensor import (
     AirQuality,
+    Battery,
     Consumption,
     Daylight,
     Humidity,

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -1,10 +1,8 @@
 """Support for deCONZ sensors."""
 from pydeconz.sensor import (
-    AncillaryControl,
-    Battery,
+    AirQuality,
     Consumption,
     Daylight,
-    DoorLock,
     Humidity,
     LightLevel,
     Power,
@@ -12,6 +10,7 @@ from pydeconz.sensor import (
     Switch,
     Temperature,
     Thermostat,
+    Time,
 )
 
 from homeassistant.components.sensor import (
@@ -47,6 +46,18 @@ from homeassistant.helpers.dispatcher import (
 from .const import ATTR_DARK, ATTR_ON, NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
+
+DECONZ_SENSORS = (
+    AirQuality,
+    Consumption,
+    Daylight,
+    Humidity,
+    LightLevel,
+    Power,
+    Pressure,
+    Temperature,
+    Time,
+)
 
 ATTR_CURRENT = "current"
 ATTR_POWER = "power"
@@ -136,13 +147,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 battery_handler.create_tracker(sensor)
 
             if (
-                not sensor.BINARY
-                and sensor.type
-                not in AncillaryControl.ZHATYPE
-                + Battery.ZHATYPE
-                + DoorLock.ZHATYPE
-                + Switch.ZHATYPE
-                + Thermostat.ZHATYPE
+                isinstance(sensor, DECONZ_SENSORS)
+                and not isinstance(sensor, Thermostat)
                 and sensor.unique_id not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzSensor(sensor, gateway))
@@ -301,7 +307,7 @@ class DeconzBattery(DeconzDevice, SensorEntity):
         """Return the state attributes of the battery."""
         attr = {}
 
-        if self._device.type in Switch.ZHATYPE:
+        if isinstance(self._device, Switch):
             for event in self.gateway.events:
                 if self._device == event.device:
                     attr[ATTR_EVENT_ID] = event.event_id

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -1,9 +1,12 @@
 """Support for deCONZ switches."""
+
+from pydeconz.light import Siren
+
 from homeassistant.components.switch import DOMAIN, SwitchEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN as DECONZ_DOMAIN, NEW_LIGHT, POWER_PLUGS, SIRENS
+from .const import DOMAIN as DECONZ_DOMAIN, NEW_LIGHT, POWER_PLUGS
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -20,10 +23,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     # Siren platform replacing sirens in switch platform added in 2021.10
     for light in gateway.api.lights.values():
-        if light.type not in SIRENS:
-            continue
-        if entity_id := entity_registry.async_get_entity_id(
-            DOMAIN, DECONZ_DOMAIN, light.unique_id
+        if isinstance(light, Siren) and (
+            entity_id := entity_registry.async_get_entity_id(
+                DOMAIN, DECONZ_DOMAIN, light.unique_id
+            )
         ):
             entity_registry.async_remove(entity_id)
 

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
     STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
 )
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
@@ -553,5 +552,4 @@ async def test_unsupported_sensor(hass, aioclient_mock):
     with patch.dict(DECONZ_WEB_REQUEST, data):
         await setup_deconz_integration(hass, aioclient_mock)
 
-    assert len(hass.states.async_all()) == 1
-    assert hass.states.get("sensor.name").state == STATE_UNKNOWN
+    assert len(hass.states.async_all()) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Trying to use more python methods when I identify those places.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
