### PR TITLE
Fix dhcp discovery matching due to deferred imports

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -303,9 +303,7 @@ class DHCPWatcher(WatcherBase):
                 return
 
             options = packet[DHCP].options
-
             request_type = _decode_dhcp_option(options, MESSAGE_TYPE)
-
             if request_type != DHCP_REQUEST:
                 # DHCP request
                 return
@@ -314,10 +312,8 @@ class DHCPWatcher(WatcherBase):
             hostname = _decode_dhcp_option(options, HOSTNAME) or ""
             mac_address = _format_mac(packet[Ether].src)
 
-            if ip_address is None or mac_address is None:
-                return
-
-            self.process_client(ip_address, hostname, mac_address)
+            if ip_address is not None and mac_address is not None:
+                self.process_client(ip_address, hostname, mac_address)
 
         # disable scapy promiscuous mode as we do not need it
         conf.sniff_promisc = 0

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -308,9 +308,6 @@ class DHCPWatcher(WatcherBase):
 
             request_type = _decode_dhcp_option(options, MESSAGE_TYPE)
 
-            _LOGGER.debug(
-                "Handle incoming packet request_type: %s -- %s", packet, request_type
-            )
             if request_type != DHCP_REQUEST:
                 # DHCP request
                 return

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -304,7 +304,6 @@ class DHCPWatcher(WatcherBase):
                 return
 
             options = packet[DHCP].options
-            _LOGGER.debug("Handle incoming packet options: %s -- %s", packet, options)
 
             request_type = _decode_dhcp_option(options, MESSAGE_TYPE)
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -319,14 +319,6 @@ class DHCPWatcher(WatcherBase):
             hostname = _decode_dhcp_option(options, HOSTNAME) or ""
             mac_address = _format_mac(packet[Ether].src)
 
-            _LOGGER.debug(
-                "Handle incoming packet ip_address, hostname, mac_address: %s %s %s %s",
-                packet,
-                ip_address,
-                hostname,
-                mac_address,
-            )
-
             if ip_address is None or mac_address is None:
                 return
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -299,7 +299,6 @@ class DHCPWatcher(WatcherBase):
 
         def _handle_dhcp_packet(packet):
             """Process a dhcp packet."""
-            _LOGGER.debug("Handle incoming packet: %s -- %s", packet, DHCP in packet)
             if DHCP not in packet:
                 return
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -282,6 +282,9 @@ class DHCPWatcher(WatcherBase):
         from scapy import (  # pylint: disable=import-outside-toplevel,unused-import  # noqa: F401
             arch,
         )
+        from scapy.layers.dhcp import DHCP  # pylint: disable=import-outside-toplevel
+        from scapy.layers.inet import IP  # pylint: disable=import-outside-toplevel
+        from scapy.layers.l2 import Ether  # pylint: disable=import-outside-toplevel
 
         #
         # Importing scapy.sendrecv will cause a scapy resync which will
@@ -293,6 +296,41 @@ class DHCPWatcher(WatcherBase):
         from scapy.sendrecv import (  # pylint: disable=import-outside-toplevel
             AsyncSniffer,
         )
+
+        def _handle_dhcp_packet(packet):
+            """Process a dhcp packet."""
+            _LOGGER.debug("Handle incoming packet: %s -- %s", packet, DHCP in packet)
+            if DHCP not in packet:
+                return
+
+            options = packet[DHCP].options
+            _LOGGER.debug("Handle incoming packet options: %s -- %s", packet, options)
+
+            request_type = _decode_dhcp_option(options, MESSAGE_TYPE)
+
+            _LOGGER.debug(
+                "Handle incoming packet request_type: %s -- %s", packet, request_type
+            )
+            if request_type != DHCP_REQUEST:
+                # DHCP request
+                return
+
+            ip_address = _decode_dhcp_option(options, REQUESTED_ADDR) or packet[IP].src
+            hostname = _decode_dhcp_option(options, HOSTNAME) or ""
+            mac_address = _format_mac(packet[Ether].src)
+
+            _LOGGER.debug(
+                "Handle incoming packet ip_address, hostname, mac_address: %s %s %s %s",
+                packet,
+                ip_address,
+                hostname,
+                mac_address,
+            )
+
+            if ip_address is None or mac_address is None:
+                return
+
+            self.process_client(ip_address, hostname, mac_address)
 
         # disable scapy promiscuous mode as we do not need it
         conf.sniff_promisc = 0
@@ -320,40 +358,13 @@ class DHCPWatcher(WatcherBase):
         self._sniffer = AsyncSniffer(
             filter=FILTER,
             started_callback=self._started.set,
-            prn=self.handle_dhcp_packet,
+            prn=_handle_dhcp_packet,
             store=0,
         )
 
         self._sniffer.start()
         if self._sniffer.thread:
             self._sniffer.thread.name = self.__class__.__name__
-
-    def handle_dhcp_packet(self, packet):
-        """Process a dhcp packet."""
-        # Local import because importing from scapy has side effects such as opening
-        # sockets
-        from scapy.layers.dhcp import DHCP  # pylint: disable=import-outside-toplevel
-        from scapy.layers.inet import IP  # pylint: disable=import-outside-toplevel
-        from scapy.layers.l2 import Ether  # pylint: disable=import-outside-toplevel
-
-        if DHCP not in packet:
-            return
-
-        options = packet[DHCP].options
-
-        request_type = _decode_dhcp_option(options, MESSAGE_TYPE)
-        if request_type != DHCP_REQUEST:
-            # DHCP request
-            return
-
-        ip_address = _decode_dhcp_option(options, REQUESTED_ADDR) or packet[IP].src
-        hostname = _decode_dhcp_option(options, HOSTNAME) or ""
-        mac_address = _format_mac(packet[Ether].src)
-
-        if ip_address is None or mac_address is None:
-            return
-
-        self.process_client(ip_address, hostname, mac_address)
 
     def create_task(self, task):
         """Pass a task to hass.add_job since we are in a thread."""

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -305,7 +305,7 @@ class DHCPWatcher(WatcherBase):
             options = packet[DHCP].options
             request_type = _decode_dhcp_option(options, MESSAGE_TYPE)
             if request_type != DHCP_REQUEST:
-                # DHCP request
+                # Not a DHCP request
                 return
 
             ip_address = _decode_dhcp_option(options, REQUESTED_ADDR) or packet[IP].src

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -151,10 +151,8 @@ async def test_dhcp_match_hostname_and_macaddress(hass):
     ]
     packet = Ether(RAW_DHCP_REQUEST)
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
         # Ensure no change is ignored
         handle_dhcp_packet(packet)
@@ -179,12 +177,8 @@ async def test_dhcp_renewal_match_hostname_and_macaddress(hass):
 
     packet = Ether(RAW_DHCP_RENEWAL)
 
-    handle_dhcp_packet = None
-
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
         # Ensure no change is ignored
         handle_dhcp_packet(packet)
@@ -207,10 +201,8 @@ async def test_dhcp_match_hostname(hass):
 
     packet = Ether(RAW_DHCP_REQUEST)
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 1
@@ -231,10 +223,8 @@ async def test_dhcp_match_macaddress(hass):
 
     packet = Ether(RAW_DHCP_REQUEST)
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 1
@@ -255,10 +245,8 @@ async def test_dhcp_match_macaddress_without_hostname(hass):
 
     packet = Ether(RAW_DHCP_REQUEST_WITHOUT_HOSTNAME)
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 1
@@ -279,10 +267,8 @@ async def test_dhcp_nomatch(hass):
 
     packet = Ether(RAW_DHCP_REQUEST)
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -294,10 +280,8 @@ async def test_dhcp_nomatch_hostname(hass):
 
     packet = Ether(RAW_DHCP_REQUEST)
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -309,10 +293,8 @@ async def test_dhcp_nomatch_non_dhcp_packet(hass):
 
     packet = Ether(b"")
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -333,10 +315,8 @@ async def test_dhcp_nomatch_non_dhcp_request_packet(hass):
         ("hostname", b"connect"),
     ]
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -357,10 +337,8 @@ async def test_dhcp_invalid_hostname(hass):
         ("hostname", "connect"),
     ]
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -381,10 +359,8 @@ async def test_dhcp_missing_hostname(hass):
         ("hostname", None),
     ]
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -405,10 +381,8 @@ async def test_dhcp_invalid_option(hass):
         ("hostname"),
     ]
 
+    handle_dhcp_packet = await _async_get_handle_dhcp_packet(hass, integration_matchers)
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
-            hass, integration_matchers
-        )
         handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -1,7 +1,7 @@
 """Test the DHCP discovery integration."""
 import datetime
 import threading
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from scapy.error import Scapy_Exception
 from scapy.layers.dhcp import DHCP
@@ -123,20 +123,41 @@ RAW_DHCP_REQUEST_WITHOUT_HOSTNAME = (
 )
 
 
-async def test_dhcp_match_hostname_and_macaddress(hass):
-    """Test matching based on hostname and macaddress."""
+async def _async_get_handle_dhcp_packet(hass, integration_matchers):
     dhcp_watcher = dhcp.DHCPWatcher(
         hass,
         {},
-        [{"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}],
+        integration_matchers,
     )
+    handle_dhcp_packet = None
 
+    def _mock_sniffer(*args, **kwargs):
+        nonlocal handle_dhcp_packet
+        handle_dhcp_packet = kwargs["prn"]
+        return MagicMock()
+
+    with patch("homeassistant.components.dhcp._verify_l2socket_setup",), patch(
+        "scapy.arch.common.compile_filter"
+    ), patch("scapy.sendrecv.AsyncSniffer", _mock_sniffer):
+        await dhcp_watcher.async_start()
+
+    return handle_dhcp_packet
+
+
+async def test_dhcp_match_hostname_and_macaddress(hass):
+    """Test matching based on hostname and macaddress."""
+    integration_matchers = [
+        {"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}
+    ]
     packet = Ether(RAW_DHCP_REQUEST)
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
         # Ensure no change is ignored
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 1
     assert mock_init.mock_calls[0][1][0] == "mock-domain"
@@ -152,18 +173,21 @@ async def test_dhcp_match_hostname_and_macaddress(hass):
 
 async def test_dhcp_renewal_match_hostname_and_macaddress(hass):
     """Test renewal matching based on hostname and macaddress."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass,
-        {},
-        [{"domain": "mock-domain", "hostname": "irobot-*", "macaddress": "501479*"}],
-    )
+    integration_matchers = [
+        {"domain": "mock-domain", "hostname": "irobot-*", "macaddress": "501479*"}
+    ]
 
     packet = Ether(RAW_DHCP_RENEWAL)
 
+    handle_dhcp_packet = None
+
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
         # Ensure no change is ignored
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 1
     assert mock_init.mock_calls[0][1][0] == "mock-domain"
@@ -179,14 +203,15 @@ async def test_dhcp_renewal_match_hostname_and_macaddress(hass):
 
 async def test_dhcp_match_hostname(hass):
     """Test matching based on hostname only."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass, {}, [{"domain": "mock-domain", "hostname": "connect"}]
-    )
+    integration_matchers = [{"domain": "mock-domain", "hostname": "connect"}]
 
     packet = Ether(RAW_DHCP_REQUEST)
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 1
     assert mock_init.mock_calls[0][1][0] == "mock-domain"
@@ -202,14 +227,15 @@ async def test_dhcp_match_hostname(hass):
 
 async def test_dhcp_match_macaddress(hass):
     """Test matching based on macaddress only."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass, {}, [{"domain": "mock-domain", "macaddress": "B8B7F1*"}]
-    )
+    integration_matchers = [{"domain": "mock-domain", "macaddress": "B8B7F1*"}]
 
     packet = Ether(RAW_DHCP_REQUEST)
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 1
     assert mock_init.mock_calls[0][1][0] == "mock-domain"
@@ -225,14 +251,15 @@ async def test_dhcp_match_macaddress(hass):
 
 async def test_dhcp_match_macaddress_without_hostname(hass):
     """Test matching based on macaddress only."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass, {}, [{"domain": "mock-domain", "macaddress": "606BBD*"}]
-    )
+    integration_matchers = [{"domain": "mock-domain", "macaddress": "606BBD*"}]
 
     packet = Ether(RAW_DHCP_REQUEST_WITHOUT_HOSTNAME)
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 1
     assert mock_init.mock_calls[0][1][0] == "mock-domain"
@@ -248,51 +275,52 @@ async def test_dhcp_match_macaddress_without_hostname(hass):
 
 async def test_dhcp_nomatch(hass):
     """Test not matching based on macaddress only."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass, {}, [{"domain": "mock-domain", "macaddress": "ABC123*"}]
-    )
+    integration_matchers = [{"domain": "mock-domain", "macaddress": "ABC123*"}]
 
     packet = Ether(RAW_DHCP_REQUEST)
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
 
 
 async def test_dhcp_nomatch_hostname(hass):
     """Test not matching based on hostname only."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass, {}, [{"domain": "mock-domain", "hostname": "nomatch*"}]
-    )
+    integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
     packet = Ether(RAW_DHCP_REQUEST)
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
 
 
 async def test_dhcp_nomatch_non_dhcp_packet(hass):
     """Test matching does not throw on a non-dhcp packet."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass, {}, [{"domain": "mock-domain", "hostname": "nomatch*"}]
-    )
+    integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
     packet = Ether(b"")
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
 
 
 async def test_dhcp_nomatch_non_dhcp_request_packet(hass):
     """Test nothing happens with the wrong message-type."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass, {}, [{"domain": "mock-domain", "hostname": "nomatch*"}]
-    )
+    integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
     packet = Ether(RAW_DHCP_REQUEST)
 
@@ -306,16 +334,17 @@ async def test_dhcp_nomatch_non_dhcp_request_packet(hass):
     ]
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
 
 
 async def test_dhcp_invalid_hostname(hass):
     """Test we ignore invalid hostnames."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass, {}, [{"domain": "mock-domain", "hostname": "nomatch*"}]
-    )
+    integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
     packet = Ether(RAW_DHCP_REQUEST)
 
@@ -329,16 +358,17 @@ async def test_dhcp_invalid_hostname(hass):
     ]
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
 
 
 async def test_dhcp_missing_hostname(hass):
     """Test we ignore missing hostnames."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass, {}, [{"domain": "mock-domain", "hostname": "nomatch*"}]
-    )
+    integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
     packet = Ether(RAW_DHCP_REQUEST)
 
@@ -352,16 +382,17 @@ async def test_dhcp_missing_hostname(hass):
     ]
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
 
 
 async def test_dhcp_invalid_option(hass):
     """Test we ignore invalid hostname option."""
-    dhcp_watcher = dhcp.DHCPWatcher(
-        hass, {}, [{"domain": "mock-domain", "hostname": "nomatch*"}]
-    )
+    integration_matchers = [{"domain": "mock-domain", "hostname": "nomatch*"}]
 
     packet = Ether(RAW_DHCP_REQUEST)
 
@@ -375,7 +406,10 @@ async def test_dhcp_invalid_option(hass):
     ]
 
     with patch.object(hass.config_entries.flow, "async_init") as mock_init:
-        dhcp_watcher.handle_dhcp_packet(packet)
+        handle_dhcp_packet = await _async_get_handle_dhcp_packet(
+            hass, integration_matchers
+        )
+        handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We need to import `DHCP`/`IP`/`Ether` before starting scapy or it will never match any packets.

I missed this when I tested #55647 since `aiodiscover` was working and I didn't test with a device that isn't discoverable with it, and didn't notice until the dhcp discovery wasn't working in #56354.

Fixes #56813

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
