### PR TITLE
Add Sure Petcare Felaqua device

### DIFF
--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Sure PetCare Flaps sensors."""
 
-    entities: list[SurePetcareSensor] = []
+    entities: list[SurePetcareEntity] = []
 
     coordinator: SurePetcareDataCoordinator = hass.data[DOMAIN][entry.entry_id]
 
@@ -51,22 +51,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SurePetcareSensor(SurePetcareEntity, SensorEntity):
-    """A sensor implementation for Sure Petcare Entities."""
-
-    def __init__(
-        self,
-        surepetcare_id: int,
-        coordinator: SurePetcareDataCoordinator,
-    ) -> None:
-        """Initialize a Sure Petcare sensor."""
-        super().__init__(surepetcare_id, coordinator)
-
-        self._attr_name = self._device_name
-        self._attr_unique_id = self._device_id
-
-
-class SureBattery(SurePetcareSensor):
+class SureBattery(SurePetcareEntity, SensorEntity):
     """A sensor implementation for Sure Petcare Entities."""
 
     _attr_device_class = DEVICE_CLASS_BATTERY
@@ -105,7 +90,7 @@ class SureBattery(SurePetcareSensor):
             self._attr_extra_state_attributes = {}
 
 
-class Felaqua(SurePetcareSensor):
+class Felaqua(SurePetcareEntity, SensorEntity):
     """Sure Petcare Felaqua."""
 
     _attr_native_unit_of_measurement = VOLUME_MILLILITERS
@@ -118,6 +103,8 @@ class Felaqua(SurePetcareSensor):
 
         surepy_entity: SurepyFelaqua = coordinator.data[surepetcare_id]
 
+        self._attr_name = self._device_name
+        self._attr_unique_id = self._device_id
         self._attr_entity_picture = surepy_entity.icon
 
     @callback

--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -41,7 +41,22 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SureBattery(SurePetcareEntity, SensorEntity):
+class SurePetcareSensor(SurePetcareEntity, SensorEntity):
+    """A sensor implementation for Sure Petcare Entities."""
+
+    def __init__(
+        self,
+        surepetcare_id: int,
+        coordinator: SurePetcareDataCoordinator,
+    ) -> None:
+        """Initialize a Sure Petcare sensor."""
+        super().__init__(surepetcare_id, coordinator)
+
+        self._attr_name = self._device_name
+        self._attr_unique_id = self._device_id
+
+
+class SureBattery(SurePetcareSensor):
     """A sensor implementation for Sure Petcare Entities."""
 
     _attr_device_class = DEVICE_CLASS_BATTERY

--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -2,13 +2,20 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
 from surepy.entities import SurepyEntity
+from surepy.entities.devices import Felaqua as SurepyFelaqua
 from surepy.enums import EntityType
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_VOLTAGE, DEVICE_CLASS_BATTERY, PERCENTAGE
+from homeassistant.const import (
+    ATTR_VOLTAGE,
+    DEVICE_CLASS_BATTERY,
+    PERCENTAGE,
+    VOLUME_MILLILITERS,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -93,3 +100,25 @@ class SureBattery(SurePetcareSensor):
             }
         else:
             self._attr_extra_state_attributes = {}
+
+
+class Felaqua(SurePetcareSensor):
+    """Sure Petcare Felaqua."""
+
+    _attr_native_unit_of_measurement = VOLUME_MILLILITERS
+
+    def __init__(
+        self, surepetcare_id: int, coordinator: SurePetcareDataCoordinator
+    ) -> None:
+        """Initialize a Sure Petcare Felaqua sensor."""
+        super().__init__(surepetcare_id, coordinator)
+
+        surepy_entity: SurepyFelaqua = coordinator.data[surepetcare_id]
+
+        self._attr_entity_picture = surepy_entity.icon
+
+    @callback
+    def _update_attr(self, surepy_entity: SurepyEntity) -> None:
+        """Update the state."""
+        surepy_entity = cast(SurepyFelaqua, surepy_entity)
+        self._attr_native_value = surepy_entity.water_remaining

--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Sure PetCare Flaps sensors."""
 
-    entities: list[SureBattery] = []
+    entities: list[SurePetcareSensor] = []
 
     coordinator: SurePetcareDataCoordinator = hass.data[DOMAIN][entry.entry_id]
 
@@ -44,6 +44,9 @@ async def async_setup_entry(
             EntityType.FELAQUA,
         ]:
             entities.append(SureBattery(surepy_entity.id, coordinator))
+
+        if surepy_entity.type == EntityType.FELAQUA:
+            entities.append(Felaqua(surepy_entity.id, coordinator))
 
     async_add_entities(entities)
 

--- a/tests/components/surepetcare/__init__.py
+++ b/tests/components/surepetcare/__init__.py
@@ -29,7 +29,7 @@ MOCK_FEEDER = {
 
 MOCK_FELAQUA = {
     "id": 31337,
-    "product_id": 3,
+    "product_id": 8,
     "household_id": HOUSEHOLD_ID,
     "name": "Felaqua",
     "parent": {"product_id": 1, "id": HUB_ID},

--- a/tests/components/surepetcare/__init__.py
+++ b/tests/components/surepetcare/__init__.py
@@ -27,6 +27,19 @@ MOCK_FEEDER = {
     },
 }
 
+MOCK_FELAQUA = {
+    "id": 31337,
+    "product_id": 3,
+    "household_id": HOUSEHOLD_ID,
+    "name": "Felaqua",
+    "parent": {"product_id": 1, "id": HUB_ID},
+    "status": {
+        "battery": 6.4,
+        "signal": {"device_rssi": 70, "hub_rssi": 65},
+        "online": True,
+    },
+}
+
 MOCK_CAT_FLAP = {
     "id": 13579,
     "product_id": 6,
@@ -66,7 +79,7 @@ MOCK_PET = {
 }
 
 MOCK_API_DATA = {
-    "devices": [MOCK_HUB, MOCK_CAT_FLAP, MOCK_PET_FLAP, MOCK_FEEDER],
+    "devices": [MOCK_HUB, MOCK_CAT_FLAP, MOCK_PET_FLAP, MOCK_FEEDER, MOCK_FELAQUA],
     "pets": [MOCK_PET],
 }
 

--- a/tests/components/surepetcare/test_sensor.py
+++ b/tests/components/surepetcare/test_sensor.py
@@ -3,12 +3,13 @@ from homeassistant.components.surepetcare.const import DOMAIN
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from . import HOUSEHOLD_ID, MOCK_CONFIG
+from . import HOUSEHOLD_ID, MOCK_CONFIG, MOCK_FELAQUA
 
 EXPECTED_ENTITY_IDS = {
     "sensor.pet_flap_battery_level": f"{HOUSEHOLD_ID}-13576-battery",
     "sensor.cat_flap_battery_level": f"{HOUSEHOLD_ID}-13579-battery",
     "sensor.feeder_battery_level": f"{HOUSEHOLD_ID}-12345-battery",
+    "sensor.felaqua_battery_level": f"{HOUSEHOLD_ID}-{MOCK_FELAQUA['id']}-battery",
 }
 
 


### PR DESCRIPTION
## Proposed change

Adds the Felaqua device to the surepetcare integration

![image](https://user-images.githubusercontent.com/512997/135444527-a554cf86-a086-44ea-ad8e-8b8422617064.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. 

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
