### PR TITLE
Add locking state to surepetcare locks

### DIFF
--- a/homeassistant/components/surepetcare/lock.py
+++ b/homeassistant/components/surepetcare/lock.py
@@ -115,4 +115,3 @@ class SurePetcareLock(SurePetcareEntity, LockEntity):
         finally:
             self._attr_is_unlocking = False
             self.async_write_ha_state()
-        self._attr_is_locked = False

--- a/homeassistant/components/surepetcare/lock.py
+++ b/homeassistant/components/surepetcare/lock.py
@@ -92,6 +92,7 @@ class SurePetcareLock(SurePetcareEntity, LockEntity):
         try:
             await self.coordinator.lock_states_callbacks[self._lock_state](self._id)
         except SurePetcareError:
+            _LOGGER.error("Lock flap failed")
             raise
         else:
             self._attr_is_locked = True
@@ -109,6 +110,7 @@ class SurePetcareLock(SurePetcareEntity, LockEntity):
         try:
             await self.coordinator.surepy.sac.unlock(self._id)
         except SurePetcareError:
+            _LOGGER.error("Unlock flap failed")
             raise
         else:
             self._attr_is_locked = False

--- a/homeassistant/components/surepetcare/lock.py
+++ b/homeassistant/components/surepetcare/lock.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from surepy.entities import SurepyEntity
 from surepy.enums import EntityType, LockState
-from surepy.exceptions import SurePetcareError
 
 from homeassistant.components.lock import STATE_LOCKED, STATE_UNLOCKED, LockEntity
 from homeassistant.config_entries import ConfigEntry
@@ -91,10 +90,6 @@ class SurePetcareLock(SurePetcareEntity, LockEntity):
 
         try:
             await self.coordinator.lock_states_callbacks[self._lock_state](self._id)
-        except SurePetcareError:
-            _LOGGER.error("Lock flap failed")
-            raise
-        else:
             self._attr_is_locked = True
         finally:
             self._attr_is_locking = False
@@ -109,10 +104,6 @@ class SurePetcareLock(SurePetcareEntity, LockEntity):
 
         try:
             await self.coordinator.surepy.sac.unlock(self._id)
-        except SurePetcareError:
-            _LOGGER.error("Unlock flap failed")
-            raise
-        else:
             self._attr_is_locked = False
         finally:
             self._attr_is_unlocking = False

--- a/homeassistant/components/surepetcare/lock.py
+++ b/homeassistant/components/surepetcare/lock.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from surepy.entities import SurepyEntity
 from surepy.enums import EntityType, LockState
+from surepy.exceptions import SurePetcareError
 
 from homeassistant.components.lock import STATE_LOCKED, STATE_UNLOCKED, LockEntity
 from homeassistant.config_entries import ConfigEntry
@@ -83,16 +84,35 @@ class SurePetcareLock(SurePetcareEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
-        if self.state == STATE_LOCKED:
+        if self.state != STATE_UNLOCKED:
             return
-        await self.coordinator.lock_states_callbacks[self._lock_state](self._id)
-        self._attr_is_locked = True
+        self._attr_is_locking = True
         self.async_write_ha_state()
+
+        try:
+            await self.coordinator.lock_states_callbacks[self._lock_state](self._id)
+        except SurePetcareError:
+            raise
+        else:
+            self._attr_is_locked = True
+        finally:
+            self._attr_is_locking = False
+            self.async_write_ha_state()
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
-        if self.state == STATE_UNLOCKED:
+        if self.state != STATE_LOCKED:
             return
-        await self.coordinator.surepy.sac.unlock(self._id)
-        self._attr_is_locked = False
+        self._attr_is_unlocking = True
         self.async_write_ha_state()
+
+        try:
+            await self.coordinator.surepy.sac.unlock(self._id)
+        except SurePetcareError:
+            raise
+        else:
+            self._attr_is_locked = False
+        finally:
+            self._attr_is_unlocking = False
+            self.async_write_ha_state()
+        self._attr_is_locked = False

--- a/tests/components/surepetcare/test_lock.py
+++ b/tests/components/surepetcare/test_lock.py
@@ -1,4 +1,6 @@
 """The tests for the Sure Petcare lock platform."""
+import pytest
+from surepy.exceptions import SurePetcareError
 
 from homeassistant.components.surepetcare.const import DOMAIN
 from homeassistant.helpers import entity_registry as er
@@ -73,3 +75,46 @@ async def test_locks(hass, surepetcare) -> None:
         state = hass.states.get(entity_id)
         assert state.state == "unlocked"
         assert surepetcare.unlock.call_count == 1
+
+
+async def test_lock_failing(hass, surepetcare) -> None:
+    """Test the generation of unique ids."""
+    assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
+    await hass.async_block_till_done()
+
+    surepetcare.lock_in.side_effect = SurePetcareError
+    surepetcare.lock_out.side_effect = SurePetcareError
+    surepetcare.lock.side_effect = SurePetcareError
+
+    for entity_id, unique_id in EXPECTED_ENTITY_IDS.items():
+        surepetcare.reset_mock()
+        await hass.services.async_call(
+            "lock", "unlock", {"entity_id": entity_id}, blocking=True
+        )
+
+        with pytest.raises(SurePetcareError):
+            await hass.services.async_call(
+                "lock", "lock", {"entity_id": entity_id}, blocking=True
+            )
+        state = hass.states.get(entity_id)
+        assert state.state == "unlocked"
+
+
+async def test_unlock_failing(hass, surepetcare) -> None:
+    """Test the generation of unique ids."""
+    assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
+    await hass.async_block_till_done()
+
+    entity_id = list(EXPECTED_ENTITY_IDS.keys())[0]
+
+    await hass.services.async_call(
+        "lock", "lock", {"entity_id": entity_id}, blocking=True
+    )
+    surepetcare.unlock.side_effect = SurePetcareError
+
+    with pytest.raises(SurePetcareError):
+        await hass.services.async_call(
+            "lock", "unlock", {"entity_id": entity_id}, blocking=True
+        )
+    state = hass.states.get(entity_id)
+    assert state.state == "locked"

--- a/tests/components/surepetcare/test_lock.py
+++ b/tests/components/surepetcare/test_lock.py
@@ -87,11 +87,6 @@ async def test_lock_failing(hass, surepetcare) -> None:
     surepetcare.lock.side_effect = SurePetcareError
 
     for entity_id, unique_id in EXPECTED_ENTITY_IDS.items():
-        surepetcare.reset_mock()
-        await hass.services.async_call(
-            "lock", "unlock", {"entity_id": entity_id}, blocking=True
-        )
-
         with pytest.raises(SurePetcareError):
             await hass.services.async_call(
                 "lock", "lock", {"entity_id": entity_id}, blocking=True

--- a/tests/components/surepetcare/test_lock.py
+++ b/tests/components/surepetcare/test_lock.py
@@ -78,7 +78,7 @@ async def test_locks(hass, surepetcare) -> None:
 
 
 async def test_lock_failing(hass, surepetcare) -> None:
-    """Test the generation of unique ids."""
+    """Test handling of lock failing."""
     assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()
 
@@ -96,7 +96,7 @@ async def test_lock_failing(hass, surepetcare) -> None:
 
 
 async def test_unlock_failing(hass, surepetcare) -> None:
-    """Test the generation of unique ids."""
+    """Test handling of unlock failing."""
     assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add locking state to surepetcare locks.
The request to lock/unlocking can take 10-15 seconds, so this will set the state to unlocking/locking when waiting for the locking response

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
