### PR TITLE
Deduplicate controls of UniFi services

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -44,7 +44,7 @@ async def async_setup_entry(hass, config_entry):
         )
 
     if not hass.data[UNIFI_DOMAIN]:
-        await async_setup_services(hass)
+        async_setup_services(hass)
 
     hass.data[UNIFI_DOMAIN][config_entry.entry_id] = controller
 
@@ -74,7 +74,7 @@ async def async_unload_entry(hass, config_entry):
     controller = hass.data[UNIFI_DOMAIN].pop(config_entry.entry_id)
 
     if not hass.data[UNIFI_DOMAIN]:
-        await async_unload_services(hass)
+        async_unload_services(hass)
 
     return await controller.async_reset()
 

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -43,8 +43,10 @@ async def async_setup_entry(hass, config_entry):
             config_entry, unique_id=controller.site_id
         )
 
+    if not hass.data[UNIFI_DOMAIN]:
+        await async_setup_services(hass)
+
     hass.data[UNIFI_DOMAIN][config_entry.entry_id] = controller
-    await async_setup_services(hass)
 
     config_entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, controller.shutdown)

--- a/homeassistant/components/unifi/services.py
+++ b/homeassistant/components/unifi/services.py
@@ -2,17 +2,11 @@
 
 from .const import DOMAIN as UNIFI_DOMAIN
 
-UNIFI_SERVICES = "unifi_services"
-
 SERVICE_REMOVE_CLIENTS = "remove_clients"
 
 
 async def async_setup_services(hass) -> None:
     """Set up services for UniFi integration."""
-    if hass.data.get(UNIFI_SERVICES, False):
-        return
-
-    hass.data[UNIFI_SERVICES] = True
 
     async def async_call_unifi_service(service_call) -> None:
         """Call correct UniFi service."""
@@ -33,11 +27,6 @@ async def async_setup_services(hass) -> None:
 
 async def async_unload_services(hass) -> None:
     """Unload UniFi services."""
-    if not hass.data.get(UNIFI_SERVICES):
-        return
-
-    hass.data[UNIFI_SERVICES] = False
-
     hass.services.async_remove(UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS)
 
 

--- a/homeassistant/components/unifi/services.py
+++ b/homeassistant/components/unifi/services.py
@@ -1,11 +1,14 @@
 """UniFi services."""
 
+from homeassistant.core import callback
+
 from .const import DOMAIN as UNIFI_DOMAIN
 
 SERVICE_REMOVE_CLIENTS = "remove_clients"
 
 
-async def async_setup_services(hass) -> None:
+@callback
+def async_setup_services(hass) -> None:
     """Set up services for UniFi integration."""
 
     async def async_call_unifi_service(service_call) -> None:
@@ -25,7 +28,8 @@ async def async_setup_services(hass) -> None:
     )
 
 
-async def async_unload_services(hass) -> None:
+@callback
+def async_unload_services(hass) -> None:
     """Unload UniFi services."""
     hass.services.async_remove(UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS)
 

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -166,6 +166,7 @@ async def setup_unifi_integration(
     known_wireless_clients=None,
     controllers=None,
     unique_id="1",
+    config_entry_id=DEFAULT_CONFIG_ENTRY_ID,
 ):
     """Create the UniFi controller."""
     assert await async_setup_component(hass, UNIFI_DOMAIN, {})
@@ -175,7 +176,7 @@ async def setup_unifi_integration(
         data=deepcopy(config),
         options=deepcopy(options),
         unique_id=unique_id,
-        entry_id=DEFAULT_CONFIG_ENTRY_ID,
+        entry_id=config_entry_id,
         version=1,
     )
     config_entry.add_to_hass(hass)

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -3,27 +3,18 @@
 from unittest.mock import patch
 
 from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
-from homeassistant.components.unifi.services import (
-    SERVICE_REMOVE_CLIENTS,
-    async_remove_clients,
-)
+from homeassistant.components.unifi.services import SERVICE_REMOVE_CLIENTS
 
 from .test_controller import setup_unifi_integration
 
 
-@patch("homeassistant.core.ServiceRegistry.async_remove")
-@patch("homeassistant.core.ServiceRegistry.async_register")
-async def test_service_setup_and_unload(
-    register_service_mock, remove_service_mock, hass, aioclient_mock
-):
+async def test_service_setup_and_unload(hass, aioclient_mock):
     """Verify service setup works."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
-    assert register_service_mock.called_with(
-        UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS, async_remove_clients
-    )
+    assert hass.services.has_service(UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS)
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
-    assert remove_service_mock.called_with(UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS)
+    assert not hass.services.has_service(UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS)
 
 
 @patch("homeassistant.core.ServiceRegistry.async_remove")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix left over comments from #56717
- no need to keep UNIFI_SERVICES if we control it is only called while UNIFI_DOMAIN is empty
- setup and unload service does not need to be async

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #56717
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
