### PR TITLE
Add offset support to time trigger

### DIFF
--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -1,5 +1,5 @@
 """Offer time listening automation rules."""
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import partial
 
 import voluptuous as vol
@@ -8,6 +8,8 @@ from homeassistant.components import sensor
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     CONF_AT,
+    CONF_ENTITY_ID,
+    CONF_OFFSET,
     CONF_PLATFORM,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -23,9 +25,21 @@ import homeassistant.util.dt as dt_util
 
 # mypy: allow-untyped-defs, no-check-untyped-defs
 
+_TIME_TRIGGER_ENTITY_REFERENCE = vol.All(
+    str, cv.entity_domain(["input_datetime", "sensor"])
+)
+
+_TIME_TRIGGER_WITH_OFFSET_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ENTITY_ID): _TIME_TRIGGER_ENTITY_REFERENCE,
+        vol.Required(CONF_OFFSET): cv.time_period,
+    }
+)
+
 _TIME_TRIGGER_SCHEMA = vol.Any(
     cv.time,
-    vol.All(str, cv.entity_domain(["input_datetime", "sensor"])),
+    _TIME_TRIGGER_ENTITY_REFERENCE,
+    _TIME_TRIGGER_WITH_OFFSET_SCHEMA,
     msg="Expected HH:MM, HH:MM:SS or Entity ID with domain 'input_datetime' or 'sensor'",
 )
 
@@ -43,6 +57,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
     entities = {}
     removes = []
     job = HassJob(action)
+    offsets = {}
 
     @callback
     def time_automation_listener(description, now, *, entity_id=None):
@@ -77,6 +92,8 @@ async def async_attach_trigger(hass, config, action, automation_info):
         if not new_state:
             return
 
+        offset = offsets[entity_id] if entity_id in offsets else timedelta(0)
+
         # Check state of entity. If valid, set up a listener.
         if new_state.domain == "input_datetime":
             has_date = new_state.attributes["has_date"]
@@ -95,14 +112,17 @@ async def async_attach_trigger(hass, config, action, automation_info):
 
             if has_date:
                 # If input_datetime has date, then track point in time.
-                trigger_dt = datetime(
-                    year,
-                    month,
-                    day,
-                    hour,
-                    minute,
-                    second,
-                    tzinfo=dt_util.DEFAULT_TIME_ZONE,
+                trigger_dt = (
+                    datetime(
+                        year,
+                        month,
+                        day,
+                        hour,
+                        minute,
+                        second,
+                        tzinfo=dt_util.DEFAULT_TIME_ZONE,
+                    )
+                    + offset
                 )
                 # Only set up listener if time is now or in the future.
                 if trigger_dt >= dt_util.now():
@@ -134,7 +154,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
             == sensor.DEVICE_CLASS_TIMESTAMP
             and new_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
         ):
-            trigger_dt = dt_util.parse_datetime(new_state.state)
+            trigger_dt = dt_util.parse_datetime(new_state.state) + offset
 
             if trigger_dt is not None and trigger_dt > dt_util.utcnow():
                 remove = async_track_point_in_time(
@@ -158,6 +178,15 @@ async def async_attach_trigger(hass, config, action, automation_info):
             # entity
             to_track.append(at_time)
             update_entity_trigger(at_time, new_state=hass.states.get(at_time))
+        elif isinstance(at_time, dict) and CONF_OFFSET in at_time:
+            # entity with offset
+            entity_id = at_time.get(CONF_ENTITY_ID)
+            to_track.append(entity_id)
+            offsets[entity_id] = at_time.get(CONF_OFFSET)
+            update_entity_trigger(
+                entity_id,
+                new_state=hass.states.get(entity_id),
+            )
         else:
             # datetime.time
             removes.append(

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -150,6 +150,96 @@ async def test_if_fires_using_at_input_datetime(hass, calls, has_date, has_time)
     )
 
 
+@pytest.mark.parametrize(
+    "offset,delta",
+    [
+        ("00:00:10", timedelta(seconds=10)),
+        ("-00:00:10", timedelta(seconds=-10)),
+        ({"minutes": 5}, timedelta(minutes=5)),
+    ],
+)
+async def test_if_fires_using_at_input_datetime_with_offset(hass, calls, offset, delta):
+    """Test for firing at input_datetime."""
+    await async_setup_component(
+        hass,
+        "input_datetime",
+        {"input_datetime": {"trigger": {"has_date": True, "has_time": True}}},
+    )
+    now = dt_util.now()
+
+    set_dt = now.replace(hour=5, minute=0, second=0, microsecond=0) + timedelta(2)
+    trigger_dt = set_dt + delta
+
+    await hass.services.async_call(
+        "input_datetime",
+        "set_datetime",
+        {
+            ATTR_ENTITY_ID: "input_datetime.trigger",
+            "datetime": str(set_dt.replace(tzinfo=None)),
+        },
+        blocking=True,
+    )
+
+    time_that_will_not_match_right_away = trigger_dt - timedelta(minutes=1)
+
+    some_data = "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}-{{ trigger.now.minute }}-{{ trigger.now.second }}-{{trigger.entity_id}}"
+    with patch(
+        "homeassistant.util.dt.utcnow",
+        return_value=dt_util.as_utc(time_that_will_not_match_right_away),
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "time",
+                        "at": {
+                            "entity_id": "input_datetime.trigger",
+                            "offset": offset,
+                        },
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": some_data},
+                    },
+                }
+            },
+        )
+        await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, trigger_dt + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"]
+        == f"time-{trigger_dt.day}-{trigger_dt.hour}-{trigger_dt.minute}-{trigger_dt.second}-input_datetime.trigger"
+    )
+
+    set_dt += timedelta(days=1, hours=1)
+    trigger_dt += timedelta(days=1, hours=1)
+
+    await hass.services.async_call(
+        "input_datetime",
+        "set_datetime",
+        {
+            ATTR_ENTITY_ID: "input_datetime.trigger",
+            "datetime": str(set_dt.replace(tzinfo=None)),
+        },
+        blocking=True,
+    )
+
+    async_fire_time_changed(hass, trigger_dt + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    assert len(calls) == 2
+    assert (
+        calls[1].data["some"]
+        == f"time-{trigger_dt.day}-{trigger_dt.hour}-{trigger_dt.minute}-{trigger_dt.second}-input_datetime.trigger"
+    )
+
+
 async def test_if_fires_using_multiple_at(hass, calls):
     """Test for firing at."""
 
@@ -499,11 +589,102 @@ async def test_if_fires_using_at_sensor(hass, calls):
 
 
 @pytest.mark.parametrize(
+    "offset,delta",
+    [
+        ("00:00:10", timedelta(seconds=10)),
+        ("-00:00:10", timedelta(seconds=-10)),
+        ({"minutes": 5}, timedelta(minutes=5)),
+    ],
+)
+async def test_if_fires_using_at_sensor_with_offset(hass, calls, offset, delta):
+    """Test for firing at sensor time."""
+    now = dt_util.now()
+
+    start_dt = now.replace(hour=5, minute=0, second=0, microsecond=0) + timedelta(2)
+    trigger_dt = start_dt + delta
+
+    hass.states.async_set(
+        "sensor.next_alarm",
+        start_dt.isoformat(),
+        {ATTR_DEVICE_CLASS: sensor.DEVICE_CLASS_TIMESTAMP},
+    )
+
+    time_that_will_not_match_right_away = trigger_dt - timedelta(minutes=1)
+
+    some_data = "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}-{{ trigger.now.minute }}-{{ trigger.now.second }}-{{trigger.entity_id}}"
+    with patch(
+        "homeassistant.util.dt.utcnow",
+        return_value=dt_util.as_utc(time_that_will_not_match_right_away),
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "time",
+                        "at": {
+                            "entity_id": "sensor.next_alarm",
+                            "offset": offset,
+                        },
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": some_data},
+                    },
+                }
+            },
+        )
+        await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, trigger_dt + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert (
+        calls[0].data["some"]
+        == f"time-{trigger_dt.day}-{trigger_dt.hour}-{trigger_dt.minute}-{trigger_dt.second}-sensor.next_alarm"
+    )
+
+    start_dt += timedelta(days=1, hours=1)
+    trigger_dt += timedelta(days=1, hours=1)
+
+    hass.states.async_set(
+        "sensor.next_alarm",
+        start_dt.isoformat(),
+        {ATTR_DEVICE_CLASS: sensor.DEVICE_CLASS_TIMESTAMP},
+    )
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, trigger_dt + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    assert len(calls) == 2
+    assert (
+        calls[1].data["some"]
+        == f"time-{trigger_dt.day}-{trigger_dt.hour}-{trigger_dt.minute}-{trigger_dt.second}-sensor.next_alarm"
+    )
+
+
+@pytest.mark.parametrize(
     "conf",
     [
         {"platform": "time", "at": "input_datetime.bla"},
         {"platform": "time", "at": "sensor.bla"},
         {"platform": "time", "at": "12:34"},
+        {
+            "platform": "time",
+            "at": {"entity_id": "input_datetime.bla", "offset": "00:01"},
+        },
+        {"platform": "time", "at": {"entity_id": "sensor.bla", "offset": "-00:01"}},
+        {
+            "platform": "time",
+            "at": [{"entity_id": "input_datetime.bla", "offset": "01:00:00"}],
+        },
+        {
+            "platform": "time",
+            "at": [{"entity_id": "sensor.bla", "offset": "-01:00:00"}],
+        },
     ],
 )
 def test_schema_valid(conf):
@@ -517,6 +698,9 @@ def test_schema_valid(conf):
         {"platform": "time", "at": "binary_sensor.bla"},
         {"platform": "time", "at": 745},
         {"platform": "time", "at": "25:00"},
+        {"platform": "time", "at": {"entity_id": "input_datetime.bla", "offset": "0:"}},
+        {"platform": "time", "at": {"entity_id": "input_datetime.bla", "offset": "a"}},
+        {"platform": "time", "at": {"entity_id": "13:00:00", "offset": "0:10"}},
     ],
 )
 def test_schema_invalid(conf):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support for setting an offset (as time delta) to the time trigger. This offset is then applied when the `at` is set to an `input_datetime` or `sensor`. This allows the, I believe, pretty common behavior of "X minutes before the alarm will go of...", which currently requires manually recalculating "alarm time - X minutes" or using a template trigger. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#19536

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
