### PR TITLE
Use entity_registry_enabled_default for Nut sensors

### DIFF
--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
+    CONF_RESOURCES,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
@@ -37,6 +38,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Network UPS Tools (NUT) from a config entry."""
+
+    # strip out the stale options CONF_RESOURCES
+    if CONF_RESOURCES in entry.options:
+        new_options = {k: v for k, v in entry.options.items() if k != CONF_RESOURCES}
+        hass.config_entries.async_update_entry(entry, options=new_options)
 
     config = entry.data
     host = config[CONF_HOST]

--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
-    CONF_RESOURCES,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
@@ -154,13 +153,6 @@ def _unique_id_from_status(status):
     if serial:
         unique_id_group.append(serial)
     return "_".join(unique_id_group)
-
-
-def find_resources_in_config_entry(config_entry):
-    """Find the configured resources in the config entry."""
-    if CONF_RESOURCES in config_entry.options:
-        return config_entry.options[CONF_RESOURCES]
-    return config_entry.data[CONF_RESOURCES]
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/nut/config_flow.py
+++ b/homeassistant/components/nut/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
-from . import PyNUTData, find_resources_in_config_entry
+from . import PyNUTData
 from .const import (
     DEFAULT_HOST,
     DEFAULT_PORT,
@@ -229,35 +229,17 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        resources = find_resources_in_config_entry(self.config_entry)
         scan_interval = self.config_entry.options.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
         )
 
-        errors = {}
-        try:
-            info = await validate_input(self.hass, self.config_entry.data)
-        except CannotConnect:
-            errors[CONF_BASE] = "cannot_connect"
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
-            errors[CONF_BASE] = "unknown"
+        base_schema = {
+            vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval): vol.All(
+                vol.Coerce(int), vol.Clamp(min=10, max=300)
+            )
+        }
 
-        if errors:
-            return self.async_show_form(step_id="abort", errors=errors)
-
-        base_schema = _resource_schema_base(info["available_resources"], resources)
-        base_schema[
-            vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval)
-        ] = cv.positive_int
-
-        return self.async_show_form(
-            step_id="init", data_schema=vol.Schema(base_schema), errors=errors
-        )
-
-    async def async_step_abort(self, user_input=None):
-        """Abort options flow."""
-        return self.async_create_entry(title="", data=self.config_entry.options)
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(base_schema))
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -48,14 +48,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         resource.lower() for resource in config_entry.data[CONF_RESOURCES]
     ]
     resources = [sensor_id for sensor_id in SENSOR_TYPES if sensor_id in status]
+    # Display status is a special case that falls back to the status value
+    # of the UPS instead.
+    if KEY_STATUS in resources:
+        resources.append(KEY_STATUS_DISPLAY)
 
     for sensor_type in resources:
-
-        # Display status is a special case that falls back to the status value
-        # of the UPS instead.
-        enabled_default = sensor_type in enabled_resources or (
-            KEY_STATUS_DISPLAY in enabled_resources and KEY_STATUS in status
-        )
 
         entities.append(
             NUTSensor(
@@ -67,7 +65,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 manufacturer,
                 model,
                 firmware,
-                enabled_default,
+                sensor_type in enabled_resources,
             )
         )
 

--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -47,7 +47,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     enabled_resources = [
         resource.lower() for resource in config_entry.data[CONF_RESOURCES]
     ]
-    resources = [sensor_id for sensor_id in SENSOR_TYPES.keys() if sensor_id in status]
+    resources = [sensor_id for sensor_id in SENSOR_TYPES if sensor_id in status]
 
     for sensor_type in resources:
 

--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -42,8 +42,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     data = pynut_data[PYNUT_DATA]
     status = data.status
 
-    entities = []
-
     enabled_resources = [
         resource.lower() for resource in config_entry.data[CONF_RESOURCES]
     ]
@@ -53,21 +51,20 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     if KEY_STATUS in resources:
         resources.append(KEY_STATUS_DISPLAY)
 
-    for sensor_type in resources:
-
-        entities.append(
-            NUTSensor(
-                coordinator,
-                data,
-                name.title(),
-                SENSOR_TYPES[sensor_type],
-                unique_id,
-                manufacturer,
-                model,
-                firmware,
-                sensor_type in enabled_resources,
-            )
+    entities = [
+        NUTSensor(
+            coordinator,
+            data,
+            name.title(),
+            SENSOR_TYPES[sensor_type],
+            unique_id,
+            manufacturer,
+            model,
+            firmware,
+            sensor_type in enabled_resources,
         )
+        for sensor_type in resources
+    ]
 
     async_add_entities(entities, True)
 

--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -44,37 +44,32 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entities = []
 
-    if CONF_RESOURCES in config_entry.options:
-        resources = config_entry.options[CONF_RESOURCES]
-    else:
-        resources = config_entry.data[CONF_RESOURCES]
+    enabled_resources = [
+        resource.lower() for resource in config_entry.data[CONF_RESOURCES]
+    ]
+    resources = [sensor_id for sensor_id in SENSOR_TYPES.keys() if sensor_id in status]
 
-    for resource in resources:
-        sensor_type = resource.lower()
+    for sensor_type in resources:
 
         # Display status is a special case that falls back to the status value
         # of the UPS instead.
-        if sensor_type in status or (
-            sensor_type == KEY_STATUS_DISPLAY and KEY_STATUS in status
-        ):
-            entities.append(
-                NUTSensor(
-                    coordinator,
-                    data,
-                    name.title(),
-                    SENSOR_TYPES[sensor_type],
-                    unique_id,
-                    manufacturer,
-                    model,
-                    firmware,
-                )
+        enabled_default = sensor_type in enabled_resources or (
+            KEY_STATUS_DISPLAY in enabled_resources and KEY_STATUS in status
+        )
+
+        entities.append(
+            NUTSensor(
+                coordinator,
+                data,
+                name.title(),
+                SENSOR_TYPES[sensor_type],
+                unique_id,
+                manufacturer,
+                model,
+                firmware,
+                enabled_default,
             )
-        else:
-            _LOGGER.info(
-                "Sensor type: %s does not appear in the NUT status "
-                "output, cannot add",
-                sensor_type,
-            )
+        )
 
     async_add_entities(entities, True)
 
@@ -92,6 +87,7 @@ class NUTSensor(CoordinatorEntity, SensorEntity):
         manufacturer: str | None,
         model: str | None,
         firmware: str | None,
+        enabled_default: bool,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -102,6 +98,7 @@ class NUTSensor(CoordinatorEntity, SensorEntity):
         self._device_name = name
         self._data = data
         self._unique_id = unique_id
+        self._attr_entity_registry_enabled_default = enabled_default
 
         self._attr_name = f"{name} {sensor_description.name}"
         if unique_id is not None:

--- a/homeassistant/components/nut/strings.json
+++ b/homeassistant/components/nut/strings.json
@@ -35,7 +35,6 @@
   "options": {
     "step": {
       "init": {
-        "description": "Choose Sensor Resources.",
         "data": {
           "scan_interval": "Scan Interval (seconds)"
         }

--- a/homeassistant/components/nut/strings.json
+++ b/homeassistant/components/nut/strings.json
@@ -37,14 +37,9 @@
       "init": {
         "description": "Choose Sensor Resources.",
         "data": {
-          "resources": "Resources",
           "scan_interval": "Scan Interval (seconds)"
         }
       }
-    },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   }
 }

--- a/homeassistant/components/nut/translations/en.json
+++ b/homeassistant/components/nut/translations/en.json
@@ -37,8 +37,7 @@
             "init": {
                 "data": {
                     "scan_interval": "Scan Interval (seconds)"
-                },
-                "description": "Choose Sensor Resources."
+                }
             }
         }
     }

--- a/homeassistant/components/nut/translations/en.json
+++ b/homeassistant/components/nut/translations/en.json
@@ -33,14 +33,9 @@
         }
     },
     "options": {
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "unknown": "Unexpected error"
-        },
         "step": {
             "init": {
                 "data": {
-                    "resources": "Resources",
                     "scan_interval": "Scan Interval (seconds)"
                 },
                 "description": "Choose Sensor Resources."

--- a/tests/components/nut/test_config_flow.py
+++ b/tests/components/nut/test_config_flow.py
@@ -296,37 +296,25 @@ async def test_options_flow(hass):
         domain=DOMAIN,
         unique_id="abcde12345",
         data=VALID_CONFIG,
-        options={CONF_RESOURCES: ["battery.charge"]},
     )
     config_entry.add_to_hass(hass)
 
-    mock_pynut = _get_mock_pynutclient(
-        list_vars={"battery.voltage": "voltage"}, list_ups=["ups1"]
-    )
-
-    with patch(
-        "homeassistant.components.nut.PyNUTClient",
-        return_value=mock_pynut,
-    ), patch("homeassistant.components.nut.async_setup_entry", return_value=True):
+    with patch("homeassistant.components.nut.async_setup_entry", return_value=True):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={CONF_RESOURCES: ["battery.voltage"]}
+            result["flow_id"], user_input={}
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert config_entry.options == {
-            CONF_RESOURCES: ["battery.voltage"],
             CONF_SCAN_INTERVAL: 60,
         }
 
-    with patch(
-        "homeassistant.components.nut.PyNUTClient",
-        return_value=mock_pynut,
-    ), patch("homeassistant.components.nut.async_setup_entry", return_value=True):
+    with patch("homeassistant.components.nut.async_setup_entry", return_value=True):
         result2 = await hass.config_entries.options.async_init(config_entry.entry_id)
 
         assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -334,11 +322,10 @@ async def test_options_flow(hass):
 
         result2 = await hass.config_entries.options.async_configure(
             result2["flow_id"],
-            user_input={CONF_RESOURCES: ["battery.voltage"], CONF_SCAN_INTERVAL: 12},
+            user_input={CONF_SCAN_INTERVAL: 12},
         )
 
         assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert config_entry.options == {
-            CONF_RESOURCES: ["battery.voltage"],
             CONF_SCAN_INTERVAL: 12,
         }

--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -202,3 +202,16 @@ async def test_blazer_usb(hass):
     assert all(
         state.attributes[key] == expected_attributes[key] for key in expected_attributes
     )
+
+
+async def test_stale_options(hass):
+    """Test creation of sensors with stale options to remove."""
+
+    config_entry = await async_init_integration(
+        hass, "blazer_usb", ["battery.charge"], True
+    )
+    registry = er.async_get(hass)
+    entry = registry.async_get("sensor.ups1_battery_charge")
+    assert entry
+    assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
+    assert config_entry.options == {}

--- a/tests/components/nut/util.py
+++ b/tests/components/nut/util.py
@@ -18,7 +18,7 @@ def _get_mock_pynutclient(list_vars=None, list_ups=None):
 
 
 async def async_init_integration(
-    hass: HomeAssistant, ups_fixture: str, resources: list
+    hass: HomeAssistant, ups_fixture: str, resources: list, add_options: bool = False
 ) -> MockConfigEntry:
     """Set up the nexia integration in Home Assistant."""
 
@@ -34,6 +34,7 @@ async def async_init_integration(
         entry = MockConfigEntry(
             domain=DOMAIN,
             data={CONF_HOST: "mock", CONF_PORT: "mock", CONF_RESOURCES: resources},
+            options={CONF_RESOURCES: resources} if add_options else {},
         )
         entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Instead of use multiple select list in option flow, just create all the available sensors and set `entity_registry_enabled_default` based on initial configuration, allowing the user to eventually enable or disable available sensors with default HA features.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
