### PR TITLE
Get min and max color temperature for Nanoleaf light from library

### DIFF
--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -1,6 +1,7 @@
 """Support for Nanoleaf Lights."""
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from aionanoleaf import Nanoleaf, Unavailable
@@ -27,8 +28,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import color as color_util
 from homeassistant.util.color import (
+    color_temperature_kelvin_to_mired as kelvin_to_mired,
     color_temperature_mired_to_kelvin as mired_to_kelvin,
 )
 
@@ -85,8 +86,10 @@ class NanoleafLight(LightEntity):
             model=self._nanoleaf.model,
             sw_version=self._nanoleaf.firmware_version,
         )
-        self._attr_min_mireds = 154
-        self._attr_max_mireds = 833
+        self._attr_min_mireds = math.ceil(
+            1000000 / self._nanoleaf.color_temperature_max
+        )
+        self._attr_max_mireds = kelvin_to_mired(self._nanoleaf.color_temperature_min)
 
     @property
     def brightness(self) -> int:
@@ -96,9 +99,7 @@ class NanoleafLight(LightEntity):
     @property
     def color_temp(self) -> int:
         """Return the current color temperature."""
-        return color_util.color_temperature_kelvin_to_mired(
-            self._nanoleaf.color_temperature
-        )
+        return kelvin_to_mired(self._nanoleaf.color_temperature)
 
     @property
     def effect(self) -> str | None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Integration should use the color temperature range returned from the API to support the Nanoleaf Elements.

> The acceptable range is 1200-6500 for Nanoleaf Shapes, Nanoleaf Canvas and Nanoleaf Light Panels. The acceptable range for Nanoleaf Elements is 1500-4000 

There is a known issue for min and max ct in the API: https://forum.nanoleaf.me/docs/openapi#_wbzvnjfhbys
>  1.5.0: - Min and max values returned for ct are wrong. They should be 1200-6500, but are returned 0-100.

---
Elements panels only support ct, but [you can connect hs+ct panels](https://user-images.githubusercontent.com/15276289/135548145-78fdfa6b-667e-4ad8-85b0-d84d1d2d5ce2.png) to an Elements controller/panel. I am not sure if I should remove color from supported_features.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19548/files

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
