### PR TITLE
update in bme680 init

### DIFF
--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -5,8 +5,13 @@ from datetime import timedelta
 import logging
 from typing import Any, Dict
 
+<<<<<<< HEAD
 from accuweather import AccuWeather, ApiError, InvalidApiKeyError, InvalidCoordinatesError, RequestsExceededError
 from aiohttp import ClientSession, ClientError
+=======
+from accuweather import AccuWeather, ApiError, InvalidApiKeyError, RequestsExceededError
+from aiohttp import ClientSession
+>>>>>>> parent of 4d12009cea (update in accuweather dependencies)
 from aiohttp.client_exceptions import ClientConnectorError
 from async_timeout import timeout
 
@@ -104,11 +109,9 @@ class AccuWeatherDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
                 )
         except (
             ApiError,
-            ClientError,
             ClientConnectorError,
             InvalidApiKeyError,
             RequestsExceededError,
-            InvalidCoordinatesError,
         ) as error:
             raise UpdateFailed(error) from error
         _LOGGER.debug("Requests remaining: %d", self.accuweather.requests_remaining)

--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -5,13 +5,8 @@ from datetime import timedelta
 import logging
 from typing import Any, Dict
 
-<<<<<<< HEAD
 from accuweather import AccuWeather, ApiError, InvalidApiKeyError, InvalidCoordinatesError, RequestsExceededError
 from aiohttp import ClientSession, ClientError
-=======
-from accuweather import AccuWeather, ApiError, InvalidApiKeyError, RequestsExceededError
-from aiohttp import ClientSession
->>>>>>> parent of 4d12009cea (update in accuweather dependencies)
 from aiohttp.client_exceptions import ClientConnectorError
 from async_timeout import timeout
 
@@ -109,9 +104,11 @@ class AccuWeatherDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
                 )
         except (
             ApiError,
+            ClientError,
             ClientConnectorError,
             InvalidApiKeyError,
             RequestsExceededError,
+            InvalidCoordinatesError,
         ) as error:
             raise UpdateFailed(error) from error
         _LOGGER.debug("Requests remaining: %d", self.accuweather.requests_remaining)

--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import logging
 from typing import Any, Dict
 
-from accuweather import AccuWeather, ApiError, InvalidApiKeyError, RequestsExceededError, InvalidCoordinatesError
+from accuweather import AccuWeather, ApiError, InvalidApiKeyError, InvalidCoordinatesError, RequestsExceededError
 from aiohttp import ClientSession, ClientError
 from aiohttp.client_exceptions import ClientConnectorError
 from async_timeout import timeout

--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -6,8 +6,13 @@ import logging
 from typing import Any, Dict
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 from accuweather import AccuWeather, ApiError, InvalidApiKeyError, InvalidCoordinatesError, RequestsExceededError
 from aiohttp import ClientSession, ClientError
+=======
+from accuweather import AccuWeather, ApiError, InvalidApiKeyError, RequestsExceededError
+from aiohttp import ClientSession
+>>>>>>> parent of 4d12009cea (update in accuweather dependencies)
 =======
 from accuweather import AccuWeather, ApiError, InvalidApiKeyError, RequestsExceededError
 from aiohttp import ClientSession

--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -5,8 +5,8 @@ from datetime import timedelta
 import logging
 from typing import Any, Dict
 
-from accuweather import AccuWeather, ApiError, InvalidApiKeyError, RequestsExceededError
-from aiohttp import ClientSession
+from accuweather import AccuWeather, ApiError, InvalidApiKeyError, RequestsExceededError, InvalidCoordinatesError
+from aiohttp import ClientSession, ClientError
 from aiohttp.client_exceptions import ClientConnectorError
 from async_timeout import timeout
 
@@ -104,9 +104,11 @@ class AccuWeatherDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
                 )
         except (
             ApiError,
+            ClientError,
             ClientConnectorError,
             InvalidApiKeyError,
             RequestsExceededError,
+            InvalidCoordinatesError,
         ) as error:
             raise UpdateFailed(error) from error
         _LOGGER.debug("Requests remaining: %d", self.accuweather.requests_remaining)

--- a/homeassistant/components/bme680/__init__.py
+++ b/homeassistant/components/bme680/__init__.py
@@ -1,1 +1,98 @@
-"""The bme680 component."""
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_SCAN_INTERVAL
+from homeassistant.helpers import config_validation as cv, discovery
+
+from .const import (
+    CONF_DELTA_TEMP,
+    CONF_FILTER_MODE,
+    CONF_I2C_ADDRESS,
+    CONF_I2C_BUS,
+    CONF_OPERATION_MODE,
+    CONF_OVERSAMPLING_HUM,
+    CONF_OVERSAMPLING_PRES,
+    CONF_OVERSAMPLING_TEMP,
+    CONF_SPI_BUS,
+    CONF_SPI_DEV,
+    CONF_T_STANDBY,
+    DEFAULT_DELTA_TEMP,
+    DEFAULT_FILTER_MODE,
+    DEFAULT_I2C_ADDRESS,
+    DEFAULT_I2C_BUS,
+    DEFAULT_MONITORED,
+    DEFAULT_NAME,
+    DEFAULT_OPERATION_MODE,
+    DEFAULT_OVERSAMPLING_HUM,
+    DEFAULT_OVERSAMPLING_PRES,
+    DEFAULT_OVERSAMPLING_TEMP,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_T_STANDBY,
+    DOMAIN,
+    SENSOR_KEYS,
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.All(
+            cv.ensure_list,
+            [
+                vol.Schema(
+                    {
+                        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                        vol.Optional(CONF_SPI_BUS): vol.Coerce(int),
+                        vol.Optional(CONF_SPI_DEV): vol.Coerce(int),
+                        vol.Optional(
+                            CONF_I2C_ADDRESS, default=DEFAULT_I2C_ADDRESS
+                        ): cv.string,
+                        vol.Optional(CONF_I2C_BUS, default=DEFAULT_I2C_BUS): vol.Coerce(
+                            int
+                        ),
+                        vol.Optional(
+                            CONF_DELTA_TEMP, default=DEFAULT_DELTA_TEMP
+                        ): vol.Coerce(float),
+                        vol.Optional(
+                            CONF_MONITORED_CONDITIONS, default=DEFAULT_MONITORED
+                        ): vol.All(cv.ensure_list, [vol.In(SENSOR_KEYS)]),
+                        vol.Optional(
+                            CONF_OVERSAMPLING_TEMP, default=DEFAULT_OVERSAMPLING_TEMP
+                        ): vol.Coerce(int),
+                        vol.Optional(
+                            CONF_OVERSAMPLING_PRES, default=DEFAULT_OVERSAMPLING_PRES
+                        ): vol.Coerce(int),
+                        vol.Optional(
+                            CONF_OVERSAMPLING_HUM, default=DEFAULT_OVERSAMPLING_HUM
+                        ): vol.Coerce(int),
+                        vol.Optional(
+                            CONF_OPERATION_MODE, default=DEFAULT_OPERATION_MODE
+                        ): vol.Coerce(int),
+                        vol.Optional(
+                            CONF_T_STANDBY, default=DEFAULT_T_STANDBY
+                        ): vol.Coerce(int),
+                        vol.Optional(
+                            CONF_FILTER_MODE, default=DEFAULT_FILTER_MODE
+                        ): vol.Coerce(int),
+                        vol.Optional(
+                            CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                        ): cv.time_period,
+                    }
+                )
+            ],
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass, config):
+    """Set up BME680 component."""
+    bme680_config = config[DOMAIN]
+    for bme680_conf in bme680_config:
+        discovery_info = {SENSOR_DOMAIN: bme680_conf}
+        hass.async_create_task(
+            discovery.async_load_platform(
+                hass, SENSOR_DOMAIN, DOMAIN, discovery_info, config
+            )
+        )
+    return True

--- a/homeassistant/components/bme680/const.py
+++ b/homeassistant/components/bme680/const.py
@@ -1,0 +1,63 @@
+"""Constants for the bme680 component."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.const import (
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    PERCENTAGE,
+    TEMP_CELSIUS,
+)
+
+# Common
+DOMAIN = "bme680"
+CONF_OVERSAMPLING_TEMP = "oversampling_temperature"
+CONF_OVERSAMPLING_PRES = "oversampling_pressure"
+CONF_OVERSAMPLING_HUM = "oversampling_humidity"
+CONF_T_STANDBY = "time_standby"
+CONF_FILTER_MODE = "filter_mode"
+DEFAULT_NAME = "BME680 Sensor"
+DEFAULT_OVERSAMPLING_TEMP = 1
+DEFAULT_OVERSAMPLING_PRES = 1
+DEFAULT_OVERSAMPLING_HUM = 1
+DEFAULT_T_STANDBY = 5
+DEFAULT_FILTER_MODE = 0
+DEFAULT_SCAN_INTERVAL = 300
+SENSOR_TEMP = "temperature"
+SENSOR_HUMID = "humidity"
+SENSOR_PRESS = "pressure"
+SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key=SENSOR_TEMP,
+        name="Temperature",
+        native_unit_of_measurement=TEMP_CELSIUS,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+    ),
+    SensorEntityDescription(
+        key=SENSOR_HUMID,
+        name="Humidity",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=DEVICE_CLASS_HUMIDITY,
+    ),
+    SensorEntityDescription(
+        key=SENSOR_PRESS,
+        name="Pressure",
+        native_unit_of_measurement="mb",
+        device_class=DEVICE_CLASS_PRESSURE,
+    ),
+)
+SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
+DEFAULT_MONITORED = [SENSOR_TEMP, SENSOR_HUMID, SENSOR_PRESS]
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=3)
+# I2C
+CONF_I2C_ADDRESS = "i2c_address"
+CONF_I2C_BUS = "i2c_bus"
+CONF_DELTA_TEMP = "delta_temperature"
+CONF_OPERATION_MODE = "operation_mode"
+DEFAULT_OPERATION_MODE = 3  # Normal mode (forced mode: 2)
+DEFAULT_I2C_ADDRESS = "0x76"
+DEFAULT_I2C_BUS = 1
+DEFAULT_DELTA_TEMP = 0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I included `ClientError` and `InvalidCoordinatesError`. As it will handle the overall error of the client as well as invalid coordinates directly. Based on the `0.2.0` version of accuweather python module


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: handle ***all client side errors*** from directly one module, i.e. aiohttp
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
