### PR TITLE
Add kPa as a pressure unit

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -470,6 +470,7 @@ FREQUENCY_GIGAHERTZ: Final = "GHz"
 # Pressure units
 PRESSURE_PA: Final = "Pa"
 PRESSURE_HPA: Final = "hPa"
+PRESSURE_KPA: Final = "kPa"
 PRESSURE_BAR: Final = "bar"
 PRESSURE_MBAR: Final = "mbar"
 PRESSURE_INHG: Final = "inHg"

--- a/homeassistant/util/pressure.py
+++ b/homeassistant/util/pressure.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
     PRESSURE_BAR,
     PRESSURE_HPA,
     PRESSURE_INHG,
+    PRESSURE_KPA,
     PRESSURE_MBAR,
     PRESSURE_PA,
     PRESSURE_PSI,
@@ -17,6 +18,7 @@ from homeassistant.const import (
 VALID_UNITS: tuple[str, ...] = (
     PRESSURE_PA,
     PRESSURE_HPA,
+    PRESSURE_KPA,
     PRESSURE_BAR,
     PRESSURE_MBAR,
     PRESSURE_INHG,
@@ -26,6 +28,7 @@ VALID_UNITS: tuple[str, ...] = (
 UNIT_CONVERSION: dict[str, float] = {
     PRESSURE_PA: 1,
     PRESSURE_HPA: 1 / 100,
+    PRESSURE_KPA: 1 / 1000,
     PRESSURE_BAR: 1 / 100000,
     PRESSURE_MBAR: 1 / 100,
     PRESSURE_INHG: 1 / 3386.389,

--- a/tests/util/test_pressure.py
+++ b/tests/util/test_pressure.py
@@ -4,6 +4,7 @@ import pytest
 from homeassistant.const import (
     PRESSURE_HPA,
     PRESSURE_INHG,
+    PRESSURE_KPA,
     PRESSURE_MBAR,
     PRESSURE_PA,
     PRESSURE_PSI,
@@ -20,6 +21,7 @@ def test_convert_same_unit():
     assert pressure_util.convert(3, PRESSURE_HPA, PRESSURE_HPA) == 3
     assert pressure_util.convert(4, PRESSURE_MBAR, PRESSURE_MBAR) == 4
     assert pressure_util.convert(5, PRESSURE_INHG, PRESSURE_INHG) == 5
+    assert pressure_util.convert(6, PRESSURE_KPA, PRESSURE_KPA) == 6
 
 
 def test_convert_invalid_unit():
@@ -49,8 +51,31 @@ def test_convert_from_hpascals():
     assert pressure_util.convert(hpascals, PRESSURE_HPA, PRESSURE_PA) == pytest.approx(
         100000
     )
+    assert pressure_util.convert(hpascals, PRESSURE_HPA, PRESSURE_KPA) == pytest.approx(
+        100
+    )
     assert pressure_util.convert(
         hpascals, PRESSURE_HPA, PRESSURE_MBAR
+    ) == pytest.approx(1000)
+
+
+def test_convert_from_kpascals():
+    """Test conversion from hPA to other units."""
+    kpascals = 100
+    assert pressure_util.convert(kpascals, PRESSURE_KPA, PRESSURE_PSI) == pytest.approx(
+        14.5037743897
+    )
+    assert pressure_util.convert(
+        kpascals, PRESSURE_KPA, PRESSURE_INHG
+    ) == pytest.approx(29.5299801647)
+    assert pressure_util.convert(kpascals, PRESSURE_KPA, PRESSURE_PA) == pytest.approx(
+        100000
+    )
+    assert pressure_util.convert(kpascals, PRESSURE_KPA, PRESSURE_HPA) == pytest.approx(
+        1000
+    )
+    assert pressure_util.convert(
+        kpascals, PRESSURE_KPA, PRESSURE_MBAR
     ) == pytest.approx(1000)
 
 
@@ -59,6 +84,9 @@ def test_convert_from_inhg():
     inhg = 30
     assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_PSI) == pytest.approx(
         14.7346266155
+    )
+    assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_KPA) == pytest.approx(
+        101.59167
     )
     assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_HPA) == pytest.approx(
         1015.9167


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add kilopascals as a standard unit, with conversions. kPa is the standard unit for reporting barometric pressure in Canada (may be used in other places too).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I'm about to submit a new Environment Canada integration and would like to be able to report in kPa. This does not fix any issues that I am aware of. No documentation change required.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/core/pull/56885

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
