### PR TITLE
Rename state to value_fn - picnic sensor

### DIFF
--- a/homeassistant/components/picnic/const.py
+++ b/homeassistant/components/picnic/const.py
@@ -42,7 +42,7 @@ class PicnicRequiredKeysMixin:
     """Mixin for required keys."""
 
     data_type: Literal["cart_data", "slot_data", "last_order_data"]
-    state: Callable[[Any], StateType]
+    value_fn: Callable[[Any], StateType]
 
 
 @dataclass
@@ -57,7 +57,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         key=SENSOR_CART_ITEMS_COUNT,
         icon="mdi:format-list-numbered",
         data_type="cart_data",
-        state=lambda cart: cart.get("total_count", 0),
+        value_fn=lambda cart: cart.get("total_count", 0),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_CART_TOTAL_PRICE,
@@ -65,7 +65,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:currency-eur",
         entity_registry_enabled_default=True,
         data_type="cart_data",
-        state=lambda cart: cart.get("total_price", 0) / 100,
+        value_fn=lambda cart: cart.get("total_price", 0) / 100,
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_SELECTED_SLOT_START,
@@ -73,7 +73,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:calendar-start",
         entity_registry_enabled_default=True,
         data_type="slot_data",
-        state=lambda slot: slot.get("window_start"),
+        value_fn=lambda slot: slot.get("window_start"),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_SELECTED_SLOT_END,
@@ -81,7 +81,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:calendar-end",
         entity_registry_enabled_default=True,
         data_type="slot_data",
-        state=lambda slot: slot.get("window_end"),
+        value_fn=lambda slot: slot.get("window_end"),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_SELECTED_SLOT_MAX_ORDER_TIME,
@@ -89,7 +89,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:clock-alert-outline",
         entity_registry_enabled_default=True,
         data_type="slot_data",
-        state=lambda slot: slot.get("cut_off_time"),
+        value_fn=lambda slot: slot.get("cut_off_time"),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_SELECTED_SLOT_MIN_ORDER_VALUE,
@@ -97,7 +97,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:currency-eur",
         entity_registry_enabled_default=True,
         data_type="slot_data",
-        state=lambda slot: (
+        value_fn=lambda slot: (
             slot["minimum_order_value"] / 100
             if slot.get("minimum_order_value")
             else None
@@ -108,20 +108,20 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         device_class=DEVICE_CLASS_TIMESTAMP,
         icon="mdi:calendar-start",
         data_type="last_order_data",
-        state=lambda last_order: last_order.get("slot", {}).get("window_start"),
+        value_fn=lambda last_order: last_order.get("slot", {}).get("window_start"),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_SLOT_END,
         device_class=DEVICE_CLASS_TIMESTAMP,
         icon="mdi:calendar-end",
         data_type="last_order_data",
-        state=lambda last_order: last_order.get("slot", {}).get("window_end"),
+        value_fn=lambda last_order: last_order.get("slot", {}).get("window_end"),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_STATUS,
         icon="mdi:list-status",
         data_type="last_order_data",
-        state=lambda last_order: last_order.get("status"),
+        value_fn=lambda last_order: last_order.get("status"),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_ETA_START,
@@ -129,7 +129,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:clock-start",
         entity_registry_enabled_default=True,
         data_type="last_order_data",
-        state=lambda last_order: last_order.get("eta", {}).get("start"),
+        value_fn=lambda last_order: last_order.get("eta", {}).get("start"),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_ETA_END,
@@ -137,7 +137,7 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:clock-end",
         entity_registry_enabled_default=True,
         data_type="last_order_data",
-        state=lambda last_order: last_order.get("eta", {}).get("end"),
+        value_fn=lambda last_order: last_order.get("eta", {}).get("end"),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_DELIVERY_TIME,
@@ -145,13 +145,13 @@ SENSOR_TYPES: tuple[PicnicSensorEntityDescription, ...] = (
         icon="mdi:timeline-clock",
         entity_registry_enabled_default=True,
         data_type="last_order_data",
-        state=lambda last_order: last_order.get("delivery_time", {}).get("start"),
+        value_fn=lambda last_order: last_order.get("delivery_time", {}).get("start"),
     ),
     PicnicSensorEntityDescription(
         key=SENSOR_LAST_ORDER_TOTAL_PRICE,
         native_unit_of_measurement=CURRENCY_EURO,
         icon="mdi:cash-marker",
         data_type="last_order_data",
-        state=lambda last_order: last_order.get("total_price", 0) / 100,
+        value_fn=lambda last_order: last_order.get("total_price", 0) / 100,
     ),
 )

--- a/homeassistant/components/picnic/sensor.py
+++ b/homeassistant/components/picnic/sensor.py
@@ -68,7 +68,7 @@ class PicnicSensor(SensorEntity, CoordinatorEntity):
             if self.coordinator.data is not None
             else {}
         )
-        return self.entity_description.state(data_set)
+        return self.entity_description.value_fn(data_set)
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
## Proposed change
Similar to #56812.
Rename `state` to `value_fn` for the `picnic` integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
