### PR TITLE
Replace strings with library constants in deCONZ climate platform

### DIFF
--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -1,7 +1,27 @@
 """Support for deCONZ climate devices."""
 from __future__ import annotations
 
-from pydeconz.sensor import Thermostat
+from pydeconz.sensor import (
+    THERMOSTAT_FAN_MODE_AUTO,
+    THERMOSTAT_FAN_MODE_HIGH,
+    THERMOSTAT_FAN_MODE_LOW,
+    THERMOSTAT_FAN_MODE_MEDIUM,
+    THERMOSTAT_FAN_MODE_OFF,
+    THERMOSTAT_FAN_MODE_ON,
+    THERMOSTAT_FAN_MODE_SMART,
+    THERMOSTAT_MODE_AUTO,
+    THERMOSTAT_MODE_COOL,
+    THERMOSTAT_MODE_HEAT,
+    THERMOSTAT_MODE_OFF,
+    THERMOSTAT_PRESET_AUTO,
+    THERMOSTAT_PRESET_BOOST,
+    THERMOSTAT_PRESET_COMFORT,
+    THERMOSTAT_PRESET_COMPLEX,
+    THERMOSTAT_PRESET_ECO,
+    THERMOSTAT_PRESET_HOLIDAY,
+    THERMOSTAT_PRESET_MANUAL,
+    Thermostat,
+)
 
 from homeassistant.components.climate import DOMAIN, ClimateEntity
 from homeassistant.components.climate.const import (
@@ -33,22 +53,22 @@ from .gateway import get_gateway_from_config_entry
 DECONZ_FAN_SMART = "smart"
 
 FAN_MODE_TO_DECONZ = {
-    DECONZ_FAN_SMART: "smart",
-    FAN_AUTO: "auto",
-    FAN_HIGH: "high",
-    FAN_MEDIUM: "medium",
-    FAN_LOW: "low",
-    FAN_ON: "on",
-    FAN_OFF: "off",
+    DECONZ_FAN_SMART: THERMOSTAT_FAN_MODE_SMART,
+    FAN_AUTO: THERMOSTAT_FAN_MODE_AUTO,
+    FAN_HIGH: THERMOSTAT_FAN_MODE_HIGH,
+    FAN_MEDIUM: THERMOSTAT_FAN_MODE_MEDIUM,
+    FAN_LOW: THERMOSTAT_FAN_MODE_LOW,
+    FAN_ON: THERMOSTAT_FAN_MODE_ON,
+    FAN_OFF: THERMOSTAT_FAN_MODE_OFF,
 }
 
 DECONZ_TO_FAN_MODE = {value: key for key, value in FAN_MODE_TO_DECONZ.items()}
 
 HVAC_MODE_TO_DECONZ = {
-    HVAC_MODE_AUTO: "auto",
-    HVAC_MODE_COOL: "cool",
-    HVAC_MODE_HEAT: "heat",
-    HVAC_MODE_OFF: "off",
+    HVAC_MODE_AUTO: THERMOSTAT_MODE_AUTO,
+    HVAC_MODE_COOL: THERMOSTAT_MODE_COOL,
+    HVAC_MODE_HEAT: THERMOSTAT_MODE_HEAT,
+    HVAC_MODE_OFF: THERMOSTAT_MODE_OFF,
 }
 
 DECONZ_PRESET_AUTO = "auto"
@@ -57,13 +77,13 @@ DECONZ_PRESET_HOLIDAY = "holiday"
 DECONZ_PRESET_MANUAL = "manual"
 
 PRESET_MODE_TO_DECONZ = {
-    DECONZ_PRESET_AUTO: "auto",
-    PRESET_BOOST: "boost",
-    PRESET_COMFORT: "comfort",
-    DECONZ_PRESET_COMPLEX: "complex",
-    PRESET_ECO: "eco",
-    DECONZ_PRESET_HOLIDAY: "holiday",
-    DECONZ_PRESET_MANUAL: "manual",
+    DECONZ_PRESET_AUTO: THERMOSTAT_PRESET_AUTO,
+    PRESET_BOOST: THERMOSTAT_PRESET_BOOST,
+    PRESET_COMFORT: THERMOSTAT_PRESET_COMFORT,
+    DECONZ_PRESET_COMPLEX: THERMOSTAT_PRESET_COMPLEX,
+    PRESET_ECO: THERMOSTAT_PRESET_ECO,
+    DECONZ_PRESET_HOLIDAY: THERMOSTAT_PRESET_HOLIDAY,
+    DECONZ_PRESET_MANUAL: THERMOSTAT_PRESET_MANUAL,
 }
 
 DECONZ_TO_PRESET_MODE = {value: key for key, value in PRESET_MODE_TO_DECONZ.items()}
@@ -116,7 +136,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         super().__init__(device, gateway)
 
         self._hvac_mode_to_deconz = dict(HVAC_MODE_TO_DECONZ)
-        if "mode" not in device.raw["config"]:
+        if not device.mode:
             self._hvac_mode_to_deconz = {
                 HVAC_MODE_HEAT: True,
                 HVAC_MODE_OFF: False,
@@ -129,10 +149,10 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
 
         self._attr_supported_features = SUPPORT_TARGET_TEMPERATURE
 
-        if "fanmode" in device.raw["config"]:
+        if device.fan_mode:
             self._attr_supported_features |= SUPPORT_FAN_MODE
 
-        if "preset" in device.raw["config"]:
+        if device.preset:
             self._attr_supported_features |= SUPPORT_PRESET_MODE
 
     # Fan control
@@ -214,7 +234,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     @property
     def target_temperature(self) -> float:
         """Return the target temperature."""
-        if self._device.mode == "cool":
+        if self._device.mode == THERMOSTAT_MODE_COOL:
             return self._device.cooling_setpoint
         return self._device.heating_setpoint
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
