### PR TITLE
Replace strings with library constants in deCONZ fan platform

### DIFF
--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -1,7 +1,14 @@
 """Support for deCONZ fans."""
 from __future__ import annotations
 
-from pydeconz.light import Fan
+from pydeconz.light import (
+    FAN_SPEED_25_PERCENT,
+    FAN_SPEED_50_PERCENT,
+    FAN_SPEED_75_PERCENT,
+    FAN_SPEED_100_PERCENT,
+    FAN_SPEED_OFF,
+    Fan,
+)
 
 from homeassistant.components.fan import (
     DOMAIN,
@@ -23,10 +30,25 @@ from .const import NEW_LIGHT
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
-ORDERED_NAMED_FAN_SPEEDS = [1, 2, 3, 4]
+ORDERED_NAMED_FAN_SPEEDS = [
+    FAN_SPEED_25_PERCENT,
+    FAN_SPEED_50_PERCENT,
+    FAN_SPEED_75_PERCENT,
+    FAN_SPEED_100_PERCENT,
+]
 
-LEGACY_SPEED_TO_DECONZ = {SPEED_OFF: 0, SPEED_LOW: 1, SPEED_MEDIUM: 2, SPEED_HIGH: 4}
-LEGACY_DECONZ_TO_SPEED = {0: SPEED_OFF, 1: SPEED_LOW, 2: SPEED_MEDIUM, 4: SPEED_HIGH}
+LEGACY_SPEED_TO_DECONZ = {
+    SPEED_OFF: FAN_SPEED_OFF,
+    SPEED_LOW: FAN_SPEED_25_PERCENT,
+    SPEED_MEDIUM: FAN_SPEED_50_PERCENT,
+    SPEED_HIGH: FAN_SPEED_100_PERCENT,
+}
+LEGACY_DECONZ_TO_SPEED = {
+    FAN_SPEED_OFF: SPEED_OFF,
+    FAN_SPEED_25_PERCENT: SPEED_LOW,
+    FAN_SPEED_50_PERCENT: SPEED_MEDIUM,
+    FAN_SPEED_100_PERCENT: SPEED_HIGH,
+}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
@@ -68,7 +90,7 @@ class DeconzFan(DeconzDevice, FanEntity):
         """Set up fan."""
         super().__init__(device, gateway)
 
-        self._default_on_speed = 2
+        self._default_on_speed = FAN_SPEED_50_PERCENT
         if self._device.speed in ORDERED_NAMED_FAN_SPEEDS:
             self._default_on_speed = self._device.speed
 
@@ -77,12 +99,12 @@ class DeconzFan(DeconzDevice, FanEntity):
     @property
     def is_on(self) -> bool:
         """Return true if fan is on."""
-        return self._device.speed != 0
+        return self._device.speed != FAN_SPEED_OFF
 
     @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
-        if self._device.speed == 0:
+        if self._device.speed == FAN_SPEED_OFF:
             return 0
         if self._device.speed not in ORDERED_NAMED_FAN_SPEEDS:
             return None
@@ -177,4 +199,4 @@ class DeconzFan(DeconzDevice, FanEntity):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off fan."""
-        await self._device.set_speed(0)
+        await self._device.set_speed(FAN_SPEED_OFF)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
