### PR TITLE
ZHA support for additional entities on ElectricalMeasurement ZCL cluster

### DIFF
--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -123,14 +123,14 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
         return self.cluster.get("ac_voltage_multiplier") or 1
 
     @property
-    def divisor(self) -> int:
+    def ac_power_divisor(self) -> int:
         """Return active power divisor."""
         return self.cluster.get(
             "ac_power_divisor", self.cluster.get("power_divisor") or 1
         )
 
     @property
-    def multiplier(self) -> int:
+    def ac_power_multiplier(self) -> int:
         """Return active power divisor."""
         return self.cluster.get(
             "ac_power_multiplier", self.cluster.get("power_multiplier") or 1

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -87,8 +87,12 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
         self.debug("async_update")
 
         # This is a polling channel. Don't allow cache.
-        attrs = [a["attr"] for a in self.REPORT_CONFIG]
-        result = await self.get_attribute_values(attrs, from_cache=False)
+        attrs = [
+            a["attr"]
+            for a in self.REPORT_CONFIG
+            if a["attr"] not in self.cluster.unsupported_attributes
+        ]
+        result = await self.get_attributes(attrs, from_cache=False)
         if result:
             for attr, value in result.items():
                 self.async_send_signal(

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -1,12 +1,15 @@
 """Home automation channels module for Zigbee Home Automation."""
 from __future__ import annotations
 
+import enum
+
 from zigpy.zcl.clusters import homeautomation
 
 from .. import registries
 from ..const import (
     CHANNEL_ELECTRICAL_MEASUREMENT,
     REPORT_CONFIG_DEFAULT,
+    REPORT_CONFIG_OP,
     SIGNAL_ATTR_UPDATED,
 )
 from .base import ZigbeeChannel
@@ -46,11 +49,36 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
 
     CHANNEL_NAME = CHANNEL_ELECTRICAL_MEASUREMENT
 
-    REPORT_CONFIG = ({"attr": "active_power", "config": REPORT_CONFIG_DEFAULT},)
+    class MeasurementType(enum.IntFlag):
+        """Measurement types."""
+
+        ACTIVE_MEASUREMENT = 1
+        REACTIVE_MEASUREMENT = 2
+        APPARENT_MEASUREMENT = 4
+        PHASE_A_MEASUREMENT = 8
+        PHASE_B_MEASUREMENT = 16
+        PHASE_C_MEASUREMENT = 32
+        DC_MEASUREMENT = 64
+        HARMONICS_MEASUREMENT = 128
+        POWER_QUALITY_MEASUREMENT = 256
+
+    REPORT_CONFIG = (
+        {"attr": "active_power", "config": REPORT_CONFIG_OP},
+        {"attr": "active_power_max", "config": REPORT_CONFIG_DEFAULT},
+        {"attr": "rms_current", "config": REPORT_CONFIG_OP},
+        {"attr": "rms_current_max", "config": REPORT_CONFIG_DEFAULT},
+        {"attr": "rms_voltage", "config": REPORT_CONFIG_OP},
+        {"attr": "rms_voltage_max", "config": REPORT_CONFIG_DEFAULT},
+    )
     ZCL_INIT_ATTRS = {
+        "ac_current_divisor": True,
+        "ac_current_multiplier": True,
         "ac_power_divisor": True,
-        "power_divisor": True,
         "ac_power_multiplier": True,
+        "ac_voltage_divisor": True,
+        "ac_voltage_multiplier": True,
+        "measurement_type": True,
+        "power_divisor": True,
         "power_multiplier": True,
     }
 
@@ -59,28 +87,60 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
         self.debug("async_update")
 
         # This is a polling channel. Don't allow cache.
-        result = await self.get_attribute_value("active_power", from_cache=False)
-        if result is not None:
-            self.async_send_signal(
-                f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
-                0x050B,
-                "active_power",
-                result,
-            )
+        attrs = [a["attr"] for a in self.REPORT_CONFIG]
+        result = await self.get_attribute_values(attrs, from_cache=False)
+        if result:
+            for attr, value in result.items():
+                self.async_send_signal(
+                    f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}",
+                    self.cluster.attridx.get(attr, attr),
+                    attr,
+                    value,
+                )
 
     @property
-    def divisor(self) -> int | None:
+    def ac_current_divisor(self) -> int:
+        """Return ac current divisor."""
+        return self.cluster.get("ac_current_divisor") or 1
+
+    @property
+    def ac_current_multiplier(self) -> int:
+        """Return ac current multiplier."""
+        return self.cluster.get("ac_current_multiplier") or 1
+
+    @property
+    def ac_voltage_divisor(self) -> int:
+        """Return ac voltage divisor."""
+        return self.cluster.get("ac_voltage_divisor") or 1
+
+    @property
+    def ac_voltage_multiplier(self) -> int:
+        """Return ac voltage multiplier."""
+        return self.cluster.get("ac_voltage_multiplier") or 1
+
+    @property
+    def divisor(self) -> int:
         """Return active power divisor."""
         return self.cluster.get(
-            "ac_power_divisor", self.cluster.get("power_divisor", 1)
+            "ac_power_divisor", self.cluster.get("power_divisor") or 1
         )
 
     @property
-    def multiplier(self) -> int | None:
+    def multiplier(self) -> int:
         """Return active power divisor."""
         return self.cluster.get(
-            "ac_power_multiplier", self.cluster.get("power_multiplier", 1)
+            "ac_power_multiplier", self.cluster.get("power_multiplier") or 1
         )
+
+    @property
+    def measurement_type(self) -> str | None:
+        """Return Measurement type."""
+        mt = self.cluster.get("measurement_type")
+        if mt is None:
+            return None
+
+        mt = self.MeasurementType(mt)
+        return ", ".join(m.name for m in self.MeasurementType if m in mt)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(

--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -139,12 +139,12 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
     @property
     def measurement_type(self) -> str | None:
         """Return Measurement type."""
-        mt = self.cluster.get("measurement_type")
-        if mt is None:
+        meas_type = self.cluster.get("measurement_type")
+        if meas_type is None:
             return None
 
-        mt = self.MeasurementType(mt)
-        return ", ".join(m.name for m in self.MeasurementType if m in mt)
+        meas_type = self.MeasurementType(meas_type)
+        return ", ".join(m.name for m in self.MeasurementType if m in meas_type)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -73,7 +73,6 @@ SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {
     zcl.clusters.general.MultistateInput.cluster_id: SENSOR,
     zcl.clusters.general.OnOff.cluster_id: SWITCH,
     zcl.clusters.general.PowerConfiguration.cluster_id: SENSOR,
-    zcl.clusters.homeautomation.ElectricalMeasurement.cluster_id: SENSOR,
     zcl.clusters.hvac.Fan.cluster_id: FAN,
     zcl.clusters.measurement.CarbonDioxideConcentration.cluster_id: SENSOR,
     zcl.clusters.measurement.CarbonMonoxideConcentration.cluster_id: SENSOR,

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -246,6 +246,7 @@ class ElectricalMeasurement(Sensor):
     _device_class = DEVICE_CLASS_POWER
     _state_class = STATE_CLASS_MEASUREMENT
     _unit = POWER_WATT
+    _div_mul_prefix = "ac_power"
 
     @property
     def should_poll(self) -> bool:
@@ -267,8 +268,10 @@ class ElectricalMeasurement(Sensor):
 
     def formatter(self, value: int) -> int | float:
         """Return 'normalized' value."""
-        value = value * self._channel.multiplier / self._channel.divisor
-        if value < 100 and self._channel.divisor > 1:
+        multiplier = getattr(self._channel, f"{self._div_mul_prefix}_multiplier")
+        divisor = getattr(self._channel, f"{self._div_mul_prefix}_divisor")
+        value = float(value * multiplier) / divisor
+        if value < 100 and divisor > 1:
             return round(value, self._decimals)
         return round(value)
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_CO,
     DEVICE_CLASS_CO2,
+    DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_POWER,
@@ -24,6 +25,7 @@ from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_MILLION,
     DEVICE_CLASS_ENERGY,
+    ELECTRIC_CURRENT_AMPERE,
     ENERGY_KILO_WATT_HOUR,
     LIGHT_LUX,
     PERCENTAGE,
@@ -238,7 +240,7 @@ class Battery(Sensor):
         return state_attrs
 
 
-@STRICT_MATCH(channel_names=CHANNEL_ELECTRICAL_MEASUREMENT)
+@MULTI_MATCH(channel_names=CHANNEL_ELECTRICAL_MEASUREMENT)
 class ElectricalMeasurement(Sensor):
     """Active power measurement."""
 
@@ -280,6 +282,36 @@ class ElectricalMeasurement(Sensor):
         if not self.available:
             return
         await super().async_update()
+
+
+@MULTI_MATCH(channel_names=CHANNEL_ELECTRICAL_MEASUREMENT)
+class ElectricalMeasurementRMSCurrent(ElectricalMeasurement, id_suffix="rms_current"):
+    """RMS current measurement."""
+
+    SENSOR_ATTR = "rms_current"
+    _device_class = DEVICE_CLASS_CURRENT
+    _unit = ELECTRIC_CURRENT_AMPERE
+    _div_mul_prefix = "ac_current"
+
+    @property
+    def should_poll(self) -> bool:
+        """Poll indirectly by ElectricalMeasurementSensor."""
+        return False
+
+
+@MULTI_MATCH(channel_names=CHANNEL_ELECTRICAL_MEASUREMENT)
+class ElectricalMeasurementRMSVoltage(ElectricalMeasurement, id_suffix="rms_voltage"):
+    """RMS Voltage measurement."""
+
+    SENSOR_ATTR = "rms_voltage"
+    _device_class = DEVICE_CLASS_CURRENT
+    _unit = ELECTRIC_CURRENT_AMPERE
+    _div_mul_prefix = "ac_voltage"
+
+    @property
+    def should_poll(self) -> bool:
+        """Poll indirectly by ElectricalMeasurementSensor."""
+        return False
 
 
 @STRICT_MATCH(generic_ids=CHANNEL_ST_HUMIDITY_CLUSTER)

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     DEVICE_CLASS_ENERGY,
     ELECTRIC_CURRENT_AMPERE,
+    ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
     LIGHT_LUX,
     PERCENTAGE,
@@ -143,8 +144,8 @@ class Sensor(ZhaEntity, SensorEntity):
 
         Return entity if it is a supported configuration, otherwise return None
         """
-        se_channel = channels[0]
-        if cls.SENSOR_ATTR in se_channel.cluster.unsupported_attributes:
+        channel = channels[0]
+        if cls.SENSOR_ATTR in channel.cluster.unsupported_attributes:
             return None
 
         return cls(unique_id, zha_device, channels, **kwargs)
@@ -305,7 +306,7 @@ class ElectricalMeasurementRMSVoltage(ElectricalMeasurement, id_suffix="rms_volt
 
     SENSOR_ATTR = "rms_voltage"
     _device_class = DEVICE_CLASS_CURRENT
-    _unit = ELECTRIC_CURRENT_AMPERE
+    _unit = ELECTRIC_POTENTIAL_VOLT
     _div_mul_prefix = "ac_voltage"
 
     @property

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -234,6 +234,15 @@ class ElectricalMeasurement(Sensor):
         """Return True if HA needs to poll for state changes."""
         return True
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return device state attrs for sensor."""
+        attrs = {}
+        if self._channel.measurement_type is not None:
+            attrs["measurement_type"] = self._channel.measurement_type
+
+        return attrs
+
     def formatter(self, value: int) -> int | float:
         """Return 'normalized' value."""
         value = value * self._channel.multiplier / self._channel.divisor

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -129,6 +129,24 @@ class Sensor(ZhaEntity, SensorEntity):
         super().__init__(unique_id, zha_device, channels, **kwargs)
         self._channel: ChannelType = channels[0]
 
+    @classmethod
+    def create_entity(
+        cls,
+        unique_id: str,
+        zha_device: ZhaDeviceType,
+        channels: list[ChannelType],
+        **kwargs,
+    ) -> ZhaEntity | None:
+        """Entity Factory.
+
+        Return entity if it is a supported configuration, otherwise return None
+        """
+        se_channel = channels[0]
+        if cls.SENSOR_ATTR in se_channel.cluster.unsupported_attributes:
+            return None
+
+        return cls(unique_id, zha_device, channels, **kwargs)
+
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""
         await super().async_added_to_hass()
@@ -310,24 +328,6 @@ class SmartEnergyMetering(Sensor):
         0x0B: "unitless",
         0x0C: f"MJ/{TIME_SECONDS}",
     }
-
-    @classmethod
-    def create_entity(
-        cls,
-        unique_id: str,
-        zha_device: ZhaDeviceType,
-        channels: list[ChannelType],
-        **kwargs,
-    ) -> ZhaEntity | None:
-        """Entity Factory.
-
-        Return entity if it is a supported configuration, otherwise return None
-        """
-        se_channel = channels[0]
-        if cls.SENSOR_ATTR in se_channel.cluster.unsupported_attributes:
-            return None
-
-        return cls(unique_id, zha_device, channels, **kwargs)
 
     def formatter(self, value: int) -> int | float:
         """Pass through channel formatter."""

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -241,6 +241,10 @@ class ElectricalMeasurement(Sensor):
         if self._channel.measurement_type is not None:
             attrs["measurement_type"] = self._channel.measurement_type
 
+        max_attr_name = f"{self.SENSOR_ATTR}_max"
+        if (max_v := self._channel.cluster.get(max_attr_name)) is not None:
+            attrs[max_attr_name] = str(self.formatter(max_v))
+
         return attrs
 
     def formatter(self, value: int) -> int | float:

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -152,7 +152,18 @@ async def poll_control_device(zha_device_restored, zigpy_device_mock):
         (0x0405, 1, {"measured_value"}),
         (0x0406, 1, {"occupancy"}),
         (0x0702, 1, {"instantaneous_demand"}),
-        (0x0B04, 1, {"active_power"}),
+        (
+            0x0B04,
+            1,
+            {
+                "active_power",
+                "active_power_max",
+                "rms_current",
+                "rms_current_max",
+                "rms_voltage",
+                "rms_voltage_max",
+            },
+        ),
     ],
 )
 async def test_in_channel_config(

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -171,6 +171,10 @@ async def async_test_electrical_measurement(hass, cluster, entity_id):
         await send_attributes_report(hass, cluster, {0: 1, 1291: 99, 10: 5000})
         assert_state(hass, entity_id, "9.9", POWER_WATT)
 
+        assert "active_power_max" not in hass.states.get(entity_id).attributes
+        await send_attributes_report(hass, cluster, {0: 1, 0x050D: 88, 10: 5000})
+        assert hass.states.get(entity_id).attributes["active_power_max"] == "8.8"
+
 
 async def async_test_powerconfiguration(hass, cluster, entity_id):
     """Test powerconfiguration/battery sensor."""
@@ -252,7 +256,7 @@ async def async_test_powerconfiguration(hass, cluster, entity_id):
             homeautomation.ElectricalMeasurement.cluster_id,
             "electrical_measurement",
             async_test_electrical_measurement,
-            1,
+            6,
             None,
             None,
         ),

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -503,6 +503,31 @@ async def test_electrical_measurement_init(
     "cluster_id, unsupported_attributes, entity_ids, missing_entity_ids",
     (
         (
+            homeautomation.ElectricalMeasurement.cluster_id,
+            {"rms_voltage", "rms_current"},
+            {"electrical_measurement"},
+            {
+                "electrical_measurement_rms_voltage",
+                "electrical_measurement_rms_current",
+            },
+        ),
+        (
+            homeautomation.ElectricalMeasurement.cluster_id,
+            {"rms_current"},
+            {"electrical_measurement_rms_voltage", "electrical_measurement"},
+            {"electrical_measurement_rms_current"},
+        ),
+        (
+            homeautomation.ElectricalMeasurement.cluster_id,
+            set(),
+            {
+                "electrical_measurement_rms_voltage",
+                "electrical_measurement",
+                "electrical_measurement_rms_current",
+            },
+            set(),
+        ),
+        (
             smartenergy.Metering.cluster_id,
             {
                 "instantaneous_demand",

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -117,6 +117,8 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.centralite_3210_l_77665544_electrical_measurement",
+            "sensor.centralite_3210_l_77665544_electrical_measurement_rms_current",
+            "sensor.centralite_3210_l_77665544_electrical_measurement_rms_voltage",
             "sensor.centralite_3210_l_77665544_smartenergy_metering",
             "sensor.centralite_3210_l_77665544_smartenergy_metering_summation_delivered",
             "switch.centralite_3210_l_77665544_on_off",
@@ -141,6 +143,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_77665544_electrical_measurement_rms_voltage",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
@@ -1436,6 +1448,8 @@ DEVICES = [
             "sensor.lumi_lumi_plug_maus01_77665544_analog_input",
             "sensor.lumi_lumi_plug_maus01_77665544_analog_input_2",
             "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement",
+            "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_rms_current",
+            "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_rms_voltage",
             "switch.lumi_lumi_plug_maus01_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
@@ -1458,6 +1472,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_rms_voltage",
             },
             ("binary_sensor", "00:11:22:33:44:55:66:77-100-15"): {
                 DEV_SIG_CHANNELS: ["binary_input"],
@@ -1493,6 +1517,8 @@ DEVICES = [
             "light.lumi_lumi_relay_c2acn01_77665544_on_off",
             "light.lumi_lumi_relay_c2acn01_77665544_on_off_2",
             "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement",
+            "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement_rms_current",
+            "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement_rms_voltage",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-1"): {
@@ -1504,6 +1530,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement_rms_voltage",
             },
             ("light", "00:11:22:33:44:55:66:77-2"): {
                 DEV_SIG_CHANNELS: ["on_off"],
@@ -2566,6 +2602,8 @@ DEVICES = [
         DEV_SIG_ENTITIES: [
             "light.osram_lightify_rt_tunable_white_77665544_level_light_color_on_off",
             "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement",
+            "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement_rms_current",
+            "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement_rms_voltage",
         ],
         DEV_SIG_ENT_MAP: {
             ("light", "00:11:22:33:44:55:66:77-3"): {
@@ -2577,6 +2615,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-3-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-3-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement_rms_voltage",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["3:0x0019"],
@@ -2598,6 +2646,8 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.osram_plug_01_77665544_electrical_measurement",
+            "sensor.osram_plug_01_77665544_electrical_measurement_rms_current",
+            "sensor.osram_plug_01_77665544_electrical_measurement_rms_voltage",
             "switch.osram_plug_01_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
@@ -2610,6 +2660,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.osram_plug_01_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-3-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.osram_plug_01_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-3-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.osram_plug_01_77665544_electrical_measurement_rms_voltage",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["3:0x0019"],
@@ -2870,6 +2930,8 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.securifi_ltd_unk_model_77665544_electrical_measurement",
+            "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_rms_current",
+            "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_rms_voltage",
             "switch.securifi_ltd_unk_model_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
@@ -2882,6 +2944,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.securifi_ltd_unk_model_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_rms_voltage",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["1:0x0005", "1:0x0006", "1:0x0019"],
@@ -2948,6 +3020,8 @@ DEVICES = [
         DEV_SIG_ENTITIES: [
             "light.sercomm_corp_sz_esw01_77665544_on_off",
             "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement",
+            "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_rms_current",
+            "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_rms_voltage",
             "sensor.sercomm_corp_sz_esw01_77665544_smartenergy_metering",
             "sensor.sercomm_corp_sz_esw01_77665544_smartenergy_metering_summation_delivered",
         ],
@@ -2971,6 +3045,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_rms_voltage",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["1:0x0019", "2:0x0006"],
@@ -3035,6 +3119,8 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement",
+            "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_rms_current",
+            "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_rms_voltage",
             "switch.sinope_technologies_rm3250zb_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
@@ -3047,6 +3133,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_rms_voltage",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
@@ -3075,6 +3171,8 @@ DEVICES = [
         DEV_SIG_ENTITIES: [
             "climate.sinope_technologies_th1123zb_77665544_thermostat",
             "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement",
+            "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_rms_current",
+            "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_rms_voltage",
             "sensor.sinope_technologies_th1123zb_77665544_temperature",
         ],
         DEV_SIG_ENT_MAP: {
@@ -3092,6 +3190,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_rms_voltage",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
@@ -3120,6 +3228,8 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement",
+            "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_rms_current",
+            "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_rms_voltage",
             "sensor.sinope_technologies_th1124zb_77665544_temperature",
             "climate.sinope_technologies_th1124zb_77665544_thermostat",
         ],
@@ -3138,6 +3248,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_rms_voltage",
             },
         },
         DEV_SIG_EVT_CHANNELS: ["1:0x0019"],
@@ -3159,6 +3279,8 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.smartthings_outletv4_77665544_electrical_measurement",
+            "sensor.smartthings_outletv4_77665544_electrical_measurement_rms_current",
+            "sensor.smartthings_outletv4_77665544_electrical_measurement_rms_voltage",
             "switch.smartthings_outletv4_77665544_on_off",
         ],
         DEV_SIG_ENT_MAP: {
@@ -3171,6 +3293,16 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.smartthings_outletv4_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.smartthings_outletv4_77665544_electrical_measurement_rms_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.smartthings_outletv4_77665544_electrical_measurement_rms_voltage",
             },
             ("binary_sensor", "00:11:22:33:44:55:66:77-1-15"): {
                 DEV_SIG_CHANNELS: ["binary_input"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No, but users need to reconfigure affected ZHA devices using ZHA device panel

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for RMS Voltage and RMS Current sensors of ElectricalMeasurement ZCL cluster.
Add state attributes for the max values as reported by device and measurement type

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
