### PR TITLE
Recreate the powerwall session/object when attempting relogin

### DIFF
--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -91,11 +91,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry_id = entry.entry_id
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN].setdefault(entry_id, {})
     http_session = requests.Session()
+    ip_address = entry.data[CONF_IP_ADDRESS]
 
     password = entry.data.get(CONF_PASSWORD)
-    power_wall = Powerwall(entry.data[CONF_IP_ADDRESS], http_session=http_session)
+    power_wall = Powerwall(ip_address, http_session=http_session)
     try:
         powerwall_data = await hass.async_add_executor_job(
             _login_and_fetch_base_info, power_wall, password
@@ -115,13 +115,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await _migrate_old_unique_ids(hass, entry_id, powerwall_data)
     login_failed_count = 0
 
+    entry_data = hass.data[DOMAIN][entry.entry_id] = {
+        POWERWALL_API_CHANGED: False,
+        POWERWALL_HTTP_SESSION: http_session,
+    }
+
+    def _recreate_powerwall_login():
+        nonlocal http_session
+        nonlocal power_wall
+        http_session.close()
+        http_session = requests.Session()
+        power_wall = Powerwall(ip_address, http_session=http_session)
+        entry_data[POWERWALL_OBJECT] = power_wall
+        entry_data[POWERWALL_HTTP_SESSION] = http_session
+        power_wall.login("", password)
+
     async def async_update_data():
         """Fetch data from API endpoint."""
         # Check if we had an error before
         nonlocal login_failed_count
         _LOGGER.debug("Checking if update failed")
-        if hass.data[DOMAIN][entry.entry_id][POWERWALL_API_CHANGED]:
-            return hass.data[DOMAIN][entry.entry_id][POWERWALL_COORDINATOR].data
+        if entry_data[POWERWALL_API_CHANGED]:
+            return entry_data[POWERWALL_COORDINATOR].data
 
         _LOGGER.debug("Updating data")
         try:
@@ -130,9 +145,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if password is None:
                 raise ConfigEntryAuthFailed from err
 
-            # If the session expired, relogin, and try again
+            # If the session expired, recreate, relogin, and try again
             try:
-                await hass.async_add_executor_job(power_wall.login, "", password)
+                await hass.async_add_executor_job(_recreate_powerwall_login)
                 return await _async_update_powerwall_data(hass, entry, power_wall)
             except AccessDeniedError as ex:
                 login_failed_count += 1
@@ -153,13 +168,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_interval=timedelta(seconds=UPDATE_INTERVAL),
     )
 
-    hass.data[DOMAIN][entry.entry_id] = powerwall_data
-    hass.data[DOMAIN][entry.entry_id].update(
+    entry_data.update(
         {
+            **powerwall_data,
             POWERWALL_OBJECT: power_wall,
             POWERWALL_COORDINATOR: coordinator,
-            POWERWALL_HTTP_SESSION: http_session,
-            POWERWALL_API_CHANGED: False,
         }
     )
 

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -115,7 +115,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await _migrate_old_unique_ids(hass, entry_id, powerwall_data)
     login_failed_count = 0
 
-    entry_data = hass.data[DOMAIN][entry.entry_id] = {
+    runtime_data = hass.data[DOMAIN][entry.entry_id] = {
         POWERWALL_API_CHANGED: False,
         POWERWALL_HTTP_SESSION: http_session,
     }
@@ -126,8 +126,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         http_session.close()
         http_session = requests.Session()
         power_wall = Powerwall(ip_address, http_session=http_session)
-        entry_data[POWERWALL_OBJECT] = power_wall
-        entry_data[POWERWALL_HTTP_SESSION] = http_session
+        runtime_data[POWERWALL_OBJECT] = power_wall
+        runtime_data[POWERWALL_HTTP_SESSION] = http_session
         power_wall.login("", password)
 
     async def async_update_data():
@@ -135,8 +135,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Check if we had an error before
         nonlocal login_failed_count
         _LOGGER.debug("Checking if update failed")
-        if entry_data[POWERWALL_API_CHANGED]:
-            return entry_data[POWERWALL_COORDINATOR].data
+        if runtime_data[POWERWALL_API_CHANGED]:
+            return runtime_data[POWERWALL_COORDINATOR].data
 
         _LOGGER.debug("Updating data")
         try:
@@ -168,7 +168,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_interval=timedelta(seconds=UPDATE_INTERVAL),
     )
 
-    entry_data.update(
+    runtime_data.update(
         {
             **powerwall_data,
             POWERWALL_OBJECT: power_wall,


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The previous session can prevent the powerwall from
  accepting a new login

Attempt at fixing #56839

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
