### PR TITLE
Use NamedTuple for darksky condition picture

### DIFF
--- a/homeassistant/components/darksky/sensor.py
+++ b/homeassistant/components/darksky/sensor.py
@@ -1,6 +1,9 @@
 """Support for Dark Sky weather service."""
+from __future__ import annotations
+
 from datetime import timedelta
 import logging
+from typing import NamedTuple
 
 import forecastio
 from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
@@ -384,23 +387,55 @@ SENSOR_TYPES = {
     "alerts": ["Alerts", None, None, None, None, None, "mdi:alert-circle-outline", []],
 }
 
-CONDITION_PICTURES = {
-    "clear-day": ["/static/images/darksky/weather-sunny.svg", "mdi:weather-sunny"],
-    "clear-night": ["/static/images/darksky/weather-night.svg", "mdi:weather-night"],
-    "rain": ["/static/images/darksky/weather-pouring.svg", "mdi:weather-pouring"],
-    "snow": ["/static/images/darksky/weather-snowy.svg", "mdi:weather-snowy"],
-    "sleet": ["/static/images/darksky/weather-hail.svg", "mdi:weather-snowy-rainy"],
-    "wind": ["/static/images/darksky/weather-windy.svg", "mdi:weather-windy"],
-    "fog": ["/static/images/darksky/weather-fog.svg", "mdi:weather-fog"],
-    "cloudy": ["/static/images/darksky/weather-cloudy.svg", "mdi:weather-cloudy"],
-    "partly-cloudy-day": [
-        "/static/images/darksky/weather-partlycloudy.svg",
-        "mdi:weather-partly-cloudy",
-    ],
-    "partly-cloudy-night": [
-        "/static/images/darksky/weather-cloudy.svg",
-        "mdi:weather-night-partly-cloudy",
-    ],
+
+class ConditionPicture(NamedTuple):
+    """Entity picture and icon for condition."""
+
+    entity_picture: str
+    icon: str
+
+
+CONDITION_PICTURES: dict[str, ConditionPicture] = {
+    "clear-day": ConditionPicture(
+        entity_picture="/static/images/darksky/weather-sunny.svg",
+        icon="mdi:weather-sunny",
+    ),
+    "clear-night": ConditionPicture(
+        entity_picture="/static/images/darksky/weather-night.svg",
+        icon="mdi:weather-night",
+    ),
+    "rain": ConditionPicture(
+        entity_picture="/static/images/darksky/weather-pouring.svg",
+        icon="mdi:weather-pouring",
+    ),
+    "snow": ConditionPicture(
+        entity_picture="/static/images/darksky/weather-snowy.svg",
+        icon="mdi:weather-snowy",
+    ),
+    "sleet": ConditionPicture(
+        entity_picture="/static/images/darksky/weather-hail.svg",
+        icon="mdi:weather-snowy-rainy",
+    ),
+    "wind": ConditionPicture(
+        entity_picture="/static/images/darksky/weather-windy.svg",
+        icon="mdi:weather-windy",
+    ),
+    "fog": ConditionPicture(
+        entity_picture="/static/images/darksky/weather-fog.svg",
+        icon="mdi:weather-fog",
+    ),
+    "cloudy": ConditionPicture(
+        entity_picture="/static/images/darksky/weather-cloudy.svg",
+        icon="mdi:weather-cloudy",
+    ),
+    "partly-cloudy-day": ConditionPicture(
+        entity_picture="/static/images/darksky/weather-partlycloudy.svg",
+        icon="mdi:weather-partly-cloudy",
+    ),
+    "partly-cloudy-night": ConditionPicture(
+        entity_picture="/static/images/darksky/weather-cloudy.svg",
+        icon="mdi:weather-night-partly-cloudy",
+    ),
 }
 
 # Language Supported Codes
@@ -595,7 +630,7 @@ class DarkSkySensor(SensorEntity):
             return None
 
         if self._icon in CONDITION_PICTURES:
-            return CONDITION_PICTURES[self._icon][0]
+            return CONDITION_PICTURES[self._icon].entity_picture
 
         return None
 
@@ -610,7 +645,7 @@ class DarkSkySensor(SensorEntity):
     def icon(self):
         """Icon to use in the frontend, if any."""
         if "summary" in self.type and self._icon in CONDITION_PICTURES:
-            return CONDITION_PICTURES[self._icon][1]
+            return CONDITION_PICTURES[self._icon].icon
 
         return SENSOR_TYPES[self.type][6]
 


### PR DESCRIPTION
## Proposed change
Use `NamedTuple` for a small code quality improvement.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
