### PR TITLE
Use NamedTuple for iqvia rating

### DIFF
--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from statistics import mean
+from typing import NamedTuple
 
 import numpy as np
 
@@ -53,12 +54,21 @@ API_CATEGORY_MAPPING = {
     TYPE_DISEASE_TODAY: TYPE_DISEASE_INDEX,
 }
 
-RATING_MAPPING = [
-    {"label": "Low", "minimum": 0.0, "maximum": 2.4},
-    {"label": "Low/Medium", "minimum": 2.5, "maximum": 4.8},
-    {"label": "Medium", "minimum": 4.9, "maximum": 7.2},
-    {"label": "Medium/High", "minimum": 7.3, "maximum": 9.6},
-    {"label": "High", "minimum": 9.7, "maximum": 12},
+
+class Rating(NamedTuple):
+    """Assign label to value range."""
+
+    label: str
+    minimum: float
+    maximum: float
+
+
+RATING_MAPPING: list[Rating] = [
+    Rating(label="Low", minimum=0.0, maximum=2.4),
+    Rating(label="Low/Medium", minimum=2.5, maximum=4.8),
+    Rating(label="Medium", minimum=4.9, maximum=7.2),
+    Rating(label="Medium/High", minimum=7.3, maximum=9.6),
+    Rating(label="High", minimum=9.7, maximum=12),
 ]
 
 
@@ -182,9 +192,7 @@ class ForecastSensor(IQVIAEntity, SensorEntity):
         indices = [p["Index"] for p in data["periods"]]
         average = round(mean(indices), 1)
         [rating] = [
-            i["label"]
-            for i in RATING_MAPPING
-            if i["minimum"] <= average <= i["maximum"]
+            i.label for i in RATING_MAPPING if i.minimum <= average <= i.maximum
         ]
 
         self._attr_native_value = average
@@ -247,9 +255,7 @@ class IndexSensor(IQVIAEntity, SensorEntity):
             return
 
         [rating] = [
-            i["label"]
-            for i in RATING_MAPPING
-            if i["minimum"] <= period["Index"] <= i["maximum"]
+            i.label for i in RATING_MAPPING if i.minimum <= period["Index"] <= i.maximum
         ]
 
         self._attr_extra_state_attributes.update(


### PR DESCRIPTION
## Proposed change
Use `NamedTuple` for a small code quality improvement.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
