### PR TITLE
Use NamedTuple for homekit valve type + service info

### DIFF
--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -1,5 +1,8 @@
 """Class to hold all switch accessories."""
+from __future__ import annotations
+
 import logging
+from typing import NamedTuple
 
 from pyhap.const import (
     CATEGORY_FAUCET,
@@ -50,11 +53,19 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-VALVE_TYPE = {
-    TYPE_FAUCET: (CATEGORY_FAUCET, 3),
-    TYPE_SHOWER: (CATEGORY_SHOWER_HEAD, 2),
-    TYPE_SPRINKLER: (CATEGORY_SPRINKLER, 1),
-    TYPE_VALVE: (CATEGORY_FAUCET, 0),
+
+class ValveInfo(NamedTuple):
+    """Category and type information for valve."""
+
+    category: int
+    valve_type: int
+
+
+VALVE_TYPE: dict[str, ValveInfo] = {
+    TYPE_FAUCET: ValveInfo(CATEGORY_FAUCET, 3),
+    TYPE_SHOWER: ValveInfo(CATEGORY_SHOWER_HEAD, 2),
+    TYPE_SPRINKLER: ValveInfo(CATEGORY_SPRINKLER, 1),
+    TYPE_VALVE: ValveInfo(CATEGORY_FAUCET, 0),
 }
 
 
@@ -199,7 +210,7 @@ class Valve(HomeAccessory):
         super().__init__(*args)
         state = self.hass.states.get(self.entity_id)
         valve_type = self.config[CONF_TYPE]
-        self.category = VALVE_TYPE[valve_type][0]
+        self.category = VALVE_TYPE[valve_type].category
 
         serv_valve = self.add_preload_service(SERV_VALVE)
         self.char_active = serv_valve.configure_char(
@@ -207,7 +218,7 @@ class Valve(HomeAccessory):
         )
         self.char_in_use = serv_valve.configure_char(CHAR_IN_USE, value=False)
         self.char_valve_type = serv_valve.configure_char(
-            CHAR_VALVE_TYPE, value=VALVE_TYPE[valve_type][1]
+            CHAR_VALVE_TYPE, value=VALVE_TYPE[valve_type].valve_type
         )
         # Set the state so it is in sync on initial
         # GET to avoid an event storm after homekit startup


### PR DESCRIPTION
## Proposed change
Use `NamedTuple` for a small code quality improvement.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
