### PR TITLE
Fix yeelight state when controlled outside of Home Assistant

### DIFF
--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -36,6 +36,9 @@ from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
+STATE_CHANGE_TIME = 0.25  # seconds
+
+
 DOMAIN = "yeelight"
 DATA_YEELIGHT = DOMAIN
 DATA_UPDATED = "yeelight_{}_data_updated"
@@ -693,11 +696,28 @@ class YeelightDevice:
         async_dispatcher_send(self._hass, DATA_UPDATED.format(self._host))
 
     @callback
+    def update_needs_bg_power_workaround(self, data):
+        """Check if a push update needs the bg_power workaround.
+
+        Some devices will push the incorrect state for bg_power.
+
+        To work around this any time we are pushed an update
+        with bg_power, we force poll state which will be correct.
+        """
+        return "bg_power" in data
+
+    async def _async_forced_update(self, _now):
+        """Call a forced update."""
+        await self.async_update(True)
+
+    @callback
     def async_update_callback(self, data):
         """Update push from device."""
         was_available = self._available
         self._available = data.get(KEY_CONNECTED, True)
-        if self._did_first_update and not was_available and self._available:
+        if self.update_needs_bg_power_workaround(data) or (
+            self._did_first_update and not was_available and self._available
+        ):
             # On reconnect the properties may be out of sync
             #
             # We need to make sure the DEVICE_INITIALIZED dispatcher is setup
@@ -708,7 +728,7 @@ class YeelightDevice:
             # to be called when async_setup_entry reaches the end of the
             # function
             #
-            asyncio.create_task(self.async_update(True))
+            async_call_later(self._hass, STATE_CHANGE_TIME, self._async_forced_update)
         async_dispatcher_send(self._hass, DATA_UPDATED.format(self._host))
 
 

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -1,7 +1,6 @@
 """Light platform support for yeelight."""
 from __future__ import annotations
 
-import asyncio
 import logging
 import math
 
@@ -208,9 +207,6 @@ SERVICE_SCHEMA_SET_AUTO_DELAY_OFF_SCENE = {
     vol.Required(ATTR_MINUTES): vol.All(vol.Coerce(int), vol.Range(min=1, max=60)),
     vol.Required(ATTR_BRIGHTNESS): VALID_BRIGHTNESS,
 }
-
-
-STATE_CHANGE_TIME = 0.25  # seconds
 
 
 @callback
@@ -762,11 +758,6 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         if self.config[CONF_SAVE_ON_CHANGE] and (brightness or colortemp or rgb):
             await self.async_set_default()
 
-        # Some devices (mainly nightlights) will not send back the on state so we need to force a refresh
-        await asyncio.sleep(STATE_CHANGE_TIME)
-        if not self.is_on:
-            await self.device.async_update(True)
-
     @_async_cmd
     async def _async_turn_off(self, duration) -> None:
         """Turn off with a given transition duration wrapped with _async_cmd."""
@@ -782,10 +773,6 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
             duration = int(kwargs.get(ATTR_TRANSITION) * 1000)  # kwarg in s
 
         await self._async_turn_off(duration)
-        # Some devices will not send back the off state so we need to force a refresh
-        await asyncio.sleep(STATE_CHANGE_TIME)
-        if self.is_on:
-            await self.device.async_update(True)
 
     @_async_cmd
     async def async_set_mode(self, mode: str):
@@ -861,7 +848,7 @@ class YeelightColorLightWithoutNightlightSwitch(
         # want to "current_brightness" since it will check
         # "bg_power" and main light could still be on
         if self.device.is_nightlight_enabled:
-            return "current_brightness"
+            return "nl_br"
         return super()._brightness_property
 
 
@@ -890,7 +877,7 @@ class YeelightWhiteTempWithoutNightlightSwitch(
         # want to "current_brightness" since it will check
         # "bg_power" and main light could still be on
         if self.device.is_nightlight_enabled:
-            return "current_brightness"
+            return "nl_br"
         return super()._brightness_property
 
 

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -907,8 +907,8 @@ class YeelightWithNightLight(
 class YeelightNightLightMode(YeelightGenericLight):
     """Representation of a Yeelight when in nightlight mode."""
 
-    _attr_color_mode = COLOR_MODE_COLOR_TEMP
-    _attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS, COLOR_MODE_COLOR_TEMP}
+    _attr_color_mode = COLOR_MODE_BRIGHTNESS
+    _attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS}
 
     @property
     def unique_id(self) -> str:
@@ -950,20 +950,9 @@ class YeelightNightLightMode(YeelightGenericLight):
         return None
 
     @property
-    def color_temp(self) -> int:
-        """Return the color temperature.
-
-        The nightlight locks the colortemp to max mireds.
-        """
-        return self._max_mireds
-
-    @property
-    def min_mireds(self) -> int:
-        """Return the color temperature.
-
-        The nightlight locks the colortemp to max mireds.
-        """
-        return self._max_mireds
+    def supported_features(self):
+        """Flag no supported features."""
+        return 0
 
 
 class YeelightNightLightModeWithAmbientSupport(YeelightNightLightMode):
@@ -982,11 +971,6 @@ class YeelightNightLightModeWithoutBrightnessControl(YeelightNightLightMode):
 
     _attr_color_mode = COLOR_MODE_ONOFF
     _attr_supported_color_modes = {COLOR_MODE_ONOFF}
-
-    @property
-    def supported_features(self):
-        """Flag no supported features."""
-        return 0
 
 
 class YeelightWithAmbientWithoutNightlight(YeelightWhiteTempWithoutNightlightSwitch):

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -855,9 +855,8 @@ class YeelightWithoutNightlightSwitchMixIn:
     def color_temp(self) -> int:
         """Return the color temperature."""
         if self.device.is_nightlight_enabled:
-            # Enabling the nightlight locks the colortemp
-            # to max
-            return self.max_mireds
+            # Enabling the nightlight locks the colortemp to max
+            return self._max_mireds
         return super().color_temp
 
 
@@ -908,6 +907,9 @@ class YeelightWithNightLight(
 class YeelightNightLightMode(YeelightGenericLight):
     """Representation of a Yeelight when in nightlight mode."""
 
+    _attr_color_mode = COLOR_MODE_COLOR_TEMP
+    _attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS, COLOR_MODE_COLOR_TEMP}
+
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
@@ -938,8 +940,30 @@ class YeelightNightLightMode(YeelightGenericLight):
         return PowerMode.MOONLIGHT
 
     @property
-    def _predefined_effects(self):
-        return YEELIGHT_TEMP_ONLY_EFFECT_LIST
+    def effect_list(self):
+        """Disable effects as they turn off the nightlight."""
+        return None
+
+    @property
+    def effect(self):
+        """Disable effects as they turn off the nightlight."""
+        return None
+
+    @property
+    def color_temp(self) -> int:
+        """Return the color temperature.
+
+        The nightlight locks the colortemp to max mireds.
+        """
+        return self._max_mireds
+
+    @property
+    def min_mireds(self) -> int:
+        """Return the color temperature.
+
+        The nightlight locks the colortemp to max mireds.
+        """
+        return self._max_mireds
 
 
 class YeelightNightLightModeWithAmbientSupport(YeelightNightLightMode):

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -248,13 +248,15 @@ def _async_cmd(func):
             # A network error happened, the bulb is likely offline now
             self.device.async_mark_unavailable()
             self.async_write_ha_state()
+            exc_message = str(ex) or type(ex)
             raise HomeAssistantError(
-                f"Error when calling {func.__name__} for bulb {self.device.name} at {self.device.host}: {ex}"
+                f"Error when calling {func.__name__} for bulb {self.device.name} at {self.device.host}: {exc_message}"
             ) from ex
         except BULB_EXCEPTIONS as ex:
             # The bulb likely responded but had an error
+            exc_message = str(ex) or type(ex)
             raise HomeAssistantError(
-                f"Error when calling {func.__name__} for bulb {self.device.name} at {self.device.host}: {ex}"
+                f"Error when calling {func.__name__} for bulb {self.device.name} at {self.device.host}: {exc_message}"
             ) from ex
 
     return _async_wrap

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -940,16 +940,6 @@ class YeelightNightLightMode(YeelightGenericLight):
         return PowerMode.MOONLIGHT
 
     @property
-    def effect_list(self):
-        """Disable effects as they turn off the nightlight."""
-        return None
-
-    @property
-    def effect(self):
-        """Disable effects as they turn off the nightlight."""
-        return None
-
-    @property
     def supported_features(self):
         """Flag no supported features."""
         return 0

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -839,10 +839,8 @@ class YeelightNightLightSupport:
         return PowerMode.NORMAL
 
 
-class YeelightColorLightWithoutNightlightSwitch(
-    YeelightColorLightSupport, YeelightGenericLight
-):
-    """Representation of a Color Yeelight light."""
+class YeelightWithoutNightlightSwitchMixIn:
+    """A mix-in for yeelights without a nightlight switch."""
 
     @property
     def _brightness_property(self):
@@ -852,6 +850,23 @@ class YeelightColorLightWithoutNightlightSwitch(
         if self.device.is_nightlight_enabled:
             return "nl_br"
         return super()._brightness_property
+
+    @property
+    def color_temp(self) -> int:
+        """Return the color temperature."""
+        if self.device.is_nightlight_enabled:
+            # Enabling the nightlight locks the colortemp
+            # to max
+            return self.max_mireds
+        return super().color_temp
+
+
+class YeelightColorLightWithoutNightlightSwitch(
+    YeelightColorLightSupport,
+    YeelightWithoutNightlightSwitchMixIn,
+    YeelightGenericLight,
+):
+    """Representation of a Color Yeelight light."""
 
 
 class YeelightColorLightWithNightlightSwitch(
@@ -869,18 +884,11 @@ class YeelightColorLightWithNightlightSwitch(
 
 
 class YeelightWhiteTempWithoutNightlightSwitch(
-    YeelightWhiteTempLightSupport, YeelightGenericLight
+    YeelightWhiteTempLightSupport,
+    YeelightWithoutNightlightSwitchMixIn,
+    YeelightGenericLight,
 ):
     """White temp light, when nightlight switch is not set to light."""
-
-    @property
-    def _brightness_property(self):
-        # If the nightlight is not active, we do not
-        # want to "current_brightness" since it will check
-        # "bg_power" and main light could still be on
-        if self.device.is_nightlight_enabled:
-            return "nl_br"
-        return super()._brightness_property
 
 
 class YeelightWithNightLight(

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -13,6 +13,7 @@ from homeassistant.components.yeelight import (
     DATA_DEVICE,
     DOMAIN,
     NIGHTLIGHT_SWITCH_TYPE_LIGHT,
+    STATE_CHANGE_TIME,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -458,6 +459,8 @@ async def test_connection_dropped_resyncs_properties(hass: HomeAssistant):
         await hass.async_block_till_done()
         assert len(mocked_bulb.async_get_properties.mock_calls) == 1
         mocked_bulb._async_callback({KEY_CONNECTED: True})
-        await hass.async_block_till_done()
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=STATE_CHANGE_TIME)
+        )
         await hass.async_block_till_done()
         assert len(mocked_bulb.async_get_properties.mock_calls) == 2

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -545,25 +545,27 @@ async def test_update_errors(hass: HomeAssistant, caplog):
 
     # Timeout usually means the bulb is overloaded with commands
     # but will still respond eventually.
-    mocked_bulb.async_get_properties = AsyncMock(side_effect=asyncio.TimeoutError)
-    await hass.services.async_call(
-        "light",
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: ENTITY_LIGHT},
-        blocking=True,
-    )
+    mocked_bulb.async_turn_off = AsyncMock(side_effect=asyncio.TimeoutError)
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_LIGHT},
+            blocking=True,
+        )
     assert hass.states.get(ENTITY_LIGHT).state == STATE_ON
 
     # socket.error usually means the bulb dropped the connection
     # or lost wifi, then came back online and forced the existing
     # connection closed with a TCP RST
-    mocked_bulb.async_get_properties = AsyncMock(side_effect=socket.error)
-    await hass.services.async_call(
-        "light",
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: ENTITY_LIGHT},
-        blocking=True,
-    )
+    mocked_bulb.async_turn_off = AsyncMock(side_effect=socket.error)
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_LIGHT},
+            blocking=True,
+        )
     assert hass.states.get(ENTITY_LIGHT).state == STATE_UNAVAILABLE
 
 
@@ -572,6 +574,7 @@ async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant):
     mocked_bulb = _mocked_bulb()
     properties = {**PROPERTIES}
     properties.pop("active_mode")
+    properties.pop("nl_br")
     properties["color_mode"] = "3"  # HSV
     mocked_bulb.last_properties = properties
     mocked_bulb.bulb_type = BulbType.Color
@@ -579,7 +582,9 @@ async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant):
         domain=DOMAIN, data={**CONFIG_ENTRY_DATA, CONF_NIGHTLIGHT_SWITCH: False}
     )
     config_entry.add_to_hass(hass)
-    with patch(f"{MODULE}.AsyncBulb", return_value=mocked_bulb):
+    with _patch_discovery(), _patch_discovery_interval(), patch(
+        f"{MODULE}.AsyncBulb", return_value=mocked_bulb
+    ):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         # We use asyncio.create_task now to avoid
@@ -623,7 +628,7 @@ async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant):
         SERVICE_TURN_ON,
         {
             ATTR_ENTITY_ID: ENTITY_LIGHT,
-            ATTR_BRIGHTNESS_PCT: PROPERTIES["current_brightness"],
+            ATTR_BRIGHTNESS_PCT: PROPERTIES["bright"],
         },
         blocking=True,
     )
@@ -708,6 +713,8 @@ async def test_device_types(hass: HomeAssistant, caplog):
         mocked_bulb.bulb_type = bulb_type
         model_specs = _MODEL_SPECS.get(model)
         type(mocked_bulb).get_model_specs = MagicMock(return_value=model_specs)
+        original_nightlight_brightness = mocked_bulb.last_properties["nl_br"]
+        mocked_bulb.last_properties["nl_br"] = "0"
         await _async_setup(config_entry)
 
         state = hass.states.get(entity_id)
@@ -715,7 +722,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
         assert state.state == "on"
         target_properties["friendly_name"] = name
         target_properties["flowing"] = False
-        target_properties["night_light"] = True
+        target_properties["night_light"] = False
         target_properties["music_mode"] = False
         assert dict(state.attributes) == target_properties
 
@@ -725,6 +732,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
         registry.async_clear_config_entry(config_entry.entry_id)
 
         # nightlight
+        mocked_bulb.last_properties["nl_br"] = original_nightlight_brightness
         if nightlight_properties is None:
             return
         config_entry = MockConfigEntry(
@@ -749,7 +757,6 @@ async def test_device_types(hass: HomeAssistant, caplog):
         await hass.async_block_till_done()
 
     bright = round(255 * int(PROPERTIES["bright"]) / 100)
-    current_brightness = round(255 * int(PROPERTIES["current_brightness"]) / 100)
     ct = color_temperature_kelvin_to_mired(int(PROPERTIES["ct"]))
     hue = int(PROPERTIES["hue"])
     sat = int(PROPERTIES["sat"])
@@ -806,7 +813,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
             "max_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["min"]
             ),
-            "brightness": current_brightness,
+            "brightness": bright,
             "color_temp": ct,
             "color_mode": "color_temp",
             "supported_color_modes": ["color_temp", "hs", "rgb"],
@@ -836,7 +843,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
             "max_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["min"]
             ),
-            "brightness": current_brightness,
+            "brightness": bright,
             "hs_color": hs_color,
             "rgb_color": color_hs_to_RGB(*hs_color),
             "xy_color": color_hs_to_xy(*hs_color),
@@ -865,7 +872,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
             "max_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["min"]
             ),
-            "brightness": current_brightness,
+            "brightness": bright,
             "hs_color": color_RGB_to_hs(*rgb_color),
             "rgb_color": rgb_color,
             "xy_color": color_RGB_to_xy(*rgb_color),
@@ -895,7 +902,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
             "max_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["min"]
             ),
-            "brightness": current_brightness,
+            "brightness": bright,
             "color_mode": "hs",
             "supported_color_modes": ["color_temp", "hs", "rgb"],
         },
@@ -922,7 +929,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
             "max_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["min"]
             ),
-            "brightness": current_brightness,
+            "brightness": bright,
             "color_mode": "rgb",
             "supported_color_modes": ["color_temp", "hs", "rgb"],
         },
@@ -973,7 +980,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
             "max_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["min"]
             ),
-            "brightness": current_brightness,
+            "brightness": bright,
             "color_temp": ct,
             "color_mode": "color_temp",
             "supported_color_modes": ["color_temp"],
@@ -1009,7 +1016,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
             "max_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["min"]
             ),
-            "brightness": current_brightness,
+            "brightness": bright,
             "color_temp": ct,
             "color_mode": "color_temp",
             "supported_color_modes": ["color_temp"],
@@ -1261,62 +1268,6 @@ async def test_effects(hass: HomeAssistant):
     await _async_test_effect("not_existed", called=False)
 
 
-async def test_state_fails_to_update_triggers_update(hass: HomeAssistant):
-    """Ensure we call async_get_properties if the turn on/off fails to update the state."""
-    mocked_bulb = _mocked_bulb()
-    properties = {**PROPERTIES}
-    properties.pop("active_mode")
-    properties["color_mode"] = "3"  # HSV
-    mocked_bulb.last_properties = properties
-    mocked_bulb.bulb_type = BulbType.Color
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data={**CONFIG_ENTRY_DATA, CONF_NIGHTLIGHT_SWITCH: False}
-    )
-    config_entry.add_to_hass(hass)
-    with patch(f"{MODULE}.AsyncBulb", return_value=mocked_bulb):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-        # We use asyncio.create_task now to avoid
-        # blocking starting so we need to block again
-        await hass.async_block_till_done()
-
-    mocked_bulb.last_properties["power"] = "off"
-    await hass.services.async_call(
-        "light",
-        SERVICE_TURN_ON,
-        {
-            ATTR_ENTITY_ID: ENTITY_LIGHT,
-        },
-        blocking=True,
-    )
-    assert len(mocked_bulb.async_turn_on.mock_calls) == 1
-    assert len(mocked_bulb.async_get_properties.mock_calls) == 2
-
-    mocked_bulb.last_properties["power"] = "on"
-    await hass.services.async_call(
-        "light",
-        SERVICE_TURN_OFF,
-        {
-            ATTR_ENTITY_ID: ENTITY_LIGHT,
-        },
-        blocking=True,
-    )
-    assert len(mocked_bulb.async_turn_off.mock_calls) == 1
-    assert len(mocked_bulb.async_get_properties.mock_calls) == 3
-
-    # But if the state is correct no calls
-    await hass.services.async_call(
-        "light",
-        SERVICE_TURN_ON,
-        {
-            ATTR_ENTITY_ID: ENTITY_LIGHT,
-        },
-        blocking=True,
-    )
-    assert len(mocked_bulb.async_turn_on.mock_calls) == 1
-    assert len(mocked_bulb.async_get_properties.mock_calls) == 3
-
-
 async def test_ambilight_with_nightlight_disabled(hass: HomeAssistant):
     """Test that main light on ambilights with the nightlight disabled shows the correct brightness."""
     mocked_bulb = _mocked_bulb()
@@ -1325,7 +1276,6 @@ async def test_ambilight_with_nightlight_disabled(hass: HomeAssistant):
     capabilities["model"] = "ceiling10"
     properties["color_mode"] = "3"  # HSV
     properties["bg_power"] = "off"
-    properties["current_brightness"] = 0
     properties["bg_lmode"] = "2"  # CT
     mocked_bulb.last_properties = properties
     mocked_bulb.bulb_type = BulbType.WhiteTempMood

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -989,8 +989,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
             "xy_color": (0.421, 0.364),
         },
         {
-            "effect_list": YEELIGHT_TEMP_ONLY_EFFECT_LIST,
-            "supported_features": SUPPORT_YEELIGHT,
+            "supported_features": 0,
             "brightness": nl_br,
             "color_mode": "brightness",
             "supported_color_modes": ["brightness"],
@@ -1025,8 +1024,7 @@ async def test_device_types(hass: HomeAssistant, caplog):
             "xy_color": (0.421, 0.364),
         },
         {
-            "effect_list": YEELIGHT_TEMP_ONLY_EFFECT_LIST,
-            "supported_features": SUPPORT_YEELIGHT,
+            "supported_features": 0,
             "brightness": nl_br,
             "color_mode": "brightness",
             "supported_color_modes": ["brightness"],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Devices with bg_power would sometimes send back the wrong state
  after turning on/off power. We now always force an update
  when we get bg_power in an update. This replaces the
  check after turn on/turn off as its more robust as we
  only poll AFTER we get the push update to make sure its
  not too soon.

- If the nightlight is enabled, we always use nl_br for the
  brightness prop.

- Report color temp when nightlight mode is enabled as
  max_mireds since nightlight mode locks color temp but
  sends no update since the native yeelight app knows this.

Fixes #56471 Fixes #56749

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
