### PR TITLE
Add wemo options enable_subscription & enable_long_press

### DIFF
--- a/homeassistant/components/wemo/config_flow.py
+++ b/homeassistant/components/wemo/config_flow.py
@@ -52,7 +52,7 @@ class WemoOptionsFlow(OptionsFlow):
             try:
                 Options(**user_input)
             except OptionsValidationError as err:
-                errors = {err.field: err.error_string}
+                errors = {err.field_key: err.error_key}
             else:
                 return self.async_create_entry(title="", data=user_input)
 

--- a/homeassistant/components/wemo/config_flow.py
+++ b/homeassistant/components/wemo/config_flow.py
@@ -1,11 +1,18 @@
 """Config flow for Wemo."""
 
+from __future__ import annotations
+
+from typing import Any
+
 import pywemo
 
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_entry_flow
+from homeassistant.config_entries import ConfigEntry, OptionsFlow
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.config_entry_flow import DiscoveryFlowHandler
 
 from .const import DOMAIN
+from .wemo_device import Options
 
 
 async def _async_has_devices(hass: HomeAssistant) -> bool:
@@ -13,4 +20,35 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
     return bool(await hass.async_add_executor_job(pywemo.discover_devices))
 
 
-config_entry_flow.register_discovery_flow(DOMAIN, "Wemo", _async_has_devices)
+class WemoFlow(DiscoveryFlowHandler, domain=DOMAIN):
+    """Discovery flow with options for Wemo."""
+
+    def __init__(self) -> None:
+        """Init discovery flow."""
+        super().__init__(DOMAIN, "Wemo", _async_has_devices)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Get the options flow for this handler."""
+        return WemoOptionsFlow(config_entry)
+
+
+class WemoOptionsFlow(OptionsFlow):
+    """Options flow for the WeMo component."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage options for the WeMo component."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=Options(**self.config_entry.options).schema(),
+        )

--- a/homeassistant/components/wemo/strings.json
+++ b/homeassistant/components/wemo/strings.json
@@ -10,6 +10,16 @@
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "enable_subscription": "Subscribe to device local push updates",
+          "enable_long_press": "Register for device long-press events"
+        }
+      }
+    }
+  },
   "device_automation": {
     "trigger_type": {
       "long_press": "Wemo button was pressed for 2 seconds"

--- a/homeassistant/components/wemo/strings.json
+++ b/homeassistant/components/wemo/strings.json
@@ -15,7 +15,8 @@
       "init": {
         "data": {
           "enable_subscription": "Subscribe to device local push updates",
-          "enable_long_press": "Register for device long-press events"
+          "enable_long_press": "Register for device long-press events",
+          "polling_interval_seconds": "Seconds to wait between polling the device"
         }
       }
     }

--- a/homeassistant/components/wemo/strings.json
+++ b/homeassistant/components/wemo/strings.json
@@ -19,6 +19,10 @@
           "polling_interval_seconds": "Seconds to wait between polling the device"
         }
       }
+    },
+    "error": {
+      "long_press_requires_subscription": "Local push update subscriptions must be enabled to use long-press events",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },
   "device_automation": {

--- a/homeassistant/components/wemo/strings.json
+++ b/homeassistant/components/wemo/strings.json
@@ -22,6 +22,7 @@
     },
     "error": {
       "long_press_requires_subscription": "Local push update subscriptions must be enabled to use long-press events",
+      "polling_interval_to_small": "Polling more frequently than 10 seconds is not supported",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -47,7 +47,7 @@ class LongPressRequiresSubscriptionError(OptionsValidationError):
     error_string = "long_press_requires_subscription"
 
 
-@dataclass
+@dataclass(frozen=True)
 class Options:
     """Configuration options for the DeviceCoordinator class."""
 

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -1,11 +1,16 @@
 """Home Assistant wrapper for a pyWeMo device."""
+from __future__ import annotations
+
 import asyncio
+from dataclasses import dataclass, fields
 from datetime import timedelta
 import logging
+import typing
 
 from pywemo import Insight, LongPressMixin, WeMoDevice
 from pywemo.exceptions import ActionException
 from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -30,8 +35,42 @@ from .const import DOMAIN, WEMO_SUBSCRIPTION_EVENT
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass
+class Options:
+    """Configuration options for the DeviceCoordinator class."""
+
+    # Subscribe to device local push updates.
+    enable_subscription: bool = True
+
+    # Register for device long-press events.
+    enable_long_press: bool = True
+
+    def __post_init__(self) -> None:
+        """Validate parameters."""
+        if self.enable_subscription is False:
+            # Long press support requires subscriptions.
+            self.enable_long_press = False
+
+    def schema(self) -> vol.Schema:
+        """Return the Voluptuous schema for the Options instance.
+
+        All values are optional. The default value is set to the current value and
+        the type hint is set to the value of the field type annotation.
+        """
+        return vol.Schema(
+            {
+                vol.Optional(
+                    field.name, default=getattr(self, field.name)
+                ): typing.get_type_hints(self)[field.name]
+                for field in fields(self)
+            }
+        )
+
+
 class DeviceCoordinator(DataUpdateCoordinator[None]):
     """Home Assistant wrapper for a pyWeMo device."""
+
+    options: Options | None = None
 
     def __init__(self, hass: HomeAssistant, wemo: WeMoDevice, device_id: str) -> None:
         """Initialize DeviceCoordinator."""
@@ -45,7 +84,7 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
         self.wemo = wemo
         self.device_id = device_id
         self.device_info = _create_device_info(wemo)
-        self.supports_long_press = wemo.supports_long_press()
+        self.supports_long_press = isinstance(wemo, LongPressMixin)
         self.update_lock = asyncio.Lock()
 
     def subscription_callback(
@@ -67,6 +106,51 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
         else:
             updated = self.wemo.subscription_update(event_type, params)
             self.hass.create_task(self._async_subscription_callback(updated))
+
+    async def _async_set_enable_subscription(self, enable_subscription: bool) -> None:
+        """Turn on/off push updates from the device."""
+        registry = self.hass.data[DOMAIN]["registry"]
+        if enable_subscription:
+            registry.on(self.wemo, None, self.subscription_callback)
+            await self.hass.async_add_executor_job(registry.register, self.wemo)
+        elif self.options is not None:
+            await self.hass.async_add_executor_job(registry.unregister, self.wemo)
+
+    async def _async_set_enable_long_press(self, enable_long_press: bool) -> None:
+        """Turn on/off long-press events from the device."""
+        if not (isinstance(self.wemo, LongPressMixin) and self.supports_long_press):
+            return
+        try:
+            if enable_long_press:
+                await self.hass.async_add_executor_job(
+                    self.wemo.ensure_long_press_virtual_device
+                )
+            elif self.options is not None:
+                await self.hass.async_add_executor_job(
+                    self.wemo.remove_long_press_virtual_device
+                )
+        # Temporarily handling all exceptions for #52996 & pywemo/pywemo/issues/276
+        # Replace this with `except: PyWeMoException` after upstream has been fixed.
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Failed to enable long press support for device: %s", self.wemo.name
+            )
+            self.supports_long_press = False
+
+    async def async_set_options(
+        self, hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> None:
+        """Update the configuration options for the device."""
+        options = Options(**config_entry.options)
+        _LOGGER.debug(
+            "async_set_options old(%s) new(%s)", repr(self.options), repr(options)
+        )
+        for field in fields(options):
+            new_value = getattr(options, field.name)
+            if self.options is None or getattr(self.options, field.name) != new_value:
+                # The value changed, call the _async_set_* method for the option.
+                await getattr(self, f"_async_set_{field.name}")(new_value)
+        self.options = options
 
     async def _async_subscription_callback(self, updated: bool) -> None:
         """Update the state by the Wemo device."""
@@ -160,20 +244,11 @@ async def async_register_device(
 
     device = DeviceCoordinator(hass, wemo, entry.id)
     hass.data[DOMAIN].setdefault("devices", {})[entry.id] = device
-    registry = hass.data[DOMAIN]["registry"]
-    registry.on(wemo, None, device.subscription_callback)
-    await hass.async_add_executor_job(registry.register, wemo)
 
-    if isinstance(wemo, LongPressMixin):
-        try:
-            await hass.async_add_executor_job(wemo.ensure_long_press_virtual_device)
-        # Temporarily handling all exceptions for #52996 & pywemo/pywemo/issues/276
-        # Replace this with `except: PyWeMoException` after upstream has been fixed.
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception(
-                "Failed to enable long press support for device: %s", wemo.name
-            )
-            device.supports_long_press = False
+    config_entry.async_on_unload(
+        config_entry.add_update_listener(device.async_set_options)
+    )
+    await device.async_set_options(hass, config_entry)
 
     return device
 

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -8,7 +8,7 @@ import logging
 from typing import Literal
 
 from pywemo import Insight, LongPressMixin, WeMoDevice
-from pywemo.exceptions import ActionException
+from pywemo.exceptions import ActionException, PyWeMoException
 from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
 
 from homeassistant.config_entries import ConfigEntry
@@ -158,9 +158,7 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
                 await self.hass.async_add_executor_job(
                     self.wemo.remove_long_press_virtual_device
                 )
-        # Temporarily handling all exceptions for #52996 & pywemo/pywemo/issues/276
-        # Replace this with `except: PyWeMoException` after upstream has been fixed.
-        except Exception:  # pylint: disable=broad-except
+        except PyWeMoException:
             _LOGGER.exception(
                 "Failed to enable long press support for device: %s", self.wemo.name
             )

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -45,6 +45,9 @@ class Options:
     # Register for device long-press events.
     enable_long_press: bool = True
 
+    # Polling interval for when subscriptions are not enabled.
+    polling_interval_seconds: int = 30
+
     def __post_init__(self) -> None:
         """Validate parameters."""
         if self.enable_subscription is False:
@@ -78,7 +81,6 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
             hass,
             _LOGGER,
             name=wemo.name,
-            update_interval=timedelta(seconds=30),
         )
         self.hass = hass
         self.wemo = wemo
@@ -136,6 +138,11 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
                 "Failed to enable long press support for device: %s", self.wemo.name
             )
             self.supports_long_press = False
+
+    async def _async_set_polling_interval_seconds(
+        self, polling_interval_seconds: int
+    ) -> None:
+        self.update_interval = timedelta(seconds=polling_interval_seconds)
 
     async def async_set_options(
         self, hass: HomeAssistant, config_entry: ConfigEntry

--- a/homeassistant/components/wemo/wemo_device.py
+++ b/homeassistant/components/wemo/wemo_device.py
@@ -57,6 +57,7 @@ class OptionsValidationError(Exception):
           field_key: Name of the options.step.init.data key that corresponds to this error.
             field_key must also match one of the field names inside the Options class.
           error_key: Name of the options.error key that corresponds to this error.
+          message: Message for the Exception class.
         """
         super().__init__(message)
         self.field_key = field_key

--- a/tests/components/wemo/test_config_flow.py
+++ b/tests/components/wemo/test_config_flow.py
@@ -4,10 +4,7 @@ from dataclasses import asdict
 
 from homeassistant import data_entry_flow
 from homeassistant.components.wemo.const import DOMAIN
-from homeassistant.components.wemo.wemo_device import (
-    LongPressRequiresSubscriptionError,
-    Options,
-)
+from homeassistant.components.wemo.wemo_device import Options
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 
@@ -57,10 +54,16 @@ async def test_invalid_options(hass: HomeAssistant) -> None:
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "init"
 
+    # enable_subscription must be True if enable_long_press is True (default).
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={"enable_subscription": False}
     )
-
     assert result["errors"] == {
-        LongPressRequiresSubscriptionError.field: LongPressRequiresSubscriptionError.error_string
+        "enable_subscription": "long_press_requires_subscription"
     }
+
+    # polling_interval_seconds must be larger than 10.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"polling_interval_seconds": 1}
+    )
+    assert result["errors"] == {"polling_interval_seconds": "polling_interval_to_small"}

--- a/tests/components/wemo/test_config_flow.py
+++ b/tests/components/wemo/test_config_flow.py
@@ -1,11 +1,17 @@
 """Tests for Wemo config flow."""
 
+from dataclasses import asdict
+
 from homeassistant import data_entry_flow
 from homeassistant.components.wemo.const import DOMAIN
+from homeassistant.components.wemo.wemo_device import (
+    LongPressRequiresSubscriptionError,
+    Options,
+)
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 
-from tests.common import patch
+from tests.common import MockConfigEntry, patch
 
 
 async def test_not_discovered(hass: HomeAssistant) -> None:
@@ -20,3 +26,41 @@ async def test_not_discovered(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
     assert result["type"] == data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
+
+
+async def test_options(hass: HomeAssistant) -> None:
+    """Test updating options."""
+    options = Options(enable_subscription=False, enable_long_press=False)
+    entry = MockConfigEntry(domain=DOMAIN, title="Wemo")
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input=asdict(options)
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert Options(**result["data"]) == options
+
+
+async def test_invalid_options(hass: HomeAssistant) -> None:
+    """Test invalid option combinations."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Wemo")
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"enable_subscription": False}
+    )
+
+    assert result["errors"] == {
+        LongPressRequiresSubscriptionError.field: LongPressRequiresSubscriptionError.error_string
+    }

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -195,11 +195,13 @@ async def test_options_enable_subscription_false(
     """Test setting Options.enable_subscription = False."""
     config_entry = hass.config_entries.async_get_entry(wemo_entity.config_entry_id)
     assert hass.config_entries.async_update_entry(
-        config_entry, options=asdict(wemo_device.Options(enable_subscription=False))
+        config_entry,
+        options=asdict(
+            wemo_device.Options(enable_subscription=False, enable_long_press=False)
+        ),
     )
     await hass.async_block_till_done()
     pywemo_registry.unregister.assert_called_once_with(pywemo_device)
-    pywemo_device.remove_long_press_virtual_device.assert_called_once_with()
 
 
 async def test_options_enable_long_press_false(hass, pywemo_device, wemo_entity):
@@ -218,7 +220,11 @@ async def test_options_polling_interval_seconds(hass, pywemo_device, wemo_entity
     assert hass.config_entries.async_update_entry(
         config_entry,
         options=asdict(
-            wemo_device.Options(enable_subscription=False, polling_interval_seconds=45)
+            wemo_device.Options(
+                enable_subscription=False,
+                enable_long_press=False,
+                polling_interval_seconds=45,
+            )
         ),
     )
     await hass.async_block_till_done()

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -1,5 +1,6 @@
 """Tests for wemo_device.py."""
 import asyncio
+from dataclasses import asdict
 from datetime import timedelta
 from unittest.mock import call, patch
 
@@ -186,6 +187,29 @@ async def test_dli_device_info(
 
     assert device_entries[0].configuration_url == "http://127.0.0.1"
     assert device_entries[0].identifiers == {(DOMAIN, "123456789")}
+
+
+async def test_options_enable_subscription_false(
+    hass, pywemo_registry, pywemo_device, wemo_entity
+):
+    """Test setting Options.enable_subscription = False."""
+    config_entry = hass.config_entries.async_get_entry(wemo_entity.config_entry_id)
+    assert hass.config_entries.async_update_entry(
+        config_entry, options=asdict(wemo_device.Options(enable_subscription=False))
+    )
+    await hass.async_block_till_done()
+    pywemo_registry.unregister.assert_called_once_with(pywemo_device)
+    pywemo_device.remove_long_press_virtual_device.assert_called_once_with()
+
+
+async def test_options_enable_long_press_false(hass, pywemo_device, wemo_entity):
+    """Test setting Options.enable_long_press = False."""
+    config_entry = hass.config_entries.async_get_entry(wemo_entity.config_entry_id)
+    assert hass.config_entries.async_update_entry(
+        config_entry, options=asdict(wemo_device.Options(enable_long_press=False))
+    )
+    await hass.async_block_till_done()
+    pywemo_device.remove_long_press_virtual_device.assert_called_once_with()
 
 
 class TestInsight:

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -212,6 +212,33 @@ async def test_options_enable_long_press_false(hass, pywemo_device, wemo_entity)
     pywemo_device.remove_long_press_virtual_device.assert_called_once_with()
 
 
+async def test_options_polling_interval_seconds(hass, pywemo_device, wemo_entity):
+    """Test setting Options.polling_interval_seconds = 45."""
+    config_entry = hass.config_entries.async_get_entry(wemo_entity.config_entry_id)
+    assert hass.config_entries.async_update_entry(
+        config_entry,
+        options=asdict(
+            wemo_device.Options(enable_subscription=False, polling_interval_seconds=45)
+        ),
+    )
+    await hass.async_block_till_done()
+
+    # Move time forward to capture the new interval.
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+    pywemo_device.get_state.reset_mock()
+
+    # Make sure no polling occurs before 45 seconds.
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+    pywemo_device.get_state.assert_not_called()
+
+    # Polling occurred after the interval.
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=46))
+    await hass.async_block_till_done()
+    pywemo_device.get_state.assert_has_calls([call(True), call()])
+
+
 class TestInsight:
     """Tests specific to the WeMo Insight device."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding ConfigFlow options for Wemo to control subscriptions and the long-press feature. 

- Under some circumstances (#62224) push subscriptions are causing devices to stop responding to requests.
- Subscriptions do not work when the Wemo device is on a different subnet. Having subscriptions enabled seems to increase the flakyness of the device connection. https://github.com/pywemo/pywemo/issues/275
- Allowing users to put the device into polling mode, and then controlling the polling frequency, will cut down on large database sizes: #63704
- I'd also like to work on improving the long-press feature. Last time, however, the feature caused issues for a few users. Adding an option to disable the feature will be helpful to avoid future issues.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #62224
- This PR is related to issue: #63704 & https://github.com/pywemo/pywemo/issues/275
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20951

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
