### PR TITLE
Fix Tuya v2 login issue

### DIFF
--- a/homeassistant/components/tuya/config_flow.py
+++ b/homeassistant/components/tuya/config_flow.py
@@ -25,7 +25,6 @@ from .const import (
 
 RESULT_SINGLE_INSTANCE = "single_instance_allowed"
 RESULT_AUTH_FAILED = "invalid_auth"
-TUYA_ENDPOINT_BASE = "https://openapi.tuyacn.com"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,6 +56,7 @@ DATA_SCHEMA_SMART_HOME = vol.Schema(
     }
 )
 
+COUNTRY_CODE_CHINA = ["86", "+86", "China"]
 
 class TuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Tuya Config Flow."""
@@ -82,7 +82,11 @@ class TuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if project_type == ProjectType.INDUSTY_SOLUTIONS:
             response = api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
         else:
-            api.endpoint = TUYA_ENDPOINT_BASE
+            if user_input[CONF_COUNTRY_CODE] in COUNTRY_CODE_CHINA:
+                api.endpoint = "https://openapi.tuyacn.com"
+            else:
+                api.endpoint = "https://openapi.tuyaus.com"
+
             response = api.login(
                 user_input[CONF_USERNAME],
                 user_input[CONF_PASSWORD],

--- a/homeassistant/components/tuya/config_flow.py
+++ b/homeassistant/components/tuya/config_flow.py
@@ -25,6 +25,8 @@ from .const import (
 
 RESULT_SINGLE_INSTANCE = "single_instance_allowed"
 RESULT_AUTH_FAILED = "invalid_auth"
+TUYA_ENDPOINT_BASE = "https://openapi.tuyacn.com"
+TUYA_ENDPOINT_OTHER = "https://openapi.tuyaus.com"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,9 +85,9 @@ class TuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             response = api.login(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
         else:
             if user_input[CONF_COUNTRY_CODE] in COUNTRY_CODE_CHINA:
-                api.endpoint = "https://openapi.tuyacn.com"
+                api.endpoint = TUYA_ENDPOINT_BASE
             else:
-                api.endpoint = "https://openapi.tuyaus.com"
+                api.endpoint = TUYA_ENDPOINT_OTHER
 
             response = api.login(
                 user_input[CONF_USERNAME],

--- a/homeassistant/components/tuya/config_flow.py
+++ b/homeassistant/components/tuya/config_flow.py
@@ -59,6 +59,7 @@ DATA_SCHEMA_SMART_HOME = vol.Schema(
     }
 )
 
+
 class TuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Tuya Config Flow."""
 

--- a/homeassistant/components/tuya/config_flow.py
+++ b/homeassistant/components/tuya/config_flow.py
@@ -27,6 +27,7 @@ RESULT_SINGLE_INSTANCE = "single_instance_allowed"
 RESULT_AUTH_FAILED = "invalid_auth"
 TUYA_ENDPOINT_BASE = "https://openapi.tuyacn.com"
 TUYA_ENDPOINT_OTHER = "https://openapi.tuyaus.com"
+COUNTRY_CODE_CHINA = ["86", "+86", "China"]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,8 +58,6 @@ DATA_SCHEMA_SMART_HOME = vol.Schema(
         vol.Required(CONF_PASSWORD): str,
     }
 )
-
-COUNTRY_CODE_CHINA = ["86", "+86", "China"]
 
 class TuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Tuya Config Flow."""

--- a/tests/components/tuya/test_config_flow.py
+++ b/tests/components/tuya/test_config_flow.py
@@ -176,7 +176,7 @@ async def test_smart_home_user_other(hass, tuya):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "login"
-    
+
     tuya().login = MagicMock(return_value={"success": False, "errorCode": 1024})
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=TUYA_IMPORT_SMART_HOME_DATA_OTHER


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the login issue of Tuya v2 integration, related to region selection. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #56873
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
