### PR TITLE
Provide device_id in hue_event

### DIFF
--- a/homeassistant/components/hue/hue_event.py
+++ b/homeassistant/components/hue/hue_event.py
@@ -85,7 +85,7 @@ class HueEvent(GenericHueDevice):
         # Fire event
         data = {
             CONF_ID: self.event_id,
-            CONF_DEVICE_ID: self.device_id,
+            CONF_DEVICE_ID: self.device_registry_id,
             CONF_UNIQUE_ID: self.unique_id,
             CONF_EVENT: state,
             CONF_LAST_UPDATED: self.sensor.lastupdated,

--- a/homeassistant/components/hue/hue_event.py
+++ b/homeassistant/components/hue/hue_event.py
@@ -8,7 +8,7 @@ from aiohue.sensors import (
     TYPE_ZLL_SWITCH,
 )
 
-from homeassistant.const import CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
+from homeassistant.const import CONF_EVENT, CONF_ID, CONF_UNIQUE_ID, CONF_DEVICE_ID
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util, slugify
 
@@ -85,6 +85,7 @@ class HueEvent(GenericHueDevice):
         # Fire event
         data = {
             CONF_ID: self.event_id,
+            CONF_DEVICE_ID: self.device_id,
             CONF_UNIQUE_ID: self.unique_id,
             CONF_EVENT: state,
             CONF_LAST_UPDATED: self.sensor.lastupdated,

--- a/homeassistant/components/hue/hue_event.py
+++ b/homeassistant/components/hue/hue_event.py
@@ -8,7 +8,7 @@ from aiohue.sensors import (
     TYPE_ZLL_SWITCH,
 )
 
-from homeassistant.const import CONF_EVENT, CONF_ID, CONF_UNIQUE_ID, CONF_DEVICE_ID
+from homeassistant.const import CONF_DEVICE_ID, CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util, slugify
 

--- a/tests/components/hue/test_sensor_base.py
+++ b/tests/components/hue/test_sensor_base.py
@@ -467,7 +467,8 @@ async def test_hue_events(hass, mock_bridge):
     assert len(hass.states.async_all()) == 7
     assert len(events) == 1
     assert events[-1].data == {
-        "id": "hue_tap",
+        "device_id": '72ac629e89f0545fd6d78827fed81414',
+	"id": "hue_tap",
         "unique_id": "00:00:00:00:00:44:23:08-f2",
         "event": 18,
         "last_updated": "2019-12-28T22:58:03",

--- a/tests/components/hue/test_sensor_base.py
+++ b/tests/components/hue/test_sensor_base.py
@@ -13,15 +13,17 @@ from homeassistant.setup import async_setup_component
 from .conftest import create_mock_bridge, setup_bridge_for_sensors as setup_bridge
 
 from tests.common import (
-	async_capture_events, 
-	async_fire_time_changed, 
+    async_capture_events,
+    async_fire_time_changed,
     mock_device_registry,
 )
-    
+
+
 @pytest.fixture
 def device_reg(hass):
     """Return an empty, loaded, registry."""
-    return mock_device_registry(hass)    
+    return mock_device_registry(hass)
+
 
 PRESENCE_SENSOR_1_PRESENT = {
     "state": {"presence": True, "lastupdated": "2019-01-01T01:00:00"},
@@ -457,10 +459,10 @@ async def test_hue_events(hass, mock_bridge, device_reg):
     assert len(hass.states.async_all()) == 7
     assert len(events) == 0
 
-	hue_tap_device = device_reg.async_get_device(
-		{(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
-	)
-	
+    hue_tap_device = device_reg.async_get_device(
+        {(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
+    )
+
     mock_bridge.api.sensors["7"].last_event = {"type": "button"}
     mock_bridge.api.sensors["8"].last_event = {"type": "button"}
 
@@ -471,7 +473,7 @@ async def test_hue_events(hass, mock_bridge, device_reg):
         "lastupdated": "2019-12-28T22:58:03",
     }
     mock_bridge.mock_sensor_responses.append(new_sensor_response)
-    
+
     # Force updates to run again
     async_fire_time_changed(
         hass, dt_util.utcnow() + sensor_base.SensorManager.SCAN_INTERVAL
@@ -490,7 +492,7 @@ async def test_hue_events(hass, mock_bridge, device_reg):
     }
 
     hue_dimmer_device = device_reg.async_get_device(
-    	{(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
+        {(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
     )
 
     new_sensor_response = dict(new_sensor_response)
@@ -536,9 +538,9 @@ async def test_hue_events(hass, mock_bridge, device_reg):
     assert len(mock_bridge.mock_requests) == 4
     assert len(hass.states.async_all()) == 7
     assert len(events) == 2
-    
-	hue_aurora_device = device_reg.async_get_device(
-    	{(hue.DOMAIN, "ff:ff:00:0f:e7:fd:bc:b7")}
+
+    hue_aurora_device = device_reg.async_get_device(
+        {(hue.DOMAIN, "ff:ff:00:0f:e7:fd:bc:b7")}
     )
 
     # Add a new remote. In discovery the new event is registered **but not fired**
@@ -600,7 +602,7 @@ async def test_hue_events(hass, mock_bridge, device_reg):
     assert len(hass.states.async_all()) == 8
     assert len(events) == 3
     assert events[-1].data == {
-    	"device_id": hue_aurora_device.id,
+        "device_id": hue_aurora_device.id,
         "id": "lutron_aurora_1",
         "unique_id": "ff:ff:00:0f:e7:fd:bc:b7-01-fc00-0014",
         "event": 2,

--- a/tests/components/hue/test_sensor_base.py
+++ b/tests/components/hue/test_sensor_base.py
@@ -3,12 +3,12 @@ import asyncio
 from unittest.mock import Mock
 
 import aiohue
+import pytest
 
 from homeassistant.components import hue
 from homeassistant.components.hue import sensor_base
 from homeassistant.components.hue.hue_event import CONF_HUE_EVENT
 from homeassistant.util import dt as dt_util
-from homeassistant.setup import async_setup_component
 
 from .conftest import create_mock_bridge, setup_bridge_for_sensors as setup_bridge
 

--- a/tests/components/hue/test_sensor_base.py
+++ b/tests/components/hue/test_sensor_base.py
@@ -4,13 +4,24 @@ from unittest.mock import Mock
 
 import aiohue
 
+from homeassistant.components import hue
 from homeassistant.components.hue import sensor_base
 from homeassistant.components.hue.hue_event import CONF_HUE_EVENT
 from homeassistant.util import dt as dt_util
+from homeassistant.setup import async_setup_component
 
 from .conftest import create_mock_bridge, setup_bridge_for_sensors as setup_bridge
 
-from tests.common import async_capture_events, async_fire_time_changed
+from tests.common import (
+	async_capture_events, 
+	async_fire_time_changed, 
+    mock_device_registry,
+)
+    
+@pytest.fixture
+def device_reg(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)    
 
 PRESENCE_SENSOR_1_PRESENT = {
     "state": {"presence": True, "lastupdated": "2019-01-01T01:00:00"},
@@ -435,7 +446,7 @@ async def test_update_unauthorized(hass, mock_bridge):
     assert len(mock_bridge.handle_unauthorized_error.mock_calls) == 1
 
 
-async def test_hue_events(hass, mock_bridge):
+async def test_hue_events(hass, mock_bridge, device_reg):
     """Test that hue remotes fire events when pressed."""
     mock_bridge.mock_sensor_responses.append(SENSOR_RESPONSE)
 
@@ -446,6 +457,10 @@ async def test_hue_events(hass, mock_bridge):
     assert len(hass.states.async_all()) == 7
     assert len(events) == 0
 
+	hue_tap_device = device_reg.async_get_device(
+		{(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
+	)
+	
     mock_bridge.api.sensors["7"].last_event = {"type": "button"}
     mock_bridge.api.sensors["8"].last_event = {"type": "button"}
 
@@ -456,7 +471,7 @@ async def test_hue_events(hass, mock_bridge):
         "lastupdated": "2019-12-28T22:58:03",
     }
     mock_bridge.mock_sensor_responses.append(new_sensor_response)
-
+    
     # Force updates to run again
     async_fire_time_changed(
         hass, dt_util.utcnow() + sensor_base.SensorManager.SCAN_INTERVAL
@@ -467,12 +482,16 @@ async def test_hue_events(hass, mock_bridge):
     assert len(hass.states.async_all()) == 7
     assert len(events) == 1
     assert events[-1].data == {
-        "device_id": '72ac629e89f0545fd6d78827fed81414',
-	"id": "hue_tap",
+        "device_id": hue_tap_device.id,
+        "id": "hue_tap",
         "unique_id": "00:00:00:00:00:44:23:08-f2",
         "event": 18,
         "last_updated": "2019-12-28T22:58:03",
     }
+
+    hue_dimmer_device = device_reg.async_get_device(
+    	{(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
+    )
 
     new_sensor_response = dict(new_sensor_response)
     new_sensor_response["8"] = dict(new_sensor_response["8"])
@@ -492,6 +511,7 @@ async def test_hue_events(hass, mock_bridge):
     assert len(hass.states.async_all()) == 7
     assert len(events) == 2
     assert events[-1].data == {
+        "device_id": hue_dimmer_device.id,
         "id": "hue_dimmer_switch_1",
         "unique_id": "00:17:88:01:10:3e:3a:dc-02-fc00",
         "event": 3002,
@@ -516,6 +536,10 @@ async def test_hue_events(hass, mock_bridge):
     assert len(mock_bridge.mock_requests) == 4
     assert len(hass.states.async_all()) == 7
     assert len(events) == 2
+    
+	hue_aurora_device = device_reg.async_get_device(
+    	{(hue.DOMAIN, "ff:ff:00:0f:e7:fd:bc:b7")}
+    )
 
     # Add a new remote. In discovery the new event is registered **but not fired**
     new_sensor_response = dict(new_sensor_response)
@@ -576,6 +600,7 @@ async def test_hue_events(hass, mock_bridge):
     assert len(hass.states.async_all()) == 8
     assert len(events) == 3
     assert events[-1].data == {
+    	"device_id": hue_aurora_device.id,
         "id": "lutron_aurora_1",
         "unique_id": "ff:ff:00:0f:e7:fd:bc:b7-01-fc00-0014",
         "event": 2,

--- a/tests/components/hue/test_sensor_base.py
+++ b/tests/components/hue/test_sensor_base.py
@@ -539,10 +539,6 @@ async def test_hue_events(hass, mock_bridge, device_reg):
     assert len(hass.states.async_all()) == 7
     assert len(events) == 2
 
-    hue_aurora_device = device_reg.async_get_device(
-        {(hue.DOMAIN, "ff:ff:00:0f:e7:fd:bc:b7")}
-    )
-
     # Add a new remote. In discovery the new event is registered **but not fired**
     new_sensor_response = dict(new_sensor_response)
     new_sensor_response["21"] = {
@@ -597,6 +593,10 @@ async def test_hue_events(hass, mock_bridge, device_reg):
         hass, dt_util.utcnow() + sensor_base.SensorManager.SCAN_INTERVAL
     )
     await hass.async_block_till_done()
+
+    hue_aurora_device = device_reg.async_get_device(
+        {(hue.DOMAIN, "ff:ff:00:0f:e7:fd:bc:b7")}
+    )
 
     assert len(mock_bridge.mock_requests) == 6
     assert len(hass.states.async_all()) == 8


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For use in blueprints with selector on devices, you will need to match the trigger against a device_id.
This patch makes it possible to match the trigger by providing device_id as in other integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #56962
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
