### PR TITLE
Change precision of Nest sensors

### DIFF
--- a/homeassistant/components/nest/sensor_sdm.py
+++ b/homeassistant/components/nest/sensor_sdm.py
@@ -89,7 +89,7 @@ class TemperatureSensor(SensorBase):
     def native_value(self) -> float:
         """Return the state of the sensor."""
         trait: TemperatureTrait = self._device.traits[TemperatureTrait.NAME]
-        return trait.ambient_temperature_celsius
+        return round(trait.ambient_temperature_celsius, 1)
 
 
 class HumiditySensor(SensorBase):
@@ -107,4 +107,4 @@ class HumiditySensor(SensorBase):
     def native_value(self) -> float:
         """Return the state of the sensor."""
         trait: HumidityTrait = self._device.traits[HumidityTrait.NAME]
-        return trait.ambient_humidity_percent
+        return round(trait.ambient_humidity_percent, 0)

--- a/homeassistant/components/nest/sensor_sdm.py
+++ b/homeassistant/components/nest/sensor_sdm.py
@@ -89,6 +89,9 @@ class TemperatureSensor(SensorBase):
     def native_value(self) -> float:
         """Return the state of the sensor."""
         trait: TemperatureTrait = self._device.traits[TemperatureTrait.NAME]
+        # Round for display purposes because the API returns 5 decimal places. 
+        # This can be removed if the SDM API issue is fixed, or a frontend
+        # display fix is added for all integrations.
         return round(trait.ambient_temperature_celsius, 1)
 
 

--- a/homeassistant/components/nest/sensor_sdm.py
+++ b/homeassistant/components/nest/sensor_sdm.py
@@ -89,10 +89,10 @@ class TemperatureSensor(SensorBase):
     def native_value(self) -> float:
         """Return the state of the sensor."""
         trait: TemperatureTrait = self._device.traits[TemperatureTrait.NAME]
-        # Round for display purposes because the API returns 5 decimal places. 
+        # Round for display purposes because the API returns 5 decimal places.
         # This can be removed if the SDM API issue is fixed, or a frontend
         # display fix is added for all integrations.
-        return round(trait.ambient_temperature_celsius, 1)
+        return float(round(trait.ambient_temperature_celsius, 1))
 
 
 class HumiditySensor(SensorBase):
@@ -107,7 +107,8 @@ class HumiditySensor(SensorBase):
         return f"{self._device_info.device_name} Humidity"
 
     @property
-    def native_value(self) -> float:
+    def native_value(self) -> int:
         """Return the state of the sensor."""
         trait: HumidityTrait = self._device.traits[HumidityTrait.NAME]
-        return round(trait.ambient_humidity_percent, 0)
+        # Cast without loss of precision because the API always returns an integer.
+        return int(trait.ambient_humidity_percent)

--- a/tests/components/nest/sensor_sdm_test.py
+++ b/tests/components/nest/sensor_sdm_test.py
@@ -43,7 +43,7 @@ async def test_thermostat_device(hass):
                         "customName": "My Sensor",
                     },
                     "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 25.1,
+                        "ambientTemperatureCelsius": 25.12345,
                     },
                     "sdm.devices.traits.Humidity": {
                         "ambientHumidityPercent": 35.0,
@@ -64,7 +64,7 @@ async def test_thermostat_device(hass):
 
     humidity = hass.states.get("sensor.my_sensor_humidity")
     assert humidity is not None
-    assert humidity.state == "35.0"
+    assert humidity.state == "35"
     assert humidity.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert humidity.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_HUMIDITY
     assert humidity.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
@@ -128,7 +128,7 @@ async def test_device_name_from_structure(hass):
                 "type": THERMOSTAT_TYPE,
                 "traits": {
                     "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 25.2,
+                        "ambientTemperatureCelsius": 25.27654,
                     },
                 },
                 "parentRelations": [
@@ -142,7 +142,7 @@ async def test_device_name_from_structure(hass):
 
     temperature = hass.states.get("sensor.some_room_temperature")
     assert temperature is not None
-    assert temperature.state == "25.2"
+    assert temperature.state == "25.3"
 
 
 async def test_event_updates_sensor(hass):
@@ -157,7 +157,7 @@ async def test_event_updates_sensor(hass):
                         "customName": "My Sensor",
                     },
                     "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 25.1,
+                        "ambientTemperatureCelsius": 25.12345,
                     },
                 },
             },
@@ -179,7 +179,7 @@ async def test_event_updates_sensor(hass):
                 "name": "some-device-id",
                 "traits": {
                     "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 26.2,
+                        "ambientTemperatureCelsius": 26.28765,
                     },
                 },
             },
@@ -191,7 +191,7 @@ async def test_event_updates_sensor(hass):
 
     temperature = hass.states.get("sensor.my_sensor_temperature")
     assert temperature is not None
-    assert temperature.state == "26.2"
+    assert temperature.state == "26.3"
 
 
 async def test_device_with_unknown_type(hass):
@@ -206,7 +206,7 @@ async def test_device_with_unknown_type(hass):
                         "customName": "My Sensor",
                     },
                     "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 25.1,
+                        "ambientTemperatureCelsius": 25.12345,
                     },
                 },
             },

--- a/tests/components/nest/sensor_sdm_test.py
+++ b/tests/components/nest/sensor_sdm_test.py
@@ -43,7 +43,7 @@ async def test_thermostat_device(hass):
                         "customName": "My Sensor",
                     },
                     "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 25.12345,
+                        "ambientTemperatureCelsius": 25.1,
                     },
                     "sdm.devices.traits.Humidity": {
                         "ambientHumidityPercent": 35.0,
@@ -128,7 +128,7 @@ async def test_device_name_from_structure(hass):
                 "type": THERMOSTAT_TYPE,
                 "traits": {
                     "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 25.27654,
+                        "ambientTemperatureCelsius": 25.2,
                     },
                 },
                 "parentRelations": [
@@ -142,7 +142,7 @@ async def test_device_name_from_structure(hass):
 
     temperature = hass.states.get("sensor.some_room_temperature")
     assert temperature is not None
-    assert temperature.state == "25.3"
+    assert temperature.state == "25.2"
 
 
 async def test_event_updates_sensor(hass):
@@ -157,7 +157,7 @@ async def test_event_updates_sensor(hass):
                         "customName": "My Sensor",
                     },
                     "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 25.12345,
+                        "ambientTemperatureCelsius": 25.1,
                     },
                 },
             },
@@ -179,7 +179,7 @@ async def test_event_updates_sensor(hass):
                 "name": "some-device-id",
                 "traits": {
                     "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 26.28765,
+                        "ambientTemperatureCelsius": 26.2,
                     },
                 },
             },
@@ -191,7 +191,7 @@ async def test_event_updates_sensor(hass):
 
     temperature = hass.states.get("sensor.my_sensor_temperature")
     assert temperature is not None
-    assert temperature.state == "26.3"
+    assert temperature.state == "26.2"
 
 
 async def test_device_with_unknown_type(hass):
@@ -206,7 +206,7 @@ async def test_device_with_unknown_type(hass):
                         "customName": "My Sensor",
                     },
                     "sdm.devices.traits.Temperature": {
-                        "ambientTemperatureCelsius": 25.12345,
+                        "ambientTemperatureCelsius": 25.1,
                     },
                 },
             },
@@ -230,3 +230,28 @@ async def test_device_with_unknown_type(hass):
     assert device.name == "My Sensor"
     assert device.model is None
     assert device.identifiers == {("nest", "some-device-id")}
+
+
+async def test_temperature_rounding(hass):
+    """Test the rounding of overly precise temperatures."""
+    devices = {
+        "some-device-id": Device.MakeDevice(
+            {
+                "name": "some-device-id",
+                "type": THERMOSTAT_TYPE,
+                "traits": {
+                    "sdm.devices.traits.Info": {
+                        "customName": "My Sensor",
+                    },
+                    "sdm.devices.traits.Temperature": {
+                        "ambientTemperatureCelsius": 25.15678,
+                    },
+                },
+            },
+            auth=None,
+        )
+    }
+    await async_setup_sensor(hass, devices)
+
+    temperature = hass.states.get("sensor.my_sensor_temperature")
+    assert temperature.state == "25.2"


### PR DESCRIPTION
## Proposed change
Adjust the precision of the Nest thermostat temperature and humidity sensors to remove unneeded digits. Temperature is rounded to one decimal place to align with the `climate` device and humidity is rounded to zero decimal places as it is reported as an integer.

![image](https://user-images.githubusercontent.com/16008714/135760522-bac3b05a-9450-48b7-8f4b-c8fbce4e4a08.png)

![image](https://user-images.githubusercontent.com/16008714/135760543-4f7b64c6-13dc-4895-98a7-aacb7b446aae.png)


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #55496 and related discussion https://community.home-assistant.io/t/how-to-round-off-value-of-nest-temperature-identity/266568/7
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
