### PR TITLE
Round tplink energy sensors to prevent insignificant updates

### DIFF
--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -44,6 +44,7 @@ class TPLinkSensorEntityDescription(SensorEntityDescription):
     """Describes TPLink sensor entity."""
 
     emeter_attr: str | None = None
+    precision: int | None = None
 
 
 ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
@@ -54,6 +55,7 @@ ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
         state_class=STATE_CLASS_MEASUREMENT,
         name="Current Consumption",
         emeter_attr="power",
+        precision=1,
     ),
     TPLinkSensorEntityDescription(
         key=ATTR_TOTAL_ENERGY_KWH,
@@ -62,6 +64,7 @@ ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
         state_class=STATE_CLASS_TOTAL_INCREASING,
         name="Total Consumption",
         emeter_attr="total",
+        precision=3,
     ),
     TPLinkSensorEntityDescription(
         key=ATTR_TODAY_ENERGY_KWH,
@@ -69,6 +72,7 @@ ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
         name="Today's Consumption",
+        precision=3,
     ),
     TPLinkSensorEntityDescription(
         key=ATTR_VOLTAGE,
@@ -77,6 +81,7 @@ ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
         state_class=STATE_CLASS_MEASUREMENT,
         name="Voltage",
         emeter_attr="voltage",
+        precision=1,
     ),
     TPLinkSensorEntityDescription(
         key=ATTR_CURRENT_A,
@@ -85,6 +90,7 @@ ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
         state_class=STATE_CLASS_MEASUREMENT,
         name="Current",
         emeter_attr="current",
+        precision=2,
     ),
 )
 
@@ -97,11 +103,11 @@ def async_emeter_from_device(
         val = getattr(device.emeter_realtime, attr)
         if val is None:
             return None
-        return cast(float, val)
+        return round(cast(float, val), description.precision)
 
     # ATTR_TODAY_ENERGY_KWH
     if (emeter_today := device.emeter_today) is not None:
-        return cast(float, emeter_today)
+        return round(cast(float, emeter_today), description.precision)
     # today's consumption not available, when device was off all the day
     # bulb's do not report this information, so filter it out
     return None if device.is_bulb else 0.0

--- a/tests/components/tplink/test_sensor.py
+++ b/tests/components/tplink/test_sensor.py
@@ -34,14 +34,14 @@ async def test_color_light_with_an_emeter(hass: HomeAssistant) -> None:
         voltage=None,
         current=5,
     )
-    bulb.emeter_today = 5000
+    bulb.emeter_today = 5000.0036
     with _patch_discovery(device=bulb), _patch_single_discovery(device=bulb):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
     expected = {
-        "sensor.my_bulb_today_s_consumption": 5000,
+        "sensor.my_bulb_today_s_consumption": 5000.004,
         "sensor.my_bulb_current": 5,
     }
     entity_id = "light.my_bulb"
@@ -69,10 +69,10 @@ async def test_plug_with_an_emeter(hass: HomeAssistant) -> None:
     plug.color_temp = None
     plug.has_emeter = True
     plug.emeter_realtime = Mock(
-        power=100,
-        total=30,
-        voltage=121,
-        current=5,
+        power=100.06,
+        total=30.0049,
+        voltage=121.19,
+        current=5.035,
     )
     plug.emeter_today = None
     with _patch_discovery(device=plug), _patch_single_discovery(device=plug):
@@ -81,11 +81,11 @@ async def test_plug_with_an_emeter(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     expected = {
-        "sensor.my_plug_current_consumption": 100,
-        "sensor.my_plug_total_consumption": 30,
+        "sensor.my_plug_current_consumption": 100.1,
+        "sensor.my_plug_total_consumption": 30.005,
         "sensor.my_plug_today_s_consumption": 0.0,
-        "sensor.my_plug_voltage": 121,
-        "sensor.my_plug_current": 5,
+        "sensor.my_plug_voltage": 121.2,
+        "sensor.my_plug_current": 5.04,
     }
     entity_id = "switch.my_plug"
     state = hass.states.get(entity_id)


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Regressed with the conversion to asyncio

- These sensors wobble quite a bit and the precision did
  not have sensible limits which generated a massive amount
  of data in the database which was not very useful

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
