### PR TITLE
Use `Final` type only when needed in Tractive

### DIFF
--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 import logging
-from typing import Any, Final, List, cast
+from typing import Any, List, cast
 
 import aiotractive
 
@@ -37,10 +37,10 @@ from .const import (
     TRACKER_POSITION_UPDATED,
 )
 
-PLATFORMS: Final = ["binary_sensor", "device_tracker", "sensor", "switch"]
+PLATFORMS = ["binary_sensor", "device_tracker", "sensor", "switch"]
 
 
-_LOGGER: Final = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Tractive binary sensors."""
 from __future__ import annotations
 
-from typing import Any, Final
+from typing import Any
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_BATTERY_CHARGING,
@@ -24,7 +24,7 @@ from .const import (
 )
 from .entity import TractiveEntity
 
-TRACKERS_WITH_BUILTIN_BATTERY: Final = ("TRNJA4", "TRAXL1")
+TRACKERS_WITH_BUILTIN_BATTERY = ("TRNJA4", "TRAXL1")
 
 
 class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
@@ -73,7 +73,7 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
         )
 
 
-SENSOR_TYPE: Final = BinarySensorEntityDescription(
+SENSOR_TYPE = BinarySensorEntityDescription(
     key=ATTR_BATTERY_CHARGING,
     name="Battery Charging",
     device_class=DEVICE_CLASS_BATTERY_CHARGING,

--- a/homeassistant/components/tractive/config_flow.py
+++ b/homeassistant/components/tractive/config_flow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Final
+from typing import Any
 
 import aiotractive
 import voluptuous as vol
@@ -15,9 +15,9 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 
-_LOGGER: Final = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
-USER_DATA_SCHEMA: Final = vol.Schema(
+USER_DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
 )
 

--- a/homeassistant/components/tractive/const.py
+++ b/homeassistant/components/tractive/const.py
@@ -1,23 +1,22 @@
 """Constants for the tractive integration."""
 
 from datetime import timedelta
-from typing import Final
 
-DOMAIN: Final = "tractive"
+DOMAIN = "tractive"
 
-RECONNECT_INTERVAL: Final = timedelta(seconds=10)
+RECONNECT_INTERVAL = timedelta(seconds=10)
 
-ATTR_DAILY_GOAL: Final = "daily_goal"
-ATTR_BUZZER: Final = "buzzer"
-ATTR_LED: Final = "led"
-ATTR_LIVE_TRACKING: Final = "live_tracking"
-ATTR_MINUTES_ACTIVE: Final = "minutes_active"
+ATTR_DAILY_GOAL = "daily_goal"
+ATTR_BUZZER = "buzzer"
+ATTR_LED = "led"
+ATTR_LIVE_TRACKING = "live_tracking"
+ATTR_MINUTES_ACTIVE = "minutes_active"
 
-CLIENT: Final = "client"
-TRACKABLES: Final = "trackables"
+CLIENT = "client"
+TRACKABLES = "trackables"
 
-TRACKER_HARDWARE_STATUS_UPDATED: Final = f"{DOMAIN}_tracker_hardware_status_updated"
-TRACKER_POSITION_UPDATED: Final = f"{DOMAIN}_tracker_position_updated"
-TRACKER_ACTIVITY_STATUS_UPDATED: Final = f"{DOMAIN}_tracker_activity_updated"
+TRACKER_HARDWARE_STATUS_UPDATED = f"{DOMAIN}_tracker_hardware_status_updated"
+TRACKER_POSITION_UPDATED = f"{DOMAIN}_tracker_position_updated"
+TRACKER_ACTIVITY_STATUS_UPDATED = f"{DOMAIN}_tracker_activity_updated"
 
-SERVER_UNAVAILABLE: Final = f"{DOMAIN}_server_unavailable"
+SERVER_UNAVAILABLE = f"{DOMAIN}_server_unavailable"

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -127,7 +127,7 @@ class TractiveActivitySensor(TractiveSensor):
         )
 
 
-SENSOR_TYPES: Final[tuple[TractiveSensorEntityDescription, ...]] = (
+SENSOR_TYPES: tuple[TractiveSensorEntityDescription, ...] = (
     TractiveSensorEntityDescription(
         key=ATTR_BATTERY_LEVEL,
         name="Battery Level",

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import Any, Final, Literal, cast
+from typing import Any, Literal, cast
 
 from aiotractive.exceptions import TractiveError
 
@@ -26,7 +26,7 @@ from .const import (
 )
 from .entity import TractiveEntity
 
-_LOGGER: Final = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -43,7 +43,7 @@ class TractiveSwitchEntityDescription(
     """Class describing Tractive switch entities."""
 
 
-SWITCH_TYPES: Final[tuple[TractiveSwitchEntityDescription, ...]] = (
+SWITCH_TYPES: tuple[TractiveSwitchEntityDescription, ...] = (
     TractiveSwitchEntityDescription(
         key=ATTR_BUZZER,
         name="Tracker Buzzer",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR addresses late review https://github.com/home-assistant/core/pull/56948#discussion_r720862222

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
