### PR TITLE
Mark auth voluptuous schema fields as required

### DIFF
--- a/homeassistant/auth/mfa_modules/insecure_example.py
+++ b/homeassistant/auth/mfa_modules/insecure_example.py
@@ -38,12 +38,12 @@ class InsecureExampleModule(MultiFactorAuthModule):
     @property
     def input_schema(self) -> vol.Schema:
         """Validate login flow input data."""
-        return vol.Schema({"pin": str})
+        return vol.Schema({vol.Required("pin"): str})
 
     @property
     def setup_schema(self) -> vol.Schema:
         """Validate async_setup_user input data."""
-        return vol.Schema({"pin": str})
+        return vol.Schema({vol.Required("pin"): str})
 
     async def async_setup_flow(self, user_id: str) -> SetupFlow:
         """Return a data entry flow handler for setup module.

--- a/homeassistant/auth/mfa_modules/notify.py
+++ b/homeassistant/auth/mfa_modules/notify.py
@@ -110,7 +110,7 @@ class NotifyAuthModule(MultiFactorAuthModule):
     @property
     def input_schema(self) -> vol.Schema:
         """Validate login flow input data."""
-        return vol.Schema({INPUT_FIELD_CODE: str})
+        return vol.Schema({vol.Required(INPUT_FIELD_CODE): str})
 
     async def _async_load(self) -> None:
         """Load stored data."""

--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -84,7 +84,7 @@ class TotpAuthModule(MultiFactorAuthModule):
     @property
     def input_schema(self) -> vol.Schema:
         """Validate login flow input data."""
-        return vol.Schema({INPUT_FIELD_CODE: str})
+        return vol.Schema({vol.Required(INPUT_FIELD_CODE): str})
 
     async def _async_load(self) -> None:
         """Load stored data."""

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import collections
 from collections.abc import Mapping
 import logging
 import os
@@ -148,10 +147,13 @@ class CommandLineLoginFlow(LoginFlow):
                 user_input.pop("password")
                 return await self.async_finish(user_input)
 
-        schema: dict[str, type] = collections.OrderedDict()
-        schema["username"] = str
-        schema["password"] = str
-
         return self.async_show_form(
-            step_id="init", data_schema=vol.Schema(schema), errors=errors
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("username"): str,
+                    vol.Required("password"): str,
+                }
+            ),
+            errors=errors,
         )

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from collections import OrderedDict
 from collections.abc import Mapping
 import logging
 from typing import Any, cast
@@ -335,10 +334,13 @@ class HassLoginFlow(LoginFlow):
                 user_input.pop("password")
                 return await self.async_finish(user_input)
 
-        schema: dict[str, type] = OrderedDict()
-        schema["username"] = str
-        schema["password"] = str
-
         return self.async_show_form(
-            step_id="init", data_schema=vol.Schema(schema), errors=errors
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("username"): str,
+                    vol.Required("password"): str,
+                }
+            ),
+            errors=errors,
         )

--- a/homeassistant/auth/providers/insecure_example.py
+++ b/homeassistant/auth/providers/insecure_example.py
@@ -1,7 +1,6 @@
 """Example auth provider."""
 from __future__ import annotations
 
-from collections import OrderedDict
 from collections.abc import Mapping
 import hmac
 from typing import Any, cast
@@ -117,10 +116,13 @@ class ExampleLoginFlow(LoginFlow):
                 user_input.pop("password")
                 return await self.async_finish(user_input)
 
-        schema: dict[str, type] = OrderedDict()
-        schema["username"] = str
-        schema["password"] = str
-
         return self.async_show_form(
-            step_id="init", data_schema=vol.Schema(schema), errors=errors
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("username"): str,
+                    vol.Required("password"): str,
+                }
+            ),
+            errors=errors,
         )

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -102,5 +102,7 @@ class LegacyLoginFlow(LoginFlow):
                 return await self.async_finish({})
 
         return self.async_show_form(
-            step_id="init", data_schema=vol.Schema({"password": str}), errors=errors
+            step_id="init",
+            data_schema=vol.Schema({vol.Required("password"): str}),
+            errors=errors,
         )

--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -244,5 +244,7 @@ class TrustedNetworksLoginFlow(LoginFlow):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema({"user": vol.In(self._available_users)}),
+            data_schema=vol.Schema(
+                {vol.Required("user"): vol.In(self._available_users)}
+            ),
         )

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -67,7 +67,7 @@ async def test_ws_setup_depose_mfa(hass, hass_ws_client):
     assert flow["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert flow["handler"] == "example_module"
     assert flow["step_id"] == "init"
-    assert flow["data_schema"][0] == {"type": "string", "name": "pin"}
+    assert flow["data_schema"][0] == {"type": "string", "name": "pin", "required": True}
 
     await client.send_json(
         {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mark the fields in the auth voluptuous schemas as required. This makes sure the frontend always sends in data and we avoid processing it if no fields are present. Previously it would cause stack traces if a person would hit the "submit" button without touching the fields.

```
2021-10-01 13:47:18 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/aiohttp/web_protocol.py", line 422, in _handle_request
    resp = await self._request_handler(request)
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/aiohttp/web_app.py", line 499, in _handle
    resp = await handler(request)
  File "/Users/paulus/dev/hass/core/venv/lib/python3.9/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/Users/paulus/dev/hass/core/homeassistant/components/http/security_filter.py", line 60, in security_filter_middleware
    return await handler(request)
  File "/Users/paulus/dev/hass/core/homeassistant/components/http/forwarded.py", line 98, in forwarded_middleware
    return await handler(request)
  File "/Users/paulus/dev/hass/core/homeassistant/components/http/request_context.py", line 24, in request_context_middleware
    return await handler(request)
  File "/Users/paulus/dev/hass/core/homeassistant/components/http/ban.py", line 78, in ban_middleware
    return await handler(request)
  File "/Users/paulus/dev/hass/core/homeassistant/components/http/auth.py", line 144, in auth_middleware
    return await handler(request)
  File "/Users/paulus/dev/hass/core/homeassistant/components/http/view.py", line 136, in handle
    result = await result
  File "/Users/paulus/dev/hass/core/homeassistant/components/http/data_validator.py", line 62, in wrapper
    result = await method(view, request, *args, **kwargs)
  File "/Users/paulus/dev/hass/core/homeassistant/components/http/ban.py", line 93, in handle_req
    resp = await func(view, request, *args, **kwargs)
  File "/Users/paulus/dev/hass/core/homeassistant/components/auth/login_flow.py", line 243, in post
    result = await self._flow_mgr.async_configure(flow_id, data)
  File "/Users/paulus/dev/hass/core/homeassistant/data_entry_flow.py", line 198, in async_configure
    result = await self._async_handle_step(flow, cur_step["step_id"], user_input)
  File "/Users/paulus/dev/hass/core/homeassistant/data_entry_flow.py", line 256, in _async_handle_step
    result: FlowResult = await getattr(flow, method)(user_input)
  File "/Users/paulus/dev/hass/core/homeassistant/auth/providers/homeassistant.py", line 329, in async_step_init
    user_input["username"], user_input["password"]
KeyError: 'username'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
