### PR TITLE
Shorten Plex album titles when browsing artist in media browser

### DIFF
--- a/homeassistant/components/plex/helpers.py
+++ b/homeassistant/components/plex/helpers.py
@@ -5,7 +5,10 @@ def pretty_title(media, short_name=False):
     """Return a formatted title for the given media item."""
     year = None
     if media.type == "album":
-        title = f"{media.parentTitle} - {media.title}"
+        if short_name:
+            title = media.title
+        else:
+            title = f"{media.parentTitle} - {media.title}"
     elif media.type == "episode":
         title = f"{media.seasonEpisode.upper()} - {media.title}"
         if not short_name:

--- a/tests/components/plex/test_browse_media.py
+++ b/tests/components/plex/test_browse_media.py
@@ -46,6 +46,18 @@ class MockPlexEpisode:
     type = "episode"
 
 
+class MockPlexArtist:
+    """Mock a plexapi Artist instance."""
+
+    ratingKey = 300
+    title = "Artist"
+    type = "artist"
+
+    def __iter__(self):
+        """Iterate over albums."""
+        yield MockPlexAlbum()
+
+
 class MockPlexAlbum:
     """Mock a plexapi Album instance."""
 
@@ -53,7 +65,7 @@ class MockPlexAlbum:
     parentTitle = "Artist"
     title = "Album"
     type = "album"
-    year = 2001
+    year = 2019
 
     def __iter__(self):
         """Iterate over tracks."""
@@ -290,11 +302,13 @@ async def test_browse_media(
     assert result[ATTR_MEDIA_CONTENT_TYPE] == "library"
     assert result["title"] == "Music"
 
-    # Browse into a Plex album
+    # Browse into a Plex artist
     msg_id += 1
-    mock_album = MockPlexAlbum()
+    mock_artist = MockPlexArtist()
+    mock_album = next(iter(MockPlexArtist()))
+    mock_track = next(iter(MockPlexAlbum()))
     with patch.object(
-        mock_plex_server, "fetch_item", return_value=mock_album
+        mock_plex_server, "fetch_item", return_value=mock_artist
     ) as mock_fetch:
         await websocket_client.send_json(
             {
@@ -315,11 +329,32 @@ async def test_browse_media(
     assert msg["success"]
     result = msg["result"]
     result_id = int(result[ATTR_MEDIA_CONTENT_ID])
+    assert result[ATTR_MEDIA_CONTENT_TYPE] == "artist"
+    assert result["title"] == mock_artist.title
+    assert result["children"][0]["title"] == f"{mock_album.title} ({mock_album.year})"
+
+    # Browse into a Plex album
+    msg_id += 1
+    await websocket_client.send_json(
+        {
+            "id": msg_id,
+            "type": "media_player/browse_media",
+            "entity_id": media_players[0],
+            ATTR_MEDIA_CONTENT_TYPE: result["children"][-1][ATTR_MEDIA_CONTENT_TYPE],
+            ATTR_MEDIA_CONTENT_ID: str(result["children"][-1][ATTR_MEDIA_CONTENT_ID]),
+        }
+    )
+    msg = await websocket_client.receive_json()
+
+    assert msg["success"]
+    result = msg["result"]
+    result_id = int(result[ATTR_MEDIA_CONTENT_ID])
     assert result[ATTR_MEDIA_CONTENT_TYPE] == "album"
     assert (
         result["title"]
-        == f"{mock_album.parentTitle} - {mock_album.title} ({mock_album.year})"
+        == f"{mock_artist.title} - {mock_album.title} ({mock_album.year})"
     )
+    assert result["children"][0]["title"] == f"{mock_track.index}. {mock_track.title}"
 
     # Browse into a non-existent TV season
     unknown_key = 99999999999999


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When using the media browser, selectively shorten album names to omit the artist's name in the title if we're already browsing the artist. This will keep the "long" name which includes the artist name when browsing mixed directories, such as all recently added albums.

A followup to https://github.com/home-assistant/core/pull/56312 where similar logic was added for episodes/shows.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
