### PR TITLE
Remove Netgear tracker link_rate check on Orbi

### DIFF
--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -11,7 +11,24 @@ DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"
 
 # update method V2 models
-MODELS_V2 = ["Orbi", "RBK", "RBR", "RBS", "RBW", "LBK", "LBR", "CBK", "CBR", "SRC", "SRK", "SRR", "SRS", "SXK", "SXR", "SXS"]
+MODELS_V2 = [
+    "Orbi",
+    "RBK",
+    "RBR",
+    "RBS",
+    "RBW",
+    "LBK",
+    "LBR",
+    "CBK",
+    "CBR",
+    "SRC",
+    "SRK",
+    "SRR",
+    "SRS",
+    "SXK",
+    "SXR",
+    "SXS",
+]
 
 # Icons
 DEVICE_ICONS = {

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -11,7 +11,7 @@ DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"
 
 # update method V2 models
-MODELS_V2 = ["Orbi"]
+MODELS_V2 = ["Orbi", "RBK", "RBR", "RBS", "RBW", "LBK", "LBR", "CBK", "CBR", "SRC", "SRK", "SRR", "SRS", "SXK", "SXR", "SXS"]
 
 # Icons
 DEVICE_ICONS = {

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -146,8 +146,9 @@ class NetgearRouter:
         self.model = self._info.get("ModelName")
         self.firmware_version = self._info.get("Firmwareversion")
 
-        if self.model in MODELS_V2:
-            self._method_version = 2
+        for model in MODELS_V2:
+            if self.model.startswith(model):
+                self._method_version = 2
 
     async def async_setup(self) -> None:
         """Set up a Netgear router."""

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -197,9 +197,9 @@ class NetgearRouter:
         new_device = False
         ntg_devices = await self.async_get_attached_devices()
         now = dt_util.utcnow()
-        
+
         if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug("Netgear scan result: \n%s", pformat(results))
+            _LOGGER.debug("Netgear scan result: \n%s", ntg_devices)
 
         for ntg_device in ntg_devices:
             device_mac = format_mac(ntg_device.mac)

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -197,12 +197,12 @@ class NetgearRouter:
         new_device = False
         ntg_devices = await self.async_get_attached_devices()
         now = dt_util.utcnow()
+        
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug("Netgear scan result: \n%s", pformat(results))
 
         for ntg_device in ntg_devices:
             device_mac = format_mac(ntg_device.mac)
-
-            if self._method_version == 2 and not ntg_device.link_rate:
-                continue
 
             if not self.devices.get(device_mac):
                 new_device = True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Do not check the link_rate of a device when using the V2 method on Orbi devices.
This check was added by @Quentame, I don't know the purpose of this check.
In the old way of the integration this check was not present (when using accesspoints in the YAML config to force V2 method).
See this Note of the documentation:

> A recent updates of Orbi APs introduced a bug which takes several hours to detects presence on your local network. The current workaround is to force this integration to use the Orbi’s API v2 by adding the accesspoints: node to your configuration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/56850
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
