### PR TITLE
Add WebSocket API for intiting a WebRTC stream

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -63,6 +63,8 @@ from .const import (
     DATA_CAMERA_PREFS,
     DOMAIN,
     SERVICE_RECORD,
+    STREAM_TYPE_HLS,
+    STREAM_TYPE_WEB_RTC,
 )
 from .img_util import scale_jpeg_camera_image
 from .prefs import CameraPreferences
@@ -207,7 +209,6 @@ async def async_get_image(
 async def async_get_stream_source(hass: HomeAssistant, entity_id: str) -> str | None:
     """Fetch the stream source for a camera entity."""
     camera = _get_camera_from_entity_id(hass, entity_id)
-
     return await camera.stream_source()
 
 
@@ -303,6 +304,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         WS_TYPE_CAMERA_THUMBNAIL, websocket_camera_thumbnail, SCHEMA_WS_CAMERA_THUMBNAIL
     )
     hass.components.websocket_api.async_register_command(ws_camera_stream)
+    hass.components.websocket_api.async_register_command(ws_camera_web_rtc_offer)
     hass.components.websocket_api.async_register_command(websocket_get_prefs)
     hass.components.websocket_api.async_register_command(websocket_update_prefs)
 
@@ -421,6 +423,18 @@ class Camera(Entity):
         """Return the interval between frames of the mjpeg stream."""
         return MIN_STREAM_INTERVAL
 
+    @property
+    def stream_type(self) -> str | None:
+        """Return the type of stream supported by this camera.
+
+        A camera may have a single stream type which is used to inform the
+        frontend which camera attributes and player to use. The default type
+        is to use HLS, and components can override to change the type.
+        """
+        if not self.supported_features & SUPPORT_STREAM:
+            return None
+        return STREAM_TYPE_HLS
+
     async def create_stream(self) -> Stream | None:
         """Create a Stream for stream_source."""
         # There is at most one stream (a decode worker) per camera
@@ -433,9 +447,19 @@ class Camera(Entity):
         return self.stream
 
     async def stream_source(self) -> str | None:
-        """Return the source of the stream."""
+        """Return the source of the stream..
+
+        This is used by cameras with SUPPORT_STREAM and STREAM_TYPE_HLS.
+        """
         # pylint: disable=no-self-use
         return None
+
+    async def async_handle_web_rtc_offer(self, offer_sdp: str) -> str | None:
+        """Handle the WebRTC offer and return an answer.
+
+        This is used by cameras with SUPPORT_STREAM and STREAM_TYPE_WEB_RTC.
+        """
+        raise NotImplementedError()
 
     def camera_image(
         self, width: int | None = None, height: int | None = None
@@ -547,6 +571,9 @@ class Camera(Entity):
 
         if self.motion_detection_enabled:
             attrs["motion_detection"] = self.motion_detection_enabled
+
+        if self.stream_type:
+            attrs["stream_type"] = self.stream_type
 
         return attrs
 
@@ -696,6 +723,49 @@ async def ws_camera_stream(
         _LOGGER.error("Timeout getting stream source")
         connection.send_error(
             msg["id"], "start_stream_failed", "Timeout getting stream source"
+        )
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "camera/web_rtc_offer",
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Required("offer"): str,
+    }
+)
+@websocket_api.async_response
+async def ws_camera_web_rtc_offer(
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict
+) -> None:
+    """Handle the signal path for a WebRTC stream.
+
+    This signal path is used to route the offer created by the client to the
+    camera device through the integration for negitioation on initial setup,
+    which returns an answer. The actual streaming is handled entirely between
+    the client and camera device.
+
+    Async friendly.
+    """
+    try:
+        entity_id = msg["entity_id"]
+        offer = msg["offer"]
+        camera = _get_camera_from_entity_id(hass, entity_id)
+        if camera.stream_type != STREAM_TYPE_WEB_RTC:
+            connection.send_error(
+                msg["id"],
+                "web_rtc_offer_failed",
+                f"Camera does not support WebRTC, stream_type={camera.stream_type}",
+            )
+            return
+        answer = await camera.async_handle_web_rtc_offer(offer)
+        connection.send_result(msg["id"], {"answer": answer})
+    except (HomeAssistantError, ValueError) as ex:
+        _LOGGER.error("Error handling WebRTC offer: %s", ex)
+        connection.send_error(msg["id"], "web_rtc_offer_failed", str(ex))
+    except asyncio.TimeoutError:
+        _LOGGER.error("Timeout handling WebRTC offer")
+        connection.send_error(
+            msg["id"], "web_rtc_offer_failed", "Timeout handling WebRTC offer"
         )
 
 

--- a/homeassistant/components/camera/const.py
+++ b/homeassistant/components/camera/const.py
@@ -14,3 +14,12 @@ CONF_DURATION: Final = "duration"
 
 CAMERA_STREAM_SOURCE_TIMEOUT: Final = 10
 CAMERA_IMAGE_TIMEOUT: Final = 10
+
+# A camera that supports CAMERA_SUPPORT_STREAM may have a single stream
+# type which is used to inform the frontend which player to use.
+# Streams with RTSP sources typically use the stream component which uses
+# HLS for display. WebRTC streams use the home assistant core for a signal
+# path to initiate a stream, but the stream itself is between the client and
+# device.
+STREAM_TYPE_HLS = "hls"
+STREAM_TYPE_WEB_RTC = "web_rtc"

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -7,7 +7,11 @@ from unittest.mock import Mock, PropertyMock, mock_open, patch
 import pytest
 
 from homeassistant.components import camera
-from homeassistant.components.camera.const import DOMAIN, PREF_PRELOAD_STREAM
+from homeassistant.components.camera.const import (
+    DOMAIN,
+    PREF_PRELOAD_STREAM,
+    STREAM_TYPE_WEB_RTC,
+)
 from homeassistant.components.camera.prefs import CameraEntityPreferences
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.config import async_process_ha_core_config
@@ -36,6 +40,24 @@ async def mock_camera_fixture(hass):
     with patch(
         "homeassistant.components.demo.camera.Path.read_bytes",
         return_value=b"Test",
+    ):
+        yield
+
+
+@pytest.fixture(name="mock_camera_web_rtc")
+async def mock_camera_web_rtc_fixture(hass):
+    """Initialize a demo camera platform."""
+    assert await async_setup_component(
+        hass, "camera", {camera.DOMAIN: {"platform": "demo"}}
+    )
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.camera.Camera.stream_type",
+        new_callable=PropertyMock(return_value=STREAM_TYPE_WEB_RTC),
+    ), patch(
+        "homeassistant.components.camera.Camera.async_handle_web_rtc_offer",
+        return_value="a=sendonly",
     ):
         yield
 
@@ -467,3 +489,99 @@ async def test_camera_proxy_stream(hass, mock_camera, hass_client):
     ):
         response = await client.get("/api/camera_proxy_stream/camera.demo_camera")
         assert response.status == HTTP_BAD_GATEWAY
+
+
+async def test_websocket_web_rtc_offer(
+    hass,
+    hass_ws_client,
+    mock_camera_web_rtc,
+):
+    """Test initiating a WebRTC stream with offer and answer."""
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 9,
+            "type": "camera/web_rtc_offer",
+            "entity_id": "camera.demo_camera",
+            "offer": "v=0\r\n",
+        }
+    )
+    response = await client.receive_json()
+
+    assert response["id"] == 9
+    assert response["type"] == TYPE_RESULT
+    assert response["success"]
+    assert response["result"]["answer"] == "a=sendonly"
+
+
+async def test_websocket_web_rtc_offer_invalid_entity(
+    hass,
+    hass_ws_client,
+    mock_camera_web_rtc,
+):
+    """Test initiating a WebRTC stream with offer and answer."""
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 9,
+            "type": "camera/web_rtc_offer",
+            "entity_id": "camera.does_not_exist",
+            "offer": "v=0\r\n",
+        }
+    )
+    response = await client.receive_json()
+
+    assert response["id"] == 9
+    assert response["type"] == TYPE_RESULT
+    assert not response["success"]
+
+
+async def test_websocket_web_rtc_offer_missing_offer(
+    hass,
+    hass_ws_client,
+    mock_camera_web_rtc,
+):
+    """Test initiating a WebRTC stream with offer and answer."""
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 9,
+            "type": "camera/web_rtc_offer",
+            "entity_id": "camera.demo_camera",
+        }
+    )
+    response = await client.receive_json()
+
+    assert response["id"] == 9
+    assert response["type"] == TYPE_RESULT
+    assert not response["success"]
+    assert response["error"]["code"] == "invalid_format"
+
+
+async def test_websocket_web_rtc_offer_failure(
+    hass,
+    hass_ws_client,
+    mock_camera_web_rtc,
+):
+    """Test initiating a WebRTC stream with offer and answer."""
+    client = await hass_ws_client(hass)
+
+    with patch(
+        "homeassistant.components.camera.Camera.async_handle_web_rtc_offer",
+        side_effect=HomeAssistantError("offer failed"),
+    ):
+        await client.send_json(
+            {
+                "id": 9,
+                "type": "camera/web_rtc_offer",
+                "entity_id": "camera.demo_camera",
+                "offer": "v=0\r\n",
+            }
+        )
+        response = await client.receive_json()
+
+    assert response["id"] == 9
+    assert response["type"] == TYPE_RESULT
+    assert not response["success"]
+    assert response["error"]["code"] == "web_rtc_offer_failed"
+    assert response["error"]["message"] == "offer failed"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add WebRTC signal path support to `camera`. The motivation is to be able to support battery powered cameras for `nest` which only support WebRTC, though with a pattern that can be used for other cameras in the future.

Inlining the proposal from https://github.com/home-assistant/architecture/discussions/640
- `Camera` entity now exposes a `stream_type` to tell the frontend the format of the stream so it knows which player to use
- The frontend (in a future PR) will  build an offer by creating a RTCPeerConnection and invoking createOffer()
- The offer is passed to a new websocket endpoint `camera/web_rtc_offer` being added in this PR,
- Components that implement `Camera` can override `async_handle_web_rtc_offer` to accept an `offer` and return an `answer` which is returned over the websocket API.
- From there, the frontend handles everything else. It first creates a RTCSessionDescription from the answer as the remote description. Then adds remote tracks as they become available, etc.
Follow up PRs will update `nest` to implement this API, and add player support to frontend.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #55302
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
