### PR TITLE
Activate mypy for rpi_power

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -90,6 +90,7 @@ homeassistant.components.recorder.statistics
 homeassistant.components.remote.*
 homeassistant.components.renault.*
 homeassistant.components.rituals_perfume_genie.*
+homeassistant.components.rpi_power.*
 homeassistant.components.samsungtv.*
 homeassistant.components.scene.*
 homeassistant.components.select.*

--- a/homeassistant/components/rpi_power/__init__.py
+++ b/homeassistant/components/rpi_power/__init__.py
@@ -11,6 +11,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/rpi_power/binary_sensor.py
+++ b/homeassistant/components/rpi_power/binary_sensor.py
@@ -5,7 +5,7 @@ Minimal Kernel needed is 4.14+
 """
 import logging
 
-from rpi_bad_power import new_under_voltage
+from rpi_bad_power import UnderVoltage, new_under_voltage
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_PROBLEM,
@@ -13,6 +13,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,8 +22,10 @@ DESCRIPTION_UNDER_VOLTAGE = "Under-voltage was detected. Consider getting a unin
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
-):
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up rpi_power binary sensor."""
     under_voltage = await hass.async_add_executor_job(new_under_voltage)
     async_add_entities([RaspberryChargerBinarySensor(under_voltage)], True)
@@ -31,43 +34,22 @@ async def async_setup_entry(
 class RaspberryChargerBinarySensor(BinarySensorEntity):
     """Binary sensor representing the rpi power status."""
 
-    def __init__(self, under_voltage):
+    def __init__(self, under_voltage: UnderVoltage) -> None:
         """Initialize the binary sensor."""
         self._under_voltage = under_voltage
-        self._is_on = None
+        self._attr_is_on = None
+        self._attr_device_class = DEVICE_CLASS_PROBLEM
+        self._attr_icon = "mdi:raspberry-pi"
+        self._attr_name = "RPi Power status"
+        self._attr_unique_id = "rpi_power"  # only one sensor possible
         self._last_is_on = False
 
-    def update(self):
+    def update(self) -> None:
         """Update the state."""
-        self._is_on = self._under_voltage.get()
-        if self._is_on != self._last_is_on:
-            if self._is_on:
+        self.attr_is_on = self._under_voltage.get()
+        if self.attr_is_on != self._last_is_on:
+            if self.attr_is_on:
                 _LOGGER.warning(DESCRIPTION_UNDER_VOLTAGE)
             else:
                 _LOGGER.info(DESCRIPTION_NORMALIZED)
-            self._last_is_on = self._is_on
-
-    @property
-    def unique_id(self):
-        """Return the unique id of the sensor."""
-        return "rpi_power"  # only one sensor possible
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return "RPi Power status"
-
-    @property
-    def is_on(self):
-        """Return if there is a problem detected."""
-        return self._is_on
-
-    @property
-    def icon(self):
-        """Return the icon of the sensor."""
-        return "mdi:raspberry-pi"
-
-    @property
-    def device_class(self):
-        """Return the class of this device."""
-        return DEVICE_CLASS_PROBLEM
+            self._last_is_on = self.attr_is_on

--- a/homeassistant/components/rpi_power/binary_sensor.py
+++ b/homeassistant/components/rpi_power/binary_sensor.py
@@ -37,19 +37,17 @@ class RaspberryChargerBinarySensor(BinarySensorEntity):
     def __init__(self, under_voltage: UnderVoltage) -> None:
         """Initialize the binary sensor."""
         self._under_voltage = under_voltage
-        self._attr_is_on = None
         self._attr_device_class = DEVICE_CLASS_PROBLEM
         self._attr_icon = "mdi:raspberry-pi"
         self._attr_name = "RPi Power status"
         self._attr_unique_id = "rpi_power"  # only one sensor possible
-        self._last_is_on = False
 
     def update(self) -> None:
         """Update the state."""
-        self.attr_is_on = self._under_voltage.get()
-        if self.attr_is_on != self._last_is_on:
-            if self.attr_is_on:
+        value = self._under_voltage.get()
+        if self._attr_is_on != value:
+            if value:
                 _LOGGER.warning(DESCRIPTION_UNDER_VOLTAGE)
             else:
                 _LOGGER.info(DESCRIPTION_NORMALIZED)
-            self._last_is_on = self.attr_is_on
+            self._attr_is_on = value

--- a/homeassistant/components/rpi_power/binary_sensor.py
+++ b/homeassistant/components/rpi_power/binary_sensor.py
@@ -34,13 +34,14 @@ async def async_setup_entry(
 class RaspberryChargerBinarySensor(BinarySensorEntity):
     """Binary sensor representing the rpi power status."""
 
+    _attr_device_class = DEVICE_CLASS_PROBLEM
+    _attr_icon = "mdi:raspberry-pi"
+    _attr_name = "RPi Power status"
+    _attr_unique_id = "rpi_power"  # only one sensor possible
+
     def __init__(self, under_voltage: UnderVoltage) -> None:
         """Initialize the binary sensor."""
         self._under_voltage = under_voltage
-        self._attr_device_class = DEVICE_CLASS_PROBLEM
-        self._attr_icon = "mdi:raspberry-pi"
-        self._attr_name = "RPi Power status"
-        self._attr_unique_id = "rpi_power"  # only one sensor possible
 
     def update(self) -> None:
         """Update the state."""

--- a/homeassistant/components/rpi_power/config_flow.py
+++ b/homeassistant/components/rpi_power/config_flow.py
@@ -35,7 +35,7 @@ class RPiPowerFlow(DiscoveryFlowHandler, domain=DOMAIN):
         self, data: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a flow initialized by onboarding."""
-        has_devices = await self._discovery_function(self.hass)
+        has_devices = await self._discovery_function(self.hass)  # type: ignore
 
         if not has_devices:
             return self.async_abort(reason="no_devices_found")

--- a/mypy.ini
+++ b/mypy.ini
@@ -1001,6 +1001,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.rpi_power.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.samsungtv.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -1671,9 +1682,6 @@ ignore_errors = true
 ignore_errors = true
 
 [mypy-homeassistant.components.ring.*]
-ignore_errors = true
-
-[mypy-homeassistant.components.rpi_power.*]
 ignore_errors = true
 
 [mypy-homeassistant.components.ruckus_unleashed.*]

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -106,7 +106,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.profiler.*",
     "homeassistant.components.rachio.*",
     "homeassistant.components.ring.*",
-    "homeassistant.components.rpi_power.*",
     "homeassistant.components.ruckus_unleashed.*",
     "homeassistant.components.screenlogic.*",
     "homeassistant.components.search.*",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type annotations and enabled strict typing.
I've also refactored some code to use `_attr_`

There is one place that I was unable to fix (homeassistant/components/rpi_power/config_flow.py), because of `DiscoveryFunctionType` so I've added type ignore comment

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
