### PR TITLE
Update esphome reconnect logic to use newer RecordUpdateListener logic

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -24,7 +24,7 @@ from aioesphomeapi import (
     UserServiceArgType,
 )
 import voluptuous as vol
-from zeroconf import DNSPointer, DNSRecord, RecordUpdateListener, Zeroconf
+from zeroconf import DNSPointer, RecordUpdate, RecordUpdateListener, Zeroconf
 
 from homeassistant import const
 from homeassistant.components import zeroconf
@@ -518,34 +518,39 @@ class ReconnectLogic(RecordUpdateListener):
         """Stop as an async callback function."""
         self._hass.async_create_task(self.stop())
 
-    @callback
-    def _set_reconnect(self) -> None:
-        self._reconnect_event.set()
+    def async_update_records(
+        self, zc: Zeroconf, now: float, records: list[RecordUpdate]
+    ) -> None:
+        """Listen to zeroconf updated mDNS records.
 
-    def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:
-        """Listen to zeroconf updated mDNS records."""
-        if not isinstance(record, DNSPointer):
-            # We only consider PTR records and match using the alias name
-            return
-        if self._entry_data is None or self._entry_data.device_info is None:
-            # Either the entry was already teared down or we haven't received device info yet
+        This is a mDNS record from the device and could mean it just woke up.
+        """
+        # Check if already connected, no lock needed for this access and
+        # bail if either the entry was already teared down or we haven't received device info yet
+        if (
+            self._connected
+            or self._entry_data is None
+            or self._entry_data.device_info is None
+        ):
             return
         filter_alias = f"{self._entry_data.device_info.name}._esphomelib._tcp.local."
-        if record.alias != filter_alias:
-            return
 
-        # This is a mDNS record from the device and could mean it just woke up
-        # Check if already connected, no lock needed for this access
-        if self._connected:
-            return
+        for record_update in records:
+            # We only consider PTR records and match using the alias name
+            if (
+                not isinstance(record_update.new, DNSPointer)
+                or record_update.new.alias != filter_alias
+            ):
+                continue
 
-        # Tell reconnection logic to retry connection attempt now (even before reconnect timer finishes)
-        _LOGGER.debug(
-            "%s: Triggering reconnect because of received mDNS record %s",
-            self._host,
-            record,
-        )
-        self._hass.add_job(self._set_reconnect)
+            # Tell reconnection logic to retry connection attempt now (even before reconnect timer finishes)
+            _LOGGER.debug(
+                "%s: Triggering reconnect because of received mDNS record %s",
+                self._host,
+                record_update.new,
+            )
+            self._reconnect_event.set()
+            return
 
 
 async def _async_setup_device_registry(

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -529,6 +529,7 @@ class ReconnectLogic(RecordUpdateListener):
         # bail if either the entry was already teared down or we haven't received device info yet
         if (
             self._connected
+            or self._reconnect_event.is_set()
             or self._entry_data is None
             or self._entry_data.device_info is None
         ):


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This needs to be adjusted to prevent it from breaking in a future zeroconf version https://github.com/jstasiak/python-zeroconf/releases/tag/0.32.0
see `RecordUpdateListener now uses async_update_records instead of update_record`
...
```
update_record has been deprecated in favor of async_update_records
A compatibility shim exists to ensure classes that use
RecordUpdateListener as a base class continue to have
update_record called, however, they should be updated
as soon as possible.

A new method async_update_records_complete is now called on each
listener when all listeners have completed processing updates
and the cache has been updated. This allows ServiceBrowsers
to delay calling handlers until they are sure the cache
has been updated as its a common pattern to call for
ServiceInfo when a ServiceBrowser handler fires.

The async_ prefix was chosen to make it clear that these
functions run in the eventloop and should never do blocking
I/O. Before 0.32+ these functions ran in a select() loop and
should not have been doing any blocking I/O, but it was not
clear to implementors that I/O would block the loop
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
