### PR TITLE
Enable template icons for template selects

### DIFF
--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -13,7 +13,13 @@ from homeassistant.components.select.const import (
     ATTR_OPTIONS,
     DOMAIN as SELECT_DOMAIN,
 )
-from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC, CONF_STATE, CONF_UNIQUE_ID
+from homeassistant.const import (
+    CONF_ICON,
+    CONF_NAME,
+    CONF_OPTIMISTIC,
+    CONF_STATE,
+    CONF_UNIQUE_ID,
+)
 from homeassistant.core import Config, HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -41,6 +47,7 @@ SELECT_SCHEMA = vol.Schema(
         vol.Optional(CONF_AVAILABILITY): cv.template,
         vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_ICON): cv.template,
     }
 )
 
@@ -64,6 +71,7 @@ async def _async_create_entities(
                 definition[ATTR_OPTIONS],
                 definition.get(CONF_OPTIMISTIC, DEFAULT_OPTIMISTIC),
                 unique_id,
+                definition.get(CONF_ICON),
             )
         )
     return entities
@@ -109,9 +117,12 @@ class TemplateSelect(TemplateEntity, SelectEntity):
         options_template: Template,
         optimistic: bool,
         unique_id: str | None,
+        icon_template: Template | None,
     ) -> None:
         """Initialize the select."""
-        super().__init__(availability_template=availability_template)
+        super().__init__(
+            availability_template=availability_template, icon_template=icon_template
+        )
         self._attr_name = DEFAULT_NAME
         name_template.hass = hass
         with contextlib.suppress(TemplateError):

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -319,7 +319,7 @@ async def test_template_icon_with_entities(hass, calls):
                         "options": f"{{{{ state_attr('{_OPTION_INPUT_SELECT}', '{INPUT_SELECT_ATTR_OPTIONS}') }}}}",
                         "select_option": {
                             "service": "input_select.select_option",
-                            "data_template": {
+                            "data": {
                                 "entity_id": _OPTION_INPUT_SELECT,
                                 "option": "{{ option }}",
                             },

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -377,7 +377,6 @@ async def test_template_icon_with_trigger(hass):
             "template": {
                 "trigger": {"platform": "state", "entity_id": _OPTION_INPUT_SELECT},
                 "select": {
-                    # "name": "Hello Name",
                     "unique_id": "b",
                     "state": "{{ trigger.to_state.state }}",
                     "options": f"{{{{ state_attr('{_OPTION_INPUT_SELECT}', '{INPUT_SELECT_ATTR_OPTIONS}') }}}}",

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -382,7 +382,7 @@ async def test_template_icon_with_trigger(hass):
                     "options": f"{{{{ state_attr('{_OPTION_INPUT_SELECT}', '{INPUT_SELECT_ATTR_OPTIONS}') }}}}",
                     "select_option": {
                         "service": "input_select.select_option",
-                        "data_template": {
+                        "data": {
                             "entity_id": _OPTION_INPUT_SELECT,
                             "option": "{{ option }}",
                         },

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -375,7 +375,6 @@ async def test_template_icon_with_trigger(hass):
         "template",
         {
             "template": {
-                # "unique_id": "listening-test-event",
                 "trigger": {"platform": "state", "entity_id": _OPTION_INPUT_SELECT},
                 "select": {
                     # "name": "Hello Name",

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -15,7 +15,7 @@ from homeassistant.components.select.const import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION as SELECT_SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import CONF_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import Context
 from homeassistant.helpers.entity_registry import async_get
 
@@ -144,7 +144,7 @@ async def test_missing_required_keys(hass, calls):
 
 
 async def test_templates_with_entities(hass, calls):
-    """Test tempalates with values from other entities."""
+    """Test templates with values from other entities."""
     with assert_setup_component(1, "input_select"):
         assert await setup.async_setup_component(
             hass,
@@ -288,3 +288,139 @@ def _verify(hass, expected_current_option, expected_options, entity_name=_TEST_S
     attributes = state.attributes
     assert state.state == str(expected_current_option)
     assert attributes.get(SELECT_ATTR_OPTIONS) == expected_options
+
+
+async def test_template_icon_with_entities(hass, calls):
+    """Test templates with values from other entities."""
+    with assert_setup_component(1, "input_select"):
+        assert await setup.async_setup_component(
+            hass,
+            "input_select",
+            {
+                "input_select": {
+                    "option": {
+                        "options": ["a", "b"],
+                        "initial": "a",
+                        "name": "Option",
+                    },
+                }
+            },
+        )
+
+    with assert_setup_component(1, "template"):
+        assert await setup.async_setup_component(
+            hass,
+            "template",
+            {
+                "template": {
+                    "unique_id": "b",
+                    "select": {
+                        "state": f"{{{{ states('{_OPTION_INPUT_SELECT}') }}}}",
+                        "options": f"{{{{ state_attr('{_OPTION_INPUT_SELECT}', '{INPUT_SELECT_ATTR_OPTIONS}') }}}}",
+                        "select_option": {
+                            "service": "input_select.select_option",
+                            "data_template": {
+                                "entity_id": _OPTION_INPUT_SELECT,
+                                "option": "{{ option }}",
+                            },
+                        },
+                        "optimistic": True,
+                        "unique_id": "a",
+                        "icon": f"{{% if (states('{_OPTION_INPUT_SELECT}') == 'a') %}}mdi:greater{{% else %}}mdi:less{{% endif %}}",
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state.state == "a"
+    assert state.attributes[ATTR_ICON] == "mdi:greater"
+
+    await hass.services.async_call(
+        INPUT_SELECT_DOMAIN,
+        INPUT_SELECT_SERVICE_SELECT_OPTION,
+        {CONF_ENTITY_ID: _OPTION_INPUT_SELECT, INPUT_SELECT_ATTR_OPTION: "b"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state.state == "b"
+    assert state.attributes[ATTR_ICON] == "mdi:less"
+
+
+async def test_template_icon_with_trigger(hass):
+    """Test trigger based template select."""
+    with assert_setup_component(1, "input_select"):
+        assert await setup.async_setup_component(
+            hass,
+            "input_select",
+            {
+                "input_select": {
+                    "option": {
+                        "options": ["a", "b"],
+                        "initial": "a",
+                        "name": "Option",
+                    },
+                }
+            },
+        )
+
+    assert await setup.async_setup_component(
+        hass,
+        "template",
+        {
+            "template": {
+                # "unique_id": "listening-test-event",
+                "trigger": {"platform": "state", "entity_id": _OPTION_INPUT_SELECT},
+                "select": {
+                    # "name": "Hello Name",
+                    "unique_id": "b",
+                    "state": "{{ trigger.to_state.state }}",
+                    "options": f"{{{{ state_attr('{_OPTION_INPUT_SELECT}', '{INPUT_SELECT_ATTR_OPTIONS}') }}}}",
+                    "select_option": {
+                        "service": "input_select.select_option",
+                        "data_template": {
+                            "entity_id": _OPTION_INPUT_SELECT,
+                            "option": "{{ option }}",
+                        },
+                    },
+                    "optimistic": True,
+                    "icon": "{% if (trigger.to_state.state or '') == 'a' %}mdi:greater{% else %}mdi:less{% endif %}",
+                },
+            },
+        },
+    )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        INPUT_SELECT_DOMAIN,
+        INPUT_SELECT_SERVICE_SELECT_OPTION,
+        {CONF_ENTITY_ID: _OPTION_INPUT_SELECT, INPUT_SELECT_ATTR_OPTION: "b"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state is not None
+    assert state.state == "b"
+    assert state.attributes[ATTR_ICON] == "mdi:less"
+
+    await hass.services.async_call(
+        INPUT_SELECT_DOMAIN,
+        INPUT_SELECT_SERVICE_SELECT_OPTION,
+        {CONF_ENTITY_ID: _OPTION_INPUT_SELECT, INPUT_SELECT_ATTR_OPTION: "a"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_TEST_SELECT)
+    assert state.state == "a"
+    assert state.attributes[ATTR_ICON] == "mdi:greater"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enable template icons for template selects

This is a follow-up to https://github.com/home-assistant/core/pull/56154

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
