### PR TITLE
Move attributes from __init__ to class attributes

### DIFF
--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -53,6 +53,7 @@ class AccuWeatherEntity(CoordinatorEntity, WeatherEntity):
     """Define an AccuWeather entity."""
 
     coordinator: AccuWeatherDataUpdateCoordinator
+    _attr_attribution = ATTRIBUTION
 
     def __init__(
         self, name: str, coordinator: AccuWeatherDataUpdateCoordinator
@@ -65,7 +66,6 @@ class AccuWeatherEntity(CoordinatorEntity, WeatherEntity):
         self._attr_temperature_unit = (
             TEMP_CELSIUS if coordinator.is_metric else TEMP_FAHRENHEIT
         )
-        self._attr_attribution = ATTRIBUTION
         self._attr_device_info = {
             "identifiers": {(DOMAIN, coordinator.location_key)},
             "name": NAME,

--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -52,8 +52,8 @@ async def async_setup_entry(
 class AccuWeatherEntity(CoordinatorEntity, WeatherEntity):
     """Define an AccuWeather entity."""
 
-    coordinator: AccuWeatherDataUpdateCoordinator
     _attr_attribution = ATTRIBUTION
+    coordinator: AccuWeatherDataUpdateCoordinator
 
     def __init__(
         self, name: str, coordinator: AccuWeatherDataUpdateCoordinator

--- a/homeassistant/components/broadlink/switch.py
+++ b/homeassistant/components/broadlink/switch.py
@@ -256,6 +256,7 @@ class BroadlinkBG1Slot(BroadlinkSwitch):
     """Representation of a Broadlink BG1 slot."""
 
     _attr_assumed_state = False
+    _attr_device_class = DEVICE_CLASS_OUTLET
 
     def __init__(self, device, slot):
         """Initialize the switch."""
@@ -264,7 +265,6 @@ class BroadlinkBG1Slot(BroadlinkSwitch):
         self._attr_is_on = self._coordinator.data[f"pwr{slot}"]
 
         self._attr_name = f"{device.name} S{slot}"
-        self._attr_device_class = DEVICE_CLASS_OUTLET
         self._attr_unique_id = f"{device.unique_id}-s{slot}"
 
     def _update_state(self, data):

--- a/homeassistant/components/demo/siren.py
+++ b/homeassistant/components/demo/siren.py
@@ -51,6 +51,8 @@ async def async_setup_entry(
 class DemoSiren(SirenEntity):
     """Representation of a demo siren device."""
 
+    _attr_should_poll = False
+
     def __init__(
         self,
         name: str,
@@ -61,7 +63,6 @@ class DemoSiren(SirenEntity):
     ) -> None:
         """Initialize the siren device."""
         self._attr_name = name
-        self._attr_should_poll = False
         self._attr_supported_features = SUPPORT_FLAGS
         self._attr_is_on = is_on
         if available_tones is not None:

--- a/homeassistant/components/devolo_home_control/cover.py
+++ b/homeassistant/components/devolo_home_control/cover.py
@@ -45,6 +45,8 @@ async def async_setup_entry(
 class DevoloCoverDeviceEntity(DevoloMultiLevelSwitchDeviceEntity, CoverEntity):
     """Representation of a cover device within devolo Home Control."""
 
+    _attr_device_class = DEVICE_CLASS_BLIND
+
     def __init__(
         self, homecontrol: HomeControl, device_instance: Zwave, element_uid: str
     ) -> None:
@@ -55,7 +57,6 @@ class DevoloCoverDeviceEntity(DevoloMultiLevelSwitchDeviceEntity, CoverEntity):
             element_uid=element_uid,
         )
 
-        self._attr_device_class = DEVICE_CLASS_BLIND
         self._attr_supported_features = (
             SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
         )

--- a/homeassistant/components/devolo_home_control/devolo_device.py
+++ b/homeassistant/components/devolo_home_control/devolo_device.py
@@ -17,6 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 class DevoloDeviceEntity(Entity):
     """Abstract representation of a device within devolo Home Control."""
 
+    _attr_should_poll = False
+
     def __init__(
         self, homecontrol: HomeControl, device_instance: Zwave, element_uid: str
     ) -> None:
@@ -30,7 +32,6 @@ class DevoloDeviceEntity(Entity):
         self._attr_name: str = device_instance.settings_property[
             "general_device_settings"
         ].name
-        self._attr_should_poll = False
         self._attr_unique_id = element_uid
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._device_instance.uid)},

--- a/homeassistant/components/devolo_home_control/sensor.py
+++ b/homeassistant/components/devolo_home_control/sensor.py
@@ -120,6 +120,8 @@ class DevoloGenericMultiLevelDeviceEntity(DevoloMultiLevelDeviceEntity):
 class DevoloBatteryEntity(DevoloMultiLevelDeviceEntity):
     """Representation of a battery entity within devolo Home Control."""
 
+    _attr_native_unit_of_measurement = PERCENTAGE
+
     def __init__(
         self, homecontrol: HomeControl, device_instance: Zwave, element_uid: str
     ) -> None:
@@ -132,7 +134,6 @@ class DevoloBatteryEntity(DevoloMultiLevelDeviceEntity):
         )
 
         self._attr_device_class = DEVICE_CLASS_MAPPING.get("battery")
-        self._attr_native_unit_of_measurement = PERCENTAGE
 
         self._value = device_instance.battery_level
 

--- a/homeassistant/components/directv/media_player.py
+++ b/homeassistant/components/directv/media_player.py
@@ -87,6 +87,8 @@ async def async_setup_entry(
 class DIRECTVMediaPlayer(DIRECTVEntity, MediaPlayerEntity):
     """Representation of a DirecTV receiver on the network."""
 
+    _attr_device_class = DEVICE_CLASS_RECEIVER
+
     def __init__(self, *, dtv: DIRECTV, name: str, address: str = "0") -> None:
         """Initialize DirecTV media player."""
         super().__init__(
@@ -96,7 +98,6 @@ class DIRECTVMediaPlayer(DIRECTVEntity, MediaPlayerEntity):
 
         self._attr_unique_id = self._device_id
         self._attr_name = name
-        self._attr_device_class = DEVICE_CLASS_RECEIVER
         self._attr_available = False
 
         self._is_recorded = None

--- a/homeassistant/components/eight_sleep/binary_sensor.py
+++ b/homeassistant/components/eight_sleep/binary_sensor.py
@@ -31,6 +31,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class EightHeatSensor(EightSleepHeatEntity, BinarySensorEntity):
     """Representation of a Eight Sleep heat-based sensor."""
 
+    _attr_device_class = DEVICE_CLASS_OCCUPANCY
+
     def __init__(self, name, eight, sensor):
         """Initialize the sensor."""
         super().__init__(eight)
@@ -44,7 +46,6 @@ class EightHeatSensor(EightSleepHeatEntity, BinarySensorEntity):
         self._usrobj = self._eight.users[self._userid]
 
         self._attr_name = f"{name} {self._mapped_name}"
-        self._attr_device_class = DEVICE_CLASS_OCCUPANCY
 
         _LOGGER.debug(
             "Presence Sensor: %s, Side: %s, User: %s",

--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -205,6 +205,8 @@ class EnergyCostSensor(SensorEntity):
     _wrong_state_class_reported = False
     _wrong_unit_reported = False
 
+    _attr_device_class = DEVICE_CLASS_MONETARY
+
     def __init__(
         self,
         adapter: SourceAdapter,
@@ -217,7 +219,6 @@ class EnergyCostSensor(SensorEntity):
         self.entity_id = (
             f"{config[adapter.entity_energy_key]}_{adapter.entity_id_suffix}"
         )
-        self._attr_device_class = DEVICE_CLASS_MONETARY
         self._attr_state_class = STATE_CLASS_TOTAL
         self._config = config
         self._last_energy_sensor_state: State | None = None

--- a/homeassistant/components/fints/sensor.py
+++ b/homeassistant/components/fints/sensor.py
@@ -162,12 +162,13 @@ class FinTsAccount(SensorEntity):
     also be negative.
     """
 
+    _attr_icon = ICON
+
     def __init__(self, client: FinTsClient, account, name: str) -> None:
         """Initialize a FinTs balance account."""
         self._client = client
         self._account = account
         self._attr_name = name
-        self._attr_icon = ICON
         self._attr_extra_state_attributes = {
             ATTR_ACCOUNT: self._account.iban,
             ATTR_ACCOUNT_TYPE: "balance",
@@ -191,13 +192,14 @@ class FinTsHoldingsAccount(SensorEntity):
     instruments, e.g. stocks.
     """
 
+    _attr_icon = ICON
+
     def __init__(self, client: FinTsClient, account, name: str) -> None:
         """Initialize a FinTs holdings account."""
         self._client = client
         self._attr_name = name
         self._account = account
         self._holdings: list[Any] = []
-        self._attr_icon = ICON
         self._attr_native_unit_of_measurement = "EUR"
 
     def update(self) -> None:

--- a/homeassistant/components/fjaraskupan/sensor.py
+++ b/homeassistant/components/fjaraskupan/sensor.py
@@ -42,6 +42,7 @@ async def async_setup_entry(
 class RssiSensor(CoordinatorEntity[State], SensorEntity):
     """Sensor device."""
 
+    _attr_device_class = DEVICE_CLASS_SIGNAL_STRENGTH
     _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
 
     def __init__(
@@ -55,7 +56,6 @@ class RssiSensor(CoordinatorEntity[State], SensorEntity):
         self._attr_unique_id = f"{device.address}-signal-strength"
         self._attr_device_info = device_info
         self._attr_name = f"{device_info['name']} Signal Strength"
-        self._attr_device_class = DEVICE_CLASS_SIGNAL_STRENGTH
         self._attr_state_class = STATE_CLASS_MEASUREMENT
         self._attr_entity_registry_enabled_default = False
 

--- a/homeassistant/components/fjaraskupan/sensor.py
+++ b/homeassistant/components/fjaraskupan/sensor.py
@@ -42,6 +42,8 @@ async def async_setup_entry(
 class RssiSensor(CoordinatorEntity[State], SensorEntity):
     """Sensor device."""
 
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator[State],
@@ -55,7 +57,6 @@ class RssiSensor(CoordinatorEntity[State], SensorEntity):
         self._attr_name = f"{device_info['name']} Signal Strength"
         self._attr_device_class = DEVICE_CLASS_SIGNAL_STRENGTH
         self._attr_state_class = STATE_CLASS_MEASUREMENT
-        self._attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
         self._attr_entity_registry_enabled_default = False
 
     @property

--- a/homeassistant/components/growatt_server/sensor.py
+++ b/homeassistant/components/growatt_server/sensor.py
@@ -954,6 +954,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class GrowattInverter(SensorEntity):
     """Representation of a Growatt Sensor."""
 
+    _attr_icon = "mdi:solar-power"
     entity_description: GrowattSensorEntityDescription
 
     def __init__(
@@ -965,7 +966,6 @@ class GrowattInverter(SensorEntity):
 
         self._attr_name = f"{name} {description.name}"
         self._attr_unique_id = unique_id
-        self._attr_icon = "mdi:solar-power"
 
     @property
     def native_value(self):

--- a/homeassistant/components/harmony/entity.py
+++ b/homeassistant/components/harmony/entity.py
@@ -14,13 +14,14 @@ TIME_MARK_DISCONNECTED = 10
 class HarmonyEntity(Entity):
     """Base entity for Harmony with connection state handling."""
 
+    _attr_should_poll = False
+
     def __init__(self, data: HarmonyData) -> None:
         """Initialize the Harmony base entity."""
         super().__init__()
         self._unsub_mark_disconnected = None
         self._name = data.name
         self._data = data
-        self._attr_should_poll = False
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -66,6 +66,8 @@ _LOGGER = logging.getLogger(__name__)
 class BasePlatform(Entity):
     """Base for readonly platforms."""
 
+    _attr_should_poll = False
+
     def __init__(self, hub: ModbusHub, entry: dict[str, Any]) -> None:
         """Initialize the Modbus binary sensor."""
         self._hub = hub
@@ -83,7 +85,6 @@ class BasePlatform(Entity):
         self._cancel_call: Callable[[], None] | None = None
 
         self._attr_name = entry[CONF_NAME]
-        self._attr_should_poll = False
         self._attr_device_class = entry.get(CONF_DEVICE_CLASS)
         self._attr_available = True
         self._attr_unit_of_measurement = None

--- a/homeassistant/components/modern_forms/sensor.py
+++ b/homeassistant/components/modern_forms/sensor.py
@@ -59,6 +59,8 @@ class ModernFormsSensor(ModernFormsDeviceEntity, SensorEntity):
 class ModernFormsLightTimerRemainingTimeSensor(ModernFormsSensor):
     """Defines the Modern Forms Light Timer remaining time sensor."""
 
+    _attr_device_class = DEVICE_CLASS_TIMESTAMP
+
     def __init__(
         self, entry_id: str, coordinator: ModernFormsDataUpdateCoordinator
     ) -> None:
@@ -70,7 +72,6 @@ class ModernFormsLightTimerRemainingTimeSensor(ModernFormsSensor):
             key="light_timer_remaining_time",
             name=f"{coordinator.data.info.device_name} Light Sleep Time",
         )
-        self._attr_device_class = DEVICE_CLASS_TIMESTAMP
 
     @property
     def native_value(self) -> StateType:
@@ -89,6 +90,8 @@ class ModernFormsLightTimerRemainingTimeSensor(ModernFormsSensor):
 class ModernFormsFanTimerRemainingTimeSensor(ModernFormsSensor):
     """Defines the Modern Forms Light Timer remaining time sensor."""
 
+    _attr_device_class = DEVICE_CLASS_TIMESTAMP
+
     def __init__(
         self, entry_id: str, coordinator: ModernFormsDataUpdateCoordinator
     ) -> None:
@@ -100,7 +103,6 @@ class ModernFormsFanTimerRemainingTimeSensor(ModernFormsSensor):
             key="fan_timer_remaining_time",
             name=f"{coordinator.data.info.device_name} Fan Sleep Time",
         )
-        self._attr_device_class = DEVICE_CLASS_TIMESTAMP
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -175,10 +175,11 @@ class OpenUV:
 class OpenUvEntity(Entity):
     """Define a generic OpenUV entity."""
 
+    _attr_should_poll = False
+
     def __init__(self, openuv: OpenUV, description: EntityDescription) -> None:
         """Initialize."""
         self._attr_extra_state_attributes = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
-        self._attr_should_poll = False
         self._attr_unique_id = (
             f"{openuv.client.latitude}_{openuv.client.longitude}_{description.key}"
         )

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -132,6 +132,8 @@ def _average_pixels(data):
 class PhilipsTVLightEntity(CoordinatorEntity, LightEntity):
     """Representation of a Philips TV exposing the JointSpace API."""
 
+    _attr_icon = "mdi:television-ambient-light"
+
     def __init__(
         self,
         coordinator: PhilipsTVDataUpdateCoordinator,
@@ -153,7 +155,6 @@ class PhilipsTVLightEntity(CoordinatorEntity, LightEntity):
         )
         self._attr_name = self._system["name"]
         self._attr_unique_id = unique_id
-        self._attr_icon = "mdi:television-ambient-light"
         self._attr_device_info = {
             "name": self._system["name"],
             "identifiers": {

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -105,6 +105,8 @@ def _async_add_entities(hass, registry, async_add_entities, server_id, new_entit
 class PlexMediaPlayer(MediaPlayerEntity):
     """Representation of a Plex device."""
 
+    _attr_should_poll = False
+
     def __init__(self, plex_server, device, player_source, session=None):
         """Initialize the Plex device."""
         self.plex_server = plex_server
@@ -125,7 +127,6 @@ class PlexMediaPlayer(MediaPlayerEntity):
         self._volume_muted = False  # since we can't retrieve remotely
 
         self._attr_available = False
-        self._attr_should_poll = False
         self._attr_state = STATE_IDLE
         self._attr_unique_id = (
             f"{self.plex_server.machine_identifier}:{self.machine_identifier}"

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -62,9 +62,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class PlexSensor(SensorEntity):
     """Representation of a Plex now playing sensor."""
 
+    _attr_icon = "mdi:plex"
+
     def __init__(self, hass, plex_server):
         """Initialize the sensor."""
-        self._attr_icon = "mdi:plex"
         self._attr_name = NAME_FORMAT.format(plex_server.friendly_name)
         self._attr_should_poll = False
         self._attr_unique_id = f"sensor-{plex_server.machine_identifier}"

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -63,11 +63,11 @@ class PlexSensor(SensorEntity):
     """Representation of a Plex now playing sensor."""
 
     _attr_icon = "mdi:plex"
+    _attr_should_poll = False
 
     def __init__(self, hass, plex_server):
         """Initialize the sensor."""
         self._attr_name = NAME_FORMAT.format(plex_server.friendly_name)
-        self._attr_should_poll = False
         self._attr_unique_id = f"sensor-{plex_server.machine_identifier}"
         self._attr_native_unit_of_measurement = "Watching"
 
@@ -120,6 +120,8 @@ class PlexSensor(SensorEntity):
 class PlexLibrarySectionSensor(SensorEntity):
     """Representation of a Plex library section sensor."""
 
+    _attr_should_poll = False
+
     def __init__(self, hass, plex_server, plex_library_section):
         """Initialize the sensor."""
         self._server = plex_server
@@ -133,7 +135,6 @@ class PlexLibrarySectionSensor(SensorEntity):
         self._attr_extra_state_attributes = {}
         self._attr_icon = LIBRARY_ICON_LOOKUP.get(self.library_type, "mdi:plex")
         self._attr_name = f"{self.server_name} Library - {plex_library_section.title}"
-        self._attr_should_poll = False
         self._attr_unique_id = f"library-{self.server_id}-{plex_library_section.uuid}"
         self._attr_native_unit_of_measurement = "Items"
 

--- a/homeassistant/components/rova/sensor.py
+++ b/homeassistant/components/rova/sensor.py
@@ -101,6 +101,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class RovaSensor(SensorEntity):
     """Representation of a Rova sensor."""
 
+    _attr_device_class = DEVICE_CLASS_TIMESTAMP
+
     def __init__(
         self, platform_name, description: SensorEntityDescription, data_service
     ):
@@ -109,7 +111,6 @@ class RovaSensor(SensorEntity):
         self.data_service = data_service
 
         self._attr_name = f"{platform_name}_{description.name}"
-        self._attr_device_class = DEVICE_CLASS_TIMESTAMP
 
     def update(self):
         """Get the latest data from the sensor and update the state."""

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -355,7 +355,7 @@ class ShellyRpcEntity(entity.Entity):
     @property
     def available(self) -> bool:
         """Available."""
-        return self.wrapper.device.connected  # type: ignore[no-any-return]
+        return self.wrapper.device.connected
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to HASS."""
@@ -619,7 +619,7 @@ class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity, RestoreEnti
         self.last_state: StateType = None
         self.wrapper = wrapper
         self.attribute = attribute
-        self.block: Block | None = block
+        self.block: Block | None = block  # type: ignore[assignment]
         self.description = description
         self._unit = self.description.unit
 

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -340,11 +340,12 @@ class ShellyBlockEntity(entity.Entity):
 class ShellyRpcEntity(entity.Entity):
     """Helper class to represent a rpc entity."""
 
+    _attr_should_poll = False
+
     def __init__(self, wrapper: RpcDeviceWrapper, key: str) -> None:
         """Initialize Shelly entity."""
         self.wrapper = wrapper
         self.key = key
-        self._attr_should_poll = False
         self._attr_device_info = {
             "connections": {(device_registry.CONNECTION_NETWORK_MAC, wrapper.mac)}
         }
@@ -354,7 +355,7 @@ class ShellyRpcEntity(entity.Entity):
     @property
     def available(self) -> bool:
         """Available."""
-        return self.wrapper.device.connected
+        return self.wrapper.device.connected  # type: ignore[no-any-return]
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to HASS."""
@@ -618,7 +619,7 @@ class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity, RestoreEnti
         self.last_state: StateType = None
         self.wrapper = wrapper
         self.attribute = attribute
-        self.block: Block | None = block  # type: ignore[assignment]
+        self.block: Block | None = block
         self.description = description
         self._unit = self.description.unit
 

--- a/homeassistant/components/sia/sia_entity_base.py
+++ b/homeassistant/components/sia/sia_entity_base.py
@@ -24,6 +24,8 @@ _LOGGER = logging.getLogger(__name__)
 class SIABaseEntity(RestoreEntity):
     """Base class for SIA entities."""
 
+    _attr_should_poll = False
+
     def __init__(
         self,
         entry: ConfigEntry,
@@ -44,7 +46,6 @@ class SIABaseEntity(RestoreEntity):
         self._cancel_availability_cb: CALLBACK_TYPE | None = None
 
         self._attr_extra_state_attributes = {}
-        self._attr_should_poll = False
         self._attr_name = SIA_NAME_FORMAT.format(
             self._port, self._account, self._zone, self._attr_device_class
         )

--- a/homeassistant/components/thermoworks_smoke/sensor.py
+++ b/homeassistant/components/thermoworks_smoke/sensor.py
@@ -94,6 +94,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ThermoworksSmokeSensor(SensorEntity):
     """Implementation of a thermoworks smoke sensor."""
 
+    _attr_device_class = DEVICE_CLASS_TEMPERATURE
+
     def __init__(self, sensor_type, serial, mgr):
         """Initialize the sensor."""
         self._name = "{name} {sensor}".format(
@@ -106,7 +108,6 @@ class ThermoworksSmokeSensor(SensorEntity):
         self._unique_id = f"{serial}-{sensor_type}"
         self.serial = serial
         self.mgr = mgr
-        self._attr_device_class = DEVICE_CLASS_TEMPERATURE
         self.update_unit()
 
     @property

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -277,6 +277,8 @@ class TibberSensor(SensorEntity):
 class TibberSensorElPrice(TibberSensor):
     """Representation of a Tibber sensor for el price."""
 
+    _attr_icon = ICON
+
     def __init__(self, tibber_home):
         """Initialize the sensor."""
         super().__init__(tibber_home=tibber_home)
@@ -296,7 +298,6 @@ class TibberSensorElPrice(TibberSensor):
             "peak": None,
             "off_peak_2": None,
         }
-        self._attr_icon = ICON
         self._attr_name = f"Electricity price {self._home_name}"
         self._attr_unique_id = f"{self._tibber_home.home_id}"
         self._model = "Price Sensor"

--- a/homeassistant/components/tradfri/light.py
+++ b/homeassistant/components/tradfri/light.py
@@ -62,6 +62,7 @@ async def async_setup_entry(
 class TradfriGroup(TradfriBaseClass, LightEntity):
     """The platform class for light groups required by hass."""
 
+    _attr_should_poll = True
     _attr_supported_features = SUPPORTED_GROUP_FEATURES
 
     def __init__(
@@ -74,7 +75,6 @@ class TradfriGroup(TradfriBaseClass, LightEntity):
         super().__init__(device, api, gateway_id)
 
         self._attr_unique_id = f"group-{gateway_id}-{device.id}"
-        self._attr_should_poll = True
         self._refresh(device)
 
     async def async_update(self) -> None:

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -162,19 +162,19 @@ async def async_setup_entry(
 class WazeTravelTime(SensorEntity):
     """Representation of a Waze travel time sensor."""
 
-    _attr_native_unit_of_measurement = TIME_MINUTES
     _attr_device_info = {
         "name": "Waze",
         "identifiers": {(DOMAIN, DOMAIN)},
         "entry_type": "service",
     }
+    _attr_icon = "mdi:car"
+    _attr_native_unit_of_measurement = TIME_MINUTES
 
     def __init__(self, unique_id, name, origin, destination, waze_data):
         """Initialize the Waze travel time sensor."""
         self._attr_unique_id = unique_id
         self._waze_data = waze_data
         self._attr_name = name
-        self._attr_icon = "mdi:car"
         self._state = None
         self._origin_entity_id = None
         self._destination_entity_id = None

--- a/homeassistant/components/youless/sensor.py
+++ b/homeassistant/components/youless/sensor.py
@@ -99,15 +99,15 @@ class YoulessBaseSensor(CoordinatorEntity, SensorEntity):
 class GasSensor(YoulessBaseSensor):
     """The Youless gas sensor."""
 
-    _attr_native_unit_of_measurement = VOLUME_CUBIC_METERS
     _attr_device_class = DEVICE_CLASS_GAS
+    _attr_icon = "mdi:fire"
+    _attr_native_unit_of_measurement = VOLUME_CUBIC_METERS
     _attr_state_class = STATE_CLASS_TOTAL_INCREASING
 
     def __init__(self, coordinator: DataUpdateCoordinator, device: str) -> None:
         """Instantiate a gas sensor."""
         super().__init__(coordinator, device, "gas", "Gas meter", "gas")
         self._attr_name = "Gas usage"
-        self._attr_icon = "mdi:fire"
 
     @property
     def get_sensor(self) -> YoulessSensor | None:
@@ -118,8 +118,8 @@ class GasSensor(YoulessBaseSensor):
 class CurrentPowerSensor(YoulessBaseSensor):
     """The current power usage sensor."""
 
-    _attr_native_unit_of_measurement = POWER_WATT
     _attr_device_class = DEVICE_CLASS_POWER
+    _attr_native_unit_of_measurement = POWER_WATT
     _attr_state_class = STATE_CLASS_MEASUREMENT
 
     def __init__(self, coordinator: DataUpdateCoordinator, device: str) -> None:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -267,6 +267,8 @@ async def async_setup_entry(
 class ZwaveSensorBase(ZWaveBaseEntity, SensorEntity):
     """Basic Representation of a Z-Wave sensor."""
 
+    _attr_force_update = True
+
     def __init__(
         self,
         config_entry: ConfigEntry,
@@ -279,7 +281,6 @@ class ZwaveSensorBase(ZWaveBaseEntity, SensorEntity):
         self.entity_description = entity_description
 
         # Entity class attributes
-        self._attr_force_update = True
         self._attr_name = self.generate_name(include_value_name=True)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move attributes from `__init__` to class attributes

List of moved attributes:

- _attr_attribution 
- _attr_device_class 
- _attr_icon
- _attr_force_update 
- _attr_should_poll
- _attr_native_unit_of_measurement 
- _attr_device_class 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
