### PR TITLE
Add config flow to Stookalert

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1000,7 +1000,8 @@ omit =
     homeassistant/components/starlingbank/sensor.py
     homeassistant/components/steam_online/sensor.py
     homeassistant/components/stiebel_eltron/*
-    homeassistant/components/stookalert/*
+    homeassistant/components/stookalert/__init__.py
+    homeassistant/components/stookalert/binary_sensor.py
     homeassistant/components/stream/*
     homeassistant/components/streamlabswater/*
     homeassistant/components/suez_water/*

--- a/.strict-typing
+++ b/.strict-typing
@@ -101,6 +101,7 @@ homeassistant.components.simplisafe.*
 homeassistant.components.slack.*
 homeassistant.components.sonos.media_player
 homeassistant.components.ssdp.*
+homeassistant.components.stookalert.*
 homeassistant.components.stream.*
 homeassistant.components.sun.*
 homeassistant.components.surepetcare.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -497,7 +497,7 @@ homeassistant/components/srp_energy/* @briglx
 homeassistant/components/starline/* @anonym-tsk
 homeassistant/components/statistics/* @fabaff
 homeassistant/components/stiebel_eltron/* @fucm
-homeassistant/components/stookalert/* @fwestenberg
+homeassistant/components/stookalert/* @fwestenberg @frenck
 homeassistant/components/stream/* @hunterjm @uvjustin @allenporter
 homeassistant/components/stt/* @pvizeli
 homeassistant/components/subaru/* @G-Two

--- a/homeassistant/components/stookalert/__init__.py
+++ b/homeassistant/components/stookalert/__init__.py
@@ -1,1 +1,1 @@
-"""The Stookalert component."""
+"""The Stookalert integration."""

--- a/homeassistant/components/stookalert/__init__.py
+++ b/homeassistant/components/stookalert/__init__.py
@@ -1,1 +1,28 @@
 """The Stookalert integration."""
+from __future__ import annotations
+
+import stookalert
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_PROVINCE, DOMAIN
+
+PLATFORMS = (BINARY_SENSOR_DOMAIN,)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Stookalert from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = stookalert.stookalert(entry.data[CONF_PROVINCE])
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload Stookalert config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        del hass.data[DOMAIN][entry.entry_id]
+    return unload_ok

--- a/homeassistant/components/stookalert/binary_sensor.py
+++ b/homeassistant/components/stookalert/binary_sensor.py
@@ -103,7 +103,3 @@ class StookalertBinarySensor(BinarySensorEntity):
         """Update the data from the Stookalert handler."""
         self._client.get_alerts()
         self._attr_is_on = self._client.state == 1
-        if self._client.last_updated:
-            self._attr_extra_state_attributes.update(
-                last_updated=self._client.last_updated.isoformat()
-            )

--- a/homeassistant/components/stookalert/config_flow.py
+++ b/homeassistant/components/stookalert/config_flow.py
@@ -1,0 +1,37 @@
+"""Config flow to configure the Stookalert integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import CONF_PROVINCE, DOMAIN, PROVINCES
+
+
+class StookalertFlowHandler(ConfigFlow, domain=DOMAIN):
+    """Config flow for Stookalert."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_PROVINCE])
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=user_input[CONF_PROVINCE], data=user_input
+            )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_PROVINCE): vol.In(PROVINCES)}),
+        )
+
+    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
+        """Handle a flow initialized by importing a config."""
+        return await self.async_step_user(config)

--- a/homeassistant/components/stookalert/const.py
+++ b/homeassistant/components/stookalert/const.py
@@ -1,0 +1,26 @@
+"""Constants for the Stookalert integration."""
+import logging
+from typing import Final
+
+DOMAIN: Final = "stookalert"
+LOGGER = logging.getLogger(__package__)
+
+CONF_PROVINCE: Final = "province"
+
+PROVINCES: Final = (
+    "Drenthe",
+    "Flevoland",
+    "Friesland",
+    "Gelderland",
+    "Groningen",
+    "Limburg",
+    "Noord-Brabant",
+    "Noord-Holland",
+    "Overijssel",
+    "Utrecht",
+    "Zeeland",
+    "Zuid-Holland",
+)
+
+ATTR_ENTRY_TYPE: Final = "entry_type"
+ENTRY_TYPE_SERVICE: Final = "service"

--- a/homeassistant/components/stookalert/manifest.json
+++ b/homeassistant/components/stookalert/manifest.json
@@ -1,8 +1,9 @@
 {
   "domain": "stookalert",
   "name": "RIVM Stookalert",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/stookalert",
-  "codeowners": ["@fwestenberg"],
+  "codeowners": ["@fwestenberg", "@frenck"],
   "requirements": ["stookalert==0.1.4"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/stookalert/strings.json
+++ b/homeassistant/components/stookalert/strings.json
@@ -2,7 +2,6 @@
   "config": {
     "step": {
       "user": {
-        "description": "Set up Stookalert to integrate with Home Assistant.",
         "data": {
           "province": "Province"
         }

--- a/homeassistant/components/stookalert/strings.json
+++ b/homeassistant/components/stookalert/strings.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Set up Stookalert to integrate with Home Assistant.",
+        "data": {
+          "province": "Province"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+    }
+  }
+}

--- a/homeassistant/components/stookalert/translations/en.json
+++ b/homeassistant/components/stookalert/translations/en.json
@@ -7,8 +7,7 @@
             "user": {
                 "data": {
                     "province": "Province"
-                },
-                "description": "Set up Stookalert to integrate with Home Assistant."
+                }
             }
         }
     }

--- a/homeassistant/components/stookalert/translations/en.json
+++ b/homeassistant/components/stookalert/translations/en.json
@@ -1,0 +1,15 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Service is already configured"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "province": "Province"
+                },
+                "description": "Set up Stookalert to integrate with Home Assistant."
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -271,6 +271,7 @@ FLOWS = [
     "squeezebox",
     "srp_energy",
     "starline",
+    "stookalert",
     "subaru",
     "surepetcare",
     "switchbot",

--- a/mypy.ini
+++ b/mypy.ini
@@ -1122,6 +1122,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.stookalert.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.stream.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1284,6 +1284,9 @@ starline==0.1.5
 # homeassistant.components.statsd
 statsd==3.2.1
 
+# homeassistant.components.stookalert
+stookalert==0.1.4
+
 # homeassistant.components.huawei_lte
 # homeassistant.components.solaredge
 # homeassistant.components.thermoworks_smoke

--- a/tests/components/stookalert/__init__.py
+++ b/tests/components/stookalert/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Stookalert integration."""

--- a/tests/components/stookalert/test_config_flow.py
+++ b/tests/components/stookalert/test_config_flow.py
@@ -1,0 +1,78 @@
+"""Tests for the Stookalert config flow."""
+from unittest.mock import patch
+
+from homeassistant.components.stookalert.const import CONF_PROVINCE, DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_full_user_flow(hass: HomeAssistant) -> None:
+    """Test the full user configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("step_id") == SOURCE_USER
+    assert "flow_id" in result
+
+    with patch(
+        "homeassistant.components.stookalert.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_PROVINCE: "Overijssel",
+            },
+        )
+
+    assert result2.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result2.get("title") == "Overijssel"
+    assert result2.get("data") == {
+        CONF_PROVINCE: "Overijssel",
+    }
+
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_already_configured(hass: HomeAssistant) -> None:
+    """Test we abort if the Stookalert province is already configured."""
+    MockConfigEntry(
+        domain=DOMAIN, data={CONF_PROVINCE: "Overijssel"}, unique_id="Overijssel"
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert "flow_id" in result
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_PROVINCE: "Overijssel",
+        },
+    )
+
+    assert result2.get("type") == RESULT_TYPE_ABORT
+    assert result2.get("reason") == "already_configured"
+
+
+async def test_import_flow(hass: HomeAssistant) -> None:
+    """Test the import configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data={"province": "Overijssel"}
+    )
+
+    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result.get("title") == "Overijssel"
+    assert result.get("data") == {
+        CONF_PROVINCE: "Overijssel",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

The Stookalert integration migrated to configuration via the UI. Configuring Stookalert via YAML configuration has been deprecated and will be removed in a future Home Assistant release.

Your existing YAML configuration is automatically imported on upgrade to this release; and thus can be safely removed from your YAML configuration after upgrading.

Additionally, the `last_updated` state attribute has been removed from the Stookalert binary sensors.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a configuration flow to the Stookalert integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19620

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
