### PR TITLE
Use current config entry standards for AirVisual

### DIFF
--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -106,8 +106,8 @@ def async_get_cloud_coordinators_by_api_key(
     """Get all DataUpdateCoordinator objects related to a particular API key."""
     coordinators = []
     for entry_id, coordinator in hass.data[DOMAIN][DATA_COORDINATOR].items():
-        config_entry = hass.config_entries.async_get_entry(entry_id)
-        if config_entry and config_entry.data.get(CONF_API_KEY) == api_key:
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry and entry.data.get(CONF_API_KEY) == api_key:
             coordinators.append(coordinator)
     return coordinators
 
@@ -137,25 +137,25 @@ def async_sync_geo_coordinator_update_intervals(
 
 @callback
 def _standardize_geography_config_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, entry: ConfigEntry
 ) -> None:
     """Ensure that geography config entries have appropriate properties."""
     entry_updates = {}
 
-    if not config_entry.unique_id:
+    if not entry.unique_id:
         # If the config entry doesn't already have a unique ID, set one:
-        entry_updates["unique_id"] = config_entry.data[CONF_API_KEY]
-    if not config_entry.options:
+        entry_updates["unique_id"] = entry.data[CONF_API_KEY]
+    if not entry.options:
         # If the config entry doesn't already have any options set, set defaults:
         entry_updates["options"] = {CONF_SHOW_ON_MAP: True}
-    if config_entry.data.get(CONF_INTEGRATION_TYPE) not in [
+    if entry.data.get(CONF_INTEGRATION_TYPE) not in [
         INTEGRATION_TYPE_GEOGRAPHY_COORDS,
         INTEGRATION_TYPE_GEOGRAPHY_NAME,
     ]:
         # If the config entry data doesn't contain an integration type that we know
         # about, infer it from the data we have:
-        entry_updates["data"] = {**config_entry.data}
-        if CONF_CITY in config_entry.data:
+        entry_updates["data"] = {**entry.data}
+        if CONF_CITY in entry.data:
             entry_updates["data"][
                 CONF_INTEGRATION_TYPE
             ] = INTEGRATION_TYPE_GEOGRAPHY_NAME
@@ -167,51 +167,49 @@ def _standardize_geography_config_entry(
     if not entry_updates:
         return
 
-    hass.config_entries.async_update_entry(config_entry, **entry_updates)
+    hass.config_entries.async_update_entry(entry, **entry_updates)
 
 
 @callback
-def _standardize_node_pro_config_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry
-) -> None:
+def _standardize_node_pro_config_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Ensure that Node/Pro config entries have appropriate properties."""
     entry_updates: dict[str, Any] = {}
 
-    if CONF_INTEGRATION_TYPE not in config_entry.data:
+    if CONF_INTEGRATION_TYPE not in entry.data:
         # If the config entry data doesn't contain the integration type, add it:
         entry_updates["data"] = {
-            **config_entry.data,
+            **entry.data,
             CONF_INTEGRATION_TYPE: INTEGRATION_TYPE_NODE_PRO,
         }
 
     if not entry_updates:
         return
 
-    hass.config_entries.async_update_entry(config_entry, **entry_updates)
+    hass.config_entries.async_update_entry(entry, **entry_updates)
 
 
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up AirVisual as config entry."""
     hass.data.setdefault(DOMAIN, {DATA_COORDINATOR: {}})
 
-    if CONF_API_KEY in config_entry.data:
-        _standardize_geography_config_entry(hass, config_entry)
+    if CONF_API_KEY in entry.data:
+        _standardize_geography_config_entry(hass, entry)
 
         websession = aiohttp_client.async_get_clientsession(hass)
-        cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
+        cloud_api = CloudAPI(entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data() -> dict[str, Any]:
             """Get new data from the API."""
-            if CONF_CITY in config_entry.data:
+            if CONF_CITY in entry.data:
                 api_coro = cloud_api.air_quality.city(
-                    config_entry.data[CONF_CITY],
-                    config_entry.data[CONF_STATE],
-                    config_entry.data[CONF_COUNTRY],
+                    entry.data[CONF_CITY],
+                    entry.data[CONF_STATE],
+                    entry.data[CONF_COUNTRY],
                 )
             else:
                 api_coro = cloud_api.air_quality.nearest_city(
-                    config_entry.data[CONF_LATITUDE],
-                    config_entry.data[CONF_LONGITUDE],
+                    entry.data[CONF_LATITUDE],
+                    entry.data[CONF_LONGITUDE],
                 )
 
             try:
@@ -225,7 +223,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         coordinator = DataUpdateCoordinator(
             hass,
             LOGGER,
-            name=async_get_geography_id(config_entry.data),
+            name=async_get_geography_id(entry.data),
             # We give a placeholder update interval in order to create the coordinator;
             # then, below, we use the coordinator's presence (along with any other
             # coordinators using the same API key) to calculate an actual, leveled
@@ -235,16 +233,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         )
 
         # Only geography-based entries have options:
-        config_entry.async_on_unload(
-            config_entry.add_update_listener(async_reload_entry)
-        )
+        entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     else:
         # Remove outdated air_quality entities from the entity registry if they exist:
         ent_reg = entity_registry.async_get(hass)
         for entity_entry in [
             e
             for e in ent_reg.entities.values()
-            if e.config_entry_id == config_entry.entry_id
+            if e.config_entry_id == entry.entry_id
             and e.entity_id.startswith("air_quality")
         ]:
             LOGGER.debug(
@@ -252,13 +248,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             )
             ent_reg.async_remove(entity_entry.entity_id)
 
-        _standardize_node_pro_config_entry(hass, config_entry)
+        _standardize_node_pro_config_entry(hass, entry)
 
         async def async_update_data() -> dict[str, Any]:
             """Get new data from the API."""
             try:
                 async with NodeSamba(
-                    config_entry.data[CONF_IP_ADDRESS], config_entry.data[CONF_PASSWORD]
+                    entry.data[CONF_IP_ADDRESS], entry.data[CONF_PASSWORD]
                 ) as node:
                     data = await node.async_get_latest_measurements()
                     return cast(Dict[str, Any], data)
@@ -275,40 +271,38 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][DATA_COORDINATOR][config_entry.entry_id] = coordinator
+    hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id] = coordinator
 
     # Reassess the interval between 2 server requests
-    if CONF_API_KEY in config_entry.data:
-        async_sync_geo_coordinator_update_intervals(
-            hass, config_entry.data[CONF_API_KEY]
-        )
+    if CONF_API_KEY in entry.data:
+        async_sync_geo_coordinator_update_intervals(hass, entry.data[CONF_API_KEY])
 
-    hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
 
 
-async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate an old config entry."""
-    version = config_entry.version
+    version = entry.version
 
     LOGGER.debug("Migrating from version %s", version)
 
     # 1 -> 2: One geography per config entry
     if version == 1:
-        version = config_entry.version = 2
+        version = entry.version = 2
 
         # Update the config entry to only include the first geography (there is always
         # guaranteed to be at least one):
-        geographies = list(config_entry.data[CONF_GEOGRAPHIES])
+        geographies = list(entry.data[CONF_GEOGRAPHIES])
         first_geography = geographies.pop(0)
         first_id = async_get_geography_id(first_geography)
 
         hass.config_entries.async_update_entry(
-            config_entry,
+            entry,
             unique_id=first_id,
             title=f"Cloud API ({first_id})",
-            data={CONF_API_KEY: config_entry.data[CONF_API_KEY], **first_geography},
+            data={CONF_API_KEY: entry.data[CONF_API_KEY], **first_geography},
         )
 
         # For any geographies that remain, create a new config entry for each one:
@@ -321,7 +315,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 hass.config_entries.flow.async_init(
                     DOMAIN,
                     context={"source": source},
-                    data={CONF_API_KEY: config_entry.data[CONF_API_KEY], **geography},
+                    data={CONF_API_KEY: entry.data[CONF_API_KEY], **geography},
                 )
             )
 
@@ -330,28 +324,24 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload an AirVisual config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        config_entry, PLATFORMS
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        hass.data[DOMAIN][DATA_COORDINATOR].pop(config_entry.entry_id)
+        hass.data[DOMAIN][DATA_COORDINATOR].pop(entry.entry_id)
 
-        if CONF_API_KEY in config_entry.data:
+        if CONF_API_KEY in entry.data:
             # Re-calculate the update interval period for any remaining consumers of
             # this API key:
-            async_sync_geo_coordinator_update_intervals(
-                hass, config_entry.data[CONF_API_KEY]
-            )
+            async_sync_geo_coordinator_update_intervals(hass, entry.data[CONF_API_KEY])
 
     return unload_ok
 
 
-async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle an options update."""
-    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 class AirVisualEntity(CoordinatorEntity):

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -348,12 +348,16 @@ class AirVisualEntity(CoordinatorEntity):
     """Define a generic AirVisual entity."""
 
     def __init__(
-        self, coordinator: DataUpdateCoordinator, description: EntityDescription
+        self,
+        coordinator: DataUpdateCoordinator,
+        entry: ConfigEntry,
+        description: EntityDescription,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
 
         self._attr_extra_state_attributes = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
+        self._entry = entry
         self.entity_description = description
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/airvisual/config_flow.py
+++ b/homeassistant/components/airvisual/config_flow.py
@@ -262,9 +262,9 @@ class AirVisualFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 class AirVisualOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle an AirVisual options flow."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    def __init__(self, entry: ConfigEntry) -> None:
         """Initialize."""
-        self.config_entry = config_entry
+        self.entry = entry
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
@@ -279,7 +279,7 @@ class AirVisualOptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Required(
                         CONF_SHOW_ON_MAP,
-                        default=self.config_entry.options.get(CONF_SHOW_ON_MAP),
+                        default=self.entry.options.get(CONF_SHOW_ON_MAP),
                     ): bool
                 }
             ),

--- a/tests/components/airvisual/test_config_flow.py
+++ b/tests/components/airvisual/test_config_flow.py
@@ -177,10 +177,8 @@ async def test_migration(hass):
         ],
     }
 
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, version=1, unique_id="abcde12345", data=conf
-    )
-    config_entry.add_to_hass(hass)
+    entry = MockConfigEntry(domain=DOMAIN, version=1, unique_id="abcde12345", data=conf)
+    entry.add_to_hass(hass)
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -222,19 +220,19 @@ async def test_options_flow(hass):
         CONF_LONGITUDE: -0.3817765,
     }
 
-    config_entry = MockConfigEntry(
+    entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="51.528308, -0.3817765",
         data=geography_conf,
         options={CONF_SHOW_ON_MAP: True},
     )
-    config_entry.add_to_hass(hass)
+    entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.airvisual.async_setup_entry", return_value=True
     ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        await hass.config_entries.async_setup(entry.entry_id)
+        result = await hass.config_entries.options.async_init(entry.entry_id)
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "init"
@@ -244,7 +242,7 @@ async def test_options_flow(hass):
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert config_entry.options == {CONF_SHOW_ON_MAP: False}
+        assert entry.options == {CONF_SHOW_ON_MAP: False}
 
 
 async def test_step_geography_by_coords(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates AirVisual to use a current config entry standard:

1. Use `entry` instead of `config_entry` where appropriate (to be consistent with new integration scaffolding)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
