### PR TITLE
Improve deCONZ signal strings

### DIFF
--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -35,7 +35,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -89,7 +88,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     config_entry.async_on_unload(
         async_dispatcher_connect(
             hass,
-            gateway.async_signal_new_device(NEW_SENSOR),
+            gateway.signal_new_sensor,
             async_add_alarm_control_panel,
         )
     )

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -26,7 +26,7 @@ from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import ATTR_DARK, ATTR_ON, NEW_SENSOR
+from .const import ATTR_DARK, ATTR_ON
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -105,7 +105,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_SENSOR), async_add_sensor
+            hass,
+            gateway.signal_new_sensor,
+            async_add_sensor,
         )
     )
 

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -46,7 +46,7 @@ from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import ATTR_LOCKED, ATTR_OFFSET, ATTR_VALVE, NEW_SENSOR
+from .const import ATTR_LOCKED, ATTR_OFFSET, ATTR_VALVE
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -118,7 +118,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_SENSOR), async_add_climate
+            hass,
+            gateway.signal_new_sensor,
+            async_add_climate,
         )
     )
 

--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -46,11 +46,6 @@ PLATFORMS = [
     SWITCH_DOMAIN,
 ]
 
-NEW_GROUP = "groups"
-NEW_LIGHT = "lights"
-NEW_SCENE = "scenes"
-NEW_SENSOR = "sensors"
-
 ATTR_DARK = "dark"
 ATTR_LOCKED = "locked"
 ATTR_OFFSET = "offset"

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -21,7 +21,6 @@ from homeassistant.components.cover import (
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import NEW_LIGHT
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -54,7 +53,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_LIGHT), async_add_cover
+            hass,
+            gateway.signal_new_light,
+            async_add_cover,
         )
     )
 

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -20,7 +20,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util import slugify
 
-from .const import CONF_ANGLE, CONF_GESTURE, LOGGER, NEW_SENSOR
+from .const import CONF_ANGLE, CONF_GESTURE, LOGGER
 from .deconz_device import DeconzBase
 
 CONF_DECONZ_EVENT = "deconz_event"
@@ -63,7 +63,9 @@ async def async_setup_events(gateway) -> None:
 
     gateway.config_entry.async_on_unload(
         async_dispatcher_connect(
-            gateway.hass, gateway.async_signal_new_device(NEW_SENSOR), async_add_sensor
+            gateway.hass,
+            gateway.signal_new_sensor,
+            async_add_sensor,
         )
     )
 

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -26,7 +26,6 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
-from .const import NEW_LIGHT
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -74,7 +73,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_LIGHT), async_add_fan
+            hass,
+            gateway.signal_new_light,
+            async_add_fan,
         )
     )
 

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -2,7 +2,7 @@
 import asyncio
 
 import async_timeout
-from pydeconz import DeconzSession, errors
+from pydeconz import DeconzSession, errors, group, light, sensor
 
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
@@ -21,10 +21,6 @@ from .const import (
     DEFAULT_ALLOW_NEW_DEVICES,
     DOMAIN as DECONZ_DOMAIN,
     LOGGER,
-    NEW_GROUP,
-    NEW_LIGHT,
-    NEW_SCENE,
-    NEW_SENSOR,
     PLATFORMS,
 )
 from .deconz_event import async_setup_events, async_unload_events
@@ -49,6 +45,20 @@ class DeconzGateway:
 
         self.available = True
         self.ignore_state_updates = False
+
+        self.signal_reachable = f"deconz-reachable-{config_entry.entry_id}"
+
+        self.signal_new_group = f"deconz_new_group_{config_entry.entry_id}"
+        self.signal_new_light = f"deconz_new_light_{config_entry.entry_id}"
+        self.signal_new_scene = f"deconz_new_scene_{config_entry.entry_id}"
+        self.signal_new_sensor = f"deconz_new_sensor_{config_entry.entry_id}"
+
+        self.deconz_resource_type_to_signal_new_device = {
+            group.RESOURCE_TYPE: self.signal_new_group,
+            light.RESOURCE_TYPE: self.signal_new_light,
+            group.RESOURCE_TYPE_SCENE: self.signal_new_scene,
+            sensor.RESOURCE_TYPE: self.signal_new_sensor,
+        }
 
         self.deconz_ids = {}
         self.entities = {}
@@ -92,24 +102,6 @@ class DeconzGateway:
             CONF_ALLOW_NEW_DEVICES, DEFAULT_ALLOW_NEW_DEVICES
         )
 
-    # Signals
-
-    @property
-    def signal_reachable(self) -> str:
-        """Gateway specific event to signal a change in connection status."""
-        return f"deconz-reachable-{self.bridgeid}"
-
-    @callback
-    def async_signal_new_device(self, device_type) -> str:
-        """Gateway specific event to signal new device."""
-        new_device = {
-            NEW_GROUP: f"deconz_new_group_{self.bridgeid}",
-            NEW_LIGHT: f"deconz_new_light_{self.bridgeid}",
-            NEW_SCENE: f"deconz_new_scene_{self.bridgeid}",
-            NEW_SENSOR: f"deconz_new_sensor_{self.bridgeid}",
-        }
-        return new_device[device_type]
-
     # Callbacks
 
     @callback
@@ -121,10 +113,14 @@ class DeconzGateway:
 
     @callback
     def async_add_device_callback(
-        self, device_type, device=None, force: bool = False
+        self, resource_type, device=None, force: bool = False
     ) -> None:
         """Handle event of new device creation in deCONZ."""
-        if not force and not self.option_allow_new_devices:
+        if (
+            not force
+            and not self.option_allow_new_devices
+            or resource_type not in self.deconz_resource_type_to_signal_new_device
+        ):
             return
 
         args = []
@@ -134,7 +130,7 @@ class DeconzGateway:
 
         async_dispatcher_send(
             self.hass,
-            self.async_signal_new_device(device_type),
+            self.deconz_resource_type_to_signal_new_device[resource_type],
             *args,  # Don't send device if None, it would override default value in listeners
         )
 
@@ -207,7 +203,7 @@ class DeconzGateway:
         deconz_ids = []
 
         if self.option_allow_clip_sensor:
-            self.async_add_device_callback(NEW_SENSOR)
+            self.async_add_device_callback(sensor.RESOURCE_TYPE)
 
         else:
             deconz_ids += [
@@ -217,7 +213,7 @@ class DeconzGateway:
             ]
 
         if self.option_allow_deconz_groups:
-            self.async_add_device_callback(NEW_GROUP)
+            self.async_add_device_callback(group.RESOURCE_TYPE)
 
         else:
             deconz_ids += [group.deconz_id for group in self.api.groups.values()]

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -37,7 +37,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.color import color_hs_to_xy
 
-from .const import DOMAIN as DECONZ_DOMAIN, NEW_GROUP, NEW_LIGHT, POWER_PLUGS
+from .const import DOMAIN as DECONZ_DOMAIN, POWER_PLUGS
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -69,7 +69,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_LIGHT), async_add_light
+            hass,
+            gateway.signal_new_light,
+            async_add_light,
         )
     )
 
@@ -95,7 +97,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_GROUP), async_add_group
+            hass,
+            gateway.signal_new_group,
+            async_add_group,
         )
     )
 

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -7,7 +7,6 @@ from homeassistant.components.lock import DOMAIN, LockEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import NEW_LIGHT, NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -35,7 +34,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_LIGHT), async_add_lock_from_light
+            hass,
+            gateway.signal_new_light,
+            async_add_lock_from_light,
         )
     )
 
@@ -58,7 +59,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     config_entry.async_on_unload(
         async_dispatcher_connect(
             hass,
-            gateway.async_signal_new_device(NEW_SENSOR),
+            gateway.signal_new_sensor,
             async_add_lock_from_sensor,
         )
     )

--- a/homeassistant/components/deconz/scene.py
+++ b/homeassistant/components/deconz/scene.py
@@ -5,7 +5,6 @@ from homeassistant.components.scene import Scene
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import NEW_SCENE
 from .gateway import get_gateway_from_config_entry
 
 
@@ -23,7 +22,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_SCENE), async_add_scene
+            hass,
+            gateway.signal_new_scene,
+            async_add_scene,
         )
     )
 

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -45,7 +45,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 
-from .const import ATTR_DARK, ATTR_ON, NEW_SENSOR
+from .const import ATTR_DARK, ATTR_ON
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -167,7 +167,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_SENSOR), async_add_sensor
+            hass,
+            gateway.signal_new_sensor,
+            async_add_sensor,
         )
     )
 
@@ -340,7 +342,7 @@ class DeconzSensorStateTracker:
         if "battery" in self.sensor.changed_keys:
             async_dispatcher_send(
                 self.gateway.hass,
-                self.gateway.async_signal_new_device(NEW_SENSOR),
+                self.gateway.signal_new_sensor,
                 [self.sensor],
             )
 

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -14,15 +14,7 @@ from homeassistant.helpers.entity_registry import (
 )
 
 from .config_flow import get_master_gateway
-from .const import (
-    CONF_BRIDGE_ID,
-    DOMAIN,
-    LOGGER,
-    NEW_GROUP,
-    NEW_LIGHT,
-    NEW_SCENE,
-    NEW_SENSOR,
-)
+from .const import CONF_BRIDGE_ID, DOMAIN, LOGGER
 
 DECONZ_SERVICES = "deconz_services"
 
@@ -145,8 +137,8 @@ async def async_refresh_devices_service(gateway):
     await gateway.api.refresh_state()
     gateway.ignore_state_updates = False
 
-    for new_device_type in (NEW_GROUP, NEW_LIGHT, NEW_SCENE, NEW_SENSOR):
-        gateway.async_add_device_callback(new_device_type, force=True)
+    for resource_type in gateway.deconz_resource_type_to_signal_new_device:
+        gateway.async_add_device_callback(resource_type, force=True)
 
 
 async def async_remove_orphaned_entries_service(gateway):

--- a/homeassistant/components/deconz/siren.py
+++ b/homeassistant/components/deconz/siren.py
@@ -13,7 +13,6 @@ from homeassistant.components.siren import (
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import NEW_LIGHT
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -41,7 +40,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_LIGHT), async_add_siren
+            hass,
+            gateway.signal_new_light,
+            async_add_siren,
         )
     )
 

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -6,7 +6,7 @@ from homeassistant.components.switch import DOMAIN, SwitchEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN as DECONZ_DOMAIN, NEW_LIGHT, POWER_PLUGS
+from .const import DOMAIN as DECONZ_DOMAIN, POWER_PLUGS
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -48,7 +48,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_LIGHT), async_add_switch
+            hass,
+            gateway.signal_new_light,
+            async_add_switch,
         )
     )
 


### PR DESCRIPTION
Best flow to review this is by looking at gateway.py first

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Generate signal strings once
Use config entry id rather than bridge id with signal.
Don't use locally defined string for resource but rather from deconz library

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
