### PR TITLE
Reorganize RainMachine services

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -60,8 +60,6 @@ SERVICE_PAUSE_WATERING = "pause_watering"
 SERVICE_STOP_ALL = "stop_all"
 SERVICE_UNPAUSE_WATERING = "unpause_watering"
 
-SERVICES = [SERVICE_PAUSE_WATERING, SERVICE_STOP_ALL, SERVICE_UNPAUSE_WATERING]
-
 
 @callback
 def async_get_controllers_for_service_call(
@@ -229,7 +227,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if len(hass.config_entries.async_entries(DOMAIN)) == 1:
         # If this is the last instance of RainMachine, deregister any services defined
         # during integration setup:
-        for service_name in SERVICES:
+        for service_name in [
+            SERVICE_PAUSE_WATERING,
+            SERVICE_STOP_ALL,
+            SERVICE_UNPAUSE_WATERING,
+        ]:
             hass.services.async_remove(DOMAIN, service_name)
 
     return unload_ok

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -57,7 +57,11 @@ CONFIG_SCHEMA = cv.deprecated(DOMAIN)
 
 PLATFORMS = ["binary_sensor", "sensor", "switch"]
 
-SERVICE_SCHEMA = vol.Schema({vol.Required(CONF_DEVICE_ID): cv.string})
+SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): vol.All(cv.ensure_list, cv.string),
+    }
+)
 
 SERVICE_NAME_PAUSE_WATERING = "pause_watering"
 SERVICE_NAME_STOP_ALL = "stop_all"

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -227,11 +227,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if len(hass.config_entries.async_entries(DOMAIN)) == 1:
         # If this is the last instance of RainMachine, deregister any services defined
         # during integration setup:
-        for service_name in [
+        for service_name in (
             SERVICE_PAUSE_WATERING,
             SERVICE_STOP_ALL,
             SERVICE_UNPAUSE_WATERING,
-        ]:
+        ):
             hass.services.async_remove(DOMAIN, service_name)
 
     return unload_ok

--- a/homeassistant/components/rainmachine/services.yaml
+++ b/homeassistant/components/rainmachine/services.yaml
@@ -6,15 +6,7 @@ disable_program:
     entity:
       integration: rainmachine
       domain: switch
-  fields:
-    program_id:
-      name: Program ID
-      description: The program to disable.
-      required: true
-      selector:
-        number:
-          min: 1
-          max: 255
+      device_class: program
 disable_zone:
   name: Disable zone
   description: Disable a zone.
@@ -22,15 +14,7 @@ disable_zone:
     entity:
       integration: rainmachine
       domain: switch
-  fields:
-    zone_id:
-      name: Zone ID
-      description: The zone to disable.
-      required: true
-      selector:
-        number:
-          min: 1
-          max: 255
+      device_class: zone
 enable_program:
   name: Enable program
   description: Enable a program.
@@ -38,15 +22,7 @@ enable_program:
     entity:
       integration: rainmachine
       domain: switch
-  fields:
-    program_id:
-      name: Program ID
-      description: The program to enable.
-      required: true
-      selector:
-        number:
-          min: 1
-          max: 255
+      device_class: program
 enable_zone:
   name: Enable zone
   description: Enable a zone.
@@ -54,22 +30,13 @@ enable_zone:
     entity:
       integration: rainmachine
       domain: switch
-  fields:
-    zone_id:
-      name: Zone ID
-      description: The zone to enable.
-      required: true
-      selector:
-        number:
-          min: 1
-          max: 255
+      device_class: zone
 pause_watering:
   name: Pause watering
   description: Pause all watering for a number of seconds.
   target:
-    entity:
+    device:
       integration: rainmachine
-      domain: switch
   fields:
     seconds:
       name: Seconds
@@ -82,20 +49,12 @@ pause_watering:
           unit_of_measurement: seconds
 start_program:
   name: Start program
-  description: Start a program.
+  description: Start a program
   target:
     entity:
       integration: rainmachine
       domain: switch
-  fields:
-    program_id:
-      name: Program ID
-      description: The program to start.
-      required: true
-      selector:
-        number:
-          min: 1
-          max: 255
+      device_class: program
 start_zone:
   name: Start zone
   description: Start a zone for a set number of seconds.
@@ -103,15 +62,8 @@ start_zone:
     entity:
       integration: rainmachine
       domain: switch
+      device_class: zone
   fields:
-    zone_id:
-      name: Zone ID
-      description: The zone to start.
-      required: true
-      selector:
-        number:
-          min: 1
-          max: 255
     zone_run_time:
       name: Zone run time
       description: The number of seconds to run the zone.
@@ -125,45 +77,27 @@ stop_all:
   name: Stop all
   description: Stop all watering activities.
   target:
-    entity:
+    device:
       integration: rainmachine
-      domain: switch
 stop_program:
   name: Stop program
-  description: Stop a program.
+  description: Start a program
   target:
     entity:
       integration: rainmachine
       domain: switch
-  fields:
-    program_id:
-      name: Program ID
-      description: The program to stop.
-      required: true
-      selector:
-        number:
-          min: 1
-          max: 255
+      device_class: program
 stop_zone:
   name: Stop zone
-  description: Stop a zone.
+  description: Stop a zone
   target:
     entity:
       integration: rainmachine
       domain: switch
-  fields:
-    zone_id:
-      name: Zone ID
-      description: The zone to stop.
-      required: true
-      selector:
-        number:
-          min: 1
-          max: 255
+      device_class: zone
 unpause_watering:
   name: Unpause watering
   description: Unpause all watering.
   target:
-    entity:
+    device:
       integration: rainmachine
-      domain: switch

--- a/homeassistant/components/rainmachine/services.yaml
+++ b/homeassistant/components/rainmachine/services.yaml
@@ -1,46 +1,46 @@
 # Describes the format for available RainMachine services
 disable_program:
-  name: Disable program
-  description: Disable a program.
+  name: Disable Program
+  description: Disable a program
   target:
     entity:
       integration: rainmachine
       domain: switch
-      device_class: program
 disable_zone:
-  name: Disable zone
-  description: Disable a zone.
+  name: Disable Zone
+  description: Disable a zone
   target:
     entity:
       integration: rainmachine
       domain: switch
-      device_class: zone
 enable_program:
-  name: Enable program
-  description: Enable a program.
+  name: Enable Program
+  description: Enable a program
   target:
     entity:
       integration: rainmachine
       domain: switch
-      device_class: program
 enable_zone:
-  name: Enable zone
-  description: Enable a zone.
+  name: Enable Zone
+  description: Enable a zone
   target:
     entity:
       integration: rainmachine
       domain: switch
-      device_class: zone
 pause_watering:
-  name: Pause watering
-  description: Pause all watering for a number of seconds.
-  target:
-    device:
-      integration: rainmachine
+  name: Pause All Watering
+  description: Pause all watering activities for a number of seconds
   fields:
+    device_id:
+      name: Controller
+      description: The controller whose watering activities should be paused
+      required: true
+      selector:
+        device:
+          integration: rainmachine
     seconds:
-      name: Seconds
-      description: The time to pause.
+      name: Duration
+      description: The amount of time (in seconds) to pause watering
       required: true
       selector:
         number:
@@ -48,25 +48,23 @@ pause_watering:
           max: 86400
           unit_of_measurement: seconds
 start_program:
-  name: Start program
+  name: Start Program
   description: Start a program
   target:
     entity:
       integration: rainmachine
       domain: switch
-      device_class: program
 start_zone:
-  name: Start zone
-  description: Start a zone for a set number of seconds.
+  name: Start Zone
+  description: Start a zone
   target:
     entity:
       integration: rainmachine
       domain: switch
-      device_class: zone
   fields:
     zone_run_time:
-      name: Zone run time
-      description: The number of seconds to run the zone.
+      name: Run Time
+      description: The amount of time (in seconds) to run the zone
       default: 600
       selector:
         number:
@@ -74,30 +72,38 @@ start_zone:
           max: 86400
           mode: box
 stop_all:
-  name: Stop all
-  description: Stop all watering activities.
-  target:
-    device:
-      integration: rainmachine
+  name: Stop All Watering
+  description: Stop all watering activities
+  fields:
+    device_id:
+      name: Controller
+      description: The controller whose watering activities should be stopped
+      required: true
+      selector:
+        device:
+          integration: rainmachine
 stop_program:
-  name: Stop program
-  description: Start a program
+  name: Stop Program
+  description: Stop a program
   target:
     entity:
       integration: rainmachine
       domain: switch
-      device_class: program
 stop_zone:
-  name: Stop zone
+  name: Stop Zone
   description: Stop a zone
   target:
     entity:
       integration: rainmachine
       domain: switch
-      device_class: zone
 unpause_watering:
-  name: Unpause watering
-  description: Unpause all watering.
-  target:
-    device:
-      integration: rainmachine
+  name: Unpause All Watering
+  description: Unpause all paused watering activities
+  fields:
+    device_id:
+      name: Controller
+      description: The controller whose watering activities should be unpaused
+      required: true
+      selector:
+        device:
+          integration: rainmachine

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -51,11 +51,10 @@ ATTR_TIME_REMAINING = "time_remaining"
 ATTR_VEGETATION_TYPE = "vegetation_type"
 ATTR_ZONES = "zones"
 
-CONF_PROGRAM_ID = "program_id"
-CONF_SECONDS = "seconds"
-CONF_ZONE_ID = "zone_id"
-
 DEFAULT_ICON = "mdi:water"
+
+DEVICE_CLASS_PROGRAM = "program"
+DEVICE_CLASS_ZONE = "zone"
 
 DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 
@@ -112,9 +111,6 @@ VEGETATION_MAP = {
     99: "Other",
 }
 
-SWITCH_TYPE_PROGRAM = "program"
-SWITCH_TYPE_ZONE = "zone"
-
 
 @dataclass
 class RainMachineSwitchDescriptionMixin:
@@ -136,42 +132,23 @@ async def async_setup_entry(
     """Set up RainMachine switches based on a config entry."""
     platform = entity_platform.async_get_current_platform()
 
-    alter_program_schema = {vol.Required(CONF_PROGRAM_ID): cv.positive_int}
-    alter_zone_schema = {vol.Required(CONF_ZONE_ID): cv.positive_int}
-
     for service_name, schema, method in (
-        ("disable_program", alter_program_schema, "async_disable_program"),
-        ("disable_zone", alter_zone_schema, "async_disable_zone"),
-        ("enable_program", alter_program_schema, "async_enable_program"),
-        ("enable_zone", alter_zone_schema, "async_enable_zone"),
-        (
-            "pause_watering",
-            {vol.Required(CONF_SECONDS): cv.positive_int},
-            "async_pause_watering",
-        ),
-        (
-            "start_program",
-            {vol.Required(CONF_PROGRAM_ID): cv.positive_int},
-            "async_start_program",
-        ),
+        ("disable_program", {}, "async_disable_program"),
+        ("disable_zone", {}, "async_disable_zone"),
+        ("enable_program", {}, "async_enable_program"),
+        ("enable_zone", {}, "async_enable_zone"),
+        ("start_program", {}, "async_start_program"),
         (
             "start_zone",
             {
-                vol.Required(CONF_ZONE_ID): cv.positive_int,
                 vol.Optional(
                     CONF_ZONE_RUN_TIME, default=DEFAULT_ZONE_RUN
-                ): cv.positive_int,
+                ): cv.positive_int
             },
             "async_start_zone",
         ),
-        ("stop_all", {}, "async_stop_all"),
-        (
-            "stop_program",
-            {vol.Required(CONF_PROGRAM_ID): cv.positive_int},
-            "async_stop_program",
-        ),
-        ("stop_zone", {vol.Required(CONF_ZONE_ID): cv.positive_int}, "async_stop_zone"),
-        ("unpause_watering", {}, "async_unpause_watering"),
+        ("stop_program", {}, "async_stop_program"),
+        ("stop_zone", {}, "async_stop_zone"),
     ):
         platform.async_register_entity_service(service_name, schema, method)
 
@@ -189,6 +166,7 @@ async def async_setup_entry(
             RainMachineSwitchDescription(
                 key=f"RainMachineProgram_{uid}",
                 name=program["name"],
+                device_class=DEVICE_CLASS_PROGRAM,
                 uid=uid,
             ),
         )
@@ -203,6 +181,7 @@ async def async_setup_entry(
                 RainMachineSwitchDescription(
                     key=f"RainMachineZone_{uid}",
                     name=zone["name"],
+                    device_class=DEVICE_CLASS_ZONE,
                     uid=uid,
                 ),
             )
@@ -267,60 +246,37 @@ class RainMachineSwitch(RainMachineEntity, SwitchEntity):
             async_update_programs_and_zones(self.hass, self._entry)
         )
 
-    async def async_disable_program(self, *, program_id: int) -> None:
+    async def async_disable_program(self) -> None:
         """Disable a program."""
-        await self._controller.programs.disable(program_id)
-        await async_update_programs_and_zones(self.hass, self._entry)
+        raise NotImplementedError("Service not implemented for this entity")
 
-    async def async_disable_zone(self, *, zone_id: int) -> None:
+    async def async_disable_zone(self) -> None:
         """Disable a zone."""
-        await self._controller.zones.disable(zone_id)
-        await async_update_programs_and_zones(self.hass, self._entry)
+        raise NotImplementedError("Service not implemented for this entity")
 
-    async def async_enable_program(self, *, program_id: int) -> None:
+    async def async_enable_program(self) -> None:
         """Enable a program."""
-        await self._controller.programs.enable(program_id)
-        await async_update_programs_and_zones(self.hass, self._entry)
+        raise NotImplementedError("Service not implemented for this entity")
 
-    async def async_enable_zone(self, *, zone_id: int) -> None:
+    async def async_enable_zone(self) -> None:
         """Enable a zone."""
-        await self._controller.zones.enable(zone_id)
-        await async_update_programs_and_zones(self.hass, self._entry)
+        raise NotImplementedError("Service not implemented for this entity")
 
-    async def async_pause_watering(self, *, seconds: int) -> None:
-        """Pause watering for a set number of seconds."""
-        await self._controller.watering.pause_all(seconds)
-        await async_update_programs_and_zones(self.hass, self._entry)
+    async def async_start_program(self) -> None:
+        """Start a program."""
+        raise NotImplementedError("Service not implemented for this entity")
 
-    async def async_start_program(self, *, program_id: int) -> None:
-        """Start a particular program."""
-        await self._controller.programs.start(program_id)
-        await async_update_programs_and_zones(self.hass, self._entry)
+    async def async_start_zone(self, *, zone_run_time: int) -> None:
+        """Start a zone."""
+        raise NotImplementedError("Service not implemented for this entity")
 
-    async def async_start_zone(self, *, zone_id: int, zone_run_time: int) -> None:
-        """Start a particular zone for a certain amount of time."""
-        await self._controller.zones.start(zone_id, zone_run_time)
-        await async_update_programs_and_zones(self.hass, self._entry)
-
-    async def async_stop_all(self) -> None:
-        """Stop all watering."""
-        await self._controller.watering.stop_all()
-        await async_update_programs_and_zones(self.hass, self._entry)
-
-    async def async_stop_program(self, *, program_id: int) -> None:
+    async def async_stop_program(self) -> None:
         """Stop a program."""
-        await self._controller.programs.stop(program_id)
-        await async_update_programs_and_zones(self.hass, self._entry)
+        raise NotImplementedError("Service not implemented for this entity")
 
-    async def async_stop_zone(self, *, zone_id: int) -> None:
+    async def async_stop_zone(self) -> None:
         """Stop a zone."""
-        await self._controller.zones.stop(zone_id)
-        await async_update_programs_and_zones(self.hass, self._entry)
-
-    async def async_unpause_watering(self) -> None:
-        """Unpause watering."""
-        await self._controller.watering.unpause_all()
-        await async_update_programs_and_zones(self.hass, self._entry)
+        raise NotImplementedError("Service not implemented for this entity")
 
     @callback
     def update_from_latest_data(self) -> None:
@@ -336,6 +292,28 @@ class RainMachineProgram(RainMachineSwitch):
     def zones(self) -> list:
         """Return a list of active zones associated with this program."""
         return [z for z in self._data["wateringTimes"] if z["active"]]
+
+    async def async_disable_program(self) -> None:
+        """Disable a program."""
+        await self._controller.programs.disable(self.entity_description.uid)
+        await async_update_programs_and_zones(self.hass, self._entry)
+
+    async def async_enable_program(self) -> None:
+        """Enable a program."""
+        await self._controller.programs.enable(self.entity_description.uid)
+        await async_update_programs_and_zones(self.hass, self._entry)
+
+    async def async_start_program(self) -> None:
+        """Start a program."""
+        if not self.available:
+            return
+        await self.async_turn_on()
+
+    async def async_stop_program(self) -> None:
+        """Stop a program."""
+        if not self.available:
+            return
+        await self.async_turn_off()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the program off."""
@@ -380,6 +358,29 @@ class RainMachineProgram(RainMachineSwitch):
 
 class RainMachineZone(RainMachineSwitch):
     """A RainMachine zone."""
+
+    async def async_disable_zone(self) -> None:
+        """Disable a zone."""
+        await self._controller.zones.disable(self.entity_description.uid)
+        await async_update_programs_and_zones(self.hass, self._entry)
+
+    async def async_enable_zone(self) -> None:
+        """Enable a zone."""
+        await self._controller.zones.enable(self.entity_description.uid)
+        await async_update_programs_and_zones(self.hass, self._entry)
+
+    async def async_start_zone(self, *, zone_run_time: int) -> None:
+        """Start a particular zone for a certain amount of time."""
+        if not self.available:
+            return
+        await self._controller.zones.start(self.entity_description.uid, zone_run_time)
+        await async_update_programs_and_zones(self.hass, self._entry)
+
+    async def async_stop_zone(self) -> None:
+        """Stop a zone."""
+        if not self.available:
+            return
+        await self.async_turn_off()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the zone off."""

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -305,14 +305,10 @@ class RainMachineProgram(RainMachineSwitch):
 
     async def async_start_program(self) -> None:
         """Start a program."""
-        if not self.available:
-            return
         await self.async_turn_on()
 
     async def async_stop_program(self) -> None:
         """Stop a program."""
-        if not self.available:
-            return
         await self.async_turn_off()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -371,15 +367,11 @@ class RainMachineZone(RainMachineSwitch):
 
     async def async_start_zone(self, *, zone_run_time: int) -> None:
         """Start a particular zone for a certain amount of time."""
-        if not self.available:
-            return
         await self._controller.zones.start(self.entity_description.uid, zone_run_time)
         await async_update_programs_and_zones(self.hass, self._entry)
 
     async def async_stop_zone(self) -> None:
         """Stop a zone."""
-        if not self.available:
-            return
         await self.async_turn_off()
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -53,9 +53,6 @@ ATTR_ZONES = "zones"
 
 DEFAULT_ICON = "mdi:water"
 
-DEVICE_CLASS_PROGRAM = "program"
-DEVICE_CLASS_ZONE = "zone"
-
 DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 
 RUN_STATUS_MAP = {0: "Not Running", 1: "Running", 2: "Queued"}
@@ -164,10 +161,7 @@ async def async_setup_entry(
             controller,
             entry,
             RainMachineSwitchDescription(
-                key=f"RainMachineProgram_{uid}",
-                name=program["name"],
-                device_class=DEVICE_CLASS_PROGRAM,
-                uid=uid,
+                key=f"RainMachineProgram_{uid}", name=program["name"], uid=uid
             ),
         )
         for uid, program in programs_coordinator.data.items()
@@ -179,10 +173,7 @@ async def async_setup_entry(
                 controller,
                 entry,
                 RainMachineSwitchDescription(
-                    key=f"RainMachineZone_{uid}",
-                    name=zone["name"],
-                    device_class=DEVICE_CLASS_ZONE,
-                    uid=uid,
+                    key=f"RainMachineZone_{uid}", name=zone["name"], uid=uid
                 ),
             )
             for uid, zone in zones_coordinator.data.items()


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
RainMachine services have been reorganized and now utilize a Home Assistant target (entity ID) or selector (device ID) instead of using an internal RainMachine identifier.

Additionally, services are restricted to only the targets that apply:

**Device Services (i.e., must be provided a device ID)**

* `pause_watering`
* `stop_all`
* `unpause_watering`

**Entity Services (i.e., must be provided an associated switch entity ID [either a program or a zone])**

* `disable_program`
* `disable_zone`
* `enable_program`
* `enable_zone`
* `start_program`
* `start_zone`
* `stop_program`
* `stop_zone`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While reviewing [a different RainMachine PR](https://github.com/home-assistant/core/pull/57051#discussion_r722576983), @MartinHjelmare pointed out that its prior implementation of entity services can be updated with new, more correct logic. To that end, this PR reorganizes RainMachine services depending on whether the target is a device (i.e., a controller) or a program/zone (which is represented in HASS as a switch).

Note that although these services:

* `start_program`
* `start_zone`
* `stop_program`
* `stop_zone`

...are a bit redundant (because they can be accomplished via the appropriate `switch.turn_off` and `switch.turn_on` calls), I left them here for completeness.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/pull/57051
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19622

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
