### PR TITLE
Refactor persistent notification to no longer route all data via a service

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -273,21 +273,17 @@ async def async_setup(hass, config):
 
     async def persistent_notification(service: ServiceCall) -> None:
         """Send notification via the built-in persistsent_notify integration."""
-        payload = {}
         message = service.data[ATTR_MESSAGE]
         message.hass = hass
         _check_templates_warn(hass, message)
-        payload[ATTR_MESSAGE] = message.async_render(parse_result=False)
 
-        title = service.data.get(ATTR_TITLE)
-        if title:
-            _check_templates_warn(hass, title)
-            title.hass = hass
-            payload[ATTR_TITLE] = title.async_render(parse_result=False)
+        title = None
+        if title_tpl := service.data.get(ATTR_TITLE):
+            _check_templates_warn(hass, title_tpl)
+            title_tpl.hass = hass
+            title = title_tpl.async_render(parse_result=False)
 
-        await hass.services.async_call(
-            pn.DOMAIN, pn.SERVICE_CREATE, payload, blocking=True
-        )
+        pn.async_create(hass, message.async_render(parse_result=False), title)
 
     async def async_setup_platform(
         integration_name, p_config=None, discovery_info=None

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -51,18 +51,12 @@ def create(
     notification_id: str | None = None,
 ) -> None:
     """Generate a notification."""
-    _LOGGER.warn(
-        "Calling persitent_notification.create is deprecated, use async_create instead"
-    )
     hass.add_job(async_create, hass, message, title, notification_id)
 
 
 @bind_hass
 def dismiss(hass: HomeAssistant, notification_id: str) -> None:
     """Remove a notification."""
-    _LOGGER.warn(
-        "Calling persitent_notification.dismiss is deprecated, use async_create instead"
-    )
     hass.add_job(async_dismiss, hass, notification_id)
 
 

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -113,16 +113,6 @@ def async_create(
             "Passing a template string to persistent_notification.async_create function is deprecated"
         )
 
-    # If exact notification already exists, and it's unread, skip it.
-    if (
-        (cur_not := notifications.get(entity_id))
-        and cur_not[ATTR_MESSAGE] == message
-        and cur_not[ATTR_NOTIFICATION_ID] == notification_id
-        and cur_not[ATTR_STATUS]
-        and cur_not[ATTR_TITLE] == title
-    ):
-        return
-
     hass.states.async_set(entity_id, STATE, attr, context=context)
 
     # Store notification and fire event

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -1,26 +1,23 @@
 """Support for displaying persistent notifications."""
 from __future__ import annotations
 
-from collections import OrderedDict
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, cast
 
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Context, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.template import Template
+from homeassistant.helpers.template import Template, is_template_string
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 from homeassistant.util import slugify
 import homeassistant.util.dt as dt_util
-
-# mypy: allow-untyped-calls, allow-untyped-defs
 
 ATTR_CREATED_AT = "created_at"
 ATTR_MESSAGE = "message"
@@ -34,21 +31,9 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
 EVENT_PERSISTENT_NOTIFICATIONS_UPDATED = "persistent_notifications_updated"
 
-SERVICE_CREATE = "create"
-SERVICE_DISMISS = "dismiss"
-SERVICE_MARK_READ = "mark_read"
-
-SCHEMA_SERVICE_CREATE = vol.Schema(
-    {
-        vol.Required(ATTR_MESSAGE): vol.Any(cv.dynamic_template, cv.string),
-        vol.Optional(ATTR_TITLE): vol.Any(cv.dynamic_template, cv.string),
-        vol.Optional(ATTR_NOTIFICATION_ID): cv.string,
-    }
+SCHEMA_SERVICE_NOTIFICATION = vol.Schema(
+    {vol.Required(ATTR_NOTIFICATION_ID): cv.string}
 )
-
-SCHEMA_SERVICE_DISMISS = vol.Schema({vol.Required(ATTR_NOTIFICATION_ID): cv.string})
-
-SCHEMA_SERVICE_MARK_READ = vol.Schema({vol.Required(ATTR_NOTIFICATION_ID): cv.string})
 
 DEFAULT_OBJECT_ID = "notification"
 _LOGGER = logging.getLogger(__name__)
@@ -59,14 +44,25 @@ STATUS_READ = "read"
 
 
 @bind_hass
-def create(hass, message, title=None, notification_id=None):
+def create(
+    hass: HomeAssistant,
+    message: str,
+    title: str | None = None,
+    notification_id: str | None = None,
+) -> None:
     """Generate a notification."""
+    _LOGGER.warn(
+        "Calling persitent_notification.create is deprecated, use async_create instead"
+    )
     hass.add_job(async_create, hass, message, title, notification_id)
 
 
 @bind_hass
-def dismiss(hass, notification_id):
+def dismiss(hass: HomeAssistant, notification_id: str) -> None:
     """Remove a notification."""
+    _LOGGER.warn(
+        "Calling persitent_notification.dismiss is deprecated, use async_create instead"
+    )
     hass.add_job(async_dismiss, hass, notification_id)
 
 
@@ -77,108 +73,115 @@ def async_create(
     message: str,
     title: str | None = None,
     notification_id: str | None = None,
+    *,
+    context: Context | None = None,
 ) -> None:
     """Generate a notification."""
-    data = {
-        key: value
-        for key, value in (
-            (ATTR_TITLE, title),
-            (ATTR_MESSAGE, message),
-            (ATTR_NOTIFICATION_ID, notification_id),
+    notifications = hass.data.get(DOMAIN)
+    if notifications is None:
+        notifications = hass.data[DOMAIN] = {}
+
+    if notification_id is not None:
+        entity_id = ENTITY_ID_FORMAT.format(slugify(notification_id))
+    else:
+        entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, DEFAULT_OBJECT_ID, hass=hass
         )
-        if value is not None
+        notification_id = entity_id.split(".")[1]
+
+    warn = False
+
+    attr: dict[str, str] = {}
+    if title is not None:
+        if is_template_string(title):
+            warn = True
+            try:
+                title = cast(
+                    str, Template(title, hass).async_render(parse_result=False)  # type: ignore[no-untyped-call]
+                )
+            except TemplateError as ex:
+                _LOGGER.error("Error rendering title %s: %s", title, ex)
+
+        attr[ATTR_TITLE] = title
+        attr[ATTR_FRIENDLY_NAME] = title
+
+    if is_template_string(message):
+        warn = True
+        try:
+            message = Template(message, hass).async_render(parse_result=False)  # type: ignore[no-untyped-call]
+        except TemplateError as ex:
+            _LOGGER.error("Error rendering message %s: %s", message, ex)
+
+    attr[ATTR_MESSAGE] = message
+
+    if warn:
+        _LOGGER.warning(
+            "Passing a template string to persistent_notification.async_create function is deprecated"
+        )
+
+    hass.states.async_set(entity_id, STATE, attr, context=context)
+
+    # Store notification and fire event
+    # This will eventually replace state machine storage
+    notifications[entity_id] = {
+        ATTR_MESSAGE: message,
+        ATTR_NOTIFICATION_ID: notification_id,
+        ATTR_STATUS: STATUS_UNREAD,
+        ATTR_TITLE: title,
+        ATTR_CREATED_AT: dt_util.utcnow(),
     }
 
-    hass.async_create_task(hass.services.async_call(DOMAIN, SERVICE_CREATE, data))
+    hass.bus.async_fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED, context=context)
 
 
 @callback
 @bind_hass
-def async_dismiss(hass: HomeAssistant, notification_id: str) -> None:
+def async_dismiss(
+    hass: HomeAssistant, notification_id: str, *, context: Context | None = None
+) -> None:
     """Remove a notification."""
-    data = {ATTR_NOTIFICATION_ID: notification_id}
+    notifications = hass.data.get(DOMAIN)
+    if notifications is None:
+        notifications = hass.data[DOMAIN] = {}
 
-    hass.async_create_task(hass.services.async_call(DOMAIN, SERVICE_DISMISS, data))
+    entity_id = ENTITY_ID_FORMAT.format(slugify(notification_id))
+
+    if entity_id not in notifications:
+        return
+
+    hass.states.async_remove(entity_id, context)
+
+    del notifications[entity_id]
+    hass.bus.async_fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the persistent notification component."""
-    persistent_notifications: MutableMapping[str, MutableMapping] = OrderedDict()
-    hass.data[DOMAIN] = {"notifications": persistent_notifications}
+    notifications = hass.data[DOMAIN] = {}
 
     @callback
-    def create_service(call):
+    def create_service(call: ServiceCall) -> None:
         """Handle a create notification service call."""
-        title = call.data.get(ATTR_TITLE)
-        message = call.data.get(ATTR_MESSAGE)
-        notification_id = call.data.get(ATTR_NOTIFICATION_ID)
-
-        if notification_id is not None:
-            entity_id = ENTITY_ID_FORMAT.format(slugify(notification_id))
-        else:
-            entity_id = async_generate_entity_id(
-                ENTITY_ID_FORMAT, DEFAULT_OBJECT_ID, hass=hass
-            )
-            notification_id = entity_id.split(".")[1]
-
-        attr = {}
-        if title is not None:
-            if isinstance(title, Template):
-                try:
-                    title.hass = hass
-                    title = title.async_render(parse_result=False)
-                except TemplateError as ex:
-                    _LOGGER.error("Error rendering title %s: %s", title, ex)
-                    title = title.template
-
-            attr[ATTR_TITLE] = title
-            attr[ATTR_FRIENDLY_NAME] = title
-
-        if isinstance(message, Template):
-            try:
-                message.hass = hass
-                message = message.async_render(parse_result=False)
-            except TemplateError as ex:
-                _LOGGER.error("Error rendering message %s: %s", message, ex)
-                message = message.template
-
-        attr[ATTR_MESSAGE] = message
-
-        hass.states.async_set(entity_id, STATE, attr)
-
-        # Store notification and fire event
-        # This will eventually replace state machine storage
-        persistent_notifications[entity_id] = {
-            ATTR_MESSAGE: message,
-            ATTR_NOTIFICATION_ID: notification_id,
-            ATTR_STATUS: STATUS_UNREAD,
-            ATTR_TITLE: title,
-            ATTR_CREATED_AT: dt_util.utcnow(),
-        }
-
-        hass.bus.async_fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED)
+        async_create(
+            hass,
+            call.data[ATTR_MESSAGE],
+            call.data.get(ATTR_TITLE),
+            call.data.get(ATTR_NOTIFICATION_ID),
+            context=call.context,
+        )
 
     @callback
-    def dismiss_service(call):
+    def dismiss_service(call: ServiceCall) -> None:
         """Handle the dismiss notification service call."""
-        notification_id = call.data.get(ATTR_NOTIFICATION_ID)
-        entity_id = ENTITY_ID_FORMAT.format(slugify(notification_id))
-
-        if entity_id not in persistent_notifications:
-            return
-
-        hass.states.async_remove(entity_id, call.context)
-
-        del persistent_notifications[entity_id]
-        hass.bus.async_fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED)
+        async_dismiss(hass, call.data[ATTR_NOTIFICATION_ID], context=call.context)
 
     @callback
-    def mark_read_service(call):
+    def mark_read_service(call: ServiceCall) -> None:
         """Handle the mark_read notification service call."""
         notification_id = call.data.get(ATTR_NOTIFICATION_ID)
         entity_id = ENTITY_ID_FORMAT.format(slugify(notification_id))
 
-        if entity_id not in persistent_notifications:
+        if entity_id not in notifications:
             _LOGGER.error(
                 "Marking persistent_notification read failed: "
                 "Notification ID %s not found",
@@ -186,19 +189,30 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
             return
 
-        persistent_notifications[entity_id][ATTR_STATUS] = STATUS_READ
-        hass.bus.async_fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED)
+        notifications[entity_id][ATTR_STATUS] = STATUS_READ
+        hass.bus.async_fire(
+            EVENT_PERSISTENT_NOTIFICATIONS_UPDATED, context=call.context
+        )
 
     hass.services.async_register(
-        DOMAIN, SERVICE_CREATE, create_service, SCHEMA_SERVICE_CREATE
+        DOMAIN,
+        "create",
+        create_service,
+        vol.Schema(
+            {
+                vol.Required(ATTR_MESSAGE): vol.Any(cv.dynamic_template, cv.string),
+                vol.Optional(ATTR_TITLE): vol.Any(cv.dynamic_template, cv.string),
+                vol.Optional(ATTR_NOTIFICATION_ID): cv.string,
+            }
+        ),
     )
 
     hass.services.async_register(
-        DOMAIN, SERVICE_DISMISS, dismiss_service, SCHEMA_SERVICE_DISMISS
+        DOMAIN, "dismiss", dismiss_service, SCHEMA_SERVICE_NOTIFICATION
     )
 
     hass.services.async_register(
-        DOMAIN, SERVICE_MARK_READ, mark_read_service, SCHEMA_SERVICE_MARK_READ
+        DOMAIN, "mark_read", mark_read_service, SCHEMA_SERVICE_NOTIFICATION
     )
 
     hass.components.websocket_api.async_register_command(websocket_get_notifications)
@@ -228,7 +242,7 @@ def websocket_get_notifications(
                         ATTR_CREATED_AT,
                     )
                 }
-                for data in hass.data[DOMAIN]["notifications"].values()
+                for data in hass.data[DOMAIN].values()
             ],
         )
     )

--- a/script/scaffold/templates/config_flow/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow/tests/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the NEW_NAME config flow."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.NEW_DOMAIN.config_flow import CannotConnect, InvalidAuth
 from homeassistant.components.NEW_DOMAIN.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -10,7 +10,6 @@ from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/airnow/test_config_flow.py
+++ b/tests/components/airnow/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from pyairnow.errors import AirNowError, InvalidKeyError
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.airnow.const import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 
@@ -68,7 +68,7 @@ MOCK_RESPONSE = [
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/airthings/test_config_flow.py
+++ b/tests/components/airthings/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import airthings
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.airthings.const import CONF_ID, CONF_SECRET, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
@@ -18,7 +18,7 @@ TEST_DATA = {
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/august/test_config_flow.py
+++ b/tests/components/august/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from yalexs.authenticator import ValidationResult
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.august.const import (
     CONF_ACCESS_TOKEN_CACHE_FILE,
     CONF_INSTALL_ID,
@@ -23,7 +23,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -6,7 +6,6 @@ from aiohttp import ClientResponseError
 from yalexs.authenticator_common import AuthenticationState
 from yalexs.exceptions import AugustApiAIOHTTPError
 
-from homeassistant import setup
 from homeassistant.components.august.const import DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -41,7 +40,6 @@ async def test_august_is_offline(hass):
     )
     config_entry.add_to_hass(hass)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         side_effect=asyncio.TimeoutError,
@@ -147,7 +145,6 @@ async def test_auth_fails(hass):
     config_entry.add_to_hass(hass)
     assert hass.config_entries.flow.async_progress() == []
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         side_effect=ClientResponseError(None, None, status=401),
@@ -173,7 +170,6 @@ async def test_bad_password(hass):
     config_entry.add_to_hass(hass)
     assert hass.config_entries.flow.async_progress() == []
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         return_value=_mock_august_authentication(
@@ -201,7 +197,6 @@ async def test_http_failure(hass):
     config_entry.add_to_hass(hass)
     assert hass.config_entries.flow.async_progress() == []
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         side_effect=ClientResponseError(None, None, status=500),
@@ -225,7 +220,6 @@ async def test_unknown_auth_state(hass):
     config_entry.add_to_hass(hass)
     assert hass.config_entries.flow.async_progress() == []
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         return_value=_mock_august_authentication("original_token", 1234, None),
@@ -251,7 +245,6 @@ async def test_requires_validation_state(hass):
     config_entry.add_to_hass(hass)
     assert hass.config_entries.flow.async_progress() == []
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         return_value=_mock_august_authentication(
@@ -278,7 +271,6 @@ async def test_unknown_auth_http_401(hass):
     config_entry.add_to_hass(hass)
     assert hass.config_entries.flow.async_progress() == []
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         return_value=_mock_august_authentication("original_token", 1234, None),

--- a/tests/components/aurora/test_config_flow.py
+++ b/tests/components/aurora/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from aiohttp import ClientError
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.aurora.const import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -18,7 +18,7 @@ DATA = {
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -47,7 +47,6 @@ async def test_form(hass):
 async def test_form_cannot_connect(hass):
     """Test if invalid response or no connection returned from the API."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -68,7 +67,7 @@ async def test_form_cannot_connect(hass):
 
 async def test_with_unknown_error(hass):
     """Test with unknown error response from the API."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/blink/test_config_flow.py
+++ b/tests/components/blink/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 from blinkpy.auth import LoginError
 from blinkpy.blinkpy import BlinkSetupError
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.blink import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -12,7 +12,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -50,7 +50,7 @@ async def test_form(hass):
 
 async def test_form_2fa(hass):
     """Test we get the 2fa form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -92,7 +92,7 @@ async def test_form_2fa(hass):
 
 async def test_form_2fa_connect_error(hass):
     """Test we report a connect error during 2fa setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -131,7 +131,7 @@ async def test_form_2fa_connect_error(hass):
 
 async def test_form_2fa_invalid_key(hass):
     """Test we report an error if key is invalid."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -170,7 +170,7 @@ async def test_form_2fa_invalid_key(hass):
 
 async def test_form_2fa_unknown_error(hass):
     """Test we report an unknown error during 2fa setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 from aiohttp import ClientConnectionError, ClientResponseError
 
-from homeassistant import config_entries, core, setup
+from homeassistant import config_entries, core
 from homeassistant.components.bond.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
 
@@ -24,7 +24,7 @@ from tests.common import MockConfigEntry
 
 async def test_user_form(hass: core.HomeAssistant):
     """Test we get the user initiated form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -53,7 +53,7 @@ async def test_user_form(hass: core.HomeAssistant):
 
 async def test_user_form_with_non_bridge(hass: core.HomeAssistant):
     """Test setup a smart by bond fan."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -170,8 +170,6 @@ async def test_user_form_one_entry_per_device_allowed(hass: core.HomeAssistant):
         data={CONF_HOST: "some host", CONF_ACCESS_TOKEN: "test-token"},
     ).add_to_hass(hass)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -193,7 +191,7 @@ async def test_user_form_one_entry_per_device_allowed(hass: core.HomeAssistant):
 
 async def test_zeroconf_form(hass: core.HomeAssistant):
     """Test we get the discovery form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
@@ -222,7 +220,7 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
 
 async def test_zeroconf_form_token_unavailable(hass: core.HomeAssistant):
     """Test we get the discovery form and we handle the token being unavailable."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch_bond_version(), patch_bond_token():
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -251,7 +249,7 @@ async def test_zeroconf_form_token_unavailable(hass: core.HomeAssistant):
 
 async def test_zeroconf_form_with_token_available(hass: core.HomeAssistant):
     """Test we get the discovery form when we can get the token."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch_bond_version(return_value={"bondid": "test-bond-id"}), patch_bond_token(
         return_value={"token": "discovered-token"}
     ), patch_bond_bridge(
@@ -284,7 +282,6 @@ async def test_zeroconf_form_with_token_available(hass: core.HomeAssistant):
 
 async def test_zeroconf_already_configured(hass: core.HomeAssistant):
     """Test starting a flow from discovery when already configured."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -9,7 +9,7 @@ from boschshcpy.exceptions import (
 )
 from boschshcpy.information import SHCInformation
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.bosch_shc.config_flow import write_tls_asset
 from homeassistant.components.bosch_shc.const import CONF_SHC_CERT, CONF_SHC_KEY, DOMAIN
 
@@ -30,7 +30,7 @@ DISCOVERY_INFO = {
 
 async def test_form_user(hass, mock_zeroconf):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -376,7 +376,7 @@ async def test_form_validate_exception(hass, mock_zeroconf):
 
 async def test_form_already_configured(hass, mock_zeroconf):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain="bosch_shc", unique_id="test-mac", data={"host": "0.0.0.0"}
     )
@@ -412,7 +412,6 @@ async def test_form_already_configured(hass, mock_zeroconf):
 
 async def test_zeroconf(hass, mock_zeroconf):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "boschshcpy.session.SHCSession.mdns_info",
@@ -481,7 +480,7 @@ async def test_zeroconf(hass, mock_zeroconf):
 
 async def test_zeroconf_already_configured(hass, mock_zeroconf):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain="bosch_shc", unique_id="test-mac", data={"host": "0.0.0.0"}
     )
@@ -539,7 +538,7 @@ async def test_zeroconf_not_bosch_shc(hass, mock_zeroconf):
 
 async def test_reauth(hass, mock_zeroconf):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     mock_config = MockConfigEntry(
         domain=DOMAIN,
         unique_id="test-mac",

--- a/tests/components/broadlink/test_config_flow.py
+++ b/tests/components/broadlink/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import call, patch
 import broadlink.exceptions as blke
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.broadlink.const import DOMAIN
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
 from homeassistant.helpers import device_registry
@@ -825,7 +825,6 @@ async def test_flow_reauth_valid_host(hass):
 
 async def test_dhcp_can_finish(hass):
     """Test DHCP discovery flow can finish right away."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     device = get_device("Living Room")
     device.host = "1.2.3.4"
@@ -864,7 +863,7 @@ async def test_dhcp_can_finish(hass):
 
 async def test_dhcp_fails_to_connect(hass):
     """Test DHCP discovery flow that fails to connect."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(DEVICE_HELLO, side_effect=blke.NetworkTimeoutError()):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -883,7 +882,7 @@ async def test_dhcp_fails_to_connect(hass):
 
 async def test_dhcp_unreachable(hass):
     """Test DHCP discovery flow that fails to connect."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(DEVICE_HELLO, side_effect=OSError(errno.ENETUNREACH, None)):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -902,7 +901,7 @@ async def test_dhcp_unreachable(hass):
 
 async def test_dhcp_connect_unknown_error(hass):
     """Test DHCP discovery flow that fails to connect with an OSError."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(DEVICE_HELLO, side_effect=OSError()):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -921,7 +920,7 @@ async def test_dhcp_connect_unknown_error(hass):
 
 async def test_dhcp_device_not_supported(hass):
     """Test DHCP discovery flow that fails because the device is not supported."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     device = get_device("Kitchen")
     mock_api = device.get_mock_api()
 
@@ -942,7 +941,7 @@ async def test_dhcp_device_not_supported(hass):
 
 async def test_dhcp_already_exists(hass):
     """Test DHCP discovery flow that fails to connect."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     device = get_device("Living Room")
     mock_entry = device.get_mock_entry()
     mock_entry.add_to_hass(hass)
@@ -967,7 +966,6 @@ async def test_dhcp_already_exists(hass):
 
 async def test_dhcp_updates_host(hass):
     """Test DHCP updates host."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     device = get_device("Living Room")
     device.host = "1.2.3.4"

--- a/tests/components/canary/test_alarm_control_panel.py
+++ b/tests/components/canary/test_alarm_control_panel.py
@@ -25,7 +25,6 @@ from tests.common import mock_registry
 
 async def test_alarm_control_panel(hass, canary) -> None:
     """Test the creation and values of the alarm_control_panel for Canary."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     registry = mock_registry(hass)
     online_device_at_home = mock_device(20, "Dining Room", True, "Canary Pro")
@@ -109,7 +108,6 @@ async def test_alarm_control_panel(hass, canary) -> None:
 
 async def test_alarm_control_panel_services(hass, canary) -> None:
     """Test the services of the alarm_control_panel for Canary."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     online_device_at_home = mock_device(20, "Dining Room", True, "Canary Pro")
 

--- a/tests/components/canary/test_config_flow.py
+++ b/tests/components/canary/test_config_flow.py
@@ -16,14 +16,12 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.setup import async_setup_component
 
 from . import USER_INPUT, _patch_async_setup, _patch_async_setup_entry, init_integration
 
 
 async def test_user_form(hass, canary_config_flow):
     """Test we get the user initiated form."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -29,7 +29,6 @@ from tests.common import async_fire_time_changed, mock_device_registry, mock_reg
 
 async def test_sensors_pro(hass, canary) -> None:
     """Test the creation and values of the sensors for Canary Pro."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
@@ -97,7 +96,6 @@ async def test_sensors_pro(hass, canary) -> None:
 
 async def test_sensors_attributes_pro(hass, canary) -> None:
     """Test the creation and values of the sensors attributes for Canary Pro."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     online_device_at_home = mock_device(20, "Dining Room", True, "Canary Pro")
 
@@ -158,7 +156,6 @@ async def test_sensors_attributes_pro(hass, canary) -> None:
 
 async def test_sensors_flex(hass, canary) -> None:
     """Test the creation and values of the sensors for Canary Flex."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)

--- a/tests/components/cloudflare/test_config_flow.py
+++ b/tests/components/cloudflare/test_config_flow.py
@@ -13,7 +13,6 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.setup import async_setup_component
 
 from . import (
     ENTRY_CONFIG,
@@ -28,7 +27,6 @@ from tests.common import MockConfigEntry
 
 async def test_user_form(hass, cfupdate_flow):
     """Test we get the user initiated form."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}

--- a/tests/components/co2signal/test_config_flow.py
+++ b/tests/components/co2signal/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.co2signal import DOMAIN, config_flow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry
 
 async def test_form_home(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -46,7 +46,7 @@ async def test_form_home(hass: HomeAssistant) -> None:
 
 async def test_form_coordinates(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -87,7 +87,7 @@ async def test_form_coordinates(hass: HomeAssistant) -> None:
 
 async def test_form_country(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -200,7 +200,6 @@ async def test_form_error_unexpected_data(hass: HomeAssistant) -> None:
 
 async def test_import(hass: HomeAssistant) -> None:
     """Test we import correctly."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "CO2Signal.get_latest",
@@ -230,7 +229,7 @@ async def test_import(hass: HomeAssistant) -> None:
 
 async def test_import_abort_existing_home(hass: HomeAssistant) -> None:
     """Test we abort if home entry found."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     MockConfigEntry(domain="co2signal", data={"api_key": "abcd"}).add_to_hass(hass)
 
     with patch(
@@ -247,7 +246,7 @@ async def test_import_abort_existing_home(hass: HomeAssistant) -> None:
 
 async def test_import_abort_existing_country(hass: HomeAssistant) -> None:
     """Test we abort if existing country found."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     MockConfigEntry(
         domain="co2signal", data={"api_key": "abcd", "country_code": "nl"}
     ).add_to_hass(hass)
@@ -274,7 +273,7 @@ async def test_import_abort_existing_country(hass: HomeAssistant) -> None:
 
 async def test_import_abort_existing_coordinates(hass: HomeAssistant) -> None:
     """Test we abort if existing coordinates found."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     MockConfigEntry(
         domain="co2signal", data={"api_key": "abcd", "latitude": 1, "longitude": 2}
     ).add_to_hass(hass)

--- a/tests/components/coinbase/test_config_flow.py
+++ b/tests/components/coinbase/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from coinbase.wallet.error import AuthenticationError
 from requests.models import Response
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.coinbase.const import (
     CONF_CURRENCIES,
     CONF_EXCHANGE_RATES,
@@ -26,7 +26,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/control4/test_config_flow.py
+++ b/tests/components/control4/test_config_flow.py
@@ -6,7 +6,7 @@ from pyControl4.account import C4Account
 from pyControl4.director import C4Director
 from pyControl4.error_handling import Unauthorized
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.control4.const import DEFAULT_SCAN_INTERVAL, DOMAIN
 from homeassistant.const import (
     CONF_HOST,
@@ -46,7 +46,7 @@ def _get_mock_c4_director(getAllItemInfo={}):
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/coronavirus/test_config_flow.py
+++ b/tests/components/coronavirus/test_config_flow.py
@@ -3,14 +3,14 @@ from unittest.mock import MagicMock, patch
 
 from aiohttp import ClientError
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.coronavirus.const import DOMAIN, OPTION_WORLDWIDE
 from homeassistant.core import HomeAssistant
 
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -39,7 +39,7 @@ async def test_abort_on_connection_error(
     mock_get_cases: MagicMock, hass: HomeAssistant
 ) -> None:
     """Test we abort on connection error."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -169,7 +169,6 @@ async def test_functional_device_trigger(
     hass, aioclient_mock, mock_deconz_websocket, automation_calls
 ):
     """Test proper matching and attachment of device trigger automation."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     data = {
         "sensors": {

--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.devolo_home_control.const import DEFAULT_MYDEVOLO, DOMAIN
 
 from .const import (
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -31,7 +31,7 @@ async def test_form(hass):
 @pytest.mark.credentials_invalid
 async def test_form_invalid_credentials_user(hass):
     """Test if we get the error message on invalid credentials."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -117,7 +117,7 @@ async def test_form_zeroconf(hass):
 @pytest.mark.credentials_invalid
 async def test_form_invalid_credentials_zeroconf(hass):
     """Test if we get the error message on invalid credentials."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},

--- a/tests/components/dexcom/test_config_flow.py
+++ b/tests/components/dexcom/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from pydexcom import AccountError, SessionError
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.dexcom.const import DOMAIN, MG_DL, MMOL_L
 from homeassistant.const import CONF_UNIT_OF_MEASUREMENT, CONF_USERNAME
 
@@ -13,7 +13,7 @@ from tests.components.dexcom import CONFIG
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import requests
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.doorbird.const import CONF_EVENTS, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 
@@ -38,7 +38,7 @@ def _get_mock_doorbirdapi_side_effects(ready=None, info=None):
 
 async def test_user_form(hass):
     """Test we get the user form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -77,7 +77,6 @@ async def test_user_form(hass):
 
 async def test_form_zeroconf_wrong_oui(hass):
     """Test we abort when we get the wrong OUI via zeroconf."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -94,7 +93,6 @@ async def test_form_zeroconf_wrong_oui(hass):
 
 async def test_form_zeroconf_link_local_ignored(hass):
     """Test we abort when we get a link local address via zeroconf."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -114,7 +112,6 @@ async def test_form_zeroconf_correct_oui(hass):
     doorbirdapi = _get_mock_doorbirdapi_return_values(
         ready=[True], info={"WIFI_MAC_ADDR": "macaddr"}
     )
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.doorbird.config_flow.DoorBird",
@@ -174,7 +171,6 @@ async def test_form_zeroconf_correct_oui_wrong_device(hass, doorbell_state_side_
         ready=[True], info={"WIFI_MAC_ADDR": "macaddr"}
     )
     type(doorbirdapi).doorbell_state = MagicMock(side_effect=doorbell_state_side_effect)
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.doorbird.config_flow.DoorBird",

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -7,7 +7,7 @@ from unittest.mock import DEFAULT, AsyncMock, MagicMock, patch, sentinel
 import serial
 import serial.tools.list_ports
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.dsmr import DOMAIN, config_flow
 
 from tests.common import MockConfigEntry
@@ -150,8 +150,6 @@ async def test_setup_serial_fail(com_mock, hass, dsmr_connection_send_validate_f
     """Test failed serial connection."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     port = com_port()
 
     result = await hass.config_entries.flow.async_init(
@@ -197,8 +195,6 @@ async def test_setup_serial_wrong_telegram(
     """Test failed telegram data."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     port = com_port()
 
     result = await hass.config_entries.flow.async_init(
@@ -231,7 +227,6 @@ async def test_setup_serial_wrong_telegram(
 
 async def test_import_usb(hass, dsmr_connection_send_validate_fixture):
     """Test we can import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -257,8 +252,6 @@ async def test_import_usb_failed_connection(
 ):
     """Test we can import."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
-
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -293,8 +286,6 @@ async def test_import_usb_no_data(hass, dsmr_connection_send_validate_fixture):
     """Test we can import."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     entry_data = {
         "port": "/dev/ttyUSB0",
         "dsmr_version": "2.2",
@@ -325,8 +316,6 @@ async def test_import_usb_wrong_telegram(hass, dsmr_connection_send_validate_fix
     """Test we can import."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     entry_data = {
         "port": "/dev/ttyUSB0",
         "dsmr_version": "2.2",
@@ -349,7 +338,6 @@ async def test_import_usb_wrong_telegram(hass, dsmr_connection_send_validate_fix
 
 async def test_import_network(hass, dsmr_connection_send_validate_fixture):
     """Test we can import from network."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry_data = {
         "host": "localhost",
@@ -373,7 +361,6 @@ async def test_import_network(hass, dsmr_connection_send_validate_fixture):
 
 async def test_import_update(hass, dsmr_connection_send_validate_fixture):
     """Test we can import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -422,7 +409,6 @@ async def test_import_update(hass, dsmr_connection_send_validate_fixture):
 
 async def test_options_flow(hass):
     """Test options flow."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -462,7 +448,6 @@ async def test_options_flow(hass):
 
 async def test_import_luxembourg(hass, dsmr_connection_send_validate_fixture):
     """Test we can import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -485,7 +470,6 @@ async def test_import_luxembourg(hass, dsmr_connection_send_validate_fixture):
 
 async def test_import_sweden(hass, dsmr_connection_send_validate_fixture):
     """Test we can import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry_data = {
         "port": "/dev/ttyUSB0",

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.elkm1.const import DOMAIN
 
 
@@ -25,7 +25,7 @@ def mock_elk(invalid_auth=None, sync_complete=None):
 
 async def test_form_user_with_secure_elk(hass):
     """Test we can setup a secure elk."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -72,7 +72,7 @@ async def test_form_user_with_secure_elk(hass):
 
 async def test_form_user_with_tls_elk(hass):
     """Test we can setup a secure elk."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -119,7 +119,7 @@ async def test_form_user_with_tls_elk(hass):
 
 async def test_form_user_with_non_secure_elk(hass):
     """Test we can setup a non-secure elk."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -164,7 +164,7 @@ async def test_form_user_with_non_secure_elk(hass):
 
 async def test_form_user_with_serial_elk(hass):
     """Test we can setup a serial elk."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -268,7 +268,6 @@ async def test_form_invalid_auth(hass):
 
 async def test_form_import(hass):
     """Test we get the form with import source."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_elk = mock_elk(invalid_auth=False, sync_complete=True)
     with patch(

--- a/tests/components/emonitor/test_config_flow.py
+++ b/tests/components/emonitor/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from aioemonitor.monitor import EmonitorNetwork, EmonitorStatus
 import aiohttp
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
 from homeassistant.components.emonitor.const import DOMAIN
 from homeassistant.const import CONF_HOST
@@ -20,7 +20,7 @@ def _mock_emonitor():
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -94,7 +94,6 @@ async def test_form_cannot_connect(hass):
 
 async def test_dhcp_can_confirm(hass):
     """Test DHCP discovery flow can confirm right away."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.emonitor.config_flow.Emonitor.async_get_status",
@@ -138,7 +137,6 @@ async def test_dhcp_can_confirm(hass):
 
 async def test_dhcp_fails_to_connect(hass):
     """Test DHCP discovery flow that fails to connect."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.emonitor.config_flow.Emonitor.async_get_status",
@@ -161,7 +159,7 @@ async def test_dhcp_fails_to_connect(hass):
 
 async def test_dhcp_already_exists(hass):
     """Test DHCP discovery flow that fails to connect."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: "1.2.3.4"},
@@ -190,7 +188,7 @@ async def test_dhcp_already_exists(hass):
 
 async def test_user_unique_id_already_exists(hass):
     """Test creating an entry where the unique_id already exists."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: "1.2.3.4"},

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.enphase_envoy.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
@@ -12,7 +12,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -120,7 +120,7 @@ async def test_form_unknown_error(hass: HomeAssistant) -> None:
 
 async def test_import(hass: HomeAssistant) -> None:
     """Test we can import from yaml."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.enphase_envoy.config_flow.EnvoyReader.getData",
         return_value=True,
@@ -153,7 +153,7 @@ async def test_import(hass: HomeAssistant) -> None:
 
 async def test_zeroconf(hass: HomeAssistant) -> None:
     """Test we can setup from zeroconf."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
@@ -198,7 +198,6 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
 
 async def test_form_host_already_exists(hass: HomeAssistant) -> None:
     """Test host already exists."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -237,7 +236,7 @@ async def test_form_host_already_exists(hass: HomeAssistant) -> None:
 
 async def test_zeroconf_serial_already_exists(hass: HomeAssistant) -> None:
     """Test serial number already exists from zeroconf."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -266,7 +265,7 @@ async def test_zeroconf_serial_already_exists(hass: HomeAssistant) -> None:
 
 async def test_zeroconf_host_already_exists(hass: HomeAssistant) -> None:
     """Test hosts already exists from zeroconf."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -306,7 +305,7 @@ async def test_zeroconf_host_already_exists(hass: HomeAssistant) -> None:
 
 async def test_reauth(hass: HomeAssistant) -> None:
     """Test we reauth auth."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/epson/test_config_flow.py
+++ b/tests/components/epson/test_config_flow.py
@@ -3,14 +3,14 @@ from unittest.mock import patch
 
 from epson_projector.const import PWR_OFF_STATE
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.epson.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME, STATE_UNAVAILABLE
 
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch("homeassistant.components.epson.Projector.get_power", return_value="01"):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/ezviz/test_config_flow.py
+++ b/tests/components/ezviz/test_config_flow.py
@@ -34,7 +34,6 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.setup import async_setup_component
 
 from . import (
     DISCOVERY_INFO,
@@ -52,7 +51,6 @@ from . import (
 
 async def test_user_form(hass, ezviz_config_flow):
     """Test the user initiated form."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -115,7 +113,6 @@ async def test_user_custom_url(hass, ezviz_config_flow):
 
 async def test_async_step_import(hass, ezviz_config_flow):
     """Test the config import flow."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     with _patch_async_setup_entry() as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
@@ -129,7 +126,6 @@ async def test_async_step_import(hass, ezviz_config_flow):
 
 async def test_async_step_import_camera(hass, ezviz_config_flow):
     """Test the config import camera flow."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     with _patch_async_setup_entry() as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
@@ -143,7 +139,6 @@ async def test_async_step_import_camera(hass, ezviz_config_flow):
 
 async def test_async_step_import_2nd_form_returns_camera(hass, ezviz_config_flow):
     """Test we get the user initiated form."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     with _patch_async_setup_entry() as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
@@ -168,7 +163,6 @@ async def test_async_step_import_2nd_form_returns_camera(hass, ezviz_config_flow
 
 async def test_async_step_import_abort(hass, ezviz_config_flow):
     """Test the config import flow with invalid data."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data=YAML_INVALID
@@ -179,7 +173,6 @@ async def test_async_step_import_abort(hass, ezviz_config_flow):
 
 async def test_step_discovery_abort_if_cloud_account_missing(hass):
     """Test discovery and confirm step, abort if cloud account was removed."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_DISCOVERY}, data=DISCOVERY_INFO
@@ -207,7 +200,6 @@ async def test_async_step_discovery(
     """Test discovery and confirm step."""
     with patch("homeassistant.components.ezviz.PLATFORMS", []):
         await init_integration(hass)
-    await async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_DISCOVERY}, data=DISCOVERY_INFO
@@ -359,8 +351,6 @@ async def test_discover_exception_step1(
     with patch("homeassistant.components.ezviz.PLATFORMS", []):
         await init_integration(hass)
 
-    await async_setup_component(hass, "persistent_notification", {})
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_DISCOVERY},
@@ -435,7 +425,6 @@ async def test_discover_exception_step3(
     """Test we handle unexpected exception on discovery."""
     with patch("homeassistant.components.ezviz.PLATFORMS", []):
         await init_integration(hass)
-    await async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/faa_delays/test_config_flow.py
+++ b/tests/components/faa_delays/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from aiohttp import ClientConnectionError
 import faadelays
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.faa_delays.const import DOMAIN
 from homeassistant.const import CONF_ID
 from homeassistant.exceptions import HomeAssistantError
@@ -19,7 +19,7 @@ async def mock_valid_airport(self, *args, **kwargs):
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/filesize/test_sensor.py
+++ b/tests/components/filesize/test_sensor.py
@@ -33,7 +33,7 @@ async def test_invalid_path(hass):
     config = {"sensor": {"platform": "filesize", CONF_FILE_PATHS: ["invalid_path"]}}
     assert await async_setup_component(hass, "sensor", config)
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids()) == 0
+    assert len(hass.states.async_entity_ids("sensor")) == 0
 
 
 async def test_valid_path(hass):
@@ -43,7 +43,7 @@ async def test_valid_path(hass):
     hass.config.allowlist_external_dirs = {TEST_DIR}
     assert await async_setup_component(hass, "sensor", config)
     await hass.async_block_till_done()
-    assert len(hass.states.async_entity_ids()) == 1
+    assert len(hass.states.async_entity_ids("sensor")) == 1
     state = hass.states.get("sensor.mock_file_test_filesize_txt")
     assert state.state == "0.0"
     assert state.attributes.get("bytes") == 4

--- a/tests/components/firmata/test_config_flow.py
+++ b/tests/components/firmata/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from pymata_express.pymata_express_serial import serial
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.firmata.const import CONF_SERIAL_PORT, DOMAIN
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -11,7 +11,6 @@ from homeassistant.core import HomeAssistant
 
 async def test_import_cannot_connect_pymata(hass: HomeAssistant) -> None:
     """Test we fail with an invalid board."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.firmata.board.PymataExpress.start_aio",
@@ -29,7 +28,6 @@ async def test_import_cannot_connect_pymata(hass: HomeAssistant) -> None:
 
 async def test_import_cannot_connect_serial(hass: HomeAssistant) -> None:
     """Test we fail with an invalid board."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.firmata.board.PymataExpress.start_aio",
@@ -47,7 +45,6 @@ async def test_import_cannot_connect_serial(hass: HomeAssistant) -> None:
 
 async def test_import_cannot_connect_serial_timeout(hass: HomeAssistant) -> None:
     """Test we fail with an invalid board."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.firmata.board.PymataExpress.start_aio",
@@ -65,7 +62,6 @@ async def test_import_cannot_connect_serial_timeout(hass: HomeAssistant) -> None
 
 async def test_import(hass: HomeAssistant) -> None:
     """Test we create an entry from config."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.firmata.board.PymataExpress", autospec=True

--- a/tests/components/fjaraskupan/test_config_flow.py
+++ b/tests/components/fjaraskupan/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from bleak.backends.device import BLEDevice
 from pytest import fixture
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.fjaraskupan.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
@@ -19,7 +19,6 @@ from homeassistant.data_entry_flow import (
 @fixture(name="mock_setup_entry", autouse=True)
 async def fixture_mock_setup_entry(hass):
     """Fixture for config entry."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.fjaraskupan.async_setup_entry", return_value=True

--- a/tests/components/flick_electric/test_config_flow.py
+++ b/tests/components/flick_electric/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from pyflick.authentication import AuthException
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.flick_electric.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
@@ -23,7 +23,7 @@ async def _flow_submit(hass):
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/flipr/test_config_flow.py
+++ b/tests/components/flipr/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from requests.exceptions import HTTPError, Timeout
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.flipr.const import CONF_FLIPR_ID, DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
@@ -21,7 +21,7 @@ def mock_setups():
 
 async def test_show_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/flo/test_config_flow.py
+++ b/tests/components/flo/test_config_flow.py
@@ -3,7 +3,7 @@ import json
 import time
 from unittest.mock import patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.flo.const import DOMAIN
 from homeassistant.const import CONTENT_TYPE_JSON
 
@@ -12,7 +12,7 @@ from .common import TEST_EMAIL_ADDRESS, TEST_PASSWORD, TEST_TOKEN, TEST_USER_ID
 
 async def test_form(hass, aioclient_mock_fixture):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/flume/test_config_flow.py
+++ b/tests/components/flume/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import requests.exceptions
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.flume.const import DOMAIN
 from homeassistant.const import (
     CONF_CLIENT_ID,
@@ -23,7 +23,7 @@ def _get_mocked_flume_device_list():
 
 async def test_form(hass):
     """Test we get the form and can setup from user input."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -66,7 +66,7 @@ async def test_form(hass):
 
 async def test_form_import(hass):
     """Test we can import the sensor platform config."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     mock_flume_device_list = _get_mocked_flume_device_list()
 
     with patch(

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.flux_led.const import (
     CONF_CUSTOM_EFFECT_COLORS,
     CONF_CUSTOM_EFFECT_SPEED_PCT,
@@ -317,7 +317,6 @@ async def test_manual_no_discovery_data(hass: HomeAssistant):
 
 async def test_discovered_by_discovery_and_dhcp(hass):
     """Test we get the form with discovery and abort for dhcp source when we get both."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with _patch_discovery(), _patch_wifibulb():
         result = await hass.config_entries.flow.async_init(
@@ -364,8 +363,6 @@ async def test_discovered_by_discovery_and_dhcp(hass):
 async def test_discovered_by_dhcp_or_discovery(hass, source, data):
     """Test we can setup when discovered from dhcp or discovery."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     with _patch_discovery(), _patch_wifibulb():
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": source}, data=data
@@ -402,7 +399,6 @@ async def test_discovered_by_dhcp_or_discovery_adds_missing_unique_id(
     """Test we can setup when discovered from dhcp or discovery."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: IP_ADDRESS})
     config_entry.add_to_hass(hass)
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with _patch_discovery(), _patch_wifibulb():
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/folder/test_sensor.py
+++ b/tests/components/folder/test_sensor.py
@@ -28,7 +28,7 @@ async def test_invalid_path(hass):
     """Test that an invalid path is caught."""
     config = {"sensor": {"platform": "folder", CONF_FOLDER_PATHS: "invalid_path"}}
     assert await async_setup_component(hass, "sensor", config)
-    assert len(hass.states.async_entity_ids()) == 0
+    assert len(hass.states.async_entity_ids("sensor")) == 0
 
 
 async def test_valid_path(hass):

--- a/tests/components/forecast_solar/conftest.py
+++ b/tests/components/forecast_solar/conftest.py
@@ -21,11 +21,6 @@ from homeassistant.util import dt as dt_util
 from tests.common import MockConfigEntry
 
 
-@pytest.fixture(autouse=True)
-async def mock_persistent_notification(hass: HomeAssistant) -> None:
-    """Set up component for persistent notifications."""
-
-
 @pytest.fixture
 def mock_config_entry() -> MockConfigEntry:
     """Return the default mocked config entry."""

--- a/tests/components/forecast_solar/conftest.py
+++ b/tests/components/forecast_solar/conftest.py
@@ -16,7 +16,6 @@ from homeassistant.components.forecast_solar.const import (
 )
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
@@ -25,7 +24,6 @@ from tests.common import MockConfigEntry
 @pytest.fixture(autouse=True)
 async def mock_persistent_notification(hass: HomeAssistant) -> None:
     """Set up component for persistent notifications."""
-    await async_setup_component(hass, "persistent_notification", {})
 
 
 @pytest.fixture

--- a/tests/components/foscam/test_config_flow.py
+++ b/tests/components/foscam/test_config_flow.py
@@ -8,7 +8,7 @@ from libpyfoscam.foscam import (
     ERROR_FOSCAM_UNKNOWN,
 )
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.foscam import config_flow
 
 from tests.common import MockConfigEntry
@@ -76,7 +76,6 @@ def setup_mock_foscam_camera(mock_foscam_camera):
 
 async def test_user_valid(hass):
     """Test valid config from user input."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -108,7 +107,6 @@ async def test_user_valid(hass):
 
 async def test_user_invalid_auth(hass):
     """Test we handle invalid auth from user input."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -137,7 +135,6 @@ async def test_user_invalid_auth(hass):
 
 async def test_user_cannot_connect(hass):
     """Test we handle cannot connect error from user input."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -166,7 +163,6 @@ async def test_user_cannot_connect(hass):
 
 async def test_user_invalid_response(hass):
     """Test we handle invalid response error from user input."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -197,7 +193,6 @@ async def test_user_invalid_response(hass):
 
 async def test_user_already_configured(hass):
     """Test we handle already configured from user input."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=config_flow.DOMAIN,
@@ -229,7 +224,6 @@ async def test_user_already_configured(hass):
 
 async def test_user_unknown_exception(hass):
     """Test we handle unknown exceptions from user input."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -255,7 +249,6 @@ async def test_user_unknown_exception(hass):
 
 async def test_import_user_valid(hass):
     """Test valid config from import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.foscam.config_flow.FoscamCamera",
@@ -282,7 +275,6 @@ async def test_import_user_valid(hass):
 
 async def test_import_user_valid_with_name(hass):
     """Test valid config with extra name from import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.foscam.config_flow.FoscamCamera",
@@ -313,7 +305,6 @@ async def test_import_user_valid_with_name(hass):
 
 async def test_import_invalid_auth(hass):
     """Test we handle invalid auth from import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.foscam.config_flow.FoscamCamera",
@@ -337,7 +328,6 @@ async def test_import_invalid_auth(hass):
 
 async def test_import_cannot_connect(hass):
     """Test we handle cannot connect error from import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.foscam.config_flow.FoscamCamera",
@@ -361,7 +351,6 @@ async def test_import_cannot_connect(hass):
 
 async def test_import_invalid_response(hass):
     """Test we handle invalid response error from import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.foscam.config_flow.FoscamCamera",
@@ -387,7 +376,6 @@ async def test_import_invalid_response(hass):
 
 async def test_import_already_configured(hass):
     """Test we handle already configured from import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=config_flow.DOMAIN,
@@ -414,7 +402,6 @@ async def test_import_already_configured(hass):
 
 async def test_import_unknown_exception(hass):
     """Test we handle unknown exceptions from import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.foscam.config_flow.FoscamCamera",

--- a/tests/components/freebox/test_init.py
+++ b/tests/components/freebox/test_init.py
@@ -46,7 +46,6 @@ async def test_setup(hass: HomeAssistant, router: Mock):
 
 async def test_setup_import(hass: HomeAssistant, router: Mock):
     """Test setup of integration from import."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/garages_amsterdam/test_config_flow.py
+++ b/tests/components/garages_amsterdam/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from aiohttp import ClientResponseError
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.garages_amsterdam.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
@@ -16,7 +16,6 @@ from homeassistant.data_entry_flow import (
 
 async def test_full_flow(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -52,7 +51,6 @@ async def test_error_handling(
     side_effect: Exception, reason: str, hass: HomeAssistant
 ) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.garages_amsterdam.config_flow.garages_amsterdam.get_garages",

--- a/tests/components/gdacs/test_geo_location.py
+++ b/tests/components/gdacs/test_geo_location.py
@@ -96,9 +96,12 @@ async def test_setup(hass, legacy_patchable_time):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
         # 3 geolocation and 1 sensor entities
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
         entity_registry = er.async_get(hass)
         assert len(entity_registry.entities) == 4
 
@@ -169,8 +172,11 @@ async def test_setup(hass, legacy_patchable_time):
         async_fire_time_changed(hass, utcnow + DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         # Simulate an update - empty data, but successful update,
         # so no changes to entities.
@@ -178,16 +184,22 @@ async def test_setup(hass, legacy_patchable_time):
         async_fire_time_changed(hass, utcnow + 2 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         # Simulate an update - empty data, removes all entities
         mock_feed_update.return_value = "ERROR", None
         async_fire_time_changed(hass, utcnow + 3 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 1
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 1
+        )
         assert len(entity_registry.entities) == 1
 
 
@@ -219,8 +231,11 @@ async def test_setup_imperial(hass, legacy_patchable_time):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 2
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 2
+        )
 
         # Test conversion of 200 miles to kilometers.
         feeds = hass.data[DOMAIN][FEED]

--- a/tests/components/gdacs/test_sensor.py
+++ b/tests/components/gdacs/test_sensor.py
@@ -61,9 +61,12 @@ async def test_setup(hass, legacy_patchable_time):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
         # 3 geolocation and 1 sensor entities
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         state = hass.states.get("sensor.gdacs_32_87336_117_22743")
         assert state is not None
@@ -83,8 +86,11 @@ async def test_setup(hass, legacy_patchable_time):
         async_fire_time_changed(hass, utcnow + DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         state = hass.states.get("sensor.gdacs_32_87336_117_22743")
         attributes = state.attributes
@@ -98,16 +104,22 @@ async def test_setup(hass, legacy_patchable_time):
         async_fire_time_changed(hass, utcnow + 2 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         # Simulate an update - empty data, removes all entities
         mock_feed_update.return_value = "ERROR", None
         async_fire_time_changed(hass, utcnow + 3 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 1
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 1
+        )
 
         state = hass.states.get("sensor.gdacs_32_87336_117_22743")
         attributes = state.attributes

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -114,13 +114,11 @@ BEACON_EXIT_CAR = {
 @pytest.fixture(autouse=True)
 def mock_dev_track(mock_device_tracker_conf):
     """Mock device tracker config loading."""
-    pass
 
 
 @pytest.fixture
 async def geofency_client(loop, hass, hass_client_no_auth):
     """Geofency mock client (unauthenticated)."""
-    assert await async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {CONF_MOBILE_BEACONS: ["Car 1"]}}

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -72,9 +72,12 @@ async def test_setup(hass):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
         # 3 geolocation and 1 sensor entities
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
         entity_registry = er.async_get(hass)
         assert len(entity_registry.entities) == 4
 
@@ -136,25 +139,32 @@ async def test_setup(hass):
         async_fire_time_changed(hass, utcnow + DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
-
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
         # Simulate an update - empty data, but successful update,
         # so no changes to entities.
         mock_feed_update.return_value = "OK_NO_DATA", None
         async_fire_time_changed(hass, utcnow + 2 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
-
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
         # Simulate an update - empty data, removes all entities
         mock_feed_update.return_value = "ERROR", None
         async_fire_time_changed(hass, utcnow + 3 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 1
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 1
+        )
         assert len(entity_registry.entities) == 1
 
 
@@ -178,8 +188,11 @@ async def test_setup_imperial(hass):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 2
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 2
+        )
 
         # Test conversion of 200 miles to kilometers.
         feeds = hass.data[DOMAIN][FEED]

--- a/tests/components/geonetnz_quakes/test_sensor.py
+++ b/tests/components/geonetnz_quakes/test_sensor.py
@@ -62,9 +62,12 @@ async def test_setup(hass, legacy_patchable_time):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
         # 3 geolocation and 1 sensor entities
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         state = hass.states.get("sensor.geonet_nz_quakes_32_87336_117_22743")
         assert state is not None
@@ -84,8 +87,11 @@ async def test_setup(hass, legacy_patchable_time):
         async_fire_time_changed(hass, utcnow + DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         state = hass.states.get("sensor.geonet_nz_quakes_32_87336_117_22743")
         attributes = state.attributes
@@ -99,16 +105,22 @@ async def test_setup(hass, legacy_patchable_time):
         async_fire_time_changed(hass, utcnow + 2 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         # Simulate an update - empty data, removes all entities
         mock_feed_update.return_value = "ERROR", None
         async_fire_time_changed(hass, utcnow + 3 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 1
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 1
+        )
 
         state = hass.states.get("sensor.geonet_nz_quakes_32_87336_117_22743")
         attributes = state.attributes

--- a/tests/components/geonetnz_volcano/test_sensor.py
+++ b/tests/components/geonetnz_volcano/test_sensor.py
@@ -57,9 +57,12 @@ async def test_setup(hass, legacy_patchable_time):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
         # 3 sensor entities
-        assert len(all_states) == 3
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 3
+        )
 
         state = hass.states.get("sensor.volcano_title_1")
         assert state is not None
@@ -101,8 +104,11 @@ async def test_setup(hass, legacy_patchable_time):
         async_fire_time_changed(hass, utcnow + DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         # Simulate an update - empty data, but successful update,
         # so no changes to entities.
@@ -110,24 +116,33 @@ async def test_setup(hass, legacy_patchable_time):
         async_fire_time_changed(hass, utcnow + 2 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         # Simulate an update - empty data, keep all entities
         mock_feed_update.return_value = "ERROR", None
         async_fire_time_changed(hass, utcnow + 3 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
         # Simulate an update - regular data for 3 entries
         mock_feed_update.return_value = "OK", [mock_entry_1, mock_entry_2, mock_entry_3]
         async_fire_time_changed(hass, utcnow + 4 * DEFAULT_SCAN_INTERVAL)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 4
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 4
+        )
 
 
 async def test_setup_imperial(hass):
@@ -149,8 +164,11 @@ async def test_setup_imperial(hass):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
 
-        all_states = hass.states.async_all()
-        assert len(all_states) == 1
+        assert (
+            len(hass.states.async_entity_ids("geo_location"))
+            + len(hass.states.async_entity_ids("sensor"))
+            == 1
+        )
 
         # Test conversion of 200 miles to kilometers.
         assert mock_feed_init.call_args[1].get("filter_radius") == 321.8688

--- a/tests/components/goalzero/test_config_flow.py
+++ b/tests/components/goalzero/test_config_flow.py
@@ -10,7 +10,6 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.setup import async_setup_component
 
 from . import (
     CONF_CONFIG_FLOW,
@@ -120,7 +119,7 @@ async def test_flow_user_unknown_error(hass):
 
 async def test_dhcp_discovery(hass):
     """Test we can process the discovery from dhcp."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     mocked_yeti = await _create_mocked_yeti()
     with _patch_config_flow_yeti(mocked_yeti), _patch_setup():
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -5,7 +5,7 @@ from ismartgate import GogoGate2Api, ISmartGateApi
 from ismartgate.common import ApiError
 from ismartgate.const import GogoGate2ApiErrorCode
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.gogogate2.const import (
     DEVICE_TYPE_GOGOGATE2,
     DEVICE_TYPE_ISMARTGATE,
@@ -102,7 +102,6 @@ async def test_auth_fail(
 
 async def test_form_homekit_unique_id_already_setup(hass):
     """Test that we abort from homekit if gogogate2 is already setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -134,7 +133,6 @@ async def test_form_homekit_unique_id_already_setup(hass):
 
 async def test_form_homekit_ip_address_already_setup(hass):
     """Test that we abort from homekit if gogogate2 is already setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -152,7 +150,6 @@ async def test_form_homekit_ip_address_already_setup(hass):
 
 async def test_form_homekit_ip_address(hass):
     """Test homekit includes the defaults ip address."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -181,7 +178,6 @@ async def test_discovered_dhcp(
     ismartgateapi_mock.return_value = api
 
     api.reset_mock()
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -227,7 +223,6 @@ async def test_discovered_dhcp(
 
 async def test_discovered_by_homekit_and_dhcp(hass):
     """Test we get the form with homekit and abort for dhcp source when we get both."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -27,13 +27,11 @@ HOME_LONGITUDE = -115.815811
 @pytest.fixture(autouse=True)
 def mock_dev_track(mock_device_tracker_conf):
     """Mock device tracker config loading."""
-    pass
 
 
 @pytest.fixture
 async def gpslogger_client(loop, hass, hass_client_no_auth):
     """Mock client for GPSLogger (unauthenticated)."""
-    assert await async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 

--- a/tests/components/habitica/test_config_flow.py
+++ b/tests/components/habitica/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import ClientResponseError
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.habitica.const import DEFAULT_URL, DOMAIN
 
 from tests.common import MockConfigEntry
@@ -11,7 +11,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Logitech Harmony Hub config flow."""
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.harmony.config_flow import CannotConnect
 from homeassistant.components.harmony.const import DOMAIN, PREVIOUS_ACTIVE_ACTIVITY
 from homeassistant.const import CONF_HOST, CONF_NAME
@@ -19,7 +19,7 @@ def _get_mock_harmonyapi(connect=None, close=None):
 
 async def test_user_form(hass):
     """Test we get the user form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -48,7 +48,6 @@ async def test_user_form(hass):
 
 async def test_form_ssdp(hass):
     """Test we get the form with ssdp source."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     harmonyapi = _get_mock_harmonyapi(connect=True)
 
@@ -97,7 +96,7 @@ async def test_form_ssdp(hass):
 
 async def test_form_ssdp_aborts_before_checking_remoteid_if_host_known(hass):
     """Test we abort without connecting if the host is already known."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={"host": "2.2.2.2", "name": "any"},

--- a/tests/components/hassio/test_config_flow.py
+++ b/tests/components/hassio/test_config_flow.py
@@ -1,13 +1,12 @@
 """Test the Home Assistant Supervisor config flow."""
 from unittest.mock import patch
 
-from homeassistant import setup
 from homeassistant.components.hassio import DOMAIN
 
 
 async def test_config_flow(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.hassio.async_setup", return_value=True
     ) as mock_setup, patch(

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -786,7 +786,6 @@ async def test_location_device_tracker_added_after_update(
         await hass.async_block_till_done()
 
         sensor = hass.states.get("sensor.test")
-        assert len(caplog.records) == 2
         assert "Unable to find entity" in caplog.text
         caplog.clear()
 
@@ -908,7 +907,6 @@ async def test_pattern_origin(hass, caplog):
     }
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
-    assert len(caplog.records) == 2
     assert "invalid latitude" in caplog.text
 
 
@@ -928,7 +926,6 @@ async def test_pattern_destination(hass, caplog):
     }
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
-    assert len(caplog.records) == 2
     assert "invalid latitude" in caplog.text
 
 
@@ -1179,7 +1176,6 @@ async def test_arrival_only_allowed_for_timetable(hass, caplog):
     }
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
-    assert len(caplog.records) == 2
     assert "[arrival] is an invalid option" in caplog.text
 
 
@@ -1204,5 +1200,4 @@ async def test_exclusive_arrival_and_departure(hass, caplog):
     }
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
-    assert len(caplog.records) == 2
     assert "two or more values in the same group of exclusion" in caplog.text

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from apyhiveapi.helper import hive_exceptions
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.hive.const import CONF_CODE, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 
@@ -181,7 +181,6 @@ async def test_user_flow_2fa(hass):
 async def test_reauth_flow(hass):
     """Test the reauth flow."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     mock_config = MockConfigEntry(
         domain=DOMAIN,
         unique_id=USERNAME,

--- a/tests/components/hlk_sw16/test_config_flow.py
+++ b/tests/components/hlk_sw16/test_config_flow.py
@@ -2,7 +2,7 @@
 import asyncio
 from unittest.mock import patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.hlk_sw16.const import DOMAIN
 
 
@@ -49,7 +49,7 @@ async def create_mock_hlk_sw16_connection(fail):
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -110,7 +110,7 @@ async def test_form(hass):
 
 async def test_import(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}
     )

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.homekit.const import DOMAIN, SHORT_BRIDGE_NAME
 from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_IMPORT
 from homeassistant.const import CONF_NAME, CONF_PORT
@@ -35,7 +35,7 @@ def _mock_config_entry_with_options_populated():
 
 async def test_setup_in_bridge_mode(hass, mock_get_source_ip):
     """Test we can setup a new instance in bridge mode."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -85,7 +85,6 @@ async def test_setup_in_bridge_mode(hass, mock_get_source_ip):
 
 async def test_setup_in_bridge_mode_name_taken(hass, mock_get_source_ip):
     """Test we can setup a new instance in bridge mode when the name is taken."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -175,7 +174,6 @@ async def test_setup_creates_entries_for_accessory_mode_devices(
     )
     accessory_mode_entry.add_to_hass(hass)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -235,7 +233,6 @@ async def test_setup_creates_entries_for_accessory_mode_devices(
 
 async def test_import(hass, mock_get_source_ip):
     """Test we can import instance."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     ignored_entry = MockConfigEntry(domain=DOMAIN, data={}, source=SOURCE_IGNORE)
     ignored_entry.add_to_hass(hass)
@@ -379,7 +376,6 @@ async def test_options_flow_devices(
     demo_config_entry = MockConfigEntry(domain="domain")
     demo_config_entry.add_to_hass(hass)
 
-    assert await async_setup_component(hass, "persistent_notification", {})
     assert await async_setup_component(hass, "demo", {"demo": {}})
     assert await async_setup_component(hass, "homekit", {"homekit": {}})
 
@@ -460,7 +456,6 @@ async def test_options_flow_devices_preserved_when_advanced_off(
     demo_config_entry = MockConfigEntry(domain="domain")
     demo_config_entry.add_to_hass(hass)
 
-    assert await async_setup_component(hass, "persistent_notification", {})
     assert await async_setup_component(hass, "homekit", {"homekit": {}})
 
     hass.states.async_set("climate.old", "off")
@@ -1006,7 +1001,7 @@ async def test_options_flow_include_mode_basic_accessory(hass, mock_get_source_i
 
 async def test_converting_bridge_to_accessory_mode(hass, hk_driver, mock_get_source_ip):
     """Test we can convert a bridge to accessory mode."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -147,7 +147,7 @@ def _mock_pyhap_bridge():
 
 async def test_setup_min(hass, mock_zeroconf):
     """Test async_setup with min config options."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_NAME: BRIDGE_NAME, CONF_PORT: DEFAULT_PORT},
@@ -186,7 +186,7 @@ async def test_setup_min(hass, mock_zeroconf):
 
 async def test_setup_auto_start_disabled(hass, mock_zeroconf):
     """Test async_setup with auto start disabled and test service calls."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_NAME: "Test Name", CONF_PORT: 11111, CONF_IP_ADDRESS: "172.0.0.0"},
@@ -370,7 +370,7 @@ async def test_homekit_setup_advertise_ip(hass, hk_driver, mock_zeroconf):
 
 async def test_homekit_add_accessory(hass, mock_zeroconf):
     """Add accessory if config exists and get_acc returns an accessory."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -408,7 +408,7 @@ async def test_homekit_warn_add_accessory_bridge(
     hass, acc_category, mock_zeroconf, caplog
 ):
     """Test we warn when adding cameras or tvs to a bridge."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -673,7 +673,7 @@ async def test_homekit_stop(hass):
 
 async def test_homekit_reset_accessories(hass, mock_zeroconf):
     """Test resetting HomeKit accessories."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -718,7 +718,7 @@ async def test_homekit_reset_accessories(hass, mock_zeroconf):
 
 async def test_homekit_unpair(hass, device_reg, mock_zeroconf):
     """Test unpairing HomeKit accessories."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -760,7 +760,7 @@ async def test_homekit_unpair(hass, device_reg, mock_zeroconf):
 
 async def test_homekit_unpair_missing_device_id(hass, device_reg, mock_zeroconf):
     """Test unpairing HomeKit accessories with invalid device id."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -798,7 +798,7 @@ async def test_homekit_unpair_missing_device_id(hass, device_reg, mock_zeroconf)
 
 async def test_homekit_unpair_not_homekit_device(hass, device_reg, mock_zeroconf):
     """Test unpairing HomeKit accessories with a non-homekit device id."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -846,7 +846,7 @@ async def test_homekit_unpair_not_homekit_device(hass, device_reg, mock_zeroconf
 
 async def test_homekit_reset_accessories_not_supported(hass, mock_zeroconf):
     """Test resetting HomeKit accessories with an unsupported entity."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -890,7 +890,7 @@ async def test_homekit_reset_accessories_not_supported(hass, mock_zeroconf):
 
 async def test_homekit_reset_accessories_state_missing(hass, mock_zeroconf):
     """Test resetting HomeKit accessories when the state goes missing."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -932,7 +932,7 @@ async def test_homekit_reset_accessories_state_missing(hass, mock_zeroconf):
 
 async def test_homekit_reset_accessories_not_bridged(hass, mock_zeroconf):
     """Test resetting HomeKit accessories when the state is not bridged."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -974,7 +974,7 @@ async def test_homekit_reset_accessories_not_bridged(hass, mock_zeroconf):
 
 async def test_homekit_reset_single_accessory(hass, mock_zeroconf):
     """Test resetting HomeKit single accessory."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -1013,7 +1013,7 @@ async def test_homekit_reset_single_accessory(hass, mock_zeroconf):
 
 async def test_homekit_reset_single_accessory_unsupported(hass, mock_zeroconf):
     """Test resetting HomeKit single accessory with an unsupported entity."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -1050,7 +1050,7 @@ async def test_homekit_reset_single_accessory_unsupported(hass, mock_zeroconf):
 
 async def test_homekit_reset_single_accessory_state_missing(hass, mock_zeroconf):
     """Test resetting HomeKit single accessory when the state goes missing."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -1086,7 +1086,7 @@ async def test_homekit_reset_single_accessory_state_missing(hass, mock_zeroconf)
 
 async def test_homekit_reset_single_accessory_no_match(hass, mock_zeroconf):
     """Test resetting HomeKit single accessory when the entity id does not match."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
     )
@@ -1292,7 +1292,7 @@ async def test_homekit_async_get_integration_fails(
 
 async def test_yaml_updates_update_config_entry_for_name(hass, mock_zeroconf):
     """Test async_setup with imported config."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         source=SOURCE_IMPORT,
@@ -1369,7 +1369,7 @@ async def test_homekit_ignored_missing_devices(
     hass, hk_driver, device_reg, entity_reg, mock_zeroconf
 ):
     """Test HomeKit handles a device in the entity registry but missing from the device registry."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = await async_init_integration(hass)
     homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE)
 
@@ -1564,7 +1564,7 @@ async def test_homekit_finds_linked_humidity_sensors(
 
 async def test_reload(hass, mock_zeroconf):
     """Test we can reload from yaml."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         source=SOURCE_IMPORT,
@@ -1729,7 +1729,7 @@ async def test_homekit_start_in_accessory_mode_missing_entity(
 
 async def test_wait_for_port_to_free(hass, hk_driver, mock_zeroconf, caplog):
     """Test we wait for the port to free before declaring unload success."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_NAME: BRIDGE_NAME, CONF_PORT: DEFAULT_PORT},

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -171,10 +171,10 @@ async def test_ip_bans_file_creation(hass, aiohttp_client):
         assert m_open.call_count == 1
 
         assert (
-            len(notifications := hass.states.async_all("persistent_notification")) == 3
+            len(notifications := hass.states.async_all("persistent_notification")) == 2
         )
         assert (
-            hass.states.get(notifications[0]).attributes["message"]
+            notifications[0].attributes["message"]
             == "Login attempt or request with invalid authentication from example.com (200.201.202.204). See the log for details."
         )
 

--- a/tests/components/http/test_ban.py
+++ b/tests/components/http/test_ban.py
@@ -24,8 +24,6 @@ from homeassistant.setup import async_setup_component
 
 from . import mock_real_ip
 
-from tests.common import async_mock_service
-
 SUPERVISOR_IP = "1.2.3.4"
 BANNED_IPS = ["200.201.202.203", "100.64.0.2"]
 BANNED_IPS_WITH_SUPERVISOR = BANNED_IPS + [SUPERVISOR_IP]
@@ -136,8 +134,6 @@ async def test_ban_middleware_loaded_by_default(hass):
 
 async def test_ip_bans_file_creation(hass, aiohttp_client):
     """Testing if banned IP file created."""
-    notification_calls = async_mock_service(hass, "persistent_notification", "create")
-
     app = web.Application()
     app["hass"] = hass
 
@@ -174,9 +170,11 @@ async def test_ip_bans_file_creation(hass, aiohttp_client):
         assert resp.status == HTTP_FORBIDDEN
         assert m_open.call_count == 1
 
-        assert len(notification_calls) == 3
         assert (
-            notification_calls[0].data["message"]
+            len(notifications := hass.states.async_all("persistent_notification")) == 3
+        )
+        assert (
+            hass.states.get(notifications[0]).attributes["message"]
             == "Login attempt or request with invalid authentication from example.com (200.201.202.204). See the log for details."
         )
 

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -108,7 +108,7 @@ async def test_fixing_unique_id_other_correct(hass, mock_bridge_setup):
 
 async def test_security_vuln_check(hass):
     """Test that we report security vulnerabilities."""
-    assert await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(domain=hue.DOMAIN, data={"host": "0.0.0.0"})
     entry.add_to_hass(hass)
 

--- a/tests/components/huisbaasje/test_config_flow.py
+++ b/tests/components/huisbaasje/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Huisbaasje config flow."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.huisbaasje.config_flow import (
     HuisbaasjeConnectionException,
     HuisbaasjeException,
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.hunterdouglas_powerview.const import DOMAIN
 
 from tests.common import MockConfigEntry, load_fixture
@@ -73,7 +73,7 @@ def _get_mock_powerview_fwversion(fwversion=None, get_resources=None):
 
 async def test_user_form(hass):
     """Test we get the user form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -116,7 +116,7 @@ async def test_user_form(hass):
 
 async def test_user_form_legacy(hass):
     """Test we get the user form with a legacy device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -164,7 +164,6 @@ async def test_user_form_legacy(hass):
 @pytest.mark.parametrize("source, discovery_info", DISCOVERY_DATA)
 async def test_form_homekit_and_dhcp_cannot_connect(hass, source, discovery_info):
     """Test we get the form with homekit and dhcp source."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     ignored_config_entry = MockConfigEntry(
         domain=DOMAIN, data={}, source=config_entries.SOURCE_IGNORE
@@ -191,7 +190,6 @@ async def test_form_homekit_and_dhcp_cannot_connect(hass, source, discovery_info
 @pytest.mark.parametrize("source, discovery_info", DISCOVERY_DATA)
 async def test_form_homekit_and_dhcp(hass, source, discovery_info):
     """Test we get the form with homekit and dhcp source."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     ignored_config_entry = MockConfigEntry(
         domain=DOMAIN, data={}, source=config_entries.SOURCE_IGNORE
@@ -244,7 +242,6 @@ async def test_form_homekit_and_dhcp(hass, source, discovery_info):
 
 async def test_discovered_by_homekit_and_dhcp(hass):
     """Test we get the form with homekit and abort for dhcp source when we get both."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mock_powerview_userdata = _get_mock_powerview_userdata()
     with patch(

--- a/tests/components/ialarm/test_config_flow.py
+++ b/tests/components/ialarm/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Antifurto365 iAlarm config flow."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.ialarm.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
 
@@ -14,7 +14,7 @@ TEST_MAC = "00:00:54:12:34:56"
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.insteon.config_flow import (
     HUB1,
     HUB2,
@@ -95,7 +95,7 @@ async def _device_form(hass, flow_id, connection, user_input):
 
 async def test_form_select_modem(hass: HomeAssistant):
     """Test we get a modem form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await _init_form(hass, HUB2)
     assert result["step_id"] == STEP_HUB_V2
     assert result["type"] == "form"
@@ -123,7 +123,7 @@ async def test_fail_on_existing(hass: HomeAssistant):
 
 async def test_form_select_plm(hass: HomeAssistant):
     """Test we set up the PLM correctly."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await _init_form(hass, PLM)
 
     result2, mock_setup, mock_setup_entry = await _device_form(
@@ -138,7 +138,7 @@ async def test_form_select_plm(hass: HomeAssistant):
 
 async def test_form_select_hub_v1(hass: HomeAssistant):
     """Test we set up the Hub v1 correctly."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await _init_form(hass, HUB1)
 
     result2, mock_setup, mock_setup_entry = await _device_form(
@@ -156,7 +156,7 @@ async def test_form_select_hub_v1(hass: HomeAssistant):
 
 async def test_form_select_hub_v2(hass: HomeAssistant):
     """Test we set up the Hub v2 correctly."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await _init_form(hass, HUB2)
 
     result2, mock_setup, mock_setup_entry = await _device_form(
@@ -174,7 +174,7 @@ async def test_form_select_hub_v2(hass: HomeAssistant):
 
 async def test_failed_connection_plm(hass: HomeAssistant):
     """Test a failed connection with the PLM."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await _init_form(hass, PLM)
 
     result2, _, _ = await _device_form(
@@ -186,7 +186,7 @@ async def test_failed_connection_plm(hass: HomeAssistant):
 
 async def test_failed_connection_hub(hass: HomeAssistant):
     """Test a failed connection with a Hub."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await _init_form(hass, HUB2)
 
     result2, _, _ = await _device_form(
@@ -208,7 +208,6 @@ async def _import_config(hass, config):
 
 async def test_import_plm(hass: HomeAssistant):
     """Test importing a minimum PLM config from yaml."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await _import_config(hass, MOCK_IMPORT_CONFIG_PLM)
 
@@ -235,7 +234,6 @@ async def _options_init_form(hass, entry_id, step):
 
 async def test_import_min_hub_v2(hass: HomeAssistant):
     """Test importing a minimum Hub v2 config from yaml."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await _import_config(
         hass, {**MOCK_IMPORT_MINIMUM_HUB_V2, CONF_PORT: 25105, CONF_HUB_VERSION: 2}
@@ -253,7 +251,6 @@ async def test_import_min_hub_v2(hass: HomeAssistant):
 
 async def test_import_min_hub_v1(hass: HomeAssistant):
     """Test importing a minimum Hub v1 config from yaml."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await _import_config(
         hass, {**MOCK_IMPORT_MINIMUM_HUB_V1, CONF_PORT: 9761, CONF_HUB_VERSION: 1}
@@ -287,7 +284,6 @@ async def test_import_existing(hass: HomeAssistant):
 
 async def test_import_failed_connection(hass: HomeAssistant):
     """Test a failed connection on import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(PATCH_CONNECTION, new=mock_failed_connection,), patch(
         PATCH_ASYNC_SETUP, return_value=True

--- a/tests/components/iotawatt/test_config_flow.py
+++ b/tests/components/iotawatt/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import httpx
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.iotawatt.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
@@ -11,7 +11,7 @@ from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -43,7 +43,6 @@ async def test_form(hass: HomeAssistant) -> None:
 async def test_form_auth(hass: HomeAssistant) -> None:
     """Test we handle auth."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from pyisy import ISYConnectionError, ISYInvalidAuthError
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp, ssdp
 from homeassistant.components.isy994.const import (
     CONF_IGNORE_STRING,
@@ -92,7 +92,7 @@ PATCH_ASYNC_SETUP_ENTRY = f"{INTEGRATION}.async_setup_entry"
 
 async def test_form(hass: HomeAssistant):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -233,7 +233,7 @@ async def test_form_no_name_in_response(hass: HomeAssistant):
 async def test_form_existing_config_entry(hass: HomeAssistant):
     """Test if config entry already exists."""
     MockConfigEntry(domain=DOMAIN, unique_id=MOCK_UUID).add_to_hass(hass)
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -316,7 +316,6 @@ async def test_import_flow_all_fields(hass: HomeAssistant) -> None:
 
 async def test_form_ssdp_already_configured(hass: HomeAssistant) -> None:
     """Test ssdp abort when the serial number is already configured."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     MockConfigEntry(
         domain=DOMAIN,
@@ -338,7 +337,6 @@ async def test_form_ssdp_already_configured(hass: HomeAssistant) -> None:
 
 async def test_form_ssdp(hass: HomeAssistant):
     """Test we can setup from ssdp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -375,7 +373,7 @@ async def test_form_ssdp(hass: HomeAssistant):
 
 async def test_form_ssdp_existing_entry(hass: HomeAssistant):
     """Test we update the ip of an existing entry from ssdp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: f"http://{MOCK_HOSTNAME}{ISY_URL_POSTFIX}"},
@@ -402,7 +400,7 @@ async def test_form_ssdp_existing_entry(hass: HomeAssistant):
 
 async def test_form_ssdp_existing_entry_with_no_port(hass: HomeAssistant):
     """Test we update the ip of an existing entry from ssdp with no port."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: f"http://{MOCK_HOSTNAME}:1443/{ISY_URL_POSTFIX}"},
@@ -429,7 +427,7 @@ async def test_form_ssdp_existing_entry_with_no_port(hass: HomeAssistant):
 
 async def test_form_ssdp_existing_entry_with_alternate_port(hass: HomeAssistant):
     """Test we update the ip of an existing entry from ssdp with an alternate port."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: f"http://{MOCK_HOSTNAME}:1443/{ISY_URL_POSTFIX}"},
@@ -456,7 +454,7 @@ async def test_form_ssdp_existing_entry_with_alternate_port(hass: HomeAssistant)
 
 async def test_form_ssdp_existing_entry_no_port_https(hass: HomeAssistant):
     """Test we update the ip of an existing entry from ssdp with no port and https."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: f"https://{MOCK_HOSTNAME}/{ISY_URL_POSTFIX}"},
@@ -483,7 +481,6 @@ async def test_form_ssdp_existing_entry_no_port_https(hass: HomeAssistant):
 
 async def test_form_dhcp(hass: HomeAssistant):
     """Test we can setup from dhcp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -520,7 +517,7 @@ async def test_form_dhcp(hass: HomeAssistant):
 
 async def test_form_dhcp_existing_entry(hass: HomeAssistant):
     """Test we update the ip of an existing entry from dhcp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: f"http://{MOCK_HOSTNAME}{ISY_URL_POSTFIX}"},
@@ -547,7 +544,7 @@ async def test_form_dhcp_existing_entry(hass: HomeAssistant):
 
 async def test_form_dhcp_existing_entry_preserves_port(hass: HomeAssistant):
     """Test we update the ip of an existing entry from dhcp preserves port."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/juicenet/test_config_flow.py
+++ b/tests/components/juicenet/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import aiohttp
 from pyjuicenet import TokenError
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.juicenet.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN
 
@@ -17,7 +17,7 @@ def _mock_juicenet_return_value(get_devices=None):
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/kmtronic/test_config_flow.py
+++ b/tests/components/kmtronic/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 from aiohttp import ClientConnectorError, ClientResponseError
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.kmtronic.const import CONF_REVERSE, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 
@@ -12,7 +12,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/kostal_plenticore/test_config_flow.py
+++ b/tests/components/kostal_plenticore/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from kostal.plenticore import PlenticoreAuthenticationException
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.kostal_plenticore.const import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -12,7 +12,7 @@ from tests.common import MockConfigEntry
 
 async def test_formx(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/kulersky/test_config_flow.py
+++ b/tests/components/kulersky/test_config_flow.py
@@ -3,13 +3,13 @@ from unittest.mock import MagicMock, patch
 
 import pykulersky
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.kulersky.config_flow import DOMAIN
 
 
 async def test_flow_success(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -41,7 +41,7 @@ async def test_flow_success(hass):
 
 async def test_flow_no_devices_found(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -68,7 +68,7 @@ async def test_flow_no_devices_found(hass):
 
 async def test_flow_exceptions_caught(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/kulersky/test_light.py
+++ b/tests/components/kulersky/test_light.py
@@ -5,7 +5,6 @@ import pykulersky
 import pytest
 from pytest import approx
 
-from homeassistant import setup
 from homeassistant.components.kulersky.const import (
     DATA_ADDRESSES,
     DATA_DISCOVERY_SUBSCRIPTION,
@@ -44,7 +43,6 @@ async def mock_entry(hass):
 @pytest.fixture
 async def mock_light(hass, mock_entry):
     """Create a mock light entity."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     light = MagicMock(spec=pykulersky.Light)
     light.address = "AA:BB:CC:11:22:33"
@@ -102,7 +100,6 @@ async def test_remove_entry_exceptions_caught(hass, mock_light, mock_entry):
 
 async def test_update_exception(hass, mock_light):
     """Test platform setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mock_light.get_color.side_effect = pykulersky.PykulerskyException
     await hass.helpers.entity_component.async_update_entity("light.bedroom")

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from pypck.connection import PchkAuthenticationError, PchkLicenseError
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.lcn.const import CONF_DIM_MODE, CONF_SK_NUM_TRIES, DOMAIN
 from homeassistant.const import (
     CONF_HOST,
@@ -29,7 +29,7 @@ IMPORT_DATA = {
 
 async def test_step_import(hass):
     """Test for import step."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch("pypck.connection.PchkConnectionManager.async_connect"), patch(
         "homeassistant.components.lcn.async_setup", return_value=True
     ), patch("homeassistant.components.lcn.async_setup_entry", return_value=True):
@@ -46,7 +46,7 @@ async def test_step_import(hass):
 
 async def test_step_import_existing_host(hass):
     """Test for update of config_entry if imported host already exists."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     # Create config entry and add it to hass
     mock_data = IMPORT_DATA.copy()
     mock_data.update({CONF_SK_NUM_TRIES: 3, CONF_DIM_MODE: 50})
@@ -77,7 +77,7 @@ async def test_step_import_existing_host(hass):
 )
 async def test_step_import_error(hass, error, reason):
     """Test for authentication error is handled correctly."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "pypck.connection.PchkConnectionManager.async_connect", side_effect=error
     ):

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -11,7 +11,6 @@ from homeassistant import config_entries
 from homeassistant.components.lcn.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.helpers import entity_registry as er
-from homeassistant.setup import async_setup_component
 
 from .conftest import MockPchkConnectionManager, init_integration, setup_component
 
@@ -98,7 +97,6 @@ async def test_async_setup_entry_raises_timeout_error(hass, entry):
 @patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_async_setup_from_configuration_yaml(hass):
     """Test a successful setup using data from configuration.yaml."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     with patch("homeassistant.components.lcn.async_setup_entry") as async_setup_entry:
         await setup_component(hass)

--- a/tests/components/litterrobot/test_config_flow.py
+++ b/tests/components/litterrobot/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from pylitterbot.exceptions import LitterRobotException, LitterRobotLoginException
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components import litterrobot
 
 from .common import CONF_USERNAME, CONFIG, DOMAIN
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass, mock_account):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -7,7 +7,7 @@ from pylutron_caseta.pairing import PAIR_CA, PAIR_CERT, PAIR_KEY
 from pylutron_caseta.smartbridge import Smartbridge
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.lutron_caseta import DOMAIN
 import homeassistant.components.lutron_caseta.config_flow as CasetaConfigFlow
 from homeassistant.components.lutron_caseta.const import (
@@ -195,7 +195,6 @@ async def test_duplicate_bridge_import(hass):
 
 async def test_already_configured_with_ignored(hass):
     """Test ignored entries do not break checking for existing entries."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={}, source=config_entries.SOURCE_IGNORE
@@ -217,7 +216,7 @@ async def test_already_configured_with_ignored(hass):
 
 async def test_form_user(hass, tmpdir):
     """Test we get the form and can pair."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     hass.config.config_dir = await hass.async_add_executor_job(
         tmpdir.mkdir, "tls_assets"
     )
@@ -268,7 +267,7 @@ async def test_form_user(hass, tmpdir):
 
 async def test_form_user_pairing_fails(hass, tmpdir):
     """Test we get the form and we handle pairing failure."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     hass.config.config_dir = await hass.async_add_executor_job(
         tmpdir.mkdir, "tls_assets"
     )
@@ -313,7 +312,7 @@ async def test_form_user_pairing_fails(hass, tmpdir):
 
 async def test_form_user_reuses_existing_assets_when_pairing_again(hass, tmpdir):
     """Test the tls assets saved on disk are reused when pairing again."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     hass.config.config_dir = await hass.async_add_executor_job(
         tmpdir.mkdir, "tls_assets"
     )
@@ -413,7 +412,7 @@ async def test_form_user_reuses_existing_assets_when_pairing_again(hass, tmpdir)
 
 async def test_zeroconf_host_already_configured(hass, tmpdir):
     """Test starting a flow from discovery when the host is already configured."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     hass.config.config_dir = await hass.async_add_executor_job(
         tmpdir.mkdir, "tls_assets"
     )
@@ -438,7 +437,6 @@ async def test_zeroconf_host_already_configured(hass, tmpdir):
 
 async def test_zeroconf_lutron_id_already_configured(hass):
     """Test starting a flow from discovery when lutron id already configured."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "4.5.6.7"}, unique_id="abc"
@@ -463,7 +461,6 @@ async def test_zeroconf_lutron_id_already_configured(hass):
 
 async def test_zeroconf_not_lutron_device(hass):
     """Test starting a flow from discovery when it is not a lutron device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -484,7 +481,7 @@ async def test_zeroconf_not_lutron_device(hass):
 )
 async def test_zeroconf(hass, source, tmpdir):
     """Test starting a flow from discovery."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     hass.config.config_dir = await hass.async_add_executor_job(
         tmpdir.mkdir, "tls_assets"
     )

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -311,7 +311,6 @@ async def test_validate_trigger_config_unknown_device(hass, calls, device_reg):
 
 async def test_validate_trigger_invalid_triggers(hass, device_reg):
     """Test for click_event with invalid triggers."""
-    notification_calls = async_mock_service(hass, "persistent_notification", "create")
     config_entry_id = await _async_setup_lutron_with_picos(hass, device_reg)
     dr_button_devices = hass.data[DOMAIN][config_entry_id][BUTTON_DEVICES]
     device_id = list(dr_button_devices)[0]
@@ -337,8 +336,10 @@ async def test_validate_trigger_invalid_triggers(hass, device_reg):
         },
     )
 
-    assert len(notification_calls) == 1
+    assert (
+        len(entity_ids := hass.states.async_entity_ids("persistent_notification")) == 1
+    )
     assert (
         "The following integrations and platforms could not be set up"
-        in notification_calls[0].data["message"]
+        in hass.states.get(entity_ids[0]).attributes["message"]
     )

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -1,7 +1,6 @@
 """The tests for Lutron Caséta device triggers."""
 import pytest
 
-from homeassistant import setup
 from homeassistant.components import automation
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
@@ -186,7 +185,7 @@ async def test_get_triggers_for_invalid_device_id(hass, device_reg):
 
 async def test_if_fires_on_button_event(hass, calls, device_reg):
     """Test for press trigger firing."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     config_entry_id = await _async_setup_lutron_with_picos(hass, device_reg)
     dr_button_devices = hass.data[DOMAIN][config_entry_id][BUTTON_DEVICES]
     device_id = list(dr_button_devices)[0]
@@ -230,7 +229,6 @@ async def test_if_fires_on_button_event(hass, calls, device_reg):
 
 async def test_validate_trigger_config_no_device(hass, calls, device_reg):
     """Test for no press with no device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(
         hass,
@@ -269,7 +267,7 @@ async def test_validate_trigger_config_no_device(hass, calls, device_reg):
 
 async def test_validate_trigger_config_unknown_device(hass, calls, device_reg):
     """Test for no press with an unknown device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     config_entry_id = await _async_setup_lutron_with_picos(hass, device_reg)
     dr_button_devices = hass.data[DOMAIN][config_entry_id][BUTTON_DEVICES]
     device_id = list(dr_button_devices)[0]

--- a/tests/components/mazda/test_config_flow.py
+++ b/tests/components/mazda/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import aiohttp
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.mazda.config_flow import (
     MazdaAccountLockedException,
     MazdaAuthenticationException,
@@ -179,7 +179,7 @@ async def test_form_unknown_error(hass):
 
 async def test_reauth_flow(hass: HomeAssistant) -> None:
     """Test reauth works."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     mock_config = MockConfigEntry(
         domain=DOMAIN,
         unique_id=FIXTURE_USER_INPUT[CONF_EMAIL],

--- a/tests/components/metoffice/test_config_flow.py
+++ b/tests/components/metoffice/test_config_flow.py
@@ -2,7 +2,7 @@
 import json
 from unittest.mock import patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.metoffice.const import DOMAIN
 
 from .const import (
@@ -26,7 +26,6 @@ async def test_form(hass, requests_mock):
     all_sites = json.dumps(mock_json["all_sites"])
     requests_mock.get("/public/data/val/wxfcs/all/json/sitelist/", text=all_sites)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/monoprice/test_config_flow.py
+++ b/tests/components/monoprice/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from serial import SerialException
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.monoprice.const import (
     CONF_SOURCE_1,
     CONF_SOURCE_4,
@@ -25,7 +25,7 @@ CONFIG = {
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/motioneye/test_config_flow.py
+++ b/tests/components/motioneye/test_config_flow.py
@@ -8,7 +8,7 @@ from motioneye_client.client import (
     MotionEyeClientRequestError,
 )
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.motioneye.const import (
     CONF_ADMIN_PASSWORD,
     CONF_ADMIN_USERNAME,
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def test_user_success(hass: HomeAssistant) -> None:
     """Test successful user flow."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -73,7 +73,7 @@ async def test_user_success(hass: HomeAssistant) -> None:
 
 async def test_hassio_success(hass: HomeAssistant) -> None:
     """Test successful Supervisor flow."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         data={"addon": "motionEye", "url": TEST_URL},
@@ -157,7 +157,7 @@ async def test_user_invalid_auth(hass: HomeAssistant) -> None:
 
 async def test_user_invalid_url(hass: HomeAssistant) -> None:
     """Test invalid url is handled correctly."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -254,7 +254,6 @@ async def test_reauth(hass: HomeAssistant) -> None:
 
     config_entry = create_mock_motioneye_config_entry(hass, data=config_data)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={
@@ -312,7 +311,6 @@ async def test_duplicate(hass: HomeAssistant) -> None:
     # Now do the usual config entry process, and verify it is rejected.
     create_mock_motioneye_config_entry(hass, data=config_data)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -393,7 +391,6 @@ async def test_hassio_abort_if_already_in_progress(hass: HomeAssistant) -> None:
 
 async def test_hassio_clean_up_on_user_flow(hass: HomeAssistant) -> None:
     """Test Supervisor discovered flow is clean up when doing user flow."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -3396,7 +3396,7 @@ async def test_reloadable(hass, mqtt_mock):
     await hass.async_block_till_done()
 
     assert hass.states.get("light.test")
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("light")) == 1
 
     yaml_path = path.join(
         _get_fixtures_base_path(),
@@ -3412,7 +3412,7 @@ async def test_reloadable(hass, mqtt_mock):
         )
         await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("light")) == 1
 
     assert hass.states.get("light.test") is None
     assert hass.states.get("light.reload")

--- a/tests/components/mullvad/test_config_flow.py
+++ b/tests/components/mullvad/test_config_flow.py
@@ -41,7 +41,7 @@ async def test_form_user(hass):
 async def test_form_user_only_once(hass):
     """Test we can setup by the user only once."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/mutesync/test_config_flow.py
+++ b/tests/components/mutesync/test_config_flow.py
@@ -5,14 +5,14 @@ from unittest.mock import patch
 import aiohttp
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.mutesync.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/myq/test_config_flow.py
+++ b/tests/components/myq/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from pymyq.errors import InvalidCredentialsError, MyQError
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.myq.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
@@ -12,7 +12,7 @@ from tests.common import MockConfigEntry
 
 async def test_form_user(hass):
     """Test we get the user form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/mysensors/test_config_flow.py
+++ b/tests/components/mysensors/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.mysensors.const import (
     CONF_BAUD_RATE,
     CONF_DEVICE,
@@ -34,7 +34,7 @@ async def get_form(
     hass: HomeAssistant, gatway_type: ConfGatewayType, expected_step_id: str
 ) -> FlowResult:
     """Get a form for the given gateway type."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     stepuser = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -92,7 +92,7 @@ async def test_config_mqtt(hass: HomeAssistant, mqtt: None) -> None:
 
 async def test_missing_mqtt(hass: HomeAssistant) -> None:
     """Test configuring a mqtt gateway without mqtt integration setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -442,7 +442,6 @@ async def test_config_invalid(
 )
 async def test_import(hass: HomeAssistant, mqtt: None, user_input: dict) -> None:
     """Test importing a gateway."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch("sys.platform", "win32"), patch(
         "homeassistant.components.mysensors.config_flow.try_connect", return_value=True
@@ -738,7 +737,6 @@ async def test_duplicate(
     expected_result: tuple[str, str] | None,
 ) -> None:
     """Test duplicate detection."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch("sys.platform", "win32"), patch(
         "homeassistant.components.mysensors.config_flow.try_connect", return_value=True

--- a/tests/components/mysensors/test_init.py
+++ b/tests/components/mysensors/test_init.py
@@ -324,7 +324,7 @@ async def test_import(
     expected_config_entry_data: list[dict[str, Any]],
 ) -> None:
     """Test importing a gateway."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     with patch("sys.platform", "win32"), patch(
         "homeassistant.components.mysensors.config_flow.try_connect", return_value=True
     ), patch(

--- a/tests/components/nexia/test_config_flow.py
+++ b/tests/components/nexia/test_config_flow.py
@@ -5,7 +5,7 @@ from nexia.const import BRAND_ASAIR, BRAND_NEXIA
 import pytest
 from requests.exceptions import ConnectTimeout, HTTPError
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.nexia.const import CONF_BRAND, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 @pytest.mark.parametrize("brand", [BRAND_ASAIR, BRAND_NEXIA])
 async def test_form(hass, brand):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/nightscout/test_config_flow.py
+++ b/tests/components/nightscout/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from aiohttp import ClientConnectionError, ClientResponseError
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.nightscout.const import DOMAIN
 from homeassistant.components.nightscout.utils import hash_from_url
 from homeassistant.const import CONF_URL
@@ -20,7 +20,7 @@ CONFIG = {CONF_URL: "https://some.url:1234"}
 
 async def test_form(hass):
     """Test we get the user initiated form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/nmap_tracker/test_config_flow.py
+++ b/tests/components/nmap_tracker/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.device_tracker.const import (
     CONF_CONSIDER_HOME,
     CONF_SCAN_INTERVAL,
@@ -25,7 +25,7 @@ from tests.common import MockConfigEntry
 )
 async def test_form(hass: HomeAssistant, hosts: str, mock_get_source_ip) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -64,7 +64,7 @@ async def test_form(hass: HomeAssistant, hosts: str, mock_get_source_ip) -> None
 
 async def test_form_range(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test we get the form and can take an ip range."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -100,7 +100,7 @@ async def test_form_range(hass: HomeAssistant, mock_get_source_ip) -> None:
 
 async def test_form_invalid_hosts(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test invalid hosts passed in."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -124,7 +124,7 @@ async def test_form_invalid_hosts(hass: HomeAssistant, mock_get_source_ip) -> No
 
 async def test_form_already_configured(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test duplicate host list."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={},
@@ -159,7 +159,7 @@ async def test_form_already_configured(hass: HomeAssistant, mock_get_source_ip) 
 
 async def test_form_invalid_excludes(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test invalid excludes passed in."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -245,7 +245,7 @@ async def test_options_flow(hass: HomeAssistant, mock_get_source_ip) -> None:
 
 async def test_import(hass: HomeAssistant, mock_get_source_ip) -> None:
     """Test we can import from yaml."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.nmap_tracker.async_setup_entry",
         return_value=True,
@@ -293,7 +293,6 @@ async def test_import_aborts_if_matching(
         },
     )
     config_entry.add_to_hass(hass)
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -87,7 +87,6 @@ class NotificationService(notify.BaseNotificationService):
 async def test_warn_template(hass, caplog):
     """Test warning when template used."""
     assert await async_setup_component(hass, "notify", {})
-    assert await async_setup_component(hass, "persistent_notification", {})
 
     await hass.services.async_call(
         "notify",

--- a/tests/components/nuheat/test_config_flow.py
+++ b/tests/components/nuheat/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.nuheat.const import CONF_SERIAL_NUMBER, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, HTTP_INTERNAL_SERVER_ERROR
 
@@ -12,7 +12,7 @@ from .mocks import _get_mock_thermostat_run
 
 async def test_form_user(hass):
     """Test we get the form with user source."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/nuki/mock.py
+++ b/tests/components/nuki/mock.py
@@ -1,5 +1,4 @@
 """Mockup Nuki device."""
-from homeassistant import setup
 
 from tests.common import MockConfigEntry
 
@@ -14,7 +13,7 @@ MOCK_INFO = {"ids": {"hardwareId": HW_ID}}
 
 async def setup_nuki_integration(hass):
     """Create the Nuki device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain="nuki",
         unique_id=HW_ID,

--- a/tests/components/nuki/test_config_flow.py
+++ b/tests/components/nuki/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from pynuki.bridge import InvalidCredentialsException
 from requests.exceptions import RequestException
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
 from homeassistant.components.nuki.const import DOMAIN
 from homeassistant.const import CONF_TOKEN
@@ -14,7 +14,7 @@ from .mock import HOST, MAC, MOCK_INFO, NAME, setup_nuki_integration
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -53,7 +53,6 @@ async def test_form(hass):
 
 async def test_import(hass):
     """Test that the import works."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.nuki.config_flow.NukiBridge.info",

--- a/tests/components/nut/test_config_flow.py
+++ b/tests/components/nut/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.nut.const import DOMAIN
 from homeassistant.const import CONF_RESOURCES, CONF_SCAN_INTERVAL
 
@@ -73,7 +73,7 @@ async def test_form_zeroconf(hass):
 
 async def test_form_user_one_ups(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -128,7 +128,6 @@ async def test_form_user_one_ups(hass):
 
 async def test_form_user_multiple_ups(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -210,7 +209,6 @@ async def test_form_user_one_ups_with_ignored_entry(hass):
     )
     ignored_entry.add_to_hass(hass)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/nws/test_config_flow.py
+++ b/tests/components/nws/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import aiohttp
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.nws.const import DOMAIN
 
 
@@ -12,7 +12,6 @@ async def test_form(hass, mock_simple_nws_config):
     hass.config.latitude = 35
     hass.config.longitude = -90
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/nzbget/test_config_flow.py
+++ b/tests/components/nzbget/test_config_flow.py
@@ -11,7 +11,6 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.setup import async_setup_component
 
 from . import (
     ENTRY_CONFIG,
@@ -28,7 +27,6 @@ from tests.common import MockConfigEntry
 
 async def test_user_form(hass):
     """Test we get the user initiated form."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -53,7 +51,6 @@ async def test_user_form(hass):
 
 async def test_user_form_show_advanced_options(hass):
     """Test we get the user initiated form with advanced options shown."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER, "show_advanced_options": True}

--- a/tests/components/omnilogic/test_config_flow.py
+++ b/tests/components/omnilogic/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from omnilogic import LoginException, OmniLogicException
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.omnilogic.const import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -13,7 +13,7 @@ DATA = {"username": "test-username", "password": "test-password"}
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -43,7 +43,6 @@ async def test_already_configured(hass):
     """Test config flow when Omnilogic component is already setup."""
     MockConfigEntry(domain="omnilogic", data=DATA).add_to_hass(hass)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -55,7 +54,6 @@ async def test_already_configured(hass):
 async def test_with_invalid_credentials(hass):
     """Test with invalid credentials."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -77,7 +75,6 @@ async def test_with_invalid_credentials(hass):
 async def test_form_cannot_connect(hass):
     """Test if invalid response or no connection returned from Hayward."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -98,7 +95,7 @@ async def test_form_cannot_connect(hass):
 
 async def test_with_unknown_error(hass):
     """Test with unknown error response from Hayward."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -20,7 +20,6 @@ from tests.components.met.conftest import mock_weather  # noqa: F401
 @pytest.fixture(autouse=True)
 def always_mock_weather(mock_weather):  # noqa: F811
     """Mock the Met weather provider."""
-    pass
 
 
 @pytest.fixture(autouse=True)
@@ -386,7 +385,6 @@ async def test_onboarding_core_sets_up_rpi_power(
 ):
     """Test that the core step sets up rpi_power on RPi."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
-    await async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(hass, "onboarding", {})
     await hass.async_block_till_done()
@@ -411,7 +409,6 @@ async def test_onboarding_core_no_rpi_power(
 ):
     """Test that the core step do not set up rpi_power on non RPi."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
-    await async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(hass, "onboarding", {})
     await hass.async_block_till_done()
@@ -453,7 +450,6 @@ async def test_onboarding_analytics(hass, hass_storage, hass_client, hass_admin_
 async def test_onboarding_installation_type(hass, hass_storage, hass_client):
     """Test returning installation type during onboarding."""
     mock_storage(hass_storage, {"done": []})
-    await async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(hass, "onboarding", {})
     await hass.async_block_till_done()
@@ -475,7 +471,6 @@ async def test_onboarding_installation_type(hass, hass_storage, hass_client):
 async def test_onboarding_installation_type_after_done(hass, hass_storage, hass_client):
     """Test raising for installation type after onboarding."""
     mock_storage(hass_storage, {"done": [const.STEP_USER]})
-    await async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(hass, "onboarding", {})
     await hass.async_block_till_done()

--- a/tests/components/onewire/test_binary_sensor.py
+++ b/tests/components/onewire/test_binary_sensor.py
@@ -6,7 +6,6 @@ import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.onewire.binary_sensor import DEVICE_BINARY_SENSORS
-from homeassistant.setup import async_setup_component
 
 from . import setup_onewire_patched_owserver_integration, setup_owproxy_mock_devices
 from .const import MOCK_OWPROXY_DEVICES
@@ -27,7 +26,7 @@ async def test_owserver_binary_sensor(owproxy, hass, device_id):
 
     This test forces all entities to be enabled.
     """
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
 
     setup_owproxy_mock_devices(owproxy, BINARY_SENSOR_DOMAIN, [device_id])

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -8,7 +8,6 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.setup import async_setup_component
 
 from . import (
     setup_onewire_owserver_integration,
@@ -94,7 +93,7 @@ async def test_registry_cleanup(owproxy, hass):
 
     As they would be on a clean setup: all binary-sensors and switches disabled.
     """
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -75,7 +75,7 @@ async def test_setup_owserver_with_port(hass):
 @patch("homeassistant.components.onewire.onewirehub.protocol.proxy")
 async def test_sensors_on_owserver_coupler(owproxy, hass, device_id):
     """Test for 1-Wire sensors connected to DS2409 coupler."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
 
     mock_coupler = MOCK_COUPLERS[device_id]
@@ -138,7 +138,7 @@ async def test_owserver_setup_valid_device(owproxy, hass, device_id, platform):
 
     As they would be on a clean setup: all binary-sensors and switches disabled.
     """
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -184,7 +184,7 @@ async def test_owserver_setup_valid_device(owproxy, hass, device_id, platform):
 @pytest.mark.parametrize("device_id", MOCK_SYSBUS_DEVICES.keys())
 async def test_onewiredirect_setup_valid_device(hass, device_id):
     """Test that sysbus config entry works correctly."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -7,7 +7,6 @@ import pytest
 from homeassistant.components.onewire.switch import DEVICE_SWITCHES
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TOGGLE, STATE_OFF, STATE_ON
-from homeassistant.setup import async_setup_component
 
 from . import setup_onewire_patched_owserver_integration, setup_owproxy_mock_devices
 from .const import MOCK_OWPROXY_DEVICES
@@ -28,7 +27,7 @@ async def test_owserver_switch(owproxy, hass, device_id):
 
     This test forces all entities to be enabled.
     """
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
 
     setup_owproxy_mock_devices(owproxy, SWITCH_DOMAIN, [device_id])

--- a/tests/components/opengarage/test_config_flow.py
+++ b/tests/components/opengarage/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import aiohttp
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.opengarage.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from pyotgw.vars import OTGW, OTGW_ABOUT
 from serial import SerialException
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.opentherm_gw.const import (
     CONF_FLOOR_TEMP,
     CONF_PRECISION,
@@ -29,7 +29,7 @@ MINIMAL_STATUS = {OTGW: {OTGW_ABOUT: "OpenTherm Gateway 4.2.5"}}
 
 async def test_form_user(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -67,7 +67,7 @@ async def test_form_user(hass):
 
 async def test_form_import(hass):
     """Test import from existing config."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.opentherm_gw.async_setup",
         return_value=True,

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -283,9 +283,6 @@ BAD_JSON_SUFFIX = "** and it ends here ^^"
 @pytest.fixture
 def setup_comp(hass, mock_device_tracker_conf, mqtt_mock):
     """Initialize components."""
-    assert hass.loop.run_until_complete(
-        async_setup_component(hass, "persistent_notification", {})
-    )
     hass.loop.run_until_complete(async_setup_component(hass, "device_tracker", {}))
 
     hass.states.async_set("zone.inner", "zoning", INNER_ZONE)

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.ozw.config_flow import TITLE
 from homeassistant.components.ozw.const import DOMAIN
@@ -81,7 +81,6 @@ def mock_start_addon():
 
 async def test_user_not_supervisor_create_entry(hass, mqtt):
     """Test the user step creates an entry not on Supervisor."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.ozw.async_setup_entry",
@@ -126,7 +125,6 @@ async def test_one_instance_allowed(hass):
 
 async def test_not_addon(hass, supervisor, mqtt):
     """Test opting out of add-on on Supervisor."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -156,7 +154,6 @@ async def test_addon_running(hass, supervisor, addon_running, addon_options):
     """Test add-on already running on Supervisor."""
     addon_options["device"] = "/test"
     addon_options["network_key"] = "abc123"
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -185,7 +182,6 @@ async def test_addon_running(hass, supervisor, addon_running, addon_options):
 async def test_addon_info_failure(hass, supervisor, addon_info):
     """Test add-on info failure."""
     addon_info.side_effect = HassioAPIError()
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -203,7 +199,6 @@ async def test_addon_installed(
     hass, supervisor, addon_installed, addon_options, set_addon_options, start_addon
 ):
     """Test add-on already installed but not running on Supervisor."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -237,7 +232,6 @@ async def test_set_addon_config_failure(
 ):
     """Test add-on set config failure."""
     set_addon_options.side_effect = HassioAPIError()
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -259,7 +253,6 @@ async def test_start_addon_failure(
 ):
     """Test add-on start failure."""
     start_addon.side_effect = HassioAPIError()
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -287,7 +280,6 @@ async def test_addon_not_installed(
 ):
     """Test add-on not installed."""
     addon_installed.return_value["version"] = None
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -330,7 +322,6 @@ async def test_install_addon_failure(hass, supervisor, addon_installed, install_
     """Test add-on install failure."""
     addon_installed.return_value["version"] = None
     install_addon.side_effect = HassioAPIError()
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -352,7 +343,6 @@ async def test_install_addon_failure(hass, supervisor, addon_installed, install_
 
 async def test_supervisor_discovery(hass, supervisor, addon_running, addon_options):
     """Test flow started from Supervisor discovery."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     addon_options["device"] = "/test"
     addon_options["network_key"] = "abc123"
@@ -385,7 +375,6 @@ async def test_clean_discovery_on_user_create(
     hass, supervisor, addon_running, addon_options
 ):
     """Test discovery flow is cleaned up when a user flow is finished."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     addon_options["device"] = "/test"
     addon_options["network_key"] = "abc123"
@@ -427,7 +416,6 @@ async def test_abort_discovery_with_user_flow(
     hass, supervisor, addon_running, addon_options
 ):
     """Test discovery flow is aborted if a user flow is in progress."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -448,7 +436,6 @@ async def test_abort_discovery_with_existing_entry(
     hass, supervisor, addon_running, addon_options
 ):
     """Test discovery flow is aborted if an entry already exists."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(domain=DOMAIN, data={}, title=TITLE, unique_id=DOMAIN)
     entry.add_to_hass(hass)
@@ -468,7 +455,6 @@ async def test_discovery_addon_not_running(
 ):
     """Test discovery with add-on already installed but not running."""
     addon_options["device"] = None
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -490,7 +476,6 @@ async def test_discovery_addon_not_installed(
 ):
     """Test discovery with add-on not installed."""
     addon_installed.return_value["version"] = None
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -5,6 +5,8 @@ import homeassistant.components.persistent_notification as pn
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.setup import async_setup_component
 
+from tests.common import async_capture_events
+
 
 @pytest.fixture(autouse=True)
 async def setup_integration(hass):
@@ -105,6 +107,7 @@ async def test_dismiss_notification(hass):
 
 async def test_mark_read(hass):
     """Ensure notification is marked as Read."""
+    events = async_capture_events(hass, pn.EVENT_PERSISTENT_NOTIFICATIONS_UPDATED)
     notifications = hass.data[pn.DOMAIN]
     assert len(notifications) == 0
 
@@ -119,6 +122,7 @@ async def test_mark_read(hass):
     assert len(notifications) == 1
     notification = notifications.get(entity_id)
     assert notification["status"] == pn.STATUS_UNREAD
+    assert len(events) == 1
 
     await hass.services.async_call(
         pn.DOMAIN, "mark_read", {"notification_id": "Beer 2"}, blocking=True
@@ -127,6 +131,7 @@ async def test_mark_read(hass):
     assert len(notifications) == 1
     notification = notifications.get(entity_id)
     assert notification["status"] == pn.STATUS_READ
+    assert len(events) == 2
 
     await hass.services.async_call(
         pn.DOMAIN,
@@ -135,6 +140,7 @@ async def test_mark_read(hass):
         blocking=True,
     )
     assert len(notifications) == 0
+    assert len(events) == 3
 
 
 async def test_ws_get_notifications(hass, hass_ws_client):

--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -1,142 +1,135 @@
 """The tests for the persistent notification component."""
+import pytest
+
 import homeassistant.components.persistent_notification as pn
 from homeassistant.components.websocket_api.const import TYPE_RESULT
-from homeassistant.setup import async_setup_component, setup_component
-
-from tests.common import get_test_home_assistant
+from homeassistant.setup import async_setup_component
 
 
-class TestPersistentNotification:
-    """Test persistent notification component."""
+@pytest.fixture(autouse=True)
+async def setup_integration(hass):
+    """Set up persistent notification integration."""
+    assert await async_setup_component(hass, pn.DOMAIN, {})
 
-    def setup_method(self, method):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        setup_component(self.hass, pn.DOMAIN, {})
 
-    def teardown_method(self, method):
-        """Stop everything that was started."""
-        self.hass.stop()
+async def test_create(hass):
+    """Test creating notification without title or notification id."""
+    notifications = hass.data[pn.DOMAIN]["notifications"]
+    assert len(hass.states.async_entity_ids(pn.DOMAIN)) == 0
+    assert len(notifications) == 0
 
-    def test_create(self):
-        """Test creating notification without title or notification id."""
-        notifications = self.hass.data[pn.DOMAIN]["notifications"]
-        assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
-        assert len(notifications) == 0
+    pn.async_create(hass, "Hello World {{ 1 + 1 }}", title="{{ 1 + 1 }} beers")
+    await hass.async_block_till_done()
 
-        pn.create(self.hass, "Hello World {{ 1 + 1 }}", title="{{ 1 + 1 }} beers")
-        self.hass.block_till_done()
+    entity_ids = hass.states.async_entity_ids(pn.DOMAIN)
+    assert len(entity_ids) == 1
+    assert len(notifications) == 1
 
-        entity_ids = self.hass.states.entity_ids(pn.DOMAIN)
-        assert len(entity_ids) == 1
-        assert len(notifications) == 1
+    state = hass.states.get(entity_ids[0])
+    assert state.state == pn.STATE
+    assert state.attributes.get("message") == "Hello World 2"
+    assert state.attributes.get("title") == "2 beers"
 
-        state = self.hass.states.get(entity_ids[0])
-        assert state.state == pn.STATE
-        assert state.attributes.get("message") == "Hello World 2"
-        assert state.attributes.get("title") == "2 beers"
+    notification = notifications.get(entity_ids[0])
+    assert notification["status"] == pn.STATUS_UNREAD
+    assert notification["message"] == "Hello World 2"
+    assert notification["title"] == "2 beers"
+    assert notification["created_at"] is not None
 
-        notification = notifications.get(entity_ids[0])
-        assert notification["status"] == pn.STATUS_UNREAD
-        assert notification["message"] == "Hello World 2"
-        assert notification["title"] == "2 beers"
-        assert notification["created_at"] is not None
-        notifications.clear()
 
-    def test_create_notification_id(self):
-        """Ensure overwrites existing notification with same id."""
-        notifications = self.hass.data[pn.DOMAIN]["notifications"]
-        assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
-        assert len(notifications) == 0
+async def test_create_notification_id(hass):
+    """Ensure overwrites existing notification with same id."""
+    notifications = hass.data[pn.DOMAIN]["notifications"]
+    assert len(hass.states.async_entity_ids(pn.DOMAIN)) == 0
+    assert len(notifications) == 0
 
-        pn.create(self.hass, "test", notification_id="Beer 2")
-        self.hass.block_till_done()
+    pn.async_create(hass, "test", notification_id="Beer 2")
+    await hass.async_block_till_done()
 
-        assert len(self.hass.states.entity_ids()) == 1
-        assert len(notifications) == 1
+    assert len(hass.states.async_entity_ids()) == 1
+    assert len(notifications) == 1
 
-        entity_id = "persistent_notification.beer_2"
-        state = self.hass.states.get(entity_id)
-        assert state.attributes.get("message") == "test"
+    entity_id = "persistent_notification.beer_2"
+    state = hass.states.get(entity_id)
+    assert state.attributes.get("message") == "test"
 
-        notification = notifications.get(entity_id)
-        assert notification["message"] == "test"
-        assert notification["title"] is None
+    notification = notifications.get(entity_id)
+    assert notification["message"] == "test"
+    assert notification["title"] is None
 
-        pn.create(self.hass, "test 2", notification_id="Beer 2")
-        self.hass.block_till_done()
+    pn.async_create(hass, "test 2", notification_id="Beer 2")
+    await hass.async_block_till_done()
 
-        # We should have overwritten old one
-        assert len(self.hass.states.entity_ids()) == 1
-        state = self.hass.states.get(entity_id)
-        assert state.attributes.get("message") == "test 2"
+    # We should have overwritten old one
+    assert len(hass.states.async_entity_ids()) == 1
+    state = hass.states.get(entity_id)
+    assert state.attributes.get("message") == "test 2"
 
-        notification = notifications.get(entity_id)
-        assert notification["message"] == "test 2"
-        notifications.clear()
+    notification = notifications.get(entity_id)
+    assert notification["message"] == "test 2"
 
-    def test_create_template_error(self):
-        """Ensure we output templates if contain error."""
-        notifications = self.hass.data[pn.DOMAIN]["notifications"]
-        assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
-        assert len(notifications) == 0
 
-        pn.create(self.hass, "{{ message + 1 }}", "{{ title + 1 }}")
-        self.hass.block_till_done()
+async def test_create_template_error(hass):
+    """Ensure we output templates if contain error."""
+    notifications = hass.data[pn.DOMAIN]["notifications"]
+    assert len(hass.states.async_entity_ids(pn.DOMAIN)) == 0
+    assert len(notifications) == 0
 
-        entity_ids = self.hass.states.entity_ids(pn.DOMAIN)
-        assert len(entity_ids) == 1
-        assert len(notifications) == 1
+    pn.async_create(hass, "{{ message + 1 }}", "{{ title + 1 }}")
+    await hass.async_block_till_done()
 
-        state = self.hass.states.get(entity_ids[0])
-        assert state.attributes.get("message") == "{{ message + 1 }}"
-        assert state.attributes.get("title") == "{{ title + 1 }}"
+    entity_ids = hass.states.async_entity_ids(pn.DOMAIN)
+    assert len(entity_ids) == 1
+    assert len(notifications) == 1
 
-        notification = notifications.get(entity_ids[0])
-        assert notification["message"] == "{{ message + 1 }}"
-        assert notification["title"] == "{{ title + 1 }}"
-        notifications.clear()
+    state = hass.states.get(entity_ids[0])
+    assert state.attributes.get("message") == "{{ message + 1 }}"
+    assert state.attributes.get("title") == "{{ title + 1 }}"
 
-    def test_dismiss_notification(self):
-        """Ensure removal of specific notification."""
-        notifications = self.hass.data[pn.DOMAIN]["notifications"]
-        assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
-        assert len(notifications) == 0
+    notification = notifications.get(entity_ids[0])
+    assert notification["message"] == "{{ message + 1 }}"
+    assert notification["title"] == "{{ title + 1 }}"
 
-        pn.create(self.hass, "test", notification_id="Beer 2")
-        self.hass.block_till_done()
 
-        assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 1
-        assert len(notifications) == 1
-        pn.dismiss(self.hass, notification_id="Beer 2")
-        self.hass.block_till_done()
+async def test_dismiss_notification(hass):
+    """Ensure removal of specific notification."""
+    notifications = hass.data[pn.DOMAIN]["notifications"]
+    assert len(hass.states.async_entity_ids(pn.DOMAIN)) == 0
+    assert len(notifications) == 0
 
-        assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
-        assert len(notifications) == 0
-        notifications.clear()
+    pn.async_create(hass, "test", notification_id="Beer 2")
+    await hass.async_block_till_done()
 
-    def test_mark_read(self):
-        """Ensure notification is marked as Read."""
-        notifications = self.hass.data[pn.DOMAIN]["notifications"]
-        assert len(notifications) == 0
+    assert len(hass.states.async_entity_ids(pn.DOMAIN)) == 1
+    assert len(notifications) == 1
+    pn.async_dismiss(hass, notification_id="Beer 2")
+    await hass.async_block_till_done()
 
-        pn.create(self.hass, "test", notification_id="Beer 2")
-        self.hass.block_till_done()
+    assert len(hass.states.async_entity_ids(pn.DOMAIN)) == 0
+    assert len(notifications) == 0
 
-        entity_id = "persistent_notification.beer_2"
-        assert len(notifications) == 1
-        notification = notifications.get(entity_id)
-        assert notification["status"] == pn.STATUS_UNREAD
 
-        self.hass.services.call(
-            pn.DOMAIN, pn.SERVICE_MARK_READ, {"notification_id": "Beer 2"}
-        )
-        self.hass.block_till_done()
+async def test_mark_read(hass):
+    """Ensure notification is marked as Read."""
+    notifications = hass.data[pn.DOMAIN]["notifications"]
+    assert len(notifications) == 0
 
-        assert len(notifications) == 1
-        notification = notifications.get(entity_id)
-        assert notification["status"] == pn.STATUS_READ
-        notifications.clear()
+    pn.async_create(hass, "test", notification_id="Beer 2")
+    await hass.async_block_till_done()
+
+    entity_id = "persistent_notification.beer_2"
+    assert len(notifications) == 1
+    notification = notifications.get(entity_id)
+    assert notification["status"] == pn.STATUS_UNREAD
+
+    await hass.services.async_call(
+        pn.DOMAIN, pn.SERVICE_MARK_READ, {"notification_id": "Beer 2"}
+    )
+    await hass.async_block_till_done()
+
+    assert len(notifications) == 1
+    notification = notifications.get(entity_id)
+    assert notification["status"] == pn.STATUS_READ
 
 
 async def test_ws_get_notifications(hass, hass_ws_client):

--- a/tests/components/philips_js/conftest.py
+++ b/tests/components/philips_js/conftest.py
@@ -4,7 +4,6 @@ from unittest.mock import create_autospec, patch
 from haphilipsjs import PhilipsTV
 from pytest import fixture
 
-from homeassistant import setup
 from homeassistant.components.philips_js.const import DOMAIN
 
 from . import MOCK_CONFIG, MOCK_ENTITY_ID, MOCK_NAME, MOCK_SERIAL_NO, MOCK_SYSTEM
@@ -15,7 +14,6 @@ from tests.common import MockConfigEntry, mock_device_registry
 @fixture(autouse=True)
 async def setup_notification(hass):
     """Configure notification system."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
 
 @fixture(autouse=True)

--- a/tests/components/picnic/test_config_flow.py
+++ b/tests/components/picnic/test_config_flow.py
@@ -4,14 +4,14 @@ from unittest.mock import patch
 from python_picnic_api.session import PicnicAuthError
 import requests
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.picnic.const import CONF_COUNTRY_CODE, DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN
 
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/plaato/test_config_flow.py
+++ b/tests/components/plaato/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from pyplaato.models.device import PlaatoDeviceType
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.plaato.const import (
     CONF_DEVICE_NAME,
     CONF_DEVICE_TYPE,
@@ -34,7 +34,7 @@ def mock_webhook_id():
 
 async def test_show_config_form(hass):
     """Test show configuration form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -36,7 +36,6 @@ from homeassistant.const import (
     CONF_URL,
     CONF_VERIFY_SSL,
 )
-from homeassistant.setup import async_setup_component
 
 from .const import DEFAULT_OPTIONS, MOCK_SERVERS, MOCK_TOKEN, PLEX_DIRECT_URL
 from .helpers import trigger_plex_update, wait_for_debouncer
@@ -755,7 +754,6 @@ async def test_trigger_reauth(
     hass, entry, mock_plex_server, mock_websocket, current_request_with_host
 ):
     """Test setup and reauthorization of a Plex token."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     assert entry.state is ConfigEntryState.LOADED
 

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -21,7 +21,6 @@ from homeassistant.const import (
     STATE_IDLE,
     STATE_PLAYING,
 )
-from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from .const import DEFAULT_DATA, DEFAULT_OPTIONS, PLEX_DIRECT_URL
@@ -186,7 +185,6 @@ async def test_setup_when_certificate_changed(
     plextv_shared_users,
 ):
     """Test setup component when the Plex certificate has changed."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     class WrongCertHostnameException(requests.exceptions.SSLError):
         """Mock the exception showing a mismatched hostname."""

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -8,7 +8,6 @@ from plugwise.exceptions import (
 )
 import pytest
 
-from homeassistant import setup
 from homeassistant.components.plugwise.const import (
     API,
     DEFAULT_PORT,
@@ -79,7 +78,7 @@ def mock_smile():
 
 async def test_form_flow_gateway(hass):
     """Test we get the form for Plugwise Gateway product type."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
@@ -97,7 +96,7 @@ async def test_form_flow_gateway(hass):
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={FLOW_TYPE: FLOW_NET}
     )
@@ -132,7 +131,7 @@ async def test_form(hass):
 
 async def test_zeroconf_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_ZEROCONF},
@@ -169,7 +168,7 @@ async def test_zeroconf_form(hass):
 
 async def test_zeroconf_stretch_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_ZEROCONF},
@@ -206,7 +205,7 @@ async def test_zeroconf_stretch_form(hass):
 
 async def test_form_username(hass):
     """Test we get the username data back."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={FLOW_TYPE: FLOW_NET}
     )

--- a/tests/components/plum_lightpad/test_config_flow.py
+++ b/tests/components/plum_lightpad/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from requests.exceptions import ConnectTimeout
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.plum_lightpad.const import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -11,7 +11,6 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -70,8 +69,6 @@ async def test_form_one_entry_per_email_allowed(hass):
         data={"username": "test-plum-username", "password": "test-plum-password"},
     ).add_to_hass(hass)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -94,7 +91,6 @@ async def test_form_one_entry_per_email_allowed(hass):
 
 async def test_import(hass):
     """Test configuring the flow using configuration.yaml."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.plum_lightpad.utils.Plum.loadCloudData"

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -8,7 +8,7 @@ from tesla_powerwall import (
     PowerwallUnreachableError,
 )
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
 from homeassistant.components.powerwall.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
@@ -22,7 +22,7 @@ VALID_CONFIG = {CONF_IP_ADDRESS: "1.2.3.4", CONF_PASSWORD: "00GGX"}
 
 async def test_form_source_user(hass):
     """Test we get config flow setup form as a user."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -137,7 +137,6 @@ async def test_form_wrong_version(hass):
 
 async def test_already_configured(hass):
     """Test we abort when already configured."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_IP_ADDRESS: "1.1.1.1"})
     config_entry.add_to_hass(hass)
@@ -157,7 +156,6 @@ async def test_already_configured(hass):
 
 async def test_already_configured_with_ignored(hass):
     """Test ignored entries do not break checking for existing entries."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={}, source=config_entries.SOURCE_IGNORE
@@ -178,7 +176,7 @@ async def test_already_configured_with_ignored(hass):
 
 async def test_dhcp_discovery(hass):
     """Test we can process the discovery from dhcp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},

--- a/tests/components/profiler/test_config_flow.py
+++ b/tests/components/profiler/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Profiler config flow."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.profiler.const import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -9,7 +9,7 @@ from tests.common import MockConfigEntry
 
 async def test_form_user(hass):
     """Test we can setup by the user."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -35,7 +35,7 @@ async def test_form_user(hass):
 async def test_form_user_only_once(hass):
     """Test we can setup by the user only once."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 import os
 from unittest.mock import patch
 
-from homeassistant import setup
 from homeassistant.components.profiler import (
     CONF_SECONDS,
     SERVICE_DUMP_LOG_OBJECTS,
@@ -25,7 +24,6 @@ async def test_basic_usage(hass, tmpdir):
     """Test we can setup and the service is registered."""
     test_dir = tmpdir.mkdir("profiles")
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
 
@@ -57,7 +55,6 @@ async def test_memory_usage(hass, tmpdir):
     """Test we can setup and the service is registered."""
     test_dir = tmpdir.mkdir("profiles")
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
 
@@ -88,7 +85,6 @@ async def test_memory_usage(hass, tmpdir):
 async def test_object_growth_logging(hass, caplog):
     """Test we can setup and the service and we can dump objects to the log."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
 
@@ -129,7 +125,6 @@ async def test_object_growth_logging(hass, caplog):
 async def test_dump_log_object(hass, caplog):
     """Test we can setup and the service is registered and logging works."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
 
@@ -153,7 +148,6 @@ async def test_dump_log_object(hass, caplog):
 async def test_log_thread_frames(hass, caplog):
     """Test we can log thread frames."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
 
@@ -175,7 +169,6 @@ async def test_log_thread_frames(hass, caplog):
 async def test_log_scheduled(hass, caplog):
     """Test we can log scheduled items in the event loop."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
 

--- a/tests/components/progettihwsw/test_config_flow.py
+++ b/tests/components/progettihwsw/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the ProgettiHWSW Automation config flow."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.progettihwsw.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import (
@@ -22,7 +22,7 @@ mock_value_step_user = {
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/prosegur/test_config_flow.py
+++ b/tests/components/prosegur/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from pytest import mark
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.prosegur.config_flow import CannotConnect, InvalidAuth
 from homeassistant.components.prosegur.const import DOMAIN
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/rachio/test_config_flow.py
+++ b/tests/components/rachio/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Rachio config flow."""
 from unittest.mock import MagicMock, patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.rachio.const import (
     CONF_CUSTOM_URL,
     CONF_MANUAL_RUN_MINS,
@@ -23,7 +23,7 @@ def _mock_rachio_return_value(get=None, info=None):
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -107,7 +107,6 @@ async def test_form_cannot_connect(hass):
 
 async def test_form_homekit(hass):
     """Test that we abort from homekit if rachio is already setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/rainforest_eagle/test_config_flow.py
+++ b/tests/components/rainforest_eagle/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Rainforest Eagle config flow."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.rainforest_eagle.const import (
     CONF_CLOUD_ID,
     CONF_HARDWARE_ADDRESS,
@@ -17,7 +17,7 @@ from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/rainforest_eagle/test_init.py
+++ b/tests/components/rainforest_eagle/test_init.py
@@ -1,7 +1,7 @@
 """Tests for the Rainforest Eagle integration."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.rainforest_eagle.const import (
     CONF_CLOUD_ID,
     CONF_HARDWARE_ADDRESS,
@@ -17,7 +17,6 @@ from homeassistant.setup import async_setup_component
 
 async def test_import(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.rainforest_eagle.data.async_get_type",

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -50,7 +50,7 @@ def create_engine_test(*args, **kwargs):
 async def test_schema_update_calls(hass):
     """Test that schema migrations occur in correct order."""
     assert await recorder.async_migration_in_progress(hass) is False
-    await async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.recorder.create_engine", new=create_engine_test
     ), patch(
@@ -74,7 +74,6 @@ async def test_schema_update_calls(hass):
 async def test_migration_in_progress(hass):
     """Test that we can check for migration in progress."""
     assert await recorder.async_migration_in_progress(hass) is False
-    await async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.recorder.create_engine", new=create_engine_test
@@ -91,7 +90,7 @@ async def test_migration_in_progress(hass):
 
 async def test_database_migration_failed(hass):
     """Test we notify if the migration fails."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     create_calls = async_mock_service(hass, "persistent_notification", "create")
     dismiss_calls = async_mock_service(hass, "persistent_notification", "dismiss")
     assert await recorder.async_migration_in_progress(hass) is False
@@ -118,7 +117,7 @@ async def test_database_migration_failed(hass):
 
 async def test_database_migration_encounters_corruption(hass):
     """Test we move away the database if its corrupt."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     assert await recorder.async_migration_in_progress(hass) is False
 
     sqlite3_exception = DatabaseError("statement", {}, [])
@@ -146,7 +145,7 @@ async def test_database_migration_encounters_corruption(hass):
 
 async def test_database_migration_encounters_corruption_not_sqlite(hass):
     """Test we fail on database error when we cannot recover."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     create_calls = async_mock_service(hass, "persistent_notification", "create")
     dismiss_calls = async_mock_service(hass, "persistent_notification", "dismiss")
     assert await recorder.async_migration_in_progress(hass) is False
@@ -179,7 +178,7 @@ async def test_events_during_migration_are_queued(hass):
     """Test that events during migration are queued."""
 
     assert await recorder.async_migration_in_progress(hass) is False
-    await async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.recorder.create_engine", new=create_engine_test
     ):
@@ -202,7 +201,7 @@ async def test_events_during_migration_are_queued(hass):
 
 async def test_events_during_migration_queue_exhausted(hass):
     """Test that events during migration takes so long the queue is exhausted."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     assert await recorder.async_migration_in_progress(hass) is False
 
     with patch(
@@ -237,8 +236,6 @@ async def test_schema_migrate(hass):
     throwing exceptions. Maintaining a set of assertions based on schema
     inspection could quickly become quite cumbersome.
     """
-
-    await async_setup_component(hass, "persistent_notification", {})
 
     def _mock_setup_run(self):
         self.run_info = RecorderRuns(

--- a/tests/components/renault/test_binary_sensor.py
+++ b/tests/components/renault/test_binary_sensor.py
@@ -8,7 +8,6 @@ from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAI
 from homeassistant.components.renault.renault_entities import ATTR_LAST_UPDATE
 from homeassistant.const import ATTR_ICON, STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from . import (
     check_device_registry,
@@ -25,7 +24,7 @@ from tests.common import mock_device_registry, mock_registry
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_binary_sensors(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault binary sensors."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -52,7 +51,7 @@ async def test_binary_sensors(hass: HomeAssistant, vehicle_type: str):
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_binary_sensor_empty(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault binary sensors with empty data from Renault."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -82,7 +81,7 @@ async def test_binary_sensor_empty(hass: HomeAssistant, vehicle_type: str):
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_binary_sensor_errors(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault binary sensors with temporary failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -118,7 +117,7 @@ async def test_binary_sensor_errors(hass: HomeAssistant, vehicle_type: str):
 
 async def test_binary_sensor_access_denied(hass):
     """Test for Renault binary sensors with access denied failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -142,7 +141,7 @@ async def test_binary_sensor_access_denied(hass):
 
 async def test_binary_sensor_not_supported(hass):
     """Test for Renault binary sensors with not supported failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 

--- a/tests/components/renault/test_device_tracker.py
+++ b/tests/components/renault/test_device_tracker.py
@@ -8,7 +8,6 @@ from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOM
 from homeassistant.components.renault.renault_entities import ATTR_LAST_UPDATE
 from homeassistant.const import ATTR_ICON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from . import (
     check_device_registry,
@@ -25,7 +24,7 @@ from tests.common import mock_device_registry, mock_registry
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_device_trackers(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault device trackers."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -52,7 +51,7 @@ async def test_device_trackers(hass: HomeAssistant, vehicle_type: str):
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_device_tracker_empty(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault device trackers with empty data from Renault."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -82,7 +81,7 @@ async def test_device_tracker_empty(hass: HomeAssistant, vehicle_type: str):
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_device_tracker_errors(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault device trackers with temporary failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -118,7 +117,7 @@ async def test_device_tracker_errors(hass: HomeAssistant, vehicle_type: str):
 
 async def test_device_tracker_access_denied(hass: HomeAssistant):
     """Test for Renault device trackers with access denied failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -142,7 +141,7 @@ async def test_device_tracker_access_denied(hass: HomeAssistant):
 
 async def test_device_tracker_not_supported(hass: HomeAssistant):
     """Test for Renault device trackers with not supported failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 

--- a/tests/components/renault/test_select.py
+++ b/tests/components/renault/test_select.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from . import (
     check_device_registry,
@@ -31,7 +30,7 @@ from tests.common import load_fixture, mock_device_registry, mock_registry
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_selects(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault selects."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -58,7 +57,7 @@ async def test_selects(hass: HomeAssistant, vehicle_type: str):
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_select_empty(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault selects with empty data from Renault."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -88,7 +87,7 @@ async def test_select_empty(hass: HomeAssistant, vehicle_type: str):
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_select_errors(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault selects with temporary failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -124,7 +123,7 @@ async def test_select_errors(hass: HomeAssistant, vehicle_type: str):
 
 async def test_select_access_denied(hass: HomeAssistant):
     """Test for Renault selects with access denied failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -148,7 +147,7 @@ async def test_select_access_denied(hass: HomeAssistant):
 
 async def test_select_not_supported(hass: HomeAssistant):
     """Test for Renault selects with access denied failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 

--- a/tests/components/renault/test_sensor.py
+++ b/tests/components/renault/test_sensor.py
@@ -8,7 +8,6 @@ from homeassistant.components.renault.renault_entities import ATTR_LAST_UPDATE
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_ICON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from . import (
     check_device_registry,
@@ -25,7 +24,7 @@ from tests.common import mock_device_registry, mock_registry
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_sensors(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault sensors."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -52,7 +51,7 @@ async def test_sensors(hass: HomeAssistant, vehicle_type: str):
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_sensor_empty(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault sensors with empty data from Renault."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -82,7 +81,7 @@ async def test_sensor_empty(hass: HomeAssistant, vehicle_type: str):
 @pytest.mark.parametrize("vehicle_type", MOCK_VEHICLES.keys())
 async def test_sensor_errors(hass: HomeAssistant, vehicle_type: str):
     """Test for Renault sensors with temporary failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -118,7 +117,7 @@ async def test_sensor_errors(hass: HomeAssistant, vehicle_type: str):
 
 async def test_sensor_access_denied(hass: HomeAssistant):
     """Test for Renault sensors with access denied failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
@@ -142,7 +141,7 @@ async def test_sensor_access_denied(hass: HomeAssistant):
 
 async def test_sensor_not_supported(hass: HomeAssistant):
     """Test for Renault sensors with access denied failure."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 

--- a/tests/components/rest/test_binary_sensor.py
+++ b/tests/components/rest/test_binary_sensor.py
@@ -26,7 +26,7 @@ async def test_setup_missing_basic_config(hass):
         hass, binary_sensor.DOMAIN, {"binary_sensor": {"platform": "rest"}}
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("binary_sensor")) == 0
 
 
 async def test_setup_missing_config(hass):
@@ -43,7 +43,7 @@ async def test_setup_missing_config(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("binary_sensor")) == 0
 
 
 @respx.mock
@@ -65,7 +65,7 @@ async def test_setup_failed_connect(hass, caplog):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("binary_sensor")) == 0
     assert "server offline" in caplog.text
 
 
@@ -85,7 +85,7 @@ async def test_setup_timeout(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("binary_sensor")) == 0
 
 
 @respx.mock
@@ -104,7 +104,7 @@ async def test_setup_minimum(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("binary_sensor")) == 1
 
 
 @respx.mock
@@ -122,7 +122,7 @@ async def test_setup_minimum_resource_template(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("binary_sensor")) == 1
 
 
 @respx.mock
@@ -141,7 +141,7 @@ async def test_setup_duplicate_resource_template(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("binary_sensor")) == 0
 
 
 @respx.mock
@@ -169,7 +169,7 @@ async def test_setup_get(hass):
     )
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("binary_sensor")) == 1
 
 
 @respx.mock
@@ -197,7 +197,7 @@ async def test_setup_get_digest_auth(hass):
     )
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("binary_sensor")) == 1
 
 
 @respx.mock
@@ -225,7 +225,7 @@ async def test_setup_post(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("binary_sensor")) == 1
 
 
 @respx.mock
@@ -252,7 +252,7 @@ async def test_setup_get_off(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("binary_sensor")) == 1
 
     state = hass.states.get("binary_sensor.foo")
     assert state.state == STATE_OFF
@@ -282,7 +282,7 @@ async def test_setup_get_on(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("binary_sensor")) == 1
 
     state = hass.states.get("binary_sensor.foo")
     assert state.state == STATE_ON
@@ -308,7 +308,7 @@ async def test_setup_with_exception(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("binary_sensor")) == 1
 
     state = hass.states.get("binary_sensor.foo")
     assert state.state == STATE_OFF
@@ -352,7 +352,7 @@ async def test_reload(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("binary_sensor")) == 1
 
     assert hass.states.get("binary_sensor.mockrest")
 
@@ -391,7 +391,7 @@ async def test_setup_query_params(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("binary_sensor")) == 1
 
 
 def _get_fixtures_base_path():

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -26,7 +26,7 @@ async def test_setup_missing_config(hass):
         hass, sensor.DOMAIN, {"sensor": {"platform": "rest"}}
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("sensor")) == 0
 
 
 async def test_setup_missing_schema(hass):
@@ -37,7 +37,7 @@ async def test_setup_missing_schema(hass):
         {"sensor": {"platform": "rest", "resource": "localhost", "method": "GET"}},
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("sensor")) == 0
 
 
 @respx.mock
@@ -58,7 +58,7 @@ async def test_setup_failed_connect(hass, caplog):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("sensor")) == 0
     assert "server offline" in caplog.text
 
 
@@ -72,7 +72,7 @@ async def test_setup_timeout(hass):
         {"sensor": {"platform": "rest", "resource": "localhost", "method": "GET"}},
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("sensor")) == 0
 
 
 @respx.mock
@@ -91,7 +91,7 @@ async def test_setup_minimum(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
 
 @respx.mock
@@ -113,7 +113,7 @@ async def test_manual_update(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
     assert hass.states.get("sensor.mysensor").state == "first"
 
     respx.get("http://localhost").respond(status_code=200, json={"data": "second"})
@@ -141,7 +141,7 @@ async def test_setup_minimum_resource_template(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
 
 @respx.mock
@@ -160,7 +160,7 @@ async def test_setup_duplicate_resource_template(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("sensor")) == 0
 
 
 @respx.mock
@@ -190,7 +190,7 @@ async def test_setup_get(hass):
     await async_setup_component(hass, "homeassistant", {})
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
     assert hass.states.get("sensor.foo").state == ""
     await hass.services.async_call(
@@ -229,7 +229,7 @@ async def test_setup_get_digest_auth(hass):
     )
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
 
 @respx.mock
@@ -258,7 +258,7 @@ async def test_setup_post(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
 
 @respx.mock
@@ -286,7 +286,7 @@ async def test_setup_get_xml(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
     state = hass.states.get("sensor.foo")
     assert state.state == "abc"
@@ -310,7 +310,7 @@ async def test_setup_query_params(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
 
 @respx.mock
@@ -339,7 +339,7 @@ async def test_update_with_json_attrs(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
     state = hass.states.get("sensor.foo")
     assert state.state == "some_json_value"
@@ -372,7 +372,7 @@ async def test_update_with_no_template(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
     state = hass.states.get("sensor.foo")
     assert state.state == '{"key": "some_json_value"}'
@@ -406,7 +406,7 @@ async def test_update_with_json_attrs_no_data(hass, caplog):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
     state = hass.states.get("sensor.foo")
     assert state.state == STATE_UNKNOWN
@@ -441,7 +441,7 @@ async def test_update_with_json_attrs_not_dict(hass, caplog):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
     state = hass.states.get("sensor.foo")
     assert state.state == ""
@@ -477,7 +477,7 @@ async def test_update_with_json_attrs_bad_JSON(hass, caplog):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
     state = hass.states.get("sensor.foo")
     assert state.state == STATE_UNKNOWN
@@ -521,7 +521,7 @@ async def test_update_with_json_attrs_with_json_attrs_path(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
     state = hass.states.get("sensor.foo")
 
     assert state.state == "master"
@@ -557,7 +557,7 @@ async def test_update_with_xml_convert_json_attrs_with_json_attrs_path(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
     state = hass.states.get("sensor.foo")
 
     assert state.state == "master"
@@ -593,7 +593,7 @@ async def test_update_with_xml_convert_json_attrs_with_jsonattr_template(hass):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
     state = hass.states.get("sensor.foo")
 
     assert state.state == "bogus"
@@ -634,7 +634,7 @@ async def test_update_with_application_xml_convert_json_attrs_with_jsonattr_temp
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
     state = hass.states.get("sensor.foo")
 
     assert state.state == "1"
@@ -669,7 +669,7 @@ async def test_update_with_xml_convert_bad_xml(hass, caplog):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
     state = hass.states.get("sensor.foo")
 
     assert state.state == STATE_UNKNOWN
@@ -704,7 +704,7 @@ async def test_update_with_failed_get(hass, caplog):
         },
     )
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
     state = hass.states.get("sensor.foo")
 
     assert state.state == STATE_UNKNOWN
@@ -734,7 +734,7 @@ async def test_reload(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("sensor")) == 1
 
     assert hass.states.get("sensor.mockrest")
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch, sentinel
 
 import serial.tools.list_ports
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.rfxtrx import DOMAIN, config_flow
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -277,7 +277,6 @@ async def test_setup_serial_manual_fail(com_mock, hass):
 
 async def test_options_global(hass):
     """Test if we can set global options."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -310,7 +309,6 @@ async def test_options_global(hass):
 
 async def test_options_add_device(hass):
     """Test we can add a device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -376,7 +374,6 @@ async def test_options_add_device(hass):
 
 async def test_options_add_duplicate_device(hass):
     """Test we can add a device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -413,7 +410,6 @@ async def test_options_add_duplicate_device(hass):
 
 async def test_options_add_remove_device(hass):
     """Test we can add a device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -497,7 +493,6 @@ async def test_options_add_remove_device(hass):
 
 async def test_options_replace_sensor_device(hass):
     """Test we can replace a sensor device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -658,7 +653,6 @@ async def test_options_replace_sensor_device(hass):
 
 async def test_options_replace_control_device(hass):
     """Test we can replace a control device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -767,7 +761,6 @@ async def test_options_replace_control_device(hass):
 
 async def test_options_remove_multiple_devices(hass):
     """Test we can add a device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -838,7 +831,6 @@ async def test_options_remove_multiple_devices(hass):
 
 async def test_options_add_and_configure_device(hass):
     """Test we can add a device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -960,7 +952,6 @@ async def test_options_add_and_configure_device(hass):
 
 async def test_options_configure_rfy_cover_device(hass):
     """Test we can configure the venetion blind mode of an Rfy cover."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -15,7 +15,6 @@ from tests.common import (
     MockConfigEntry,
     assert_lists_same,
     async_get_device_automations,
-    async_mock_service,
     mock_device_registry,
     mock_registry,
 )
@@ -169,7 +168,6 @@ async def test_action(
 async def test_invalid_action(hass, device_reg: DeviceRegistry):
     """Test for invalid actions."""
     device = DEVICE_LIGHTING_1
-    notification_calls = async_mock_service(hass, "persistent_notification", "create")
 
     await setup_entry(hass, {device.code: {"signal_repetitions": 1}})
 
@@ -199,8 +197,8 @@ async def test_invalid_action(hass, device_reg: DeviceRegistry):
     )
     await hass.async_block_till_done()
 
-    assert len(notification_calls) == 1
+    assert len(notifications := hass.states.async_all("persistent_notification")) == 1
     assert (
         "The following integrations and platforms could not be set up"
-        in notification_calls[0].data["message"]
+        in notifications[0].attributes["message"]
     )

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -148,7 +148,6 @@ async def test_firing_event(hass, device_reg: DeviceRegistry, rfxtrx, event):
 async def test_invalid_trigger(hass, device_reg: DeviceRegistry):
     """Test for invalid actions."""
     event = EVENT_LIGHTING_1
-    notification_calls = async_mock_service(hass, "persistent_notification", "create")
 
     await setup_entry(hass, {event.code: {"fire_event": True, "signal_repetitions": 1}})
 
@@ -179,8 +178,8 @@ async def test_invalid_trigger(hass, device_reg: DeviceRegistry):
     )
     await hass.async_block_till_done()
 
-    assert len(notification_calls) == 1
+    assert len(notifications := hass.states.async_all("persistent_notification")) == 1
     assert (
         "The following integrations and platforms could not be set up"
-        in notification_calls[0].data["message"]
+        in notifications[0].attributes["message"]
     )

--- a/tests/components/ring/test_config_flow.py
+++ b/tests/components/ring/test_config_flow.py
@@ -1,14 +1,14 @@
 """Test the Ring config flow."""
 from unittest.mock import Mock, patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.ring import DOMAIN
 from homeassistant.components.ring.config_flow import InvalidAuth
 
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/roku/test_config_flow.py
+++ b/tests/components/roku/test_config_flow.py
@@ -10,7 +10,6 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.setup import async_setup_component
 
 from tests.components.roku import (
     HOMEKIT_HOST,
@@ -59,7 +58,7 @@ async def test_duplicate_error(
 
 async def test_form(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test the user step."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     mock_connection(aioclient_mock)
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 from roombapy import RoombaConnectionError, RoombaInfo
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
 from homeassistant.components.roomba import config_flow
 from homeassistant.components.roomba.const import CONF_BLID, CONF_CONTINUOUS, DOMAIN
@@ -114,7 +114,6 @@ def _mocked_connection_refused_on_getpassword(*_):
 
 async def test_form_user_discovery_and_password_fetch(hass):
     """Test we can discovery and fetch the password."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         roomba_connected=True,
@@ -173,7 +172,6 @@ async def test_form_user_discovery_and_password_fetch(hass):
 
 async def test_form_user_discovery_skips_known(hass):
     """Test discovery proceeds to manual if all discovered are already known."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="BLID")
     entry.add_to_hass(hass)
@@ -193,7 +191,6 @@ async def test_form_user_discovery_skips_known(hass):
 
 async def test_form_user_no_devices_found_discovery_aborts_already_configured(hass):
     """Test if we manually configure an existing host we abort."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="BLID")
     entry.add_to_hass(hass)
@@ -222,7 +219,6 @@ async def test_form_user_no_devices_found_discovery_aborts_already_configured(ha
 
 async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
     """Test discovery skipped and we can auto fetch the password."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         roomba_connected=True,
@@ -293,7 +289,6 @@ async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
 
 async def test_form_user_discover_fails_aborts_already_configured(hass):
     """Test if we manually configure an existing host we abort after failed discovery."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="BLID")
     entry.add_to_hass(hass)
@@ -324,7 +319,6 @@ async def test_form_user_discovery_manual_and_auto_password_fetch_but_cannot_con
     hass,
 ):
     """Test discovery skipped and we can auto fetch the password then we fail to connect."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery
@@ -363,7 +357,6 @@ async def test_form_user_discovery_manual_and_auto_password_fetch_but_cannot_con
 
 async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(hass):
     """Test discovery finds no devices and we can auto fetch the password."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         roomba_connected=True,
@@ -425,7 +418,6 @@ async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(hass
 
 async def test_form_user_discovery_no_devices_found_and_password_fetch_fails(hass):
     """Test discovery finds no devices and password fetch fails."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         roomba_connected=True,
@@ -496,7 +488,6 @@ async def test_form_user_discovery_not_devices_found_and_password_fetch_fails_an
     hass,
 ):
     """Test discovery finds no devices and password fetch fails then we cannot connect."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         connect=RoombaConnectionError,
@@ -558,7 +549,6 @@ async def test_form_user_discovery_not_devices_found_and_password_fetch_fails_an
 
 async def test_form_user_discovery_and_password_fetch_gets_connection_refused(hass):
     """Test we can discovery and fetch the password manually."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         roomba_connected=True,
@@ -625,7 +615,6 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(ha
 @pytest.mark.parametrize("discovery_data", DHCP_DISCOVERY_DEVICES)
 async def test_dhcp_discovery_and_roomba_discovery_finds(hass, discovery_data):
     """Test we can process the discovery from dhcp and roomba discovery matches the device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         roomba_connected=True,
@@ -679,7 +668,6 @@ async def test_dhcp_discovery_and_roomba_discovery_finds(hass, discovery_data):
 @pytest.mark.parametrize("discovery_data", DHCP_DISCOVERY_DEVICES_WITHOUT_MATCHING_IP)
 async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
     """Test we can process the discovery from dhcp but roomba discovery cannot find the specific device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         roomba_connected=True,
@@ -752,7 +740,6 @@ async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
 @pytest.mark.parametrize("discovery_data", DHCP_DISCOVERY_DEVICES_WITHOUT_MATCHING_IP)
 async def test_dhcp_discovery_no_devices_falls_back_to_manual(hass, discovery_data):
     """Test we can process the discovery from dhcp but roomba discovery cannot find any devices."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
         roomba_connected=True,
@@ -816,7 +803,6 @@ async def test_dhcp_discovery_no_devices_falls_back_to_manual(hass, discovery_da
 
 async def test_dhcp_discovery_with_ignored(hass):
     """Test ignored entries do not break checking for existing entries."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={}, source=config_entries.SOURCE_IGNORE
@@ -842,7 +828,6 @@ async def test_dhcp_discovery_with_ignored(hass):
 
 async def test_dhcp_discovery_already_configured_host(hass):
     """Test we abort if the host is already configured."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: MOCK_IP})
     config_entry.add_to_hass(hass)
@@ -867,7 +852,6 @@ async def test_dhcp_discovery_already_configured_host(hass):
 
 async def test_dhcp_discovery_already_configured_blid(hass):
     """Test we abort if the blid is already configured."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_BLID: "BLID"}, unique_id="BLID"
@@ -894,7 +878,6 @@ async def test_dhcp_discovery_already_configured_blid(hass):
 
 async def test_dhcp_discovery_not_irobot(hass):
     """Test we abort if the discovered device is not an irobot device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_BLID: "BLID"}, unique_id="BLID"
@@ -921,7 +904,6 @@ async def test_dhcp_discovery_not_irobot(hass):
 
 async def test_dhcp_discovery_partial_hostname(hass):
     """Test we abort flows when we have a partial hostname."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the roon config flow."""
 from unittest.mock import patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.roon.const import DOMAIN
 
 
@@ -64,7 +64,6 @@ class RoonDiscoveryFailedMock(RoonDiscoveryMock):
 async def test_successful_discovery_and_auth(hass):
     """Test when discovery and auth both work ok."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "homeassistant.components.roon.config_flow.RoonApi",
         return_value=RoonApiMock(),
@@ -102,7 +101,6 @@ async def test_successful_discovery_and_auth(hass):
 async def test_unsuccessful_discovery_user_form_and_auth(hass):
     """Test unsuccessful discover, user adding the host via the form and then successful auth."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "homeassistant.components.roon.config_flow.RoonApi",
         return_value=RoonApiMock(),
@@ -143,7 +141,6 @@ async def test_unsuccessful_discovery_user_form_and_auth(hass):
 async def test_successful_discovery_no_auth(hass):
     """Test successful discover, but failed auth."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "homeassistant.components.roon.config_flow.RoonApi",
         return_value=RoonApiMockNoToken(),
@@ -182,7 +179,6 @@ async def test_successful_discovery_no_auth(hass):
 async def test_unexpected_exception(hass):
     """Test successful discover, and unexpected exception during auth."""
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
         "homeassistant.components.roon.config_flow.RoonApi",
         return_value=RoonApiMockException(),

--- a/tests/components/samsungtv/__init__.py
+++ b/tests/components/samsungtv/__init__.py
@@ -1,14 +1,13 @@
 """Tests for the samsungtv component."""
 from homeassistant.components.samsungtv.const import DOMAIN as SAMSUNGTV_DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
 async def setup_samsungtv(hass: HomeAssistant, config: dict):
     """Set up mock Samsung TV."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(domain=SAMSUNGTV_DOMAIN, data=config)
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -125,7 +125,7 @@ async def test_setup_duplicate_config(hass: HomeAssistant, remote: Mock, caplog)
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, DUPLICATE)
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID) is None
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("media_player")) == 0
     assert "duplicate host entries found" in caplog.text
 
 

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -136,6 +136,6 @@ async def test_setup_duplicate_entries(
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID)
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("media_player")) == 1
     await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("media_player")) == 1

--- a/tests/components/screenlogic/test_config_flow.py
+++ b/tests/components/screenlogic/test_config_flow.py
@@ -10,7 +10,7 @@ from screenlogicpy.const import (
     SL_GATEWAY_TYPE,
 )
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS
 from homeassistant.components.screenlogic.config_flow import (
     GATEWAY_MANUAL_ENTRY,
@@ -28,7 +28,7 @@ from tests.common import MockConfigEntry
 
 async def test_flow_discovery(hass):
     """Test the flow works with basic discovery."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.screenlogic.config_flow.discovery.async_discover",
         return_value=[
@@ -72,7 +72,7 @@ async def test_flow_discovery(hass):
 
 async def test_flow_discover_none(hass):
     """Test when nothing is discovered."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.screenlogic.config_flow.discovery.async_discover",
         return_value=[],
@@ -88,7 +88,7 @@ async def test_flow_discover_none(hass):
 
 async def test_flow_discover_error(hass):
     """Test when discovery errors."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.screenlogic.config_flow.discovery.async_discover",
         side_effect=ScreenLogicError("Fake error"),
@@ -134,7 +134,7 @@ async def test_flow_discover_error(hass):
 
 async def test_dhcp(hass):
     """Test DHCP discovery flow."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
@@ -180,7 +180,7 @@ async def test_dhcp(hass):
 
 async def test_form_manual_entry(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.screenlogic.config_flow.discovery.async_discover",
         return_value=[

--- a/tests/components/sense/test_config_flow.py
+++ b/tests/components/sense/test_config_flow.py
@@ -3,13 +3,13 @@ from unittest.mock import patch
 
 from sense_energy import SenseAPITimeoutException, SenseAuthenticationException
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.sense.const import DOMAIN
 
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/sentry/test_config_flow.py
+++ b/tests/components/sentry/test_config_flow.py
@@ -22,14 +22,13 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
 async def test_full_user_flow_implementation(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -166,7 +166,7 @@ async def test_invalid_config(hass):
     """Ensure nothing is created when config is wrong."""
     assert await async_setup_component(hass, "sensor", INVALID_CONFIG)
 
-    assert not hass.states.async_entity_ids()
+    assert not hass.states.async_entity_ids("sensor")
 
 
 async def test_add_package(hass):

--- a/tests/components/sharkiq/test_config_flow.py
+++ b/tests/components/sharkiq/test_config_flow.py
@@ -5,7 +5,7 @@ import aiohttp
 import pytest
 from sharkiqpy import AylaApi, SharkIqAuthError
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.sharkiq.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -6,7 +6,7 @@ import aiohttp
 import aioshelly
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.shelly.const import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -28,7 +28,7 @@ MOCK_CONFIG = {
 @pytest.mark.parametrize("gen", [1, 2])
 async def test_form(hass, gen):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -81,7 +81,7 @@ async def test_form(hass, gen):
 
 async def test_title_without_name(hass):
     """Test we set the title to the hostname when the device doesn't have a name."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -227,7 +227,7 @@ async def test_form_errors_test_connection(hass, error):
 
 async def test_form_already_configured(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain="shelly", unique_id="test-mac", data={"host": "0.0.0.0"}
     )
@@ -255,7 +255,7 @@ async def test_form_already_configured(hass):
 
 async def test_user_setup_ignored_device(hass):
     """Test user can successfully setup an ignored device."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain="shelly",
         unique_id="test-mac",
@@ -361,7 +361,6 @@ async def test_form_auth_errors_test_connection(hass, error):
 
 async def test_zeroconf(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "aioshelly.common.get_info",
@@ -415,7 +414,6 @@ async def test_zeroconf(hass):
 
 async def test_zeroconf_sleeping_device(hass):
     """Test sleeping device configuration via zeroconf."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "aioshelly.common.get_info",
@@ -489,7 +487,6 @@ async def test_zeroconf_sleeping_device(hass):
 async def test_zeroconf_sleeping_device_error(hass, error):
     """Test sleeping device configuration via zeroconf with error."""
     exc = error
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "aioshelly.common.get_info",
@@ -514,7 +511,7 @@ async def test_zeroconf_sleeping_device_error(hass, error):
 
 async def test_zeroconf_already_configured(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain="shelly", unique_id="test-mac", data={"host": "0.0.0.0"}
     )
@@ -566,7 +563,6 @@ async def test_zeroconf_cannot_connect(hass):
 
 async def test_zeroconf_require_auth(hass):
     """Test zeroconf if auth is required."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "aioshelly.common.get_info",

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from homeassistant import setup
 from homeassistant.components import automation
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
@@ -187,7 +186,6 @@ async def test_get_triggers_for_invalid_device_id(hass, device_reg, coap_wrapper
 async def test_if_fires_on_click_event_block_device(hass, calls, coap_wrapper):
     """Test for click_event trigger firing for block device."""
     assert coap_wrapper
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(
         hass,
@@ -226,7 +224,6 @@ async def test_if_fires_on_click_event_block_device(hass, calls, coap_wrapper):
 async def test_if_fires_on_click_event_rpc_device(hass, calls, rpc_wrapper):
     """Test for click_event trigger firing for rpc device."""
     assert rpc_wrapper
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(
         hass,
@@ -265,7 +262,6 @@ async def test_if_fires_on_click_event_rpc_device(hass, calls, rpc_wrapper):
 async def test_validate_trigger_block_device_not_ready(hass, calls, coap_wrapper):
     """Test validate trigger config when block device is not ready."""
     assert coap_wrapper
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(
         hass,
@@ -303,7 +299,6 @@ async def test_validate_trigger_block_device_not_ready(hass, calls, coap_wrapper
 async def test_validate_trigger_rpc_device_not_ready(hass, calls, rpc_wrapper):
     """Test validate trigger config when RPC device is not ready."""
     assert rpc_wrapper
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(
         hass,

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -25,7 +25,6 @@ from tests.common import (
     MockConfigEntry,
     assert_lists_same,
     async_get_device_automations,
-    async_mock_service,
 )
 
 
@@ -336,7 +335,6 @@ async def test_validate_trigger_rpc_device_not_ready(hass, calls, rpc_wrapper):
 async def test_validate_trigger_invalid_triggers(hass, coap_wrapper):
     """Test for click_event with invalid triggers."""
     assert coap_wrapper
-    notification_calls = async_mock_service(hass, "persistent_notification", "create")
 
     assert await async_setup_component(
         hass,
@@ -360,8 +358,8 @@ async def test_validate_trigger_invalid_triggers(hass, coap_wrapper):
         },
     )
 
-    assert len(notification_calls) == 1
+    assert len(notifications := hass.states.async_all("persistent_notification")) == 1
     assert (
         "The following integrations and platforms could not be set up"
-        in notification_calls[0].data["message"]
+        in notifications[0].attributes["message"]
     )

--- a/tests/components/sma/test_config_flow.py
+++ b/tests/components/sma/test_config_flow.py
@@ -7,7 +7,6 @@ from pysma.exceptions import (
     SmaReadException,
 )
 
-from homeassistant import setup
 from homeassistant.components.sma.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.data_entry_flow import (
@@ -28,7 +27,7 @@ from . import (
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -153,7 +152,6 @@ async def test_form_already_configured(hass, mock_config_entry):
 
 async def test_import(hass):
     """Test we can import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch("pysma.SMA.new_session", return_value=True), patch(
         "pysma.SMA.device_info", return_value=MOCK_DEVICE
@@ -174,7 +172,6 @@ async def test_import(hass):
 
 async def test_import_sensor_dict(hass):
     """Test we can import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with patch("pysma.SMA.new_session", return_value=True), patch(
         "pysma.SMA.device_info", return_value=MOCK_DEVICE

--- a/tests/components/smart_meter_texas/test_config_flow.py
+++ b/tests/components/smart_meter_texas/test_config_flow.py
@@ -9,7 +9,7 @@ from smart_meter_texas.exceptions import (
     SmartMeterTexasAuthError,
 )
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.smart_meter_texas.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
@@ -20,7 +20,7 @@ TEST_LOGIN = {CONF_USERNAME: "test-username", CONF_PASSWORD: "test-password"}
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/smarthab/test_config_flow.py
+++ b/tests/components/smarthab/test_config_flow.py
@@ -3,14 +3,14 @@ from unittest.mock import patch
 
 import pysmarthab
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.smarthab import DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -98,7 +98,6 @@ async def test_form_unknown_error(hass):
 
 async def test_import(hass):
     """Test import."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     imported_conf = {
         CONF_EMAIL: "mock@example.com",

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -22,14 +22,13 @@ from homeassistant.components.smartthings.const import (
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
 async def test_migration_creates_new_flow(hass, smartthings_mock, config_entry):
     """Test migration deletes app and creates new flow."""
-    assert await async_setup_component(hass, "persistent_notification", {})
+
     config_entry.version = 1
     config_entry.add_to_hass(hass)
 
@@ -55,7 +54,7 @@ async def test_unrecoverable_api_errors_create_new_flow(
     403 (forbidden/not found): Occurs when the app or installed app could
         not be retrieved/found (likely deleted?)
     """
-    assert await async_setup_component(hass, "persistent_notification", {})
+
     config_entry.add_to_hass(hass)
     request_info = Mock(real_url="http://example.com")
     smartthings_mock.app.side_effect = ClientResponseError(

--- a/tests/components/solarlog/test_config_flow.py
+++ b/tests/components/solarlog/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.solarlog import config_flow
 from homeassistant.components.solarlog.const import DEFAULT_HOST, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME
@@ -16,7 +16,7 @@ HOST = "http://1.1.1.1"
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/somfy_mylink/test_config_flow.py
+++ b/tests/components/somfy_mylink/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
 from homeassistant.components.somfy_mylink.const import (
     CONF_REVERSED_TARGET_IDS,
@@ -18,7 +18,7 @@ from tests.common import MockConfigEntry
 
 async def test_form_user(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -54,7 +54,6 @@ async def test_form_user(hass):
 
 async def test_form_user_already_configured(hass):
     """Test we abort if already configured."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -163,7 +162,6 @@ async def test_form_unknown_error(hass):
 
 async def test_options_not_loaded(hass):
     """Test options will not display until loaded."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -183,7 +181,6 @@ async def test_options_not_loaded(hass):
 @pytest.mark.parametrize("reversed", [True, False])
 async def test_options_with_targets(hass, reversed):
     """Test we can configure reverse for a target."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -238,7 +235,6 @@ async def test_options_with_targets(hass, reversed):
 
 async def test_form_user_already_configured_from_dhcp(hass):
     """Test we abort if already configured from dhcp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -271,7 +267,6 @@ async def test_form_user_already_configured_from_dhcp(hass):
 
 async def test_already_configured_with_ignored(hass):
     """Test ignored entries do not break checking for existing entries."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={}, source=config_entries.SOURCE_IGNORE
@@ -292,7 +287,7 @@ async def test_already_configured_with_ignored(hass):
 
 async def test_dhcp_discovery(hass):
     """Test we can process the discovery from dhcp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},

--- a/tests/components/sonos/test_config_flow.py
+++ b/tests/components/sonos/test_config_flow.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from homeassistant import config_entries, core, setup
+from homeassistant import config_entries, core
 from homeassistant.components.sonos.const import DATA_SONOS_DISCOVERY_MANAGER, DOMAIN
 
 
 @patch("homeassistant.components.sonos.config_flow.soco.discover", return_value=True)
 async def test_user_form(discover_mock: MagicMock, hass: core.HomeAssistant):
     """Test we get the user initiated form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -38,7 +38,7 @@ async def test_user_form(discover_mock: MagicMock, hass: core.HomeAssistant):
 
 async def test_zeroconf_form(hass: core.HomeAssistant):
     """Test we pass sonos devices to the discovery manager."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     mock_manager = hass.data[DATA_SONOS_DISCOVERY_MANAGER] = MagicMock()
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -78,7 +78,7 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
 async def test_zeroconf_form_not_sonos(hass: core.HomeAssistant):
     """Test we abort on non-sonos devices."""
     mock_manager = hass.data[DATA_SONOS_DISCOVERY_MANAGER] = MagicMock()
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},

--- a/tests/components/spider/test_config_flow.py
+++ b/tests/components/spider/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.spider.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
@@ -27,7 +27,7 @@ def spider_fixture() -> Mock:
 
 async def test_user(hass, spider):
     """Test user config."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -57,7 +57,7 @@ async def test_user(hass, spider):
 
 async def test_import(hass, spider):
     """Test import step."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.spider.async_setup",
         return_value=True,

--- a/tests/components/surepetcare/test_config_flow.py
+++ b/tests/components/surepetcare/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import NonCallableMagicMock, patch
 
 from surepy.exceptions import SurePetcareAuthenticationError, SurePetcareError
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.surepetcare.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
@@ -22,7 +22,7 @@ INPUT_DATA = {
 
 async def test_form(hass: HomeAssistant, surepetcare: NonCallableMagicMock) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -14,7 +14,6 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.setup import async_setup_component
 
 from . import (
     USER_INPUT,
@@ -29,7 +28,6 @@ DOMAIN = "switchbot"
 
 async def test_user_form_valid_mac(hass):
     """Test the user initiated form with password and valid mac."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -94,7 +92,6 @@ async def test_user_form_valid_mac(hass):
 
 async def test_async_step_import(hass):
     """Test the config import flow."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     with _patch_async_setup_entry() as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
@@ -113,7 +110,6 @@ async def test_async_step_import(hass):
 
 async def test_user_form_exception(hass, switchbot_config_flow):
     """Test we handle exception on user form."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     switchbot_config_flow.side_effect = NotConnectedError
 

--- a/tests/components/syncthing/test_config_flow.py
+++ b/tests/components/syncthing/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from aiosyncthing.exceptions import UnauthorizedError
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.syncthing.const import DOMAIN
 from homeassistant.const import CONF_NAME, CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 
@@ -25,7 +25,7 @@ MOCK_ENTRY = {
 
 async def test_show_setup_form(hass):
     """Test that the setup form is served."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/syncthru/test_config_flow.py
+++ b/tests/components/syncthru/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from pysyncthru import SyncThruAPINotSupported
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import ssdp
 from homeassistant.components.syncthru.config_flow import SyncThru
 from homeassistant.components.syncthru.const import DOMAIN
@@ -49,7 +49,7 @@ async def test_show_setup_form(hass):
 
 async def test_already_configured_by_url(hass, aioclient_mock):
     """Test we match and update already configured devices by URL."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     udn = "uuid:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
     MockConfigEntry(
         domain=DOMAIN,
@@ -103,7 +103,7 @@ async def test_unknown_state(hass):
 
 async def test_success(hass, aioclient_mock):
     """Test successful flow provides entry creation data."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     mock_connection(aioclient_mock)
 
     with patch(
@@ -123,7 +123,7 @@ async def test_success(hass, aioclient_mock):
 
 async def test_ssdp(hass, aioclient_mock):
     """Test SSDP discovery initiates config properly."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     mock_connection(aioclient_mock)
 
     url = "http://192.168.1.2/"

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -10,7 +10,7 @@ from synology_dsm.exceptions import (
     SynologyDSMRequestException,
 )
 
-from homeassistant import data_entry_flow, setup
+from homeassistant import data_entry_flow
 from homeassistant.components import ssdp
 from homeassistant.components.synology_dsm.config_flow import CONF_OTP_CODE
 from homeassistant.components.synology_dsm.const import (
@@ -383,7 +383,6 @@ async def test_missing_data_after_login(hass: HomeAssistant, service_failed: Mag
 
 async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):
     """Test we can setup from ssdp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -419,7 +418,6 @@ async def test_form_ssdp(hass: HomeAssistant, service: MagicMock):
 
 async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
     """Test re-configuration of already existing entry by ssdp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     MockConfigEntry(
         domain=DOMAIN,
@@ -447,7 +445,6 @@ async def test_reconfig_ssdp(hass: HomeAssistant, service: MagicMock):
 
 async def test_existing_ssdp(hass: HomeAssistant, service: MagicMock):
     """Test abort of already existing entry by ssdp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from aiohttp.client_exceptions import ClientConnectionError
 from systembridge.exceptions import BridgeAuthenticationException
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.system_bridge.const import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 
@@ -279,7 +279,7 @@ async def test_zeroconf_flow(
     hass, aiohttp_client, aioclient_mock, current_request_with_host
 ) -> None:
     """Test zeroconf flow."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
@@ -314,7 +314,7 @@ async def test_zeroconf_cannot_connect(
     hass, aiohttp_client, aioclient_mock, current_request_with_host
 ) -> None:
     """Test zeroconf cannot connect flow."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
@@ -342,7 +342,7 @@ async def test_zeroconf_bad_zeroconf_info(
     hass, aiohttp_client, aioclient_mock, current_request_with_host
 ) -> None:
     """Test zeroconf cannot connect flow."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},

--- a/tests/components/tado/test_config_flow.py
+++ b/tests/components/tado/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.tado.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
@@ -21,7 +21,7 @@ def _get_mock_tado_api(getMe=None):
 
 async def test_form(hass):
     """Test we can setup though the user path."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -121,7 +121,6 @@ async def test_no_homes(hass):
 
 async def test_form_homekit(hass):
     """Test that we abort from homekit if tado is already setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -284,7 +284,7 @@ async def test_no_action_scripts(hass, start_ha):
 )
 async def test_template_syntax_error(hass, msg, start_ha, caplog_setup_text):
     """Test templating syntax error."""
-    assert len(hass.states.async_all()) == 0
+    assert len(hass.states.async_all("alarm_control_panel")) == 0
     assert (msg) in caplog_setup_text
 
 

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -78,7 +78,7 @@ async def test_setup_legacy(hass, start_ha):
 )
 async def test_setup_invalid_sensors(hass, count, start_ha):
     """Test setup with no sensors."""
-    assert len(hass.states.async_entity_ids()) == count
+    assert len(hass.states.async_entity_ids("binary_sensor")) == count
 
 
 @pytest.mark.parametrize("count,domain", [(1, binary_sensor.DOMAIN)])

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -327,7 +327,7 @@ async def test_template_out_of_bounds(hass, start_ha):
 )
 async def test_template_open_or_position(hass, start_ha, caplog_setup_text):
     """Test that at least one of open_cover or set_position is used."""
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("cover") == []
     assert "Invalid config for [cover.template]" in caplog_setup_text
 
 

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -126,7 +126,7 @@ async def test_missing_optional_config(hass, start_ha):
 )
 async def test_wrong_template_config(hass, start_ha):
     """Test: missing 'value_template' will fail."""
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("fan") == []
 
 
 @pytest.mark.parametrize("count,domain", [(1, DOMAIN)])

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -163,10 +163,10 @@ async def test_reloadable_handles_partial_valid_config(hass, start_ha):
     hass.states.async_set("sensor.test_sensor", "mytest")
     await hass.async_block_till_done()
     assert hass.states.get("sensor.state").state == "mytest"
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all("sensor")) == 2
 
     await async_yaml_patch_helper(hass, "broken_configuration.yaml")
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all("sensor")) == 3
 
     assert hass.states.get("sensor.state") is None
     assert hass.states.get("sensor.watching_tv_in_master_bedroom").state == "off"

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -210,7 +210,7 @@ async def test_templatex_state_boolean(hass, expected_state, start_ha):
 )
 async def test_template_syntax_error(hass, start_ha):
     """Test templating syntax error."""
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("light") == []
 
 
 SET_VAL1 = '"value_template": "{{ 1== 1}}",'
@@ -241,9 +241,9 @@ SET_VAL3 = '"turn_off": {"service": "light.turn_off","entity_id": "light.test_st
 async def test_missing_key(hass, count, start_ha):
     """Test missing template."""
     if count:
-        assert hass.states.async_all() != []
+        assert hass.states.async_all("light") != []
     else:
-        assert hass.states.async_all() == []
+        assert hass.states.async_all("light") == []
 
 
 @pytest.mark.parametrize("count,domain", [(1, light.DOMAIN)])
@@ -1471,4 +1471,4 @@ async def test_invalid_availability_template_keeps_component_available(
 )
 async def test_unique_id(hass, start_ha):
     """Test unique_id option only creates one light per id."""
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("light")) == 1

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -146,7 +146,7 @@ async def test_template_state_boolean_off(hass, start_ha):
 )
 async def test_template_syntax_error(hass, start_ha):
     """Test templating syntax error."""
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("lock") == []
 
 
 @pytest.mark.parametrize("count,domain", [(1, lock.DOMAIN)])
@@ -376,4 +376,4 @@ async def test_unique_id(hass, start_ha):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("lock")) == 1

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -109,7 +109,7 @@ async def test_missing_required_keys(hass, calls):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("number") == []
 
 
 async def test_all_optional_config(hass, calls):

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -140,7 +140,7 @@ async def test_missing_required_keys(hass, calls):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("select") == []
 
 
 async def test_templates_with_entities(hass, calls):

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -234,7 +234,7 @@ async def test_friendly_name_template(hass, attribute, start_ha):
 )
 async def test_template_syntax_error(hass, start_ha):
     """Test setup with invalid device_class."""
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("sensor") == []
 
 
 @pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -256,7 +256,7 @@ async def test_template_syntax_error(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("switch") == []
 
 
 async def test_invalid_name_does_not_create(hass):
@@ -289,7 +289,7 @@ async def test_invalid_name_does_not_create(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("switch") == []
 
 
 async def test_invalid_switch_does_not_create(hass):
@@ -310,7 +310,7 @@ async def test_invalid_switch_does_not_create(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("switch") == []
 
 
 async def test_no_switches_does_not_create(hass):
@@ -324,7 +324,7 @@ async def test_no_switches_does_not_create(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("switch") == []
 
 
 async def test_missing_on_does_not_create(hass):
@@ -357,7 +357,7 @@ async def test_missing_on_does_not_create(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("switch") == []
 
 
 async def test_missing_off_does_not_create(hass):
@@ -390,7 +390,7 @@ async def test_missing_off_does_not_create(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.async_all() == []
+    assert hass.states.async_all("switch") == []
 
 
 async def test_on_action(hass, calls):
@@ -721,4 +721,4 @@ async def test_unique_id(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("switch")) == 1

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -92,7 +92,7 @@ _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
 )
 async def test_valid_configs(hass, count, parm1, parm2, start_ha):
     """Test: configs."""
-    assert len(hass.states.async_all()) == count
+    assert len(hass.states.async_all("vacuum")) == count
     _verify(hass, parm1, parm2)
 
 
@@ -114,7 +114,7 @@ async def test_valid_configs(hass, count, parm1, parm2, start_ha):
 )
 async def test_invalid_configs(hass, count, start_ha):
     """Test: configs."""
-    assert len(hass.states.async_all()) == count
+    assert len(hass.states.async_all("vacuum")) == count
 
 
 @pytest.mark.parametrize(
@@ -276,7 +276,7 @@ async def test_attribute_templates(hass, start_ha):
 )
 async def test_invalid_attribute_template(hass, start_ha, caplog_setup_text):
     """Test that errors are logged if rendering template fails."""
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("vacuum")) == 1
     assert "test_attribute" in caplog_setup_text
     assert "TemplateError" in caplog_setup_text
 
@@ -309,7 +309,7 @@ async def test_invalid_attribute_template(hass, start_ha, caplog_setup_text):
 )
 async def test_unique_id(hass, start_ha):
     """Test unique_id option only creates one vacuum per id."""
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all("vacuum")) == 1
 
 
 async def test_unused_services(hass):

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -293,7 +293,6 @@ async def test_manual_no_capabilities(hass: HomeAssistant):
 
 async def test_discovered_by_discovery_and_dhcp(hass):
     """Test we get the form with discovery and abort for dhcp source when we get both."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with _patch_discovery(), _patch_single_discovery():
         result = await hass.config_entries.flow.async_init(
@@ -351,7 +350,6 @@ async def test_discovered_by_discovery_and_dhcp(hass):
 )
 async def test_discovered_by_dhcp_or_discovery(hass, source, data):
     """Test we can setup when discovered from dhcp or discovery."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with _patch_discovery(), _patch_single_discovery():
         result = await hass.config_entries.flow.async_init(
@@ -393,7 +391,6 @@ async def test_discovered_by_dhcp_or_discovery(hass, source, data):
 )
 async def test_discovered_by_dhcp_or_discovery_failed_to_get_device(hass, source, data):
     """Test we abort if we cannot get the unique id when discovered from dhcp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with _patch_discovery(no_device=True), _patch_single_discovery(no_device=True):
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/traccar/test_init.py
+++ b/tests/components/traccar/test_init.py
@@ -30,7 +30,6 @@ def mock_dev_track(mock_device_tracker_conf):
 @pytest.fixture(name="client")
 async def traccar_client(loop, hass, hass_client_no_auth):
     """Mock client for Traccar (unauthenticated)."""
-    assert await async_setup_component(hass, "persistent_notification", {})
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 

--- a/tests/components/tractive/test_config_flow.py
+++ b/tests/components/tractive/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import aiotractive
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.tractive.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
@@ -17,7 +17,7 @@ USER_INPUT = {
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/trend/test_binary_sensor.py
+++ b/tests/components/trend/test_binary_sensor.py
@@ -347,7 +347,7 @@ class TestTrendBinarySensor:
                     }
                 },
             )
-        assert self.hass.states.all() == []
+        assert self.hass.states.all("binary_sensor") == []
 
     def test_invalid_sensor_does_not_create(self):
         """Test invalid sensor."""
@@ -364,7 +364,7 @@ class TestTrendBinarySensor:
                     }
                 },
             )
-        assert self.hass.states.all() == []
+        assert self.hass.states.all("binary_sensor") == []
 
     def test_no_sensors_does_not_create(self):
         """Test no sensors."""
@@ -372,7 +372,7 @@ class TestTrendBinarySensor:
             assert setup.setup_component(
                 self.hass, "binary_sensor", {"binary_sensor": {"platform": "trend"}}
             )
-        assert self.hass.states.all() == []
+        assert self.hass.states.all("binary_sensor") == []
 
 
 async def test_reload(hass):

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import aiounifi
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.unifi.config_flow import async_discover_unifi
 from homeassistant.components.unifi.const import (
     CONF_ALLOW_BANDWIDTH_SENSORS,
@@ -543,7 +543,6 @@ async def test_simple_option_flow(hass, aioclient_mock):
 
 async def test_form_ssdp(hass):
     """Test we get the form with ssdp source."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN,
@@ -571,7 +570,7 @@ async def test_form_ssdp(hass):
 
 async def test_form_ssdp_aborts_if_host_already_exists(hass):
     """Test we abort if the host is already configured."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=UNIFI_DOMAIN,
         data={"host": "192.168.208.1", "site": "site_id"},
@@ -593,7 +592,7 @@ async def test_form_ssdp_aborts_if_host_already_exists(hass):
 
 async def test_form_ssdp_aborts_if_serial_already_exists(hass):
     """Test we abort if the serial is already configured."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=UNIFI_DOMAIN,
         data={"controller": {"host": "1.2.3.4", "site": "site_id"}},
@@ -616,7 +615,7 @@ async def test_form_ssdp_aborts_if_serial_already_exists(hass):
 
 async def test_form_ssdp_gets_form_with_ignored_entry(hass):
     """Test we can still setup if there is an ignored entry."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=UNIFI_DOMAIN,
         data={"not_controller_key": None},

--- a/tests/components/upb/test_config_flow.py
+++ b/tests/components/upb/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, PropertyMock, patch
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.upb.const import DOMAIN
 
 
@@ -24,7 +24,7 @@ def mocked_upb(sync_complete=True, config_ok=True):
 
 async def valid_tcp_flow(hass, sync_complete=True, config_ok=True):
     """Get result dict that are standard for most tests."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with mocked_upb(sync_complete, config_ok), patch(
         "homeassistant.components.upb.async_setup_entry", return_value=True
     ):
@@ -40,7 +40,6 @@ async def valid_tcp_flow(hass, sync_complete=True, config_ok=True):
 
 async def test_full_upb_flow_with_serial_port(hass):
     """Test a full UPB config flow with serial port."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with mocked_upb(), patch(
         "homeassistant.components.upb.async_setup_entry", return_value=True
@@ -110,7 +109,6 @@ async def test_form_user_with_already_configured(hass):
 
 async def test_form_import(hass):
     """Test we get the form with import source."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with mocked_upb(), patch(
         "homeassistant.components.upb.async_setup_entry", return_value=True
@@ -131,7 +129,6 @@ async def test_form_import(hass):
 
 async def test_form_junk_input(hass):
     """Test we get the form with import source."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     with mocked_upb():
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/uptimerobot/test_config_flow.py
+++ b/tests/components/uptimerobot/test_config_flow.py
@@ -5,7 +5,7 @@ import pytest
 from pytest import LogCaptureFixture
 from pyuptimerobot import UptimeRobotAuthenticationException, UptimeRobotException
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.uptimerobot.const import DOMAIN
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
@@ -29,7 +29,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -3,14 +3,14 @@ from unittest.mock import Mock, patch
 
 import vilfo
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.vilfo.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, CONF_ID, CONF_MAC
 
 
 async def test_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     mock_mac = "FF-00-00-00-00-00"
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/watttime/test_config_flow.py
+++ b/tests/components/watttime/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 from aiowatttime.errors import CoordinatesNotFoundError, InvalidCredentialsError
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.watttime.config_flow import (
     CONF_LOCATION_TYPE,
     LOCATION_TYPE_COORDINATES,
@@ -121,7 +121,7 @@ async def test_step_coordinates_unknown_coordinates(
     hass: HomeAssistant, client_login
 ) -> None:
     """Test that providing coordinates with no data is handled."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER},
@@ -146,7 +146,7 @@ async def test_step_coordinates_unknown_error(
     hass: HomeAssistant, client_login
 ) -> None:
     """Test that providing coordinates with no data is handled."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER},
@@ -164,7 +164,7 @@ async def test_step_coordinates_unknown_error(
 
 async def test_step_login_coordinates(hass: HomeAssistant, client_login) -> None:
     """Test a full login flow (inputting custom coordinates)."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.watttime.async_setup_entry",
         return_value=True,
@@ -198,7 +198,7 @@ async def test_step_login_coordinates(hass: HomeAssistant, client_login) -> None
 
 async def test_step_user_home(hass: HomeAssistant, client_login) -> None:
     """Test a full login flow (selecting the home location)."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.watttime.async_setup_entry",
         return_value=True,
@@ -228,7 +228,7 @@ async def test_step_user_home(hass: HomeAssistant, client_login) -> None:
 
 async def test_step_user_invalid_credentials(hass: HomeAssistant) -> None:
     """Test that invalid credentials are handled."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.watttime.config_flow.Client.async_login",
         AsyncMock(side_effect=InvalidCredentialsError),
@@ -247,7 +247,7 @@ async def test_step_user_invalid_credentials(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize("get_grid_region", [AsyncMock(side_effect=Exception)])
 async def test_step_user_unknown_error(hass: HomeAssistant, client_login) -> None:
     """Test that an unknown error during the login step is handled."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     with patch(
         "homeassistant.components.watttime.config_flow.Client.async_login",
         AsyncMock(side_effect=Exception),

--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -9,7 +9,6 @@ from wled import Device as WLEDDevice
 from homeassistant.components.wled.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_MAC
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, load_fixture
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
@@ -18,7 +17,6 @@ from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 @pytest.fixture(autouse=True)
 async def mock_persistent_notification(hass: HomeAssistant) -> None:
     """Set up component for persistent notifications."""
-    await async_setup_component(hass, "persistent_notification", {})
 
 
 @pytest.fixture

--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -14,11 +14,6 @@ from tests.common import MockConfigEntry, load_fixture
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 
-@pytest.fixture(autouse=True)
-async def mock_persistent_notification(hass: HomeAssistant) -> None:
-    """Set up component for persistent notifications."""
-
-
 @pytest.fixture
 def mock_config_entry() -> MockConfigEntry:
     """Return the default mocked config entry."""

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -5,7 +5,7 @@ from httpcore import ConnectError
 from wolf_smartset.models import Device
 from wolf_smartset.token_auth import InvalidAuth
 
-from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.wolflink.const import (
     DEVICE_GATEWAY,
     DEVICE_ID,
@@ -34,7 +34,7 @@ DEVICE = Device(CONFIG[DEVICE_ID], CONFIG[DEVICE_GATEWAY], CONFIG[DEVICE_NAME])
 
 async def test_show_form(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -797,7 +797,7 @@ async def test_options_flow_incomplete(hass):
 
 async def test_reauth(hass):
     """Test a reauth flow."""
-    # await setup.async_setup_component(hass, "persistent_notification", {})
+    #
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
         unique_id=TEST_GATEWAY_ID,

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -797,7 +797,6 @@ async def test_options_flow_incomplete(hass):
 
 async def test_reauth(hass):
     """Test a reauth flow."""
-    #
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
         unique_id=TEST_GATEWAY_ID,

--- a/tests/components/yale_smart_alarm/test_config_flow.py
+++ b/tests/components/yale_smart_alarm/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 from yalesmartalarmclient.client import AuthenticationError
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.yale_smart_alarm.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.yeelight import (
     CONF_MODE_MUSIC,
     CONF_MODEL,
@@ -402,7 +402,6 @@ async def test_manual_no_capabilities(hass: HomeAssistant):
 
 async def test_discovered_by_homekit_and_dhcp(hass):
     """Test we get the form with homekit and abort for dhcp source when we get both."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_bulb = _mocked_bulb()
     with _patch_discovery(), _patch_discovery_interval(), patch(
@@ -471,7 +470,6 @@ async def test_discovered_by_homekit_and_dhcp(hass):
 )
 async def test_discovered_by_dhcp_or_homekit(hass, source, data):
     """Test we can setup when discovered from dhcp or homekit."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_bulb = _mocked_bulb()
     with _patch_discovery(), _patch_discovery_interval(), patch(
@@ -518,7 +516,6 @@ async def test_discovered_by_dhcp_or_homekit(hass, source, data):
 )
 async def test_discovered_by_dhcp_or_homekit_failed_to_get_id(hass, source, data):
     """Test we abort if we cannot get the unique id when discovered from dhcp or homekit."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_bulb = _mocked_bulb()
     with _patch_discovery(
@@ -535,7 +532,6 @@ async def test_discovered_by_dhcp_or_homekit_failed_to_get_id(hass, source, data
 
 async def test_discovered_ssdp(hass):
     """Test we can setup when discovered from ssdp."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_bulb = _mocked_bulb()
     with _patch_discovery(), _patch_discovery_interval(), patch(
@@ -581,7 +577,6 @@ async def test_discovered_ssdp(hass):
 
 async def test_discovered_zeroconf(hass):
     """Test we can setup when discovered from zeroconf."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_bulb = _mocked_bulb()
     with _patch_discovery(), _patch_discovery_interval(), patch(

--- a/tests/components/zerproc/test_config_flow.py
+++ b/tests/components/zerproc/test_config_flow.py
@@ -3,13 +3,13 @@ from unittest.mock import patch
 
 import pyzerproc
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.zerproc.config_flow import DOMAIN
 
 
 async def test_flow_success(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -41,7 +41,7 @@ async def test_flow_success(hass):
 
 async def test_flow_no_devices_found(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -71,7 +71,7 @@ async def test_flow_no_devices_found(hass):
 
 async def test_flow_exceptions_caught(hass):
     """Test we get the form."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import pyzerproc
 
-from homeassistant import setup
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
@@ -45,7 +44,6 @@ async def mock_entry(hass):
 @pytest.fixture
 async def mock_light(hass, mock_entry):
     """Create a mock light entity."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mock_entry.add_to_hass(hass)
 
@@ -72,7 +70,6 @@ async def mock_light(hass, mock_entry):
 
 async def test_init(hass, mock_entry):
     """Test platform setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mock_entry.add_to_hass(hass)
 
@@ -133,7 +130,6 @@ async def test_init(hass, mock_entry):
 
 async def test_discovery_exception(hass, mock_entry):
     """Test platform setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     mock_entry.add_to_hass(hass)
 

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -7,7 +7,7 @@ import serial.tools.list_ports
 import zigpy.config
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.ssdp import (
     ATTR_SSDP_LOCATION,
     ATTR_UPNP_MANUFACTURER_URL,
@@ -208,7 +208,7 @@ async def test_discovery_via_usb_no_radio(detect_mock, hass):
 @patch("zigpy_znp.zigbee.application.ControllerApplication.probe", return_value=True)
 async def test_discovery_via_usb_already_setup(detect_mock, hass):
     """Test usb flow -- already setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     MockConfigEntry(
         domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE_PATH: "/dev/ttyUSB1"}}
     ).add_to_hass(hass)
@@ -233,7 +233,7 @@ async def test_discovery_via_usb_already_setup(detect_mock, hass):
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 async def test_discovery_via_usb_path_changes(hass):
     """Test usb flow already setup and the path changes."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="AAAA:AAAA_1234_test_zigbee radio",
@@ -386,7 +386,7 @@ async def test_discovery_already_setup(detect_mock, hass):
         "hostname": "_tube_zb_gw._tcp.local.",
         "properties": {"name": "tube_123456"},
     }
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     MockConfigEntry(
         domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE_PATH: "/dev/ttyUSB1"}}
     ).add_to_hass(hass)
@@ -498,7 +498,7 @@ async def test_user_flow_existing_config_entry(hass):
     MockConfigEntry(
         domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE_PATH: "/dev/ttyUSB1"}}
     ).add_to_hass(hass)
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USER}
     )
@@ -599,7 +599,6 @@ async def test_user_port_config_fail(probe_mock, hass):
 @patch("bellows.zigbee.application.ControllerApplication.probe", return_value=True)
 async def test_user_port_config(probe_mock, hass):
     """Test port config."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -89,7 +89,6 @@ async def test_migration_from_v1_wrong_baudrate(hass, config_entry_v1):
 )
 async def test_config_depreciation(hass, zha_config):
     """Test config option depreciation."""
-    await async_setup_component(hass, "persistent_notification", {})
 
     with patch(
         "homeassistant.components.zha.async_setup", return_value=True

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -6,7 +6,7 @@ import aiohttp
 import pytest
 from zwave_js_server.version import VersionInfo
 
-from homeassistant import config_entries, setup
+from homeassistant import config_entries
 from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.zwave_js.config_flow import SERVER_VERSION_TIMEOUT, TITLE
 from homeassistant.components.zwave_js.const import DOMAIN
@@ -46,12 +46,6 @@ CP2652_ZIGBEE_DISCOVERY_INFO = {
     "description": "cp2652",
     "manufacturer": "generic",
 }
-
-
-@pytest.fixture(name="persistent_notification", autouse=True)
-async def setup_persistent_notification(hass):
-    """Set up persistent notification integration."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
 
 @pytest.fixture(name="setup_entry")
@@ -139,7 +133,7 @@ def mock_addon_setup_time():
 
 async def test_manual(hass):
     """Test we create an entry with manual step."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -251,7 +245,6 @@ async def test_manual_already_configured(hass):
     )
     entry.add_to_hass(hass)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -278,7 +271,6 @@ async def test_supervisor_discovery(
     hass, supervisor, addon_running, addon_options, get_addon_discovery_info
 ):
     """Test flow started from Supervisor discovery."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     addon_options["device"] = "/test"
     addon_options["s0_legacy_key"] = "new123"
@@ -325,7 +317,6 @@ async def test_supervisor_discovery_cannot_connect(
     hass, supervisor, get_addon_discovery_info
 ):
     """Test Supervisor discovery and cannot connect."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -342,7 +333,6 @@ async def test_clean_discovery_on_user_create(
     hass, supervisor, addon_running, addon_options, get_addon_discovery_info
 ):
     """Test discovery flow is cleaned up when a user flow is finished."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     addon_options["device"] = "/test"
     addon_options["s0_legacy_key"] = "new123"
@@ -407,7 +397,6 @@ async def test_abort_discovery_with_existing_entry(
     hass, supervisor, addon_running, addon_options
 ):
     """Test discovery flow is aborted if an entry already exists."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     entry = MockConfigEntry(
         domain=DOMAIN, data={"url": "ws://localhost:3000"}, title=TITLE, unique_id=1234
@@ -635,7 +624,6 @@ async def test_discovery_addon_not_running(
 ):
     """Test discovery with add-on already installed but not running."""
     addon_options["device"] = None
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -718,7 +706,6 @@ async def test_discovery_addon_not_installed(
 ):
     """Test discovery with add-on not installed."""
     addon_installed.return_value["version"] = None
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -876,7 +863,6 @@ async def test_abort_usb_discovery_aborts_specific_devices(
 
 async def test_not_addon(hass, supervisor):
     """Test opting out of add-on on Supervisor."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -936,7 +922,6 @@ async def test_addon_running(
     addon_options["s2_access_control_key"] = "new456"
     addon_options["s2_authenticated_key"] = "new789"
     addon_options["s2_unauthenticated_key"] = "new987"
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -1017,7 +1002,6 @@ async def test_addon_running_failures(
     """Test all failures when add-on is running."""
     addon_options["device"] = "/test"
     addon_options["network_key"] = "abc123"
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -1060,7 +1044,6 @@ async def test_addon_running_already_configured(
     )
     entry.add_to_hass(hass)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -1093,7 +1076,6 @@ async def test_addon_installed(
     get_addon_discovery_info,
 ):
     """Test add-on already installed but not running on Supervisor."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -1179,7 +1161,6 @@ async def test_addon_installed_start_failure(
     get_addon_discovery_info,
 ):
     """Test add-on start failure when add-on is installed."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -1255,7 +1236,6 @@ async def test_addon_installed_failures(
     get_addon_discovery_info,
 ):
     """Test all failures when add-on is installed."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -1322,7 +1302,6 @@ async def test_addon_installed_set_options_failure(
     get_addon_discovery_info,
 ):
     """Test all failures when add-on is installed."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -1396,7 +1375,6 @@ async def test_addon_installed_already_configured(
     )
     entry.add_to_hass(hass)
 
-    await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -1467,7 +1445,6 @@ async def test_addon_not_installed(
 ):
     """Test add-on not installed."""
     addon_installed.return_value["version"] = None
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -1553,7 +1530,6 @@ async def test_install_addon_failure(hass, supervisor, addon_installed, install_
     """Test add-on install failure."""
     addon_installed.return_value["version"] = None
     install_addon.side_effect = HassioAPIError()
-    await setup.async_setup_component(hass, "persistent_notification", {})
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.generated import config_flows
 from homeassistant.helpers import translation
 from homeassistant.loader import async_get_integration
-from homeassistant.setup import async_setup_component, setup_component
+from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture
@@ -202,7 +202,7 @@ async def test_get_translations_while_loading_components(hass):
         nonlocal load_count
         load_count += 1
         # Mimic race condition by loading a component during setup
-        setup_component(hass, "persistent_notification", {})
+
         return {"component1": {"title": "world"}}
 
     with patch(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -673,7 +673,6 @@ async def test_discovery_notification(hass):
     """Test that we create/dismiss a notification when source is discovery."""
     mock_integration(hass, MockModule("test"))
     mock_entity_platform(hass, "config_flow.test", None)
-    await async_setup_component(hass, "persistent_notification", {})
 
     with patch.dict(config_entries.HANDLERS):
 
@@ -726,7 +725,6 @@ async def test_reauth_notification(hass):
     """Test that we create/dismiss a notification when source is reauth."""
     mock_integration(hass, MockModule("test"))
     mock_entity_platform(hass, "config_flow.test", None)
-    await async_setup_component(hass, "persistent_notification", {})
 
     with patch.dict(config_entries.HANDLERS):
 
@@ -794,7 +792,6 @@ async def test_discovery_notification_not_created(hass):
     """Test that we not create a notification when discovery is aborted."""
     mock_integration(hass, MockModule("test"))
     mock_entity_platform(hass, "config_flow.test", None)
-    await async_setup_component(hass, "persistent_notification", {})
 
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -1002,7 +999,6 @@ async def test_create_entry_options(hass):
         ),
     )
     mock_entity_platform(hass, "config_flow.comp", None)
-    await async_setup_component(hass, "persistent_notification", {})
 
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -2199,7 +2195,6 @@ async def test_partial_flows_hidden(hass, manager):
     async_setup_entry = AsyncMock(return_value=True)
     mock_integration(hass, MockModule("comp", async_setup_entry=async_setup_entry))
     mock_entity_platform(hass, "config_flow.comp", None)
-    await async_setup_component(hass, "persistent_notification", {})
 
     # A flag to test our assertion that `async_step_discovery` was called and is in its blocked state
     # This simulates if the step was e.g. doing network i/o
@@ -2275,7 +2270,6 @@ async def test_async_setup_init_entry(hass):
         ),
     )
     mock_entity_platform(hass, "config_flow.comp", None)
-    await async_setup_component(hass, "persistent_notification", {})
 
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -2328,7 +2322,6 @@ async def test_async_setup_update_entry(hass):
         ),
     )
     mock_entity_platform(hass, "config_flow.comp", None)
-    await async_setup_component(hass, "persistent_notification", {})
 
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -2916,8 +2909,6 @@ async def test__async_abort_entries_match(hass, manager, matchers, reason):
         source=config_entries.SOURCE_IGNORE,
         data={"ip": "7.7.7.7", "host": "4.5.6.7", "port": 23},
     ).add_to_hass(hass)
-
-    await async_setup_component(hass, "persistent_notification", {})
 
     mock_setup_entry = AsyncMock(return_value=True)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -7,7 +7,7 @@ from homeassistant import core, loader
 from homeassistant.components import http, hue
 from homeassistant.components.hue import light as hue_light
 
-from tests.common import MockModule, async_mock_service, mock_integration
+from tests.common import MockModule, mock_integration
 
 
 async def test_component_dependencies(hass):
@@ -69,13 +69,10 @@ def test_component_loader_non_existing(hass):
 
 async def test_component_wrapper(hass):
     """Test component wrapper."""
-    calls = async_mock_service(hass, "persistent_notification", "create")
-
     components = loader.Components(hass)
     components.persistent_notification.async_create("message")
-    await hass.async_block_till_done()
 
-    assert len(calls) == 1
+    assert len(hass.states.async_entity_ids("persistent_notification")) == 1
 
 
 async def test_helpers_wrapper(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

**For developers:** It is deprecated to pass template strings to the `persistent_notification.async_create` method via Python (this is not the service). 


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Persistent notifications still used the old (old old) approach of having functions call services to do the work. This meant that a lot of services got called, especially as we started to add more and more discovery. @bdraco started noticing it in his traces. This removes that logic and bypasses the services. This is the same approach as we have done in basically all other cases where we had this pattern.

I also took the liberty to:
 - Convert the tests to async (first commit)
 - Type the integration

Because we no longer route all data via services, it's no longer processing the input data as templates when called directly from another integration. This has been deprecated and a warning is logged.

The sync methods to create notifications have also been deprecated.

Fixes #56853
Fixes #56710

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
