### PR TITLE
Allow resetting an MQTT number

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -134,6 +134,7 @@ ABBREVIATIONS = {
     "pl_osc_off": "payload_oscillation_off",
     "pl_osc_on": "payload_oscillation_on",
     "pl_paus": "payload_pause",
+    "pl_rst": "payload_reset",
     "pl_rst_hum": "payload_reset_humidity",
     "pl_rst_mode": "payload_reset_mode",
     "pl_rst_pct": "payload_reset_percentage",

--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -35,10 +35,12 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_MIN = "min"
 CONF_MAX = "max"
+CONF_PAYLOAD_RESET = "payload_reset"
 CONF_STEP = "step"
 
 DEFAULT_NAME = "MQTT Number"
 DEFAULT_OPTIMISTIC = False
+DEFAULT_PAYLOAD_RESET = "None"
 
 MQTT_NUMBER_ATTRIBUTES_BLOCKED = frozenset(
     {
@@ -64,6 +66,7 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(CONF_MIN, default=DEFAULT_MIN_VALUE): vol.Coerce(float),
             vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
             vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
+            vol.Optional(CONF_PAYLOAD_RESET, default=DEFAULT_PAYLOAD_RESET): cv.string,
             vol.Optional(CONF_STEP, default=DEFAULT_STEP): vol.All(
                 vol.Coerce(float), vol.Range(min=1e-3)
             ),
@@ -138,7 +141,9 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
             if value_template is not None:
                 payload = value_template.async_render_with_possible_json_value(payload)
             try:
-                if payload.isnumeric():
+                if payload == self._config[CONF_PAYLOAD_RESET]:
+                    num_value = None
+                elif payload.isnumeric():
                     num_value = int(payload)
                 else:
                     num_value = float(payload)
@@ -146,7 +151,9 @@ class MqttNumber(MqttEntity, NumberEntity, RestoreEntity):
                 _LOGGER.warning("Payload '%s' is not a Number", msg.payload)
                 return
 
-            if num_value < self.min_value or num_value > self.max_value:
+            if num_value is not None and (
+                num_value < self.min_value or num_value > self.max_value
+            ):
                 _LOGGER.error(
                     "Invalid value for %s: %s (range %s - %s)",
                     self.entity_id,

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -66,6 +66,7 @@ async def test_run_number_setup(hass, mqtt_mock):
                 "state_topic": topic,
                 "command_topic": topic,
                 "name": "Test Number",
+                "payload_reset": "reset!",
             }
         },
     )
@@ -84,6 +85,13 @@ async def test_run_number_setup(hass, mqtt_mock):
 
     state = hass.states.get("number.test_number")
     assert state.state == "20.5"
+
+    async_fire_mqtt_message(hass, topic, "reset!")
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test_number")
+    assert state.state == "unknown"
 
 
 async def test_value_template(hass, mqtt_mock):
@@ -117,6 +125,13 @@ async def test_value_template(hass, mqtt_mock):
 
     state = hass.states.get("number.test_number")
     assert state.state == "20.5"
+
+    async_fire_mqtt_message(hass, topic, '{"val":null}')
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test_number")
+    assert state.state == "unknown"
 
 
 async def test_run_number_service_optimistic(hass, mqtt_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow resetting an MQTT number to `None`.

The number will be reset if a configurable special payload, `payload_reset` is received.
`payload_reset` defaults to `None` meaning a value template returning `"None"` will reset the number to `None`.


Example where the payload is JSON:
```yaml
            "number": {
                "platform": "mqtt",
                "state_topic": topic,
                "command_topic": topic,
                "name": "Test Number",
                "value_template": "{{ value_json.val }}",
            }
```

Receiving `{"val":null}` will reset the number to `None`.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19644

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
