### PR TITLE
Convert val to str when needed while calling zwave_js.set_value

### DIFF
--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -426,16 +426,19 @@ class ZWaveServices:
                 property_key=property_key,
             )
             # If value has a string type but the new value is not a string, we need to
-            # convert it to one
+            # convert it to one. We use new variable `new_value_` to convert the data
+            # so we can preserve the original `new_value` for every node.
             if (
                 value_id in node.values
                 and node.values[value_id].metadata.type == "string"
                 and not isinstance(new_value, str)
             ):
-                new_value = str(new_value)
+                new_value_ = str(new_value)
+            else:
+                new_value_ = new_value
             success = await node.async_set_value(
                 value_id,
-                new_value,
+                new_value_,
                 options=options,
                 wait_for_result=wait_for_result,
             )

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -408,7 +408,7 @@ class ZWaveServices:
     async def async_set_value(self, service: ServiceCall) -> None:
         """Set a value on a node."""
         # pylint: disable=no-self-use
-        nodes = service.data[const.ATTR_NODES]
+        nodes: set[ZwaveNode] = service.data[const.ATTR_NODES]
         command_class = service.data[const.ATTR_COMMAND_CLASS]
         property_ = service.data[const.ATTR_PROPERTY]
         property_key = service.data.get(const.ATTR_PROPERTY_KEY)
@@ -418,14 +418,23 @@ class ZWaveServices:
         options = service.data.get(const.ATTR_OPTIONS)
 
         for node in nodes:
+            value_id = get_value_id(
+                node,
+                command_class,
+                property_,
+                endpoint=endpoint,
+                property_key=property_key,
+            )
+            # If value has a string type but the new value is not a string, we need to
+            # convert it to one
+            if (
+                value_id in node.values
+                and node.values[value_id].metadata.type == "string"
+                and not isinstance(new_value, str)
+            ):
+                new_value = str(new_value)
             success = await node.async_set_value(
-                get_value_id(
-                    node,
-                    command_class,
-                    property_,
-                    endpoint=endpoint,
-                    property_key=property_key,
-                ),
+                value_id,
                 new_value,
                 options=options,
                 wait_for_result=wait_for_result,
@@ -452,11 +461,16 @@ class ZWaveServices:
             await self.async_set_value(service)
             return
 
+        command_class = service.data[const.ATTR_COMMAND_CLASS]
+        property_ = service.data[const.ATTR_PROPERTY]
+        property_key = service.data.get(const.ATTR_PROPERTY_KEY)
+        endpoint = service.data.get(const.ATTR_ENDPOINT)
+
         value = {
-            "commandClass": service.data[const.ATTR_COMMAND_CLASS],
-            "property": service.data[const.ATTR_PROPERTY],
-            "propertyKey": service.data.get(const.ATTR_PROPERTY_KEY),
-            "endpoint": service.data.get(const.ATTR_ENDPOINT),
+            "commandClass": command_class,
+            "property": property_,
+            "propertyKey": property_key,
+            "endpoint": endpoint,
         }
         new_value = service.data[const.ATTR_VALUE]
 
@@ -464,12 +478,30 @@ class ZWaveServices:
         # schema validation and can use that to get the client, otherwise we can just
         # get the client from the node.
         client: ZwaveClient = None
-        first_node = next((node for node in nodes), None)
+        first_node: ZwaveNode = next((node for node in nodes), None)
         if first_node:
             client = first_node.client
         else:
             entry_id = self._hass.config_entries.async_entries(const.DOMAIN)[0].entry_id
             client = self._hass.data[const.DOMAIN][entry_id][const.DATA_CLIENT]
+            first_node = next(
+                node
+                for node in client.driver.controller.nodes.values()
+                if get_value_id(node, command_class, property_, endpoint, property_key)
+                in node.values
+            )
+
+        # If value has a string type but the new value is not a string, we need to
+        # convert it to one
+        value_id = get_value_id(
+            first_node, command_class, property_, endpoint, property_key
+        )
+        if (
+            value_id in first_node.values
+            and first_node.values[value_id].metadata.type == "string"
+            and not isinstance(new_value, str)
+        ):
+            new_value = str(new_value)
 
         success = await async_multicast_set_value(
             client=client,


### PR DESCRIPTION
## Proposed change
Our services `set_value` and `multicast_set_value` first attempt to convert input values to numbers before accepting them as strings, and if they can be coerced into a number, the service assumed that was the intention. From #57154 there are cases where a number can appear to be a number but should be sent to the driver as a string.

In this PR, we check the metadata of the Z-Wave value that we are setting the value of to see the data type and convert the input back to a string if needed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #57154
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
