### PR TITLE
Correct SQL query generated by get_metadata_with_session

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -13,6 +13,7 @@ from sqlalchemy import bindparam, func
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext import baked
 from sqlalchemy.orm.scoping import scoped_session
+from sqlalchemy.sql.expression import true
 
 from homeassistant.const import (
     PRESSURE_PA,
@@ -396,9 +397,9 @@ def get_metadata_with_session(
             StatisticsMeta.statistic_id.in_(bindparam("statistic_ids"))
         )
     if statistic_type == "mean":
-        baked_query += lambda q: q.filter(StatisticsMeta.has_mean == True)  # noqa: E712
+        baked_query += lambda q: q.filter(StatisticsMeta.has_mean == true())
     elif statistic_type == "sum":
-        baked_query += lambda q: q.filter(StatisticsMeta.has_sum == True)  # noqa: E712
+        baked_query += lambda q: q.filter(StatisticsMeta.has_sum == true())
     result = execute(baked_query(session).params(statistic_ids=statistic_ids))
     if not result:
         return {}

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -396,9 +396,9 @@ def get_metadata_with_session(
             StatisticsMeta.statistic_id.in_(bindparam("statistic_ids"))
         )
     if statistic_type == "mean":
-        baked_query += lambda q: q.filter(StatisticsMeta.has_mean.isnot(False))
+        baked_query += lambda q: q.filter(StatisticsMeta.has_mean == True)  # noqa: E712
     elif statistic_type == "sum":
-        baked_query += lambda q: q.filter(StatisticsMeta.has_sum.isnot(False))
+        baked_query += lambda q: q.filter(StatisticsMeta.has_sum == True)  # noqa: E712
     result = execute(baked_query(session).params(statistic_ids=statistic_ids))
     if not result:
         return {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correct SQL query generated by get_metadata_with_session

The generated query is changed from:
```sql
SELECT statistics_meta.id AS statistics_meta_id, statistics_meta.statistic_id AS statistics_meta_statistic_id, statistics_meta.unit_of_measurement AS statistics_meta_unit_of_measurement, statistics_meta.has_mean AS statistics_meta_has_mean, statistics_meta.has_sum AS statistics_meta_has_sum
FROM statistics_meta
WHERE statistics_meta.has_sum IS NOT 0
```

To:
```sql
SELECT statistics_meta.id AS statistics_meta_id, statistics_meta.statistic_id AS statistics_meta_statistic_id, statistics_meta.unit_of_measurement AS statistics_meta_unit_of_measurement, statistics_meta.has_mean AS statistics_meta_has_mean, statistics_meta.has_sum AS statistics_meta_has_sum
FROM statistics_meta
WHERE statistics_meta.has_sum = 1
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/57194

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
