### PR TITLE
Fix RGB only (no color temp) devices with tplink

### DIFF
--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -145,7 +145,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     def color_mode(self) -> str | None:
         """Return the active color mode."""
         if self.device.is_color:
-            if self.device.color_temp:
+            if self.device.is_variable_color_temp and self.device.color_temp:
                 return COLOR_MODE_COLOR_TEMP
             return COLOR_MODE_HS
         if self.device.is_variable_color_temp:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Fixes
```
2021-10-07 08:38:37 ERROR (MainThread) [homeassistant.components.light] Error while setting up tplink platform for light
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity_platform.py", line 257, in _async_setup_platform
    await asyncio.gather(*pending)
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity_platform.py", line 382, in async_add_entities
    await asyncio.gather(*tasks)
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity_platform.py", line 587, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity.py", line 682, in add_to_platform_finish
    self.async_write_ha_state()
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity.py", line 456, in async_write_ha_state
    self._async_write_ha_state()
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity.py", line 491, in _async_write_ha_state
    attr.update(self.state_attributes or {})
  File "/Users/bdraco/home-assistant/homeassistant/components/light/__init__.py", line 854, in state_attributes
    color_mode = self._light_internal_color_mode
  File "/Users/bdraco/home-assistant/homeassistant/components/light/__init__.py", line 682, in _light_internal_color_mode
    color_mode = self.color_mode
  File "/Users/bdraco/home-assistant/homeassistant/components/tplink/light.py", line 148, in color_mode
    if self.device.color_temp:
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/kasa/smartdevice.py", line 87, in wrapped
    return f(*args, **kwargs)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/kasa/smartbulb.py", line 281, in color_temp
    raise SmartDeviceException("Bulb does not support colortemp.")
kasa.exceptions.SmartDeviceException: Bulb does not support colortemp.

```



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
