### PR TITLE
Add events to Datadog and change metric name

### DIFF
--- a/homeassistant/components/datadog/__init__.py
+++ b/homeassistant/components/datadog/__init__.py
@@ -76,16 +76,21 @@ def setup(hass, config):
             return
 
         states = dict(state.attributes)
-        metric = f"{prefix}.{state.domain}"
-        tags = [f"entity:{state.entity_id}"]
+        metric = f"{prefix}.{state.entity_id}"
+        tags = [f"entity:{state.entity_id}", f"domain:{state.domain}"]
 
         for key, value in states.items():
             if isinstance(value, (float, int)):
-                attribute = f"{metric}.{key.replace(' ', '_')}"
+                name = f"{metric}.{key.replace(' ', '_')}"
                 value = int(value) if isinstance(value, bool) else value
-                statsd.gauge(attribute, value, sample_rate=sample_rate, tags=tags)
+                statsd.gauge(
+                    name,
+                    value,
+                    sample_rate=sample_rate,
+                    tags=tags + [f"attribute:{key}"],
+                )
 
-                _LOGGER.debug("Sent metric %s: %s (tags: %s)", attribute, value, tags)
+                _LOGGER.debug("Sent metric %s: %s (tags: %s)", name, value, tags)
 
         # If the state can be expressed as number, send the value as a gauge,
         # otherwise, create a datadog event.

--- a/tests/components/datadog/test_init.py
+++ b/tests/components/datadog/test_init.py
@@ -128,7 +128,7 @@ async def test_state_changed(hass):
         for in_, out in valid.items():
             state = mock.MagicMock(
                 domain="sensor",
-                entity_id="sensor.foo.bar",
+                entity_id="foo.bar",
                 state=in_,
                 attributes=attributes,
             )
@@ -141,19 +141,23 @@ async def test_state_changed(hass):
                 mock_statsd.gauge.assert_has_calls(
                     [
                         mock.call(
-                            f"ha.sensor.{attribute}",
+                            f"ha.foo.bar.{attribute}",
                             value,
                             sample_rate=1,
-                            tags=[f"entity:{state.entity_id}"],
+                            tags=[
+                                f"entity:{state.entity_id}",
+                                f"domain:{state.domain}",
+                                f"attribute:{attribute}",
+                            ],
                         )
                     ]
                 )
 
             assert mock_statsd.gauge.call_args == mock.call(
-                "ha.sensor",
+                "ha.foo.bar",
                 out,
                 sample_rate=1,
-                tags=[f"entity:{state.entity_id}"],
+                tags=[f"entity:{state.entity_id}", f"domain:{state.domain}"],
             )
 
             mock_statsd.gauge.reset_mock()

--- a/tests/components/datadog/test_init.py
+++ b/tests/components/datadog/test_init.py
@@ -163,3 +163,4 @@ async def test_state_changed(hass):
                 mock.MagicMock(data={"new_state": ha.State("domain.test", invalid, {})})
             )
             assert not mock_statsd.gauge.called
+            assert mock_statsd.event.called


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
- Metric names are now `prefix.entity_id.state_attribute` (e.g. `hass.sun.rising` instead of `hass.sensor` with entity as a tag)
- entity_id, domain and state_attribute are now tags 

This means that you'll have to recreate dashboards and the like.

## Proposed change
<!--
Describe the big picture of your changes here to communicate to the   maintainers why we should accept this pull request. If it fixes a bug  or resolves a feature request, be sure to link to that issue in the additional information section.
-->
This PR adds events to Datadog for non-numerical state changes. Before, changes like "weather: cloudy" would be ignored, since they can't be expressed as a number. But now anything that isn't a number is captured as a datadog event.

Additionally this PR changes Datadog metric names to include the entity_id in order to correctly use metrics in datadog.
Before this commit metrics were named based on their domain, like `hass.sensor` or `hass.switch` and `entity_id`s were only expressed as tags. This however is somewhat incorrect, since in datadog a metic can have a type (gauge, rate or count) and a unit (like bits/second or ampere). Having all switches or all sensors express the same metric and distinguish makes it impossible to define a unit and type.

This commit refactors the datadog integration into the following:
- Metric names are now `prefix.entity_id.state_attribute` (e.g. `hass.sun.rising` instead of `hass.sensor` with entity as a tag)
- entity_id, domain and state_attribute are now tags 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
