### PR TITLE
2021.10.1

### DIFF
--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "requirements": [
-    "home-assistant-frontend==20211006.0"
+    "home-assistant-frontend==20211007.0"
   ],
   "dependencies": [
     "api",

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
   "requirements": [
-    "HAP-python==4.2.1",
+    "HAP-python==4.3.0",
     "fnvhash==0.1.0",
     "PyQRCode==1.2.1",
     "base36==0.1.1"

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -81,6 +81,30 @@ def has_date_or_time(conf):
     raise vol.Invalid("Entity needs at least a date or a time")
 
 
+def valid_initial(conf):
+    """Check the initial value is valid."""
+    initial = conf.get(CONF_INITIAL)
+    if not initial:
+        return conf
+
+    if conf[CONF_HAS_DATE] and conf[CONF_HAS_TIME]:
+        parsed_value = dt_util.parse_datetime(initial)
+        if parsed_value is not None:
+            return conf
+        raise vol.Invalid(f"Initial value '{initial}' can't be parsed as a datetime")
+
+    if conf[CONF_HAS_DATE]:
+        parsed_value = dt_util.parse_date(initial)
+        if parsed_value is not None:
+            return conf
+        raise vol.Invalid(f"Initial value '{initial}' can't be parsed as a date")
+
+    parsed_value = dt_util.parse_time(initial)
+    if parsed_value is not None:
+        return conf
+    raise vol.Invalid(f"Initial value '{initial}' can't be parsed as a time")
+
+
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: cv.schema_with_slug_keys(
@@ -93,6 +117,7 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Optional(CONF_INITIAL): cv.string,
                 },
                 has_date_or_time,
+                valid_initial,
             )
         )
     },

--- a/homeassistant/components/mill/manifest.json
+++ b/homeassistant/components/mill/manifest.json
@@ -2,7 +2,7 @@
   "domain": "mill",
   "name": "Mill",
   "documentation": "https://www.home-assistant.io/integrations/mill",
-  "requirements": ["millheater==0.6.0"],
+  "requirements": ["millheater==0.6.1"],
   "codeowners": ["@danielhiversen"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -4,6 +4,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
+    DOMAIN as DEVICE_TRACKER_DOMAIN,
     PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
     SOURCE_TYPE_ROUTER,
 )
@@ -50,7 +51,7 @@ async def async_get_scanner(hass, config):
         hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_IMPORT},
-            data=config,
+            data=config[DEVICE_TRACKER_DOMAIN],
         )
     )
 

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -13,6 +13,7 @@ from sqlalchemy import bindparam, func
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext import baked
 from sqlalchemy.orm.scoping import scoped_session
+from sqlalchemy.sql.expression import true
 
 from homeassistant.const import (
     PRESSURE_PA,
@@ -396,9 +397,9 @@ def get_metadata_with_session(
             StatisticsMeta.statistic_id.in_(bindparam("statistic_ids"))
         )
     if statistic_type == "mean":
-        baked_query += lambda q: q.filter(StatisticsMeta.has_mean.isnot(False))
+        baked_query += lambda q: q.filter(StatisticsMeta.has_mean == true())
     elif statistic_type == "sum":
-        baked_query += lambda q: q.filter(StatisticsMeta.has_sum.isnot(False))
+        baked_query += lambda q: q.filter(StatisticsMeta.has_sum == true())
     result = execute(baked_query(session).params(statistic_ids=statistic_ids))
     if not result:
         return {}

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -145,7 +145,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     def color_mode(self) -> str | None:
         """Return the active color mode."""
         if self.device.is_color:
-            if self.device.color_temp:
+            if self.device.is_variable_color_temp and self.device.color_temp:
                 return COLOR_MODE_COLOR_TEMP
             return COLOR_MODE_HS
         if self.device.is_variable_color_temp:

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -63,7 +63,9 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     @async_refresh_after
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
-        transition = kwargs.get(ATTR_TRANSITION)
+        if (transition := kwargs.get(ATTR_TRANSITION)) is not None:
+            transition = int(transition * 1_000)
+
         if (brightness := kwargs.get(ATTR_BRIGHTNESS)) is not None:
             brightness = round((brightness * 100.0) / 255.0)
 
@@ -92,7 +94,9 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
     @async_refresh_after
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
-        await self.device.turn_off(transition=kwargs.get(ATTR_TRANSITION))
+        if (transition := kwargs.get(ATTR_TRANSITION)) is not None:
+            transition = int(transition * 1_000)
+        await self.device.turn_off(transition=transition)
 
     @property
     def min_mireds(self) -> int:

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -69,6 +69,14 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         if (brightness := kwargs.get(ATTR_BRIGHTNESS)) is not None:
             brightness = round((brightness * 100.0) / 255.0)
 
+        if self.device.is_dimmer and transition is None:
+            # This is a stopgap solution for inconsistent set_brightness handling
+            # in the upstream library, see #57265.
+            # This should be removed when the upstream has fixed the issue.
+            # The device logic is to change the settings without turning it on
+            # except when transition is defined, so we leverage that here for now.
+            transition = 1
+
         # Handle turning to temp mode
         if ATTR_COLOR_TEMP in kwargs:
             color_tmp = mired_to_kelvin(int(kwargs[ATTR_COLOR_TEMP]))

--- a/homeassistant/components/xiaomi_miio/select.py
+++ b/homeassistant/components/xiaomi_miio/select.py
@@ -146,10 +146,14 @@ class XiaomiAirHumidifierSelector(XiaomiSelector):
     @callback
     def _handle_coordinator_update(self):
         """Fetch state from the device."""
-        self._current_led_brightness = self._extract_value_from_attribute(
+        led_brightness = self._extract_value_from_attribute(
             self.coordinator.data, self.entity_description.key
         )
-        self.async_write_ha_state()
+        # Sometimes (quite rarely) the device returns None as the LED brightness so we
+        # check that the value is not None before updating the state.
+        if led_brightness:
+            self._current_led_brightness = led_brightness
+            self.async_write_ha_state()
 
     @property
     def current_option(self):

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -2,7 +2,7 @@
   "domain": "yeelight",
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
-  "requirements": ["yeelight==0.7.6", "async-upnp-client==0.22.5"],
+  "requirements": ["yeelight==0.7.7", "async-upnp-client==0.22.5"],
   "codeowners": ["@rytilahti", "@zewelor", "@shenxn", "@starkillerOG"],
   "config_flow": true,
   "dependencies": ["network"],

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 10
-PATCH_VERSION: Final = "0"
+PATCH_VERSION: Final = "1"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -15,7 +15,7 @@ ciso8601==2.2.0
 cryptography==3.4.8
 emoji==1.5.0
 hass-nabucasa==0.50.0
-home-assistant-frontend==20211006.0
+home-assistant-frontend==20211007.0
 httpx==0.19.0
 ifaddr==0.1.7
 jinja2==3.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1005,7 +1005,7 @@ micloud==0.3
 miflora==0.7.0
 
 # homeassistant.components.mill
-millheater==0.6.0
+millheater==0.6.1
 
 # homeassistant.components.minio
 minio==4.0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2459,7 +2459,7 @@ yalesmartalarmclient==0.3.4
 yalexs==1.1.13
 
 # homeassistant.components.yeelight
-yeelight==0.7.6
+yeelight==0.7.7
 
 # homeassistant.components.yeelightsunflower
 yeelightsunflower==0.0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -810,7 +810,7 @@ hole==0.5.1
 holidays==0.11.3.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20211006.0
+home-assistant-frontend==20211007.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -14,7 +14,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.1.1
 
 # homeassistant.components.homekit
-HAP-python==4.2.1
+HAP-python==4.3.0
 
 # homeassistant.components.mastodon
 Mastodon.py==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -485,7 +485,7 @@ hole==0.5.1
 holidays==0.11.3.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20211006.0
+home-assistant-frontend==20211007.0
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1403,7 +1403,7 @@ yalesmartalarmclient==0.3.4
 yalexs==1.1.13
 
 # homeassistant.components.yeelight
-yeelight==0.7.6
+yeelight==0.7.7
 
 # homeassistant.components.youless
 youless-api==0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -585,7 +585,7 @@ mficlient==0.3.0
 micloud==0.3
 
 # homeassistant.components.mill
-millheater==0.6.0
+millheater==0.6.1
 
 # homeassistant.components.minio
 minio==4.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 AEMET-OpenData==0.2.1
 
 # homeassistant.components.homekit
-HAP-python==4.2.1
+HAP-python==4.3.0
 
 # homeassistant.components.flick_electric
 PyFlick==0.0.2

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -297,7 +297,7 @@ async def test_fan_speed(hass, hk_driver, events):
     )
     await hass.async_add_executor_job(acc.char_speed.client_update_value, 42)
     await hass.async_block_till_done()
-    assert acc.char_speed.value == 42
+    assert acc.char_speed.value == 50
     assert acc.char_active.value == 1
 
     assert call_set_percentage[0]
@@ -309,7 +309,7 @@ async def test_fan_speed(hass, hk_driver, events):
     # Verify speed is preserved from off to on
     hass.states.async_set(entity_id, STATE_OFF, {ATTR_PERCENTAGE: 42})
     await hass.async_block_till_done()
-    assert acc.char_speed.value == 42
+    assert acc.char_speed.value == 50
     assert acc.char_active.value == 0
 
     hk_driver.set_characteristics(
@@ -325,7 +325,7 @@ async def test_fan_speed(hass, hk_driver, events):
         "mock_addr",
     )
     await hass.async_block_till_done()
-    assert acc.char_speed.value == 42
+    assert acc.char_speed.value == 50
     assert acc.char_active.value == 1
 
 

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -1,5 +1,7 @@
 """Test different accessory types: Media Players."""
 
+import pytest
+
 from homeassistant.components.homekit.const import (
     ATTR_KEY_NAME,
     ATTR_VALUE,
@@ -353,8 +355,9 @@ async def test_media_player_television(hass, hk_driver, events, caplog):
 
     hass.bus.async_listen(EVENT_HOMEKIT_TV_REMOTE_KEY_PRESSED, listener)
 
-    await hass.async_add_executor_job(acc.char_remote_key.client_update_value, 20)
-    await hass.async_block_till_done()
+    with pytest.raises(ValueError):
+        await hass.async_add_executor_job(acc.char_remote_key.client_update_value, 20)
+        await hass.async_block_till_done()
 
     await hass.async_add_executor_job(acc.char_remote_key.client_update_value, 7)
     await hass.async_block_till_done()

--- a/tests/components/homekit/test_type_remote.py
+++ b/tests/components/homekit/test_type_remote.py
@@ -1,5 +1,7 @@
 """Test different accessory types: Remotes."""
 
+import pytest
+
 from homeassistant.components.homekit.const import (
     ATTR_KEY_NAME,
     ATTR_VALUE,
@@ -140,8 +142,9 @@ async def test_activity_remote(hass, hk_driver, events, caplog):
 
     hass.bus.async_listen(EVENT_HOMEKIT_TV_REMOTE_KEY_PRESSED, listener)
 
-    acc.char_remote_key.client_update_value(20)
-    await hass.async_block_till_done()
+    with pytest.raises(ValueError):
+        acc.char_remote_key.client_update_value(20)
+        await hass.async_block_till_done()
 
     acc.char_remote_key.client_update_value(7)
     await hass.async_block_till_done()

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -1746,11 +1746,7 @@ async def test_water_heater(hass, hk_driver, events):
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] == f"52.0{TEMP_CELSIUS}"
 
-    await hass.async_add_executor_job(acc.char_target_heat_cool.client_update_value, 0)
-    await hass.async_block_till_done()
-    assert acc.char_target_heat_cool.value == 1
-
-    await hass.async_add_executor_job(acc.char_target_heat_cool.client_update_value, 2)
+    await hass.async_add_executor_job(acc.char_target_heat_cool.client_update_value, 1)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -744,3 +744,30 @@ async def test_timestamp(hass):
 
     finally:
         dt_util.set_default_time_zone(ORIG_TIMEZONE)
+
+
+@pytest.mark.parametrize(
+    "config, error",
+    [
+        (
+            {"has_time": True, "has_date": True, "initial": "abc"},
+            "'abc' can't be parsed as a datetime",
+        ),
+        (
+            {"has_time": False, "has_date": True, "initial": "abc"},
+            "'abc' can't be parsed as a date",
+        ),
+        (
+            {"has_time": True, "has_date": False, "initial": "abc"},
+            "'abc' can't be parsed as a time",
+        ),
+    ],
+)
+async def test_invalid_initial(hass, caplog, config, error):
+    """Test configuration is rejected if the initial value is invalid."""
+    assert not await async_setup_component(
+        hass,
+        DOMAIN,
+        {DOMAIN: {"test_date": config}},
+    )
+    assert error in caplog.text

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -33,6 +33,7 @@ def _mocked_bulb() -> SmartBulb:
     bulb.is_color = True
     bulb.is_strip = False
     bulb.is_plug = False
+    bulb.is_dimmer = False
     bulb.hsv = (10, 30, 5)
     bulb.device_id = MAC_ADDRESS
     bulb.valid_temperature_range.min = 4000

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -1,27 +1,41 @@
 """Tests for the TP-Link component."""
 from __future__ import annotations
 
-from unittest.mock import patch
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
 
 from homeassistant.components import tplink
 from homeassistant.components.tplink.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from . import IP_ADDRESS, MAC_ADDRESS, _patch_discovery, _patch_single_discovery
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_configuring_tplink_causes_discovery(hass):
     """Test that specifying empty config does discovery."""
     with patch("homeassistant.components.tplink.Discover.discover") as discover:
-        discover.return_value = {"host": 1234}
+        discover.return_value = {MagicMock(): MagicMock()}
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
+        call_count = len(discover.mock_calls)
+        assert discover.mock_calls
 
-    assert len(discover.mock_calls) == 1
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+        assert len(discover.mock_calls) == call_count * 2
+
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=15))
+        await hass.async_block_till_done()
+        assert len(discover.mock_calls) == call_count * 3
+
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=30))
+        await hass.async_block_till_done()
+        assert len(discover.mock_calls) == call_count * 4
 
 
 async def test_config_entry_reload(hass):

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -1,5 +1,6 @@
 """Tests for light platform."""
 
+from typing import Optional
 from unittest.mock import PropertyMock
 
 import pytest
@@ -14,6 +15,7 @@ from homeassistant.components.light import (
     ATTR_MIN_MIREDS,
     ATTR_RGB_COLOR,
     ATTR_SUPPORTED_COLOR_MODES,
+    ATTR_TRANSITION,
     ATTR_XY_COLOR,
     DOMAIN as LIGHT_DOMAIN,
 )
@@ -45,8 +47,9 @@ async def test_light_unique_id(hass: HomeAssistant) -> None:
     assert entity_registry.async_get(entity_id).unique_id == "AABBCCDDEEFF"
 
 
-async def test_color_light(hass: HomeAssistant) -> None:
-    """Test a light."""
+@pytest.mark.parametrize("transition", [2.0, None])
+async def test_color_light(hass: HomeAssistant, transition: Optional[float]) -> None:
+    """Test a color light and that all transitions are correctly passed."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
     )
@@ -58,6 +61,11 @@ async def test_color_light(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entity_id = "light.my_bulb"
+    KASA_TRANSITION_VALUE = transition * 1_000 if transition is not None else None
+
+    BASE_PAYLOAD = {ATTR_ENTITY_ID: entity_id}
+    if transition:
+        BASE_PAYLOAD[ATTR_TRANSITION] = transition
 
     state = hass.states.get(entity_id)
     assert state.state == "on"
@@ -72,50 +80,52 @@ async def test_color_light(hass: HomeAssistant) -> None:
     assert attributes[ATTR_XY_COLOR] == (0.42, 0.336)
 
     await hass.services.async_call(
-        LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+        LIGHT_DOMAIN, "turn_off", BASE_PAYLOAD, blocking=True
     )
-    bulb.turn_off.assert_called_once()
+    bulb.turn_off.assert_called_once_with(transition=KASA_TRANSITION_VALUE)
 
-    await hass.services.async_call(
-        LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
-    )
-    bulb.turn_on.assert_called_once()
+    await hass.services.async_call(LIGHT_DOMAIN, "turn_on", BASE_PAYLOAD, blocking=True)
+    bulb.turn_on.assert_called_once_with(transition=KASA_TRANSITION_VALUE)
     bulb.turn_on.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
-        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
+        {**BASE_PAYLOAD, ATTR_BRIGHTNESS: 100},
         blocking=True,
     )
-    bulb.set_brightness.assert_called_with(39, transition=None)
+    bulb.set_brightness.assert_called_with(39, transition=KASA_TRANSITION_VALUE)
     bulb.set_brightness.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
-        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 150},
+        {**BASE_PAYLOAD, ATTR_COLOR_TEMP: 150},
         blocking=True,
     )
-    bulb.set_color_temp.assert_called_with(6666, brightness=None, transition=None)
+    bulb.set_color_temp.assert_called_with(
+        6666, brightness=None, transition=KASA_TRANSITION_VALUE
+    )
     bulb.set_color_temp.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
-        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 150},
+        {**BASE_PAYLOAD, ATTR_COLOR_TEMP: 150},
         blocking=True,
     )
-    bulb.set_color_temp.assert_called_with(6666, brightness=None, transition=None)
+    bulb.set_color_temp.assert_called_with(
+        6666, brightness=None, transition=KASA_TRANSITION_VALUE
+    )
     bulb.set_color_temp.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
-        {ATTR_ENTITY_ID: entity_id, ATTR_HS_COLOR: (10, 30)},
+        {**BASE_PAYLOAD, ATTR_HS_COLOR: (10, 30)},
         blocking=True,
     )
-    bulb.set_hsv.assert_called_with(10, 30, None, transition=None)
+    bulb.set_hsv.assert_called_with(10, 30, None, transition=KASA_TRANSITION_VALUE)
     bulb.set_hsv.reset_mock()
 
 


### PR DESCRIPTION
- Recreate the powerwall session/object when attempting relogin ([@bdraco] - [#56935]) ([powerwall docs])
- Update led brightness select state only if valid data is available, Xiaomi Miio integration ([@bieniu] - [#57197]) ([xiaomi_miio docs])
- Convert val to str when needed while calling zwave_js.set_value ([@raman325] - [#57216]) ([zwave_js docs])
- Discover tplink devices periodically ([@bdraco] - [#57221]) ([tplink docs])
- Correct SQL query generated by get_metadata_with_session ([@emontnemery] - [#57225]) ([recorder docs])
- Fix netgear config flow import ([@MartinHjelmare] - [#57253]) ([netgear docs])
- Validate initial value for input_datetime ([@emontnemery] - [#57256]) ([input_datetime docs])
- Bump Mill library to 0.6.1 ([@Danielhiversen] - [#57261]) ([mill docs])
- Fix RGB only (no color temp) devices with tplink ([@bdraco] - [#57267]) ([tplink docs])
- Update frontend to 20211007.0 ([@bramkragten] - [#57268]) ([frontend docs])
- Fix transition handling for tplink lights ([@rytilahti] - [#57272]) ([tplink docs])
- Bump HAP-python to 4.30 ([@bdraco] - [#57284]) ([homekit docs])
- Stopgap fix for inconsistent upstream API of tplink dimmers ([@rytilahti] - [#57285]) ([tplink docs])
- Bump yeelight to 0.7.7 ([@bdraco] - [#57290]) ([yeelight docs])

[#56935]: https://github.com/home-assistant/core/pull/56935
[#57197]: https://github.com/home-assistant/core/pull/57197
[#57216]: https://github.com/home-assistant/core/pull/57216
[#57221]: https://github.com/home-assistant/core/pull/57221
[#57225]: https://github.com/home-assistant/core/pull/57225
[#57253]: https://github.com/home-assistant/core/pull/57253
[#57256]: https://github.com/home-assistant/core/pull/57256
[#57261]: https://github.com/home-assistant/core/pull/57261
[#57267]: https://github.com/home-assistant/core/pull/57267
[#57268]: https://github.com/home-assistant/core/pull/57268
[#57272]: https://github.com/home-assistant/core/pull/57272
[#57284]: https://github.com/home-assistant/core/pull/57284
[#57285]: https://github.com/home-assistant/core/pull/57285
[#57290]: https://github.com/home-assistant/core/pull/57290
[@Danielhiversen]: https://github.com/Danielhiversen
[@MartinHjelmare]: https://github.com/MartinHjelmare
[@bdraco]: https://github.com/bdraco
[@bieniu]: https://github.com/bieniu
[@bramkragten]: https://github.com/bramkragten
[@emontnemery]: https://github.com/emontnemery
[@raman325]: https://github.com/raman325
[@rytilahti]: https://github.com/rytilahti
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[homekit docs]: https://www.home-assistant.io/integrations/homekit/
[input_datetime docs]: https://www.home-assistant.io/integrations/input_datetime/
[mill docs]: https://www.home-assistant.io/integrations/mill/
[netgear docs]: https://www.home-assistant.io/integrations/netgear/
[powerwall docs]: https://www.home-assistant.io/integrations/powerwall/
[recorder docs]: https://www.home-assistant.io/integrations/recorder/
[tplink docs]: https://www.home-assistant.io/integrations/tplink/
[xiaomi_miio docs]: https://www.home-assistant.io/integrations/xiaomi_miio/
[yeelight docs]: https://www.home-assistant.io/integrations/yeelight/
[zwave_js docs]: https://www.home-assistant.io/integrations/zwave_js/