### PR TITLE
Add Nest WebRTC and support Nest Battery Camera and Nest Battery Doorbell

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -447,7 +447,7 @@ class Camera(Entity):
         return self.stream
 
     async def stream_source(self) -> str | None:
-        """Return the source of the stream.
+        """Return the source of the stream..
 
         This is used by cameras with SUPPORT_STREAM and STREAM_TYPE_HLS.
         """

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -447,7 +447,7 @@ class Camera(Entity):
         return self.stream
 
     async def stream_source(self) -> str | None:
-        """Return the source of the stream..
+        """Return the source of the stream.
 
         This is used by cameras with SUPPORT_STREAM and STREAM_TYPE_HLS.
         """

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -267,12 +267,12 @@ class NestCamera(Camera):
         self._event_image_bytes = None
         self._event_image_cleanup_unsub = None
 
-    async def async_handle_web_rtc_offer(self, offer: str) -> str:
+    async def async_handle_web_rtc_offer(self, offer_sdp: str) -> str:
         """Return the source of the stream."""
         if not self.supported_features & SUPPORT_STREAM:
             raise ValueError("Camera does not support streaming")
         if self.stream_type != STREAM_TYPE_WEB_RTC:
             raise ValueError("Camera does not support Web RTC")
         trait: CameraLiveStreamTrait = self._device.traits[CameraLiveStreamTrait.NAME]
-        stream = await trait.generate_web_rtc_stream(offer)
+        stream = await trait.generate_web_rtc_stream(offer_sdp)
         return stream.answer_sdp

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -12,6 +12,7 @@ from google_nest_sdm.camera_traits import (
     CameraLiveStreamTrait,
     EventImageGenerator,
     RtspStream,
+    StreamingProtocol,
 )
 from google_nest_sdm.device import Device
 from google_nest_sdm.event import ImageEventBase
@@ -19,6 +20,7 @@ from google_nest_sdm.exceptions import GoogleNestException
 from haffmpeg.tools import IMAGE_JPEG
 
 from homeassistant.components.camera import SUPPORT_STREAM, Camera
+from homeassistant.components.camera.const import STREAM_TYPE_HLS, STREAM_TYPE_WEB_RTC
 from homeassistant.components.ffmpeg import async_get_image
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -114,9 +116,21 @@ class NestCamera(Camera):
             supported_features |= SUPPORT_STREAM
         return supported_features
 
+    @property
+    def stream_type(self) -> str | None:
+        """Return the type of stream supported by this camera."""
+        if CameraLiveStreamTrait.NAME not in self._device.traits:
+            return None
+        trait = self._device.traits[CameraLiveStreamTrait.NAME]
+        if StreamingProtocol.WEB_RTC in trait.supported_protocols:
+            return STREAM_TYPE_WEB_RTC
+        return STREAM_TYPE_HLS
+
     async def stream_source(self) -> str | None:
         """Return the source of the stream."""
-        if CameraLiveStreamTrait.NAME not in self._device.traits:
+        if not self.supported_features & SUPPORT_STREAM:
+            return None
+        if self.stream_type != STREAM_TYPE_HLS:
             return None
         trait = self._device.traits[CameraLiveStreamTrait.NAME]
         if not self._stream:
@@ -252,3 +266,13 @@ class NestCamera(Camera):
         self._event_id = None
         self._event_image_bytes = None
         self._event_image_cleanup_unsub = None
+
+    async def async_handle_web_rtc_offer(self, offer: str) -> str:
+        """Return the source of the stream."""
+        if not self.supported_features & SUPPORT_STREAM:
+            raise ValueError("Camera does not support streaming")
+        if self.stream_type != STREAM_TYPE_WEB_RTC:
+            raise ValueError("Camera does not support Web RTC")
+        trait: CameraLiveStreamTrait = self._device.traits[CameraLiveStreamTrait.NAME]
+        stream = await trait.generate_web_rtc_stream(offer)
+        return stream.answer_sdp

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -269,10 +269,6 @@ class NestCamera(Camera):
 
     async def async_handle_web_rtc_offer(self, offer_sdp: str) -> str:
         """Return the source of the stream."""
-        if not self.supported_features & SUPPORT_STREAM:
-            raise ValueError("Camera does not support streaming")
-        if self.stream_type != STREAM_TYPE_WEB_RTC:
-            raise ValueError("Camera does not support Web RTC")
         trait: CameraLiveStreamTrait = self._device.traits[CameraLiveStreamTrait.NAME]
         stream = await trait.generate_web_rtc_stream(offer_sdp)
         return stream.answer_sdp


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for WebRTC streams and which allow Nest Battery Camera and Nest Battery Doorbell cameras to work with Home Assistant.

This is an implementation of https://github.com/home-assistant/architecture/discussions/640 and the websocket API for WebRTC was added in PR #57034.

A stream is initiated on the client side, which passes through an `offer` to the integration. This signaling path sends an RPC to the nest SDM API endpoint [GenerateWebRtcStream](https://developers.google.com/nest/device-access/traits/device/camera-live-stream#generatewebrtcstream) which returns an `answer` that is passed back up to the client which handles the rest of the stream logic.

See https://webrtc.org/getting-started/ for more general background on how WebRTC works.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #55302
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19664

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
