### PR TITLE
Improve state of cover groups

### DIFF
--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -259,25 +259,31 @@ class CoverGroup(GroupEntity, CoverEntity):
         """Update state and attributes."""
         self._attr_assumed_state = False
 
-        self._attr_is_closed = None
+        self._attr_is_closed = True
         self._attr_is_closing = False
         self._attr_is_opening = False
+        has_valid_state = False
         for entity_id in self._entities:
             state = self.hass.states.get(entity_id)
             if not state:
                 continue
             if state.state == STATE_OPEN:
                 self._attr_is_closed = False
+                has_valid_state = True
                 continue
             if state.state == STATE_CLOSED:
-                self._attr_is_closed = True
+                has_valid_state = True
                 continue
             if state.state == STATE_CLOSING:
                 self._attr_is_closing = True
+                has_valid_state = True
                 continue
             if state.state == STATE_OPENING:
                 self._attr_is_opening = True
+                has_valid_state = True
                 continue
+        if has_valid_state is False:
+            self._attr_is_closed = None
 
         position_covers = self._covers[KEY_POSITION]
         all_position_states = [self.hass.states.get(x) for x in position_covers]

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -282,7 +282,7 @@ class CoverGroup(GroupEntity, CoverEntity):
                 self._attr_is_opening = True
                 has_valid_state = True
                 continue
-        if has_valid_state is False:
+        if not has_valid_state:
             self._attr_is_closed = None
 
         position_covers = self._covers[KEY_POSITION]

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -97,6 +97,106 @@ async def setup_comp(hass, config_count):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
+async def test_state(hass, setup_comp):
+    """Test handling of state."""
+    state = hass.states.get(COVER_GROUP)
+    # No entity has a valid state -> group state unknown
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_FRIENDLY_NAME] == DEFAULT_NAME
+    assert state.attributes[ATTR_ENTITY_ID] == [
+        DEMO_COVER,
+        DEMO_COVER_POS,
+        DEMO_COVER_TILT,
+        DEMO_TILT,
+    ]
+    assert ATTR_ASSUMED_STATE not in state.attributes
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+    assert ATTR_CURRENT_POSITION not in state.attributes
+    assert ATTR_CURRENT_TILT_POSITION not in state.attributes
+
+    # Set all entities as closed -> group state closed
+    hass.states.async_set(DEMO_COVER, STATE_CLOSED, {})
+    hass.states.async_set(DEMO_COVER_POS, STATE_CLOSED, {})
+    hass.states.async_set(DEMO_COVER_TILT, STATE_CLOSED, {})
+    hass.states.async_set(DEMO_TILT, STATE_CLOSED, {})
+    await hass.async_block_till_done()
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_CLOSED
+
+    # Set all entities as open -> group state open
+    hass.states.async_set(DEMO_COVER, STATE_OPEN, {})
+    hass.states.async_set(DEMO_COVER_POS, STATE_OPEN, {})
+    hass.states.async_set(DEMO_COVER_TILT, STATE_OPEN, {})
+    hass.states.async_set(DEMO_TILT, STATE_OPEN, {})
+    await hass.async_block_till_done()
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_OPEN
+
+    # Set first entity as open -> group state open
+    hass.states.async_set(DEMO_COVER, STATE_OPEN, {})
+    hass.states.async_set(DEMO_COVER_POS, STATE_CLOSED, {})
+    hass.states.async_set(DEMO_COVER_TILT, STATE_CLOSED, {})
+    hass.states.async_set(DEMO_TILT, STATE_CLOSED, {})
+    await hass.async_block_till_done()
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_OPEN
+
+    # Set last entity as open -> group state open
+    hass.states.async_set(DEMO_COVER, STATE_OPEN, {})
+    hass.states.async_set(DEMO_COVER_POS, STATE_CLOSED, {})
+    hass.states.async_set(DEMO_COVER_TILT, STATE_CLOSED, {})
+    hass.states.async_set(DEMO_TILT, STATE_CLOSED, {})
+    await hass.async_block_till_done()
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_OPEN
+
+    # Set conflicting valid states -> opening state has priority
+    hass.states.async_set(DEMO_COVER, STATE_OPEN, {})
+    hass.states.async_set(DEMO_COVER_POS, STATE_OPENING, {})
+    hass.states.async_set(DEMO_COVER_TILT, STATE_CLOSING, {})
+    hass.states.async_set(DEMO_TILT, STATE_CLOSED, {})
+    await hass.async_block_till_done()
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_OPENING
+
+    # Set all entities to unknown state -> group state unknown
+    hass.states.async_set(DEMO_COVER, STATE_UNKNOWN, {})
+    hass.states.async_set(DEMO_COVER_POS, STATE_UNKNOWN, {})
+    hass.states.async_set(DEMO_COVER_TILT, STATE_UNKNOWN, {})
+    hass.states.async_set(DEMO_TILT, STATE_UNKNOWN, {})
+    await hass.async_block_till_done()
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_UNKNOWN
+
+    # Set one entity to unknown state -> open state has priority
+    hass.states.async_set(DEMO_COVER, STATE_OPEN, {})
+    hass.states.async_set(DEMO_COVER_POS, STATE_UNKNOWN, {})
+    hass.states.async_set(DEMO_COVER_TILT, STATE_CLOSED, {})
+    hass.states.async_set(DEMO_TILT, STATE_OPEN, {})
+    await hass.async_block_till_done()
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_OPEN
+
+    # Set one entity to unknown state -> opening state has priority
+    hass.states.async_set(DEMO_COVER, STATE_OPEN, {})
+    hass.states.async_set(DEMO_COVER_POS, STATE_OPENING, {})
+    hass.states.async_set(DEMO_COVER_TILT, STATE_UNKNOWN, {})
+    hass.states.async_set(DEMO_TILT, STATE_CLOSED, {})
+    await hass.async_block_till_done()
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_OPENING
+
+    # Set one entity to unknown state -> closing state has priority
+    hass.states.async_set(DEMO_COVER, STATE_OPEN, {})
+    hass.states.async_set(DEMO_COVER_POS, STATE_UNKNOWN, {})
+    hass.states.async_set(DEMO_COVER_TILT, STATE_CLOSING, {})
+    hass.states.async_set(DEMO_TILT, STATE_CLOSED, {})
+    await hass.async_block_till_done()
+    state = hass.states.get(COVER_GROUP)
+    assert state.state == STATE_CLOSING
+
+
+@pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
 async def test_attributes(hass, setup_comp):
     """Test handling of state attributes."""
     state = hass.states.get(COVER_GROUP)
@@ -196,7 +296,7 @@ async def test_attributes(hass, setup_comp):
     # ### Test assumed state ###
     # ##########################
 
-    # For covers
+    # For covers - assumed state set true if position differ
     hass.states.async_set(
         DEMO_COVER, STATE_OPEN, {ATTR_SUPPORTED_FEATURES: 4, ATTR_CURRENT_POSITION: 100}
     )
@@ -220,7 +320,7 @@ async def test_attributes(hass, setup_comp):
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 60
 
-    # For tilts
+    # For tilts - assumed state set true if tilt position differ
     hass.states.async_set(
         DEMO_TILT,
         STATE_OPEN,
@@ -252,6 +352,7 @@ async def test_attributes(hass, setup_comp):
     state = hass.states.get(COVER_GROUP)
     assert state.attributes[ATTR_ASSUMED_STATE] is True
 
+    # Test entity registry integration
     entity_registry = er.async_get(hass)
     entry = entity_registry.async_get(COVER_GROUP)
     assert entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve state of cover groups:
  - if at least one of the group's entities is `opening`, the state of the group will be `opening`
  - else if at least one of the group's entities is `closing`, the state of the group will be `closing`
  - else if at least one of the group's entities is `open`, the state of the group will be `open`
  - else if at least one of the group's entities is `closed`, the state of the group will be `closed`
    Note: In this case, all the group's entities are either `closed` or in an unknown state
  - else, the group has no valid states and its state will be set to `unknown`

Note: The priority between the `opening`, `closing` and `open` states is the default prioritization by the cover base entity, we don't currently override it in the cover group.

This PR corrects a regression introduced by #56739

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/57257

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
