### PR TITLE
Use switch format unique ids for tplink dimmers

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import network
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryNotReady
 from homeassistant.const import (
     CONF_HOST,
@@ -19,7 +20,11 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
@@ -158,10 +163,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except SmartDeviceException as ex:
         raise ConfigEntryNotReady from ex
 
+    if device.is_dimmer:
+        async_fix_dimmer_unique_id(hass, entry, device)
+
     hass.data[DOMAIN][entry.entry_id] = TPLinkDataUpdateCoordinator(hass, device)
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
+
+
+@callback
+def async_fix_dimmer_unique_id(
+    hass: HomeAssistant, entry: ConfigEntry, device: SmartDevice
+) -> None:
+    """Migrate the unique id of dimmers back to the legacy one.
+
+    Dimmers used to use the switch format since pyHS100 treated them as SmartPlug but
+    the old code created them as lights
+
+    https://github.com/home-assistant/core/blob/2021.9.7/homeassistant/components/tplink/common.py#L86
+    """
+
+    # This is the unique id before 2021.0/2021.1
+    original_unique_id = legacy_device_id(device)
+
+    # This is the unique id that was used in 2021.0/2021.1 rollout
+    rollout_unique_id = device.mac.replace(":", "").upper()
+
+    entity_registry = er.async_get(hass)
+
+    rollout_entity_id = entity_registry.async_get_entity_id(
+        LIGHT_DOMAIN, DOMAIN, rollout_unique_id
+    )
+    original_entry_id = entity_registry.async_get_entity_id(
+        LIGHT_DOMAIN, DOMAIN, original_unique_id
+    )
+
+    # If they are now using the 2021.0/2021.1 rollout rollout entity id
+    # and have deleted the original entity id, we want to update that entity id
+    # so they don't end up with another _2 entity, but only if they deleted
+    # the original
+    if rollout_entity_id and not original_entry_id:
+        entity_registry.async_update_entity(
+            rollout_entity_id, new_unique_id=original_unique_id
+        )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -199,7 +199,7 @@ def async_fix_dimmer_unique_id(
         LIGHT_DOMAIN, DOMAIN, original_unique_id
     )
 
-    # If they are now using the 2021.0/2021.1 rollout rollout entity id
+    # If they are now using the 2021.0/2021.1 rollout entity id
     # and have deleted the original entity id, we want to update that entity id
     # so they don't end up with another _2 entity, but only if they deleted
     # the original

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from kasa import SmartBulb, SmartPlug, SmartStrip
+from kasa import SmartBulb, SmartDimmer, SmartPlug, SmartStrip
 from kasa.exceptions import SmartDeviceException
 from kasa.protocol import TPLinkSmartHomeProtocol
 
@@ -46,6 +46,33 @@ def _mocked_bulb() -> SmartBulb:
     bulb.set_color_temp = AsyncMock()
     bulb.protocol = _mock_protocol()
     return bulb
+
+
+def _mocked_dimmer() -> SmartDimmer:
+    dimmer = MagicMock(auto_spec=SmartDimmer)
+    dimmer.update = AsyncMock()
+    dimmer.mac = MAC_ADDRESS
+    dimmer.alias = ALIAS
+    dimmer.model = MODEL
+    dimmer.host = IP_ADDRESS
+    dimmer.brightness = 50
+    dimmer.color_temp = 4000
+    dimmer.is_color = True
+    dimmer.is_strip = False
+    dimmer.is_plug = False
+    dimmer.is_dimmer = True
+    dimmer.hsv = (10, 30, 5)
+    dimmer.device_id = MAC_ADDRESS
+    dimmer.valid_temperature_range.min = 4000
+    dimmer.valid_temperature_range.max = 9000
+    dimmer.hw_info = {"sw_ver": "1.0.0"}
+    dimmer.turn_off = AsyncMock()
+    dimmer.turn_on = AsyncMock()
+    dimmer.set_brightness = AsyncMock()
+    dimmer.set_hsv = AsyncMock()
+    dimmer.set_color_temp = AsyncMock()
+    dimmer.protocol = _mock_protocol()
+    return dimmer
 
 
 def _mocked_plug() -> SmartPlug:

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -4,14 +4,23 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from homeassistant import setup
 from homeassistant.components import tplink
 from homeassistant.components.tplink.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from . import IP_ADDRESS, MAC_ADDRESS, _patch_discovery, _patch_single_discovery
+from . import (
+    IP_ADDRESS,
+    MAC_ADDRESS,
+    _mocked_dimmer,
+    _patch_discovery,
+    _patch_single_discovery,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -63,3 +72,73 @@ async def test_config_entry_retry(hass):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
         assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
+
+
+async def test_dimmer_switch_unique_id_fix_original_entity_was_deleted(
+    hass: HomeAssistant, entity_reg: EntityRegistry
+):
+    """Test that roll out unique id entity id changed to the original unique id."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=MAC_ADDRESS)
+    config_entry.add_to_hass(hass)
+    dimmer = _mocked_dimmer()
+    rollout_unique_id = MAC_ADDRESS.replace(":", "").upper()
+    original_unique_id = tplink.legacy_device_id(dimmer)
+    rollout_dimmer_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=rollout_unique_id,
+        original_name="Rollout dimmer",
+    )
+
+    with _patch_discovery(device=dimmer), _patch_single_discovery(device=dimmer):
+        await setup.async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    migrated_dimmer_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=original_unique_id,
+        original_name="Migrated dimmer",
+    )
+    assert migrated_dimmer_entity_reg.entity_id == rollout_dimmer_entity_reg.entity_id
+
+
+async def test_dimmer_switch_unique_id_fix_original_entity_still_exists(
+    hass: HomeAssistant, entity_reg: EntityRegistry
+):
+    """Test no migration happens if the original entity id still exists."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=MAC_ADDRESS)
+    config_entry.add_to_hass(hass)
+    dimmer = _mocked_dimmer()
+    rollout_unique_id = MAC_ADDRESS.replace(":", "").upper()
+    original_unique_id = tplink.legacy_device_id(dimmer)
+    original_dimmer_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=original_unique_id,
+        original_name="Original dimmer",
+    )
+    rollout_dimmer_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=rollout_unique_id,
+        original_name="Rollout dimmer",
+    )
+
+    with _patch_discovery(device=dimmer), _patch_single_discovery(device=dimmer):
+        await setup.async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    migrated_dimmer_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=original_unique_id,
+        original_name="Migrated dimmer",
+    )
+    assert migrated_dimmer_entity_reg.entity_id == original_dimmer_entity_reg.entity_id
+    assert migrated_dimmer_entity_reg.entity_id != rollout_dimmer_entity_reg.entity_id


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fixes backwards compat with dimmer entities appearing as _2

Dimmers used to use the switch format since pyHS100 treated them as SmartPlug but the old code created them as lights
see https://github.com/home-assistant/core/blob/2021.9.7/homeassistant/components/tplink/common.py#L86

If the user already renamed their _2 entity and deleted the orphaned entity, we will update the unique id on the the renamed entity so they don't have to do it again

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
