### PR TITLE
Add service to Rainmachine to push weather data from Home Assistant

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -81,11 +81,11 @@ CV_WX_DATA_VALID_WIND_SPEED = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=
 CV_WX_DATA_VALID_PRESSURE = vol.All(vol.Coerce(float), vol.Range(min=60.0, max=110.0))
 CV_WX_DATA_VALID_SOLARRAD = vol.All(vol.Coerce(float), vol.Range(min=0.0, max=5.0))
 
-
 SERVICE_NAME_PAUSE_WATERING = "pause_watering"
 SERVICE_NAME_PUSH_WEATHER_DATA = "push_weather_data"
 SERVICE_NAME_STOP_ALL = "stop_all"
 SERVICE_NAME_UNPAUSE_WATERING = "unpause_watering"
+
 SERVICE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_DEVICE_ID): cv.string,

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -17,3 +17,21 @@ DATA_ZONES = "zones"
 
 DEFAULT_PORT = 8080
 DEFAULT_ZONE_RUN = 60 * 10
+
+# Constants expected by the RainMachine API for Service Data
+CONF_CONDITION = "condition"
+CONF_DEWPOINT = "dewpoint"
+CONF_ET = "et"
+CONF_MAXRH = "maxrh"
+CONF_MAXTEMP = "maxtemp"
+CONF_MINRH = "minrh"
+CONF_MINTEMP = "mintemp"
+CONF_PRESSURE = "pressure"
+CONF_QPF = "qpf"
+CONF_RAIN = "rain"
+CONF_SECONDS = "seconds"
+CONF_SOLARRAD = "solarrad"
+CONF_TEMPERATURE = "temperature"
+CONF_TIMESTAMP = "timestamp"
+CONF_WEATHER = "weather"
+CONF_WIND = "wind"

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -17,21 +17,3 @@ DATA_ZONES = "zones"
 
 DEFAULT_PORT = 8080
 DEFAULT_ZONE_RUN = 60 * 10
-
-# Constants expected by the RainMachine API for Service Data
-CONF_CONDITION = "condition"
-CONF_DEWPOINT = "dewpoint"
-CONF_ET = "et"
-CONF_MAXRH = "maxrh"
-CONF_MAXTEMP = "maxtemp"
-CONF_MINRH = "minrh"
-CONF_MINTEMP = "mintemp"
-CONF_PRESSURE = "pressure"
-CONF_QPF = "qpf"
-CONF_RAIN = "rain"
-CONF_SECONDS = "seconds"
-CONF_SOLARRAD = "solarrad"
-CONF_TEMPERATURE = "temperature"
-CONF_TIMESTAMP = "timestamp"
-CONF_WEATHER = "weather"
-CONF_WIND = "wind"

--- a/homeassistant/components/rainmachine/manifest.json
+++ b/homeassistant/components/rainmachine/manifest.json
@@ -3,12 +3,12 @@
   "name": "RainMachine",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rainmachine",
-  "requirements": ["regenmaschine==3.1.5"],
+  "requirements": ["regenmaschine==3.2.0"],
   "codeowners": ["@bachya"],
   "iot_class": "local_polling",
   "homekit": {
     "models": ["Touch HD", "SPK5"]
-  },  
+  },
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/homeassistant/components/rainmachine/services.yaml
+++ b/homeassistant/components/rainmachine/services.yaml
@@ -116,14 +116,10 @@ push_weather_data:
     Units must be sent in metric; no conversions are performed by the integraion.
 
     See details of RainMachine API Here: https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post
-  target:
-    entity:
-      integration: rainmachine
-      domain: switch
   fields:
     device_id:
       name: Controller
-      description: The controller whose watering activities should be unpaused
+      description: The controller for the weather data to be pushed.
       required: true
       selector:
         device:

--- a/homeassistant/components/rainmachine/services.yaml
+++ b/homeassistant/components/rainmachine/services.yaml
@@ -107,3 +107,141 @@ unpause_watering:
       selector:
         device:
           integration: rainmachine
+push_weather_data:
+  name: Push Weather Data
+  description: >-
+    Push Weather Data from Home Assistant to the RainMachine device.
+
+    Local Weather Push service should be enabled from Settings > Weather > Developer tab for RainMachine to consider the values being sent.
+    Units must be sent in metric; no conversions are performed by the integraion.
+
+    See details of RainMachine API Here: https://rainmachine.docs.apiary.io/#reference/weather-services/parserdata/post
+  target:
+    entity:
+      integration: rainmachine
+      domain: switch
+  fields:
+    device_id:
+      name: Controller
+      description: The controller whose watering activities should be unpaused
+      required: true
+      selector:
+        device:
+          integration: rainmachine
+    timestamp:
+      name: Timestamp
+      description: UNIX Timestamp for the Weather Data. If omitted, the RainMachine device's local time at the time of the call is used.
+      selector:
+        text:
+    mintemp:
+      name: Min Temp
+      description: Minimum Temperature (°C).
+      selector:
+        number:
+          min: -40
+          max: 40
+          step: 0.1
+          unit_of_measurement: '°C'
+    maxtemp:
+      name: Max Temp
+      description: Maximum Temperature (°C).
+      selector:
+        number:
+          min: -40
+          max: 40
+          step: 0.1
+          unit_of_measurement: '°C'
+    temperature:
+      name: Temperature
+      description: Current Temperature (°C).
+      selector:
+        number:
+          min: -40
+          max: 40
+          step: 0.1
+          unit_of_measurement: '°C'
+    wind:
+      name: Wind Speed
+      description: Wind Speed (m/s)
+      selector:
+        number:
+          min: 0
+          max: 65
+          unit_of_measurement: 'm/s'
+    solarrad:
+      name: Solar Radiation
+      description: Solar Radiation (MJ/m²/h)
+      selector:
+        number:
+          min: 0
+          max: 5
+          step: 0.1
+          unit_of_measurement: 'MJ/m²/h'
+    et:
+      name: Evapotranspiration
+      description: Evapotranspiration (mm)
+      selector:
+        number:
+          min: 0
+          max: 1000
+          unit_of_measurement: 'mm'
+    qpf:
+      name: Quantitative Precipitation Forecast
+      description: >-
+        Quantitative Precipitation Forecast (mm), or QPF. Note: QPF values shouldn't
+        be send as cumulative values but the measured/forecasted values for each hour or day.
+        The RainMachine Mixer will sum all QPF values in the current day to have the day total QPF.
+      selector:
+        number:
+          min: 0
+          max: 1000
+          unit_of_measurement: 'mm'
+    rain:
+      name: Measured Rainfall
+      description: >-
+        Measured Rainfail (mm). Note: RAIN values shouldn't be send as cumulative values but the
+        measured/forecasted values for each hour or day. The RainMachine Mixer will sum all RAIN values
+        in the current day to have the day total RAIN.
+      selector:
+        number:
+          min: 0
+          max: 1000
+          unit_of_measurement: 'mm'
+    minrh:
+      name: Min Relative Humidity
+      description: Min Relative Humidity (%RH)
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: '%'
+    maxrh:
+      name: Max Relative Humidity
+      description: Max Relative Humidity (%RH)
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: '%'
+    condition:
+      name: Weather Condition Code
+      description: Current weather condition code (WNUM).
+      selector:
+        text:
+    pressure:
+      name: Barametric Pressure
+      description: Barametric Pressure (kPa)
+      selector:
+        number:
+          min: 60
+          max: 110
+          unit_of_measurement: "kPa"
+    dewpoint:
+      name: Dew Point
+      description: Dew Point (°C).
+      selector:
+        number:
+          min: -40
+          max: 40
+          step: 0.1
+          unit_of_measurement: '°C'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2043,7 +2043,7 @@ raincloudy==0.0.7
 raspyrfm-client==1.2.8
 
 # homeassistant.components.rainmachine
-regenmaschine==3.1.5
+regenmaschine==3.2.0
 
 # homeassistant.components.renault
 renault-api==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1172,7 +1172,7 @@ pyzerproc==0.4.8
 rachiopy==1.0.3
 
 # homeassistant.components.rainmachine
-regenmaschine==3.1.5
+regenmaschine==3.2.0
 
 # homeassistant.components.renault
 renault-api==0.1.4


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add service to push weather data from Home Assistant to a Rainmachine controller. This will allow users to send Home Assistant data to the sprinkler controller to allow it to manage the amount of watering required. For example, you can push weather from a personal weather station already feeding data into Home Assistant, and use it to feed the actual rainfall amounts for the day, instead of just relying on the forecasted data to be accurate for your property.

Bump regenmaschine==3.2.0 to enable the endpoint in the upstream library. https://github.com/bachya/regenmaschine/releases/tag/3.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/bachya/regenmaschine/pull/103 https://github.com/bachya/regenmaschine/pull/102 **Replaces**:#57051
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19600

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
