### PR TITLE
Fix netgear renamed mdi icons

### DIFF
--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -35,7 +35,7 @@ DEVICE_ICONS = {
     0: "mdi:access-point-network",  # Router (Orbi ...)
     1: "mdi:book-open-variant",  # Amazon Kindle
     2: "mdi:android",  # Android Device
-    3: "mdi:cellphone-android",  # Android Phone
+    3: "mdi:cellphone",  # Android Phone
     4: "mdi:tablet-android",  # Android Tablet
     5: "mdi:router-wireless",  # Apple Airport Express
     6: "mdi:disc-player",  # Blu-ray Player
@@ -46,15 +46,15 @@ DEVICE_ICONS = {
     11: "mdi:play-network",  # DVR
     12: "mdi:gamepad-variant",  # Gaming Console
     13: "mdi:desktop-mac",  # iMac
-    14: "mdi:tablet-ipad",  # iPad
-    15: "mdi:tablet-ipad",  # iPad Mini
-    16: "mdi:cellphone-iphone",  # iPhone 5/5S/5C
-    17: "mdi:cellphone-iphone",  # iPhone
+    14: "mdi:tablet",  # iPad
+    15: "mdi:tablet",  # iPad Mini
+    16: "mdi:cellphone",  # iPhone 5/5S/5C
+    17: "mdi:cellphone",  # iPhone
     18: "mdi:ipod",  # iPod Touch
     19: "mdi:linux",  # Linux PC
     20: "mdi:apple-finder",  # Mac Mini
     21: "mdi:desktop-tower",  # Mac Pro
-    22: "mdi:laptop-mac",  # MacBook
+    22: "mdi:laptop",  # MacBook
     23: "mdi:play-network",  # Media Device
     24: "mdi:network",  # Network Device
     25: "mdi:play-network",  # Other STB
@@ -71,7 +71,7 @@ DEVICE_ICONS = {
     36: "mdi:tablet",  # Tablet
     37: "mdi:desktop-classic",  # UNIX PC
     38: "mdi:desktop-tower-monitor",  # Windows PC
-    39: "mdi:laptop-windows",  # Surface
+    39: "mdi:laptop",  # Surface
     40: "mdi:access-point-network",  # Wifi Extender
-    41: "mdi:apple-airplay",  # Apple TV
+    41: "mdi:cast-variant",  # Apple TV
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix netgear renamed mdi icons

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #57407
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
