### PR TITLE
Fix Netgear orbi port in ssdp discovery

### DIFF
--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -142,9 +142,7 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         updated_data[CONF_PORT] = DEFAULT_PORT
         for model in MODELS_V2:
-            if discovery_info.get(ssdp.ATTR_UPNP_MODEL_NUMBER, "").startswith(
-                model
-            ) or discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME, "").startswith(model):
+            if discovery_info.get(ssdp.ATTR_UPNP_MODEL_NUMBER, "").startswith(model):
                 updated_data[CONF_PORT] = ORBI_PORT
 
         self.placeholders.update(updated_data)

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -17,7 +17,14 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME, DEFAULT_NAME, DOMAIN, MODELS_V2, ORBI_PORT
+from .const import (
+    CONF_CONSIDER_HOME,
+    DEFAULT_CONSIDER_HOME,
+    DEFAULT_NAME,
+    DOMAIN,
+    MODELS_V2,
+    ORBI_PORT,
+)
 from .errors import CannotLoginException
 from .router import get_api
 
@@ -135,7 +142,9 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         updated_data[CONF_PORT] = DEFAULT_PORT
         for model in MODELS_V2:
-            if self.model.startswith(discovery_info.get(ssdp.ATTR_UPNP_MODEL_NUMBER)) or self.model.startswith(discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME)):
+            if self.model.startswith(
+                discovery_info.get(ssdp.ATTR_UPNP_MODEL_NUMBER)
+            ) or self.model.startswith(discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME)):
                 updated_data[CONF_PORT] = ORBI_PORT
 
         self.placeholders.update(updated_data)

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -142,9 +142,9 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         updated_data[CONF_PORT] = DEFAULT_PORT
         for model in MODELS_V2:
-            if model.startswith(
-                discovery_info.get(ssdp.ATTR_UPNP_MODEL_NUMBER)
-            ) or model.startswith(discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME)):
+            if discovery_info.get(ssdp.ATTR_UPNP_MODEL_NUMBER, "").startswith(
+                model
+            ) or discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME, "").startswith(model):
                 updated_data[CONF_PORT] = ORBI_PORT
 
         self.placeholders.update(updated_data)

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -142,9 +142,9 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         updated_data[CONF_PORT] = DEFAULT_PORT
         for model in MODELS_V2:
-            if self.model.startswith(
+            if model.startswith(
                 discovery_info.get(ssdp.ATTR_UPNP_MODEL_NUMBER)
-            ) or self.model.startswith(discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME)):
+            ) or model.startswith(discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME)):
                 updated_data[CONF_PORT] = ORBI_PORT
 
         self.placeholders.update(updated_data)

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME, DEFAULT_NAME, DOMAIN
+from .const import CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME, DEFAULT_NAME, DOMAIN, MODELS_V2, ORBI_PORT
 from .errors import CannotLoginException
 from .router import get_api
 
@@ -133,8 +133,10 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(discovery_info[ssdp.ATTR_UPNP_SERIAL])
         self._abort_if_unique_id_configured(updates=updated_data)
 
-        if device_url.port:
-            updated_data[CONF_PORT] = device_url.port
+        updated_data[CONF_PORT] = DEFAULT_PORT
+        for model in MODELS_V2:
+            if self.model.startswith(discovery_info.get(ssdp.ATTR_UPNP_MODEL_NUMBER)) or self.model.startswith(discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME)):
+                updated_data[CONF_PORT] = ORBI_PORT
 
         self.placeholders.update(updated_data)
         self.discovered = True

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -29,6 +29,7 @@ MODELS_V2 = [
     "SXR",
     "SXS",
 ]
+ORBI_PORT = 80
 
 # Icons
 DEVICE_ICONS = {

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -7,7 +7,7 @@ import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components import ssdp
-from homeassistant.components.netgear.const import CONF_CONSIDER_HOME, DOMAIN
+from homeassistant.components.netgear.const import CONF_CONSIDER_HOME, DOMAIN, ORBI_PORT
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import (
     CONF_HOST,
@@ -247,7 +247,7 @@ async def test_ssdp(hass, service):
     assert result["result"].unique_id == SERIAL
     assert result["title"] == TITLE
     assert result["data"].get(CONF_HOST) == HOST
-    assert result["data"].get(CONF_PORT) == PORT
+    assert result["data"].get(CONF_PORT) == ORBI_PORT
     assert result["data"].get(CONF_SSL) == SSL
     assert result["data"].get(CONF_USERNAME) == DEFAULT_USER
     assert result["data"][CONF_PASSWORD] == PASSWORD


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Netgear SSDP discovery information allways reports port 5000, even on the orbi models that need port 80 for correct communication. Therfore ignore the port from the discovery infromation and use the model number from the discovery information to match to known Orbi models and determine if to use port 5000 or 80.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/57244 fixes # https://github.com/home-assistant/core/issues/57196
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
