### PR TITLE
Convert flux_led to use asyncio

### DIFF
--- a/homeassistant/components/flux_led/const.py
+++ b/homeassistant/components/flux_led/const.py
@@ -1,5 +1,6 @@
 """Constants of the FluxLed/MagicHome Integration."""
 
+import asyncio
 import socket
 from typing import Final
 
@@ -7,6 +8,7 @@ DOMAIN: Final = "flux_led"
 
 API: Final = "flux_api"
 
+SIGNAL_STATE_UPDATED = "flux_led_{}_state_updated"
 
 CONF_AUTOMATIC_ADD: Final = "automatic_add"
 DEFAULT_NETWORK_SCAN_INTERVAL: Final = 120
@@ -15,7 +17,12 @@ DEFAULT_EFFECT_SPEED: Final = 50
 
 FLUX_LED_DISCOVERY: Final = "flux_led_discovery"
 
-FLUX_LED_EXCEPTIONS: Final = (socket.timeout, BrokenPipeError)
+FLUX_LED_EXCEPTIONS: Final = (
+    asyncio.TimeoutError,
+    socket.error,
+    RuntimeError,
+    BrokenPipeError,
+)
 
 STARTUP_SCAN_TIMEOUT: Final = 5
 DISCOVER_SCAN_TIMEOUT: Final = 10

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -2,12 +2,11 @@
 from __future__ import annotations
 
 import ast
-from functools import partial
 import logging
 import random
 from typing import Any, Final, cast
 
-from flux_led import WifiLedBulb
+from flux_led.aiodevice import AIOWifiLedBulb
 from flux_led.const import (
     COLOR_MODE_CCT as FLUX_COLOR_MODE_CCT,
     COLOR_MODE_DIM as FLUX_COLOR_MODE_DIM,
@@ -15,7 +14,6 @@ from flux_led.const import (
     COLOR_MODE_RGBW as FLUX_COLOR_MODE_RGBW,
     COLOR_MODE_RGBWW as FLUX_COLOR_MODE_RGBWW,
 )
-from flux_led.device import MAX_TEMP, MIN_TEMP
 from flux_led.utils import (
     color_temp_to_white_levels,
     rgbcw_brightness,
@@ -61,9 +59,10 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PROTOCOL,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_platform
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -91,6 +90,7 @@ from .const import (
     MODE_RGB,
     MODE_RGBW,
     MODE_WHITE,
+    SIGNAL_STATE_UPDATED,
     TRANSITION_GRADUAL,
     TRANSITION_JUMP,
     TRANSITION_STROBE,
@@ -254,7 +254,7 @@ async def async_setup_entry(
     platform.async_register_entity_service(
         SERVICE_CUSTOM_EFFECT,
         CUSTOM_EFFECT_DICT,
-        "set_custom_effect",
+        "async_set_custom_effect",
     )
     options = entry.options
 
@@ -298,17 +298,18 @@ class FluxLight(CoordinatorEntity, LightEntity):
     ) -> None:
         """Initialize the light."""
         super().__init__(coordinator)
-        self._bulb: WifiLedBulb = coordinator.device
+        self._device: AIOWifiLedBulb = coordinator.device
+        self._responding = True
         self._attr_name = name
         self._attr_unique_id = unique_id
         self._attr_supported_features = SUPPORT_FLUX_LED
         self._attr_min_mireds = (
-            color_temperature_kelvin_to_mired(MAX_TEMP) + 1
+            color_temperature_kelvin_to_mired(self._device.max_temp) + 1
         )  # for rounding
-        self._attr_max_mireds = color_temperature_kelvin_to_mired(MIN_TEMP)
+        self._attr_max_mireds = color_temperature_kelvin_to_mired(self._device.min_temp)
         self._attr_supported_color_modes = {
             FLUX_COLOR_MODE_TO_HASS.get(mode, COLOR_MODE_ONOFF)
-            for mode in self._bulb.color_modes
+            for mode in self._device.color_modes
         }
         self._attr_effect_list = FLUX_EFFECT_LIST
         if custom_effect_colors:
@@ -317,82 +318,80 @@ class FluxLight(CoordinatorEntity, LightEntity):
         self._custom_effect_speed_pct = custom_effect_speed_pct
         self._custom_effect_transition = custom_effect_transition
         if self.unique_id:
-            old_protocol = self._bulb.protocol == "LEDENET_ORIGINAL"
-            raw_state = self._bulb.raw_state
             self._attr_device_info = {
                 "connections": {(dr.CONNECTION_NETWORK_MAC, self.unique_id)},
-                ATTR_MODEL: f"0x{self._bulb.model_num:02X}",
+                ATTR_MODEL: f"0x{self._device.model_num:02X}",
                 ATTR_NAME: self.name,
-                ATTR_SW_VERSION: "1" if old_protocol else str(raw_state.version_number),
+                ATTR_SW_VERSION: str(self._device.version_num),
                 ATTR_MANUFACTURER: "FluxLED/Magic Home",
             }
 
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
-        return cast(bool, self._bulb.is_on)
+        return cast(bool, self._device.is_on)
 
     @property
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
-        return cast(int, self._bulb.brightness)
+        return cast(int, self._device.brightness)
 
     @property
     def color_temp(self) -> int:
         """Return the kelvin value of this light in mired."""
-        return color_temperature_kelvin_to_mired(self._bulb.getWhiteTemperature()[0])
+        return color_temperature_kelvin_to_mired(self._device.color_temp)
 
     @property
     def rgb_color(self) -> tuple[int, int, int]:
         """Return the rgb color value."""
-        rgb: tuple[int, int, int] = self._bulb.rgb
+        rgb: tuple[int, int, int] = self._device.rgb
         return rgb
 
     @property
     def rgbw_color(self) -> tuple[int, int, int, int]:
         """Return the rgbw color value."""
-        rgbw: tuple[int, int, int, int] = self._bulb.rgbw
+        rgbw: tuple[int, int, int, int] = self._device.rgbw
         return rgbw
 
     @property
     def rgbww_color(self) -> tuple[int, int, int, int, int]:
         """Return the rgbww aka rgbcw color value."""
-        rgbcw: tuple[int, int, int, int, int] = self._bulb.rgbcw
+        rgbcw: tuple[int, int, int, int, int] = self._device.rgbcw
         return rgbcw
 
     @property
     def rgbwc_color(self) -> tuple[int, int, int, int, int]:
         """Return the rgbwc color value."""
-        rgbwc: tuple[int, int, int, int, int] = self._bulb.rgbww
+        rgbwc: tuple[int, int, int, int, int] = self._device.rgbww
         return rgbwc
 
     @property
     def color_mode(self) -> str:
         """Return the color mode of the light."""
-        return FLUX_COLOR_MODE_TO_HASS.get(self._bulb.color_mode, COLOR_MODE_ONOFF)
+        return FLUX_COLOR_MODE_TO_HASS.get(self._device.color_mode, COLOR_MODE_ONOFF)
 
     @property
     def effect(self) -> str | None:
         """Return the current effect."""
-        if (current_mode := self._bulb.raw_state.preset_pattern) == EFFECT_CUSTOM_CODE:
+        if (current_mode := self._device.preset_pattern_num) == EFFECT_CUSTOM_CODE:
             return EFFECT_CUSTOM
         return EFFECT_ID_NAME.get(current_mode)
 
     @property
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the attributes."""
-        return {"ip_address": self._bulb.ipaddr}
+        return {"ip_address": self._device.ipaddr}
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified or all lights on."""
-        await self.hass.async_add_executor_job(partial(self._turn_on, **kwargs))
+        await self._async_turn_on(**kwargs)
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
-    def _turn_on(self, **kwargs: Any) -> None:
+    async def _async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified or all lights on."""
         if not self.is_on:
-            self._bulb.turnOn()
+            await self._device.async_turn_on()
             if not kwargs:
                 return
 
@@ -404,21 +403,23 @@ class FluxLight(CoordinatorEntity, LightEntity):
             color_temp_mired = kwargs[ATTR_COLOR_TEMP]
             color_temp_kelvin = color_temperature_mired_to_kelvin(color_temp_mired)
             if self.color_mode != COLOR_MODE_RGBWW:
-                self._bulb.setWhiteTemperature(color_temp_kelvin, brightness)
+                await self._device.async_set_white_temp(color_temp_kelvin, brightness)
                 return
 
             # When switching to color temp from RGBWW mode,
             # we do not want the overall brightness, we only
             # want the brightness of the white channels
             brightness = kwargs.get(
-                ATTR_BRIGHTNESS, self._bulb.getWhiteTemperature()[1]
+                ATTR_BRIGHTNESS, self._device.getWhiteTemperature()[1]
             )
             cold, warm = color_temp_to_white_levels(color_temp_kelvin, brightness)
-            self._bulb.set_levels(r=0, b=0, g=0, w=warm, w2=cold)
+            await self._device.async_set_levels(r=0, b=0, g=0, w=warm, w2=cold)
             return
         # Handle switch to HS Color Mode
         if ATTR_RGB_COLOR in kwargs:
-            self._bulb.set_levels(*kwargs[ATTR_RGB_COLOR], brightness=brightness)
+            await self._device.async_set_levels(
+                *kwargs[ATTR_RGB_COLOR], brightness=brightness
+            )
             return
         # Handle switch to RGBW Color Mode
         if ATTR_RGBW_COLOR in kwargs:
@@ -426,7 +427,7 @@ class FluxLight(CoordinatorEntity, LightEntity):
                 rgbw = rgbw_brightness(kwargs[ATTR_RGBW_COLOR], brightness)
             else:
                 rgbw = kwargs[ATTR_RGBW_COLOR]
-            self._bulb.set_levels(*rgbw)
+            await self._device.async_set_levels(*rgbw)
             return
         # Handle switch to RGBWW Color Mode
         if ATTR_RGBWW_COLOR in kwargs:
@@ -434,17 +435,17 @@ class FluxLight(CoordinatorEntity, LightEntity):
                 rgbcw = rgbcw_brightness(kwargs[ATTR_RGBWW_COLOR], brightness)
             else:
                 rgbcw = kwargs[ATTR_RGBWW_COLOR]
-            self._bulb.set_levels(*rgbcw_to_rgbwc(rgbcw))
+            await self._device.async_set_levels(*rgbcw_to_rgbwc(rgbcw))
             return
         # Handle switch to White Color Mode
         if ATTR_WHITE in kwargs:
-            self._bulb.set_levels(w=kwargs[ATTR_WHITE])
+            await self._device.async_set_levels(w=kwargs[ATTR_WHITE])
             return
         if ATTR_EFFECT in kwargs:
             effect = kwargs[ATTR_EFFECT]
             # Random color effect
             if effect == EFFECT_RANDOM:
-                self._bulb.set_levels(
+                await self._device.async_set_levels(
                     random.randint(0, 255),
                     random.randint(0, 255),
                     random.randint(0, 255),
@@ -453,7 +454,7 @@ class FluxLight(CoordinatorEntity, LightEntity):
             # Custom effect
             if effect == EFFECT_CUSTOM:
                 if self._custom_effect_colors:
-                    self._bulb.setCustomPattern(
+                    await self._device.async_set_custom_pattern(
                         self._custom_effect_colors,
                         self._custom_effect_speed_pct,
                         self._custom_effect_transition,
@@ -461,39 +462,41 @@ class FluxLight(CoordinatorEntity, LightEntity):
                 return
             # Effect selection
             if effect in EFFECT_MAP:
-                self._bulb.setPresetPattern(EFFECT_MAP[effect], DEFAULT_EFFECT_SPEED)
+                await self._device.async_set_preset_pattern(
+                    EFFECT_MAP[effect], DEFAULT_EFFECT_SPEED
+                )
                 return
             raise ValueError(f"Unknown effect {effect}")
         # Handle brightness adjustment in CCT Color Mode
         if self.color_mode == COLOR_MODE_COLOR_TEMP:
-            self._bulb.setWhiteTemperature(
-                self._bulb.getWhiteTemperature()[0], brightness
-            )
+            await self._device.async_set_white_temp(self._device.color_temp, brightness)
             return
         # Handle brightness adjustment in RGB Color Mode
         if self.color_mode == COLOR_MODE_RGB:
-            self._bulb.set_levels(*self.rgb_color, brightness=brightness)
+            await self._device.async_set_levels(*self.rgb_color, brightness=brightness)
             return
         # Handle brightness adjustment in RGBW Color Mode
         if self.color_mode == COLOR_MODE_RGBW:
-            self._bulb.set_levels(*rgbw_brightness(self.rgbw_color, brightness))
+            await self._device.async_set_levels(
+                *rgbw_brightness(self.rgbw_color, brightness)
+            )
             return
         # Handle brightness adjustment in RGBWW Color Mode
         if self.color_mode == COLOR_MODE_RGBWW:
             rgbwc = self.rgbwc_color
-            self._bulb.set_levels(*rgbww_brightness(rgbwc, brightness))
+            await self._device.async_set_levels(*rgbww_brightness(rgbwc, brightness))
             return
         # Handle White Color Mode and Brightness Only Color Mode
         if self.color_mode in (COLOR_MODE_WHITE, COLOR_MODE_BRIGHTNESS):
-            self._bulb.set_levels(w=brightness)
+            await self._device.async_set_levels(w=brightness)
             return
         raise ValueError(f"Unsupported color mode {self.color_mode}")
 
-    def set_custom_effect(
+    async def async_set_custom_effect(
         self, colors: list[tuple[int, int, int]], speed_pct: int, transition: str
     ) -> None:
         """Set a custom effect on the bulb."""
-        self._bulb.setCustomPattern(
+        await self._device.async_set_custom_pattern(
             colors,
             speed_pct,
             transition,
@@ -501,6 +504,24 @@ class FluxLight(CoordinatorEntity, LightEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the specified or all lights off."""
-        await self.hass.async_add_executor_job(self._bulb.turnOff)
+        await self._device.async_turn_off()
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if self.coordinator.last_update_success != self._responding:
+            self.async_write_ha_state()
+        self._responding = self.coordinator.last_update_success
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_STATE_UPDATED.format(self._device.ipaddr),
+                self.async_write_ha_state,
+            )
+        )
+        await super().async_added_to_hass()

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -28,14 +28,14 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
-    ATTR_RGB_COLOR,
+    ATTR_HS_COLOR,
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     ATTR_WHITE,
     COLOR_MODE_BRIGHTNESS,
     COLOR_MODE_COLOR_TEMP,
+    COLOR_MODE_HS,
     COLOR_MODE_ONOFF,
-    COLOR_MODE_RGB,
     COLOR_MODE_RGBW,
     COLOR_MODE_RGBWW,
     COLOR_MODE_WHITE,
@@ -67,6 +67,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.color import (
+    color_hs_to_RGB,
+    color_RGB_to_hs,
     color_temperature_kelvin_to_mired,
     color_temperature_mired_to_kelvin,
 )
@@ -102,7 +104,10 @@ SUPPORT_FLUX_LED: Final = SUPPORT_EFFECT | SUPPORT_TRANSITION
 
 
 FLUX_COLOR_MODE_TO_HASS: Final = {
-    FLUX_COLOR_MODE_RGB: COLOR_MODE_RGB,
+    # If the bulb is in RGB mode and does not support RGBW or RGBWW
+    # the UI will decrease the brightness every time the color is adjusted
+    # via https://github.com/home-assistant/frontend/blob/e797c017614797bb11671496d6bd65863de22063/src/dialogs/more-info/controls/more-info-light.ts#L263
+    FLUX_COLOR_MODE_RGB: COLOR_MODE_HS,
     FLUX_COLOR_MODE_RGBW: COLOR_MODE_RGBW,
     FLUX_COLOR_MODE_RGBWW: COLOR_MODE_RGBWW,
     FLUX_COLOR_MODE_CCT: COLOR_MODE_COLOR_TEMP,
@@ -342,10 +347,9 @@ class FluxLight(CoordinatorEntity, LightEntity):
         return color_temperature_kelvin_to_mired(self._device.color_temp)
 
     @property
-    def rgb_color(self) -> tuple[int, int, int]:
-        """Return the rgb color value."""
-        rgb: tuple[int, int, int] = self._device.rgb
-        return rgb
+    def hs_color(self) -> tuple[float, float]:
+        """Return the hs color value."""
+        return color_RGB_to_hs(*self._device.rgb)
 
     @property
     def rgbw_color(self) -> tuple[int, int, int, int]:
@@ -416,9 +420,9 @@ class FluxLight(CoordinatorEntity, LightEntity):
             await self._device.async_set_levels(r=0, b=0, g=0, w=warm, w2=cold)
             return
         # Handle switch to HS Color Mode
-        if ATTR_RGB_COLOR in kwargs:
+        if ATTR_HS_COLOR in kwargs:
             await self._device.async_set_levels(
-                *kwargs[ATTR_RGB_COLOR], brightness=brightness
+                *color_hs_to_RGB(*kwargs[ATTR_HS_COLOR]), brightness=brightness
             )
             return
         # Handle switch to RGBW Color Mode
@@ -471,9 +475,10 @@ class FluxLight(CoordinatorEntity, LightEntity):
         if self.color_mode == COLOR_MODE_COLOR_TEMP:
             await self._device.async_set_white_temp(self._device.color_temp, brightness)
             return
-        # Handle brightness adjustment in RGB Color Mode
-        if self.color_mode == COLOR_MODE_RGB:
-            await self._device.async_set_levels(*self.rgb_color, brightness=brightness)
+        # Handle brightness adjustment in HS Color Mode
+        if self.color_mode == COLOR_MODE_HS:
+            rgb = color_hs_to_RGB(*self.hs_color)
+            await self._device.async_set_levels(*rgb, brightness=brightness)
             return
         # Handle brightness adjustment in RGBW Color Mode
         if self.color_mode == COLOR_MODE_RGBW:

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -67,6 +67,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.color import (
+    color_hs_to_RGB,
+    color_RGB_to_hs,
     color_temperature_kelvin_to_mired,
     color_temperature_mired_to_kelvin,
 )
@@ -344,7 +346,10 @@ class FluxLight(CoordinatorEntity, LightEntity):
     @property
     def rgb_color(self) -> tuple[int, int, int]:
         """Return the rgb color value."""
-        rgb: tuple[int, int, int] = self._device.rgb
+        # Note that we call color_RGB_to_hs and not color_RGB_to_hsv
+        # to get the unscaled value since this is what the frontend wants
+        # https://github.com/home-assistant/frontend/blob/e797c017614797bb11671496d6bd65863de22063/src/dialogs/more-info/controls/more-info-light.ts#L263
+        rgb: tuple[int, int, int] = color_hs_to_RGB(*color_RGB_to_hs(*self._device.rgb))
         return rgb
 
     @property
@@ -415,7 +420,7 @@ class FluxLight(CoordinatorEntity, LightEntity):
             cold, warm = color_temp_to_white_levels(color_temp_kelvin, brightness)
             await self._device.async_set_levels(r=0, b=0, g=0, w=warm, w2=cold)
             return
-        # Handle switch to HS Color Mode
+        # Handle switch to RGB Color Mode
         if ATTR_RGB_COLOR in kwargs:
             await self._device.async_set_levels(
                 *kwargs[ATTR_RGB_COLOR], brightness=brightness

--- a/tests/components/flux_led/__init.py__
+++ b/tests/components/flux_led/__init.py__
@@ -1,1 +1,0 @@
-"""Tests for the flux_led integration."""

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -247,7 +247,7 @@ async def test_import(hass: HomeAssistant):
     assert result["reason"] == "already_configured"
 
 
-async def test_manual(hass: HomeAssistant):
+async def test_manual_working_discovery(hass: HomeAssistant):
     """Test manually setup."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -276,8 +276,8 @@ async def test_manual(hass: HomeAssistant):
         )
         await hass.async_block_till_done()
     assert result4["type"] == "create_entry"
-    assert result4["title"] == IP_ADDRESS
-    assert result4["data"] == {CONF_HOST: IP_ADDRESS, CONF_NAME: IP_ADDRESS}
+    assert result4["title"] == DEFAULT_ENTRY_TITLE
+    assert result4["data"] == {CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE}
 
     # Duplicate
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -1,6 +1,6 @@
 """Tests for light platform."""
 from datetime import timedelta
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from flux_led.const import (
     COLOR_MODE_ADDRESSABLE as FLUX_COLOR_MODE_ADDRESSABLE,
@@ -50,6 +50,7 @@ from homeassistant.const import (
     CONF_PROTOCOL,
     STATE_OFF,
     STATE_ON,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -63,6 +64,8 @@ from . import (
     _mocked_bulb,
     _patch_discovery,
     _patch_wifibulb,
+    async_mock_bulb_turn_off,
+    async_mock_bulb_turn_on,
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -84,6 +87,40 @@ async def test_light_unique_id(hass: HomeAssistant) -> None:
     entity_id = "light.az120444_aabbccddeeff"
     entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == MAC_ADDRESS
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+
+async def test_light_goes_unavailable_and_recovers(hass: HomeAssistant) -> None:
+    """Test a light goes unavailable and then recovers."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    with _patch_discovery(device=bulb), _patch_wifibulb(device=bulb):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "light.az120444_aabbccddeeff"
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get(entity_id).unique_id == MAC_ADDRESS
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    now = utcnow()
+    bulb.async_update = AsyncMock(side_effect=RuntimeError)
+    for i in range(10, 50, 10):
+        async_fire_time_changed(hass, now + timedelta(seconds=i))
+        await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+    bulb.async_update = AsyncMock()
+    for i in range(60, 100, 10):
+        async_fire_time_changed(hass, now + timedelta(seconds=i))
+        await hass.async_block_till_done()
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
 
@@ -120,6 +157,7 @@ async def test_light_device_registry(
     )
     config_entry.add_to_hass(hass)
     bulb = _mocked_bulb()
+    bulb.version_num = sw_version
     bulb.protocol = protocol
     bulb.raw_state = bulb.raw_state._replace(model_num=model, version_number=sw_version)
     bulb.model_num = model
@@ -166,18 +204,16 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOff.assert_called_once()
+    bulb.async_turn_off.assert_called_once()
 
-    bulb.is_on = False
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
+    await async_mock_bulb_turn_off(hass, bulb)
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOn.assert_called_once()
-    bulb.turnOn.reset_mock()
+    bulb.async_turn_on.assert_called_once()
+    bulb.async_turn_on.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -185,8 +221,8 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(255, 0, 0, brightness=100)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(255, 0, 0, brightness=100)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -194,8 +230,8 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_HS_COLOR: (10, 30)},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(255, 191, 178, brightness=128)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(255, 191, 178, brightness=128)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -203,8 +239,8 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "random"},
         blocking=True,
     )
-    bulb.set_levels.assert_called_once()
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_once()
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -212,8 +248,8 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
         blocking=True,
     )
-    bulb.setPresetPattern.assert_called_with(43, 50)
-    bulb.setPresetPattern.reset_mock()
+    bulb.async_set_preset_pattern.assert_called_with(43, 50)
+    bulb.async_set_preset_pattern.reset_mock()
 
     with pytest.raises(ValueError):
         await hass.services.async_call(
@@ -254,18 +290,16 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOff.assert_called_once()
+    bulb.async_turn_off.assert_called_once()
+    await async_mock_bulb_turn_off(hass, bulb)
 
-    bulb.is_on = False
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOn.assert_called_once()
-    bulb.turnOn.reset_mock()
+    bulb.async_turn_on.assert_called_once()
+    bulb.async_turn_on.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -273,8 +307,8 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(255, 0, 0, brightness=100)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(255, 0, 0, brightness=100)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -282,8 +316,8 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_HS_COLOR: (10, 30)},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(255, 191, 178, brightness=128)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(255, 191, 178, brightness=128)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -291,8 +325,8 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "random"},
         blocking=True,
     )
-    bulb.set_levels.assert_called_once()
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_once()
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -300,17 +334,16 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
         blocking=True,
     )
-    bulb.setPresetPattern.assert_called_with(43, 50)
-    bulb.setPresetPattern.reset_mock()
-
-    bulb.is_on = True
+    bulb.async_set_preset_pattern.assert_called_with(43, 50)
+    bulb.async_set_preset_pattern.reset_mock()
     bulb.color_mode = FLUX_COLOR_MODE_CCT
     bulb.getWhiteTemperature = Mock(return_value=(5000, 128))
+    bulb.color_temp = 5000
+
     bulb.raw_state = bulb.raw_state._replace(
         red=0, green=0, blue=0, warm_white=1, cool_white=2
     )
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=60))
-    await hass.async_block_till_done()
+    await async_mock_bulb_turn_on(hass, bulb)
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     attributes = state.attributes
@@ -325,8 +358,8 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 370},
         blocking=True,
     )
-    bulb.setWhiteTemperature.assert_called_with(2702, 128)
-    bulb.setWhiteTemperature.reset_mock()
+    bulb.async_set_white_temp.assert_called_with(2702, 128)
+    bulb.async_set_white_temp.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -334,8 +367,8 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 255},
         blocking=True,
     )
-    bulb.setWhiteTemperature.assert_called_with(5000, 255)
-    bulb.setWhiteTemperature.reset_mock()
+    bulb.async_set_white_temp.assert_called_with(5000, 255)
+    bulb.async_set_white_temp.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -343,8 +376,8 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
         blocking=True,
     )
-    bulb.setWhiteTemperature.assert_called_with(5000, 128)
-    bulb.setWhiteTemperature.reset_mock()
+    bulb.async_set_white_temp.assert_called_with(5000, 128)
+    bulb.async_set_white_temp.reset_mock()
 
 
 async def test_rgbw_light(hass: HomeAssistant) -> None:
@@ -376,18 +409,16 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOff.assert_called_once()
+    bulb.async_turn_off.assert_called_once()
+    await async_mock_bulb_turn_off(hass, bulb)
 
-    bulb.is_on = False
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOn.assert_called_once()
-    bulb.turnOn.reset_mock()
+    bulb.async_turn_on.assert_called_once()
+    bulb.async_turn_on.reset_mock()
     bulb.is_on = True
 
     await hass.services.async_call(
@@ -396,8 +427,8 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(168, 0, 0, 33)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(168, 0, 0, 33)
+    bulb.async_set_levels.reset_mock()
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
 
@@ -411,8 +442,8 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
         },
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(128, 128, 128, 128)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(128, 128, 128, 128)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -420,8 +451,8 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_RGBW_COLOR: (255, 255, 255, 255)},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(255, 255, 255, 255)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(255, 255, 255, 255)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -429,8 +460,8 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_RGBW_COLOR: (255, 191, 178, 0)},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(255, 191, 178, 0)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(255, 191, 178, 0)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -438,8 +469,8 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "random"},
         blocking=True,
     )
-    bulb.set_levels.assert_called_once()
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_once()
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -447,8 +478,8 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
         blocking=True,
     )
-    bulb.setPresetPattern.assert_called_with(43, 50)
-    bulb.setPresetPattern.reset_mock()
+    bulb.async_set_preset_pattern.assert_called_with(43, 50)
+    bulb.async_set_preset_pattern.reset_mock()
 
 
 async def test_rgbcw_light(hass: HomeAssistant) -> None:
@@ -481,18 +512,16 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOff.assert_called_once()
+    bulb.async_turn_off.assert_called_once()
+    await async_mock_bulb_turn_off(hass, bulb)
 
-    bulb.is_on = False
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOn.assert_called_once()
-    bulb.turnOn.reset_mock()
+    bulb.async_turn_on.assert_called_once()
+    bulb.async_turn_on.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -500,8 +529,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(250, 0, 0, 49, 0)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(250, 0, 0, 49, 0)
+    bulb.async_set_levels.reset_mock()
     bulb.is_on = True
 
     await hass.services.async_call(
@@ -514,8 +543,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         },
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(192, 192, 192, 192, 0)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(192, 192, 192, 192, 0)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -523,8 +552,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_RGBWW_COLOR: (255, 255, 255, 255, 50)},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(255, 255, 255, 50, 255)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(255, 255, 255, 50, 255)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -532,8 +561,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 154},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(r=0, b=0, g=0, w=0, w2=127)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(r=0, b=0, g=0, w=0, w2=127)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -541,8 +570,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 154, ATTR_BRIGHTNESS: 255},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(r=0, b=0, g=0, w=0, w2=255)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(r=0, b=0, g=0, w=0, w2=255)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -550,8 +579,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP: 290},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(r=0, b=0, g=0, w=102, w2=25)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(r=0, b=0, g=0, w=102, w2=25)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -559,8 +588,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_RGBWW_COLOR: (255, 191, 178, 0, 0)},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(255, 191, 178, 0, 0)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(255, 191, 178, 0, 0)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -568,8 +597,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "random"},
         blocking=True,
     )
-    bulb.set_levels.assert_called_once()
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_once()
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -577,8 +606,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
         blocking=True,
     )
-    bulb.setPresetPattern.assert_called_with(43, 50)
-    bulb.setPresetPattern.reset_mock()
+    bulb.async_set_preset_pattern.assert_called_with(43, 50)
+    bulb.async_set_preset_pattern.reset_mock()
 
 
 async def test_white_light(hass: HomeAssistant) -> None:
@@ -610,18 +639,16 @@ async def test_white_light(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOff.assert_called_once()
+    bulb.async_turn_off.assert_called_once()
+    await async_mock_bulb_turn_off(hass, bulb)
 
-    bulb.is_on = False
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOn.assert_called_once()
-    bulb.turnOn.reset_mock()
+    bulb.async_turn_on.assert_called_once()
+    bulb.async_turn_on.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -629,8 +656,8 @@ async def test_white_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(w=100)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(w=100)
+    bulb.async_set_levels.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -638,8 +665,8 @@ async def test_white_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_WHITE: 100},
         blocking=True,
     )
-    bulb.set_levels.assert_called_with(w=100)
-    bulb.set_levels.reset_mock()
+    bulb.async_set_levels.assert_called_with(w=100)
+    bulb.async_set_levels.reset_mock()
 
 
 async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
@@ -677,10 +704,8 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOff.assert_called_once()
-
-    bulb.is_on = False
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
+    bulb.async_turn_off.assert_called_once()
+    await async_mock_bulb_turn_off(hass, bulb)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 
@@ -690,12 +715,13 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "custom"},
         blocking=True,
     )
-    bulb.setCustomPattern.assert_called_with([[0, 0, 255], [255, 0, 0]], 88, "jump")
-    bulb.setCustomPattern.reset_mock()
-    bulb.raw_state = bulb.raw_state._replace(preset_pattern=EFFECT_CUSTOM_CODE)
-    bulb.is_on = True
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=20))
-    await hass.async_block_till_done()
+    bulb.async_set_custom_pattern.assert_called_with(
+        [[0, 0, 255], [255, 0, 0]], 88, "jump"
+    )
+    bulb.async_set_custom_pattern.reset_mock()
+    bulb.preset_pattern_num = EFFECT_CUSTOM_CODE
+    await async_mock_bulb_turn_on(hass, bulb)
+
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     attributes = state.attributes
@@ -707,12 +733,13 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 55, ATTR_EFFECT: "custom"},
         blocking=True,
     )
-    bulb.setCustomPattern.assert_called_with([[0, 0, 255], [255, 0, 0]], 88, "jump")
-    bulb.setCustomPattern.reset_mock()
-    bulb.raw_state = bulb.raw_state._replace(preset_pattern=EFFECT_CUSTOM_CODE)
-    bulb.is_on = True
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=20))
-    await hass.async_block_till_done()
+    bulb.async_set_custom_pattern.assert_called_with(
+        [[0, 0, 255], [255, 0, 0]], 88, "jump"
+    )
+    bulb.async_set_custom_pattern.reset_mock()
+    bulb.preset_pattern_num = EFFECT_CUSTOM_CODE
+    await async_mock_bulb_turn_on(hass, bulb)
+
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     attributes = state.attributes
@@ -783,11 +810,9 @@ async def test_rgb_light_custom_effect_via_service(
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOff.assert_called_once()
+    bulb.async_turn_off.assert_called_once()
 
-    bulb.is_on = False
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
+    await async_mock_bulb_turn_off(hass, bulb)
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await hass.services.async_call(
@@ -801,8 +826,10 @@ async def test_rgb_light_custom_effect_via_service(
         },
         blocking=True,
     )
-    bulb.setCustomPattern.assert_called_with([(0, 0, 255), (255, 0, 0)], 30, "jump")
-    bulb.setCustomPattern.reset_mock()
+    bulb.async_set_custom_pattern.assert_called_with(
+        [(0, 0, 255), (255, 0, 0)], 30, "jump"
+    )
+    bulb.async_set_custom_pattern.reset_mock()
 
 
 async def test_migrate_from_yaml(hass: HomeAssistant) -> None:
@@ -882,19 +909,17 @@ async def test_addressable_light(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOff.assert_called_once()
+    bulb.async_turn_off.assert_called_once()
 
-    bulb.is_on = False
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
+    await async_mock_bulb_turn_off(hass, bulb)
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await hass.services.async_call(
         LIGHT_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
-    bulb.turnOn.assert_called_once()
-    bulb.turnOn.reset_mock()
-    bulb.is_on = True
+    bulb.async_turn_on.assert_called_once()
+    bulb.async_turn_on.reset_mock()
+    await async_mock_bulb_turn_on(hass, bulb)
 
     with pytest.raises(ValueError):
         await hass.services.async_call(

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -196,9 +196,9 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "rgb"
+    assert attributes[ATTR_COLOR_MODE] == "hs"
     assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
     await hass.services.async_call(
@@ -282,9 +282,9 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "rgb"
+    assert attributes[ATTR_COLOR_MODE] == "hs"
     assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "rgb"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "hs"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
     await hass.services.async_call(
@@ -349,7 +349,7 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
     assert attributes[ATTR_COLOR_MODE] == "color_temp"
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "rgb"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "hs"]
     assert attributes[ATTR_COLOR_TEMP] == 200
 
     await hass.services.async_call(
@@ -696,9 +696,9 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "rgb"
+    assert attributes[ATTR_COLOR_MODE] == "hs"
     assert attributes[ATTR_EFFECT_LIST] == [*FLUX_EFFECT_LIST, "custom"]
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
     await hass.services.async_call(
@@ -773,9 +773,9 @@ async def test_rgb_light_custom_effects_invalid_colors(hass: HomeAssistant) -> N
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "rgb"
+    assert attributes[ATTR_COLOR_MODE] == "hs"
     assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
 
@@ -802,9 +802,9 @@ async def test_rgb_light_custom_effect_via_service(
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "rgb"
+    assert attributes[ATTR_COLOR_MODE] == "hs"
     assert attributes[ATTR_EFFECT_LIST] == [*FLUX_EFFECT_LIST]
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
     await hass.services.async_call(

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -196,9 +196,9 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "hs"
+    assert attributes[ATTR_COLOR_MODE] == "rgb"
     assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
     await hass.services.async_call(
@@ -282,9 +282,9 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "hs"
+    assert attributes[ATTR_COLOR_MODE] == "rgb"
     assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "hs"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "rgb"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
     await hass.services.async_call(
@@ -349,7 +349,7 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
     assert attributes[ATTR_COLOR_MODE] == "color_temp"
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "hs"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "rgb"]
     assert attributes[ATTR_COLOR_TEMP] == 200
 
     await hass.services.async_call(
@@ -696,9 +696,9 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "hs"
+    assert attributes[ATTR_COLOR_MODE] == "rgb"
     assert attributes[ATTR_EFFECT_LIST] == [*FLUX_EFFECT_LIST, "custom"]
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
     await hass.services.async_call(
@@ -773,9 +773,9 @@ async def test_rgb_light_custom_effects_invalid_colors(hass: HomeAssistant) -> N
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "hs"
+    assert attributes[ATTR_COLOR_MODE] == "rgb"
     assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
 
@@ -802,9 +802,9 @@ async def test_rgb_light_custom_effect_via_service(
     assert state.state == STATE_ON
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
-    assert attributes[ATTR_COLOR_MODE] == "hs"
+    assert attributes[ATTR_COLOR_MODE] == "rgb"
     assert attributes[ATTR_EFFECT_LIST] == [*FLUX_EFFECT_LIST]
-    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
+    assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
     await hass.services.async_call(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Convert flux_led to use asyncio

```
---------- coverage: platform darwin, python 3.9.6-final-0 -----------
Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
homeassistant/components/flux_led/__init__.py         91      0   100%
homeassistant/components/flux_led/config_flow.py     113      0   100%
homeassistant/components/flux_led/const.py            33      0   100%
homeassistant/components/flux_led/light.py           213      0   100%
--------------------------------------------------------------------------------
TOTAL                                                450      0   100%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
