### PR TITLE
Add the switch platform to flux_led

### DIFF
--- a/homeassistant/components/flux_led/entity.py
+++ b/homeassistant/components/flux_led/entity.py
@@ -1,0 +1,92 @@
+"""Support for FluxLED/MagicHome lights."""
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, cast
+
+from flux_led.aiodevice import AIOWifiLedBulb
+
+from homeassistant.const import (
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SW_VERSION,
+)
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import FluxLedUpdateCoordinator
+from .const import SIGNAL_STATE_UPDATED
+
+
+class FluxEntity(CoordinatorEntity):
+    """Representation of a Flux entity."""
+
+    coordinator: FluxLedUpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: FluxLedUpdateCoordinator,
+        unique_id: str | None,
+        name: str,
+    ) -> None:
+        """Initialize the light."""
+        super().__init__(coordinator)
+        self._device: AIOWifiLedBulb = coordinator.device
+        self._responding = True
+        self._attr_name = name
+        self._attr_unique_id = unique_id
+        if self.unique_id:
+            self._attr_device_info = {
+                "connections": {(dr.CONNECTION_NETWORK_MAC, self.unique_id)},
+                ATTR_MODEL: f"0x{self._device.model_num:02X}",
+                ATTR_NAME: self.name,
+                ATTR_SW_VERSION: str(self._device.version_num),
+                ATTR_MANUFACTURER: "FluxLED/Magic Home",
+            }
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is on."""
+        return cast(bool, self._device.is_on)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return the attributes."""
+        return {"ip_address": self._device.ipaddr}
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the specified device on."""
+        await self._async_turn_on(**kwargs)
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    @abstractmethod
+    async def _async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the specified device on."""
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the specified device off."""
+        await self._device.async_turn_off()
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if self.coordinator.last_update_success != self._responding:
+            self.async_write_ha_state()
+        self._responding = self.coordinator.last_update_success
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_STATE_UPDATED.format(self._device.ipaddr),
+                self.async_write_ha_state,
+            )
+        )
+        await super().async_added_to_hass()

--- a/homeassistant/components/flux_led/switch.py
+++ b/homeassistant/components/flux_led/switch.py
@@ -1,0 +1,42 @@
+"""Support for FluxLED/MagicHome switches."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant import config_entries
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import FluxLedUpdateCoordinator
+from .const import DOMAIN
+from .entity import FluxEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Flux lights."""
+    coordinator: FluxLedUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [
+            FluxSwitch(
+                coordinator,
+                entry.unique_id,
+                entry.data[CONF_NAME],
+            )
+        ]
+    )
+
+
+class FluxSwitch(FluxEntity, CoordinatorEntity, SwitchEntity):
+    """Representation of a Flux switch."""
+
+    async def _async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        if not self.is_on:
+            await self._device.async_turn_on()

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -64,8 +64,8 @@ from . import (
     _mocked_bulb,
     _patch_discovery,
     _patch_wifibulb,
-    async_mock_bulb_turn_off,
-    async_mock_bulb_turn_on,
+    async_mock_device_turn_off,
+    async_mock_device_turn_on,
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -206,7 +206,7 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
     )
     bulb.async_turn_off.assert_called_once()
 
-    await async_mock_bulb_turn_off(hass, bulb)
+    await async_mock_device_turn_off(hass, bulb)
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await hass.services.async_call(
@@ -291,7 +291,7 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
     bulb.async_turn_off.assert_called_once()
-    await async_mock_bulb_turn_off(hass, bulb)
+    await async_mock_device_turn_off(hass, bulb)
 
     assert hass.states.get(entity_id).state == STATE_OFF
 
@@ -343,7 +343,7 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
     bulb.raw_state = bulb.raw_state._replace(
         red=0, green=0, blue=0, warm_white=1, cool_white=2
     )
-    await async_mock_bulb_turn_on(hass, bulb)
+    await async_mock_device_turn_on(hass, bulb)
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     attributes = state.attributes
@@ -410,7 +410,7 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
     bulb.async_turn_off.assert_called_once()
-    await async_mock_bulb_turn_off(hass, bulb)
+    await async_mock_device_turn_off(hass, bulb)
 
     assert hass.states.get(entity_id).state == STATE_OFF
 
@@ -513,7 +513,7 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
     bulb.async_turn_off.assert_called_once()
-    await async_mock_bulb_turn_off(hass, bulb)
+    await async_mock_device_turn_off(hass, bulb)
 
     assert hass.states.get(entity_id).state == STATE_OFF
 
@@ -640,7 +640,7 @@ async def test_white_light(hass: HomeAssistant) -> None:
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
     bulb.async_turn_off.assert_called_once()
-    await async_mock_bulb_turn_off(hass, bulb)
+    await async_mock_device_turn_off(hass, bulb)
 
     assert hass.states.get(entity_id).state == STATE_OFF
 
@@ -705,7 +705,7 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
         LIGHT_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
     bulb.async_turn_off.assert_called_once()
-    await async_mock_bulb_turn_off(hass, bulb)
+    await async_mock_device_turn_off(hass, bulb)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 
@@ -720,7 +720,7 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
     )
     bulb.async_set_custom_pattern.reset_mock()
     bulb.preset_pattern_num = EFFECT_CUSTOM_CODE
-    await async_mock_bulb_turn_on(hass, bulb)
+    await async_mock_device_turn_on(hass, bulb)
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
@@ -738,7 +738,7 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
     )
     bulb.async_set_custom_pattern.reset_mock()
     bulb.preset_pattern_num = EFFECT_CUSTOM_CODE
-    await async_mock_bulb_turn_on(hass, bulb)
+    await async_mock_device_turn_on(hass, bulb)
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
@@ -812,7 +812,7 @@ async def test_rgb_light_custom_effect_via_service(
     )
     bulb.async_turn_off.assert_called_once()
 
-    await async_mock_bulb_turn_off(hass, bulb)
+    await async_mock_device_turn_off(hass, bulb)
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await hass.services.async_call(
@@ -911,7 +911,7 @@ async def test_addressable_light(hass: HomeAssistant) -> None:
     )
     bulb.async_turn_off.assert_called_once()
 
-    await async_mock_bulb_turn_off(hass, bulb)
+    await async_mock_device_turn_off(hass, bulb)
     assert hass.states.get(entity_id).state == STATE_OFF
 
     await hass.services.async_call(
@@ -919,7 +919,7 @@ async def test_addressable_light(hass: HomeAssistant) -> None:
     )
     bulb.async_turn_on.assert_called_once()
     bulb.async_turn_on.reset_mock()
-    await async_mock_bulb_turn_on(hass, bulb)
+    await async_mock_device_turn_on(hass, bulb)
 
     with pytest.raises(ValueError):
         await hass.services.async_call(

--- a/tests/components/flux_led/test_switch.py
+++ b/tests/components/flux_led/test_switch.py
@@ -1,0 +1,62 @@
+"""Tests for switch platform."""
+from homeassistant.components import flux_led
+from homeassistant.components.flux_led.const import DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_HOST,
+    CONF_NAME,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import (
+    DEFAULT_ENTRY_TITLE,
+    IP_ADDRESS,
+    MAC_ADDRESS,
+    _mocked_switch,
+    _patch_discovery,
+    _patch_wifibulb,
+    async_mock_device_turn_off,
+    async_mock_device_turn_on,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_switch_on_off(hass: HomeAssistant) -> None:
+    """Test a switch light."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        unique_id=MAC_ADDRESS,
+    )
+    config_entry.add_to_hass(hass)
+    switch = _mocked_switch()
+    with _patch_discovery(device=switch), _patch_wifibulb(device=switch):
+        await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "switch.az120444_aabbccddeeff"
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    switch.async_turn_off.assert_called_once()
+
+    await async_mock_device_turn_off(hass, switch)
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    switch.async_turn_on.assert_called_once()
+    switch.async_turn_on.reset_mock()
+
+    await async_mock_device_turn_on(hass, switch)
+    assert hass.states.get(entity_id).state == STATE_ON


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the switch platform to `flux_led`

These were previously being shown as lights since we didn't know how to distingish between them.

```
---------- coverage: platform darwin, python 3.9.6-final-0 -----------
Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
homeassistant/components/flux_led/__init__.py         94      0   100%
homeassistant/components/flux_led/config_flow.py     113      0   100%
homeassistant/components/flux_led/const.py            33      0   100%
homeassistant/components/flux_led/entity.py           45      0   100%
homeassistant/components/flux_led/light.py           183      0   100%
homeassistant/components/flux_led/switch.py           18      0   100%
--------------------------------------------------------------------------------
TOTAL                                                486      0   100%
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19720

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
