### PR TITLE
2021.10.3

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -277,6 +277,10 @@ class DHCPWatcher(WatcherBase):
 
     async def async_start(self):
         """Start watching for dhcp packets."""
+        await self.hass.async_add_executor_job(self._start)
+
+    def _start(self):
+        """Start watching for dhcp packets."""
         # Local import because importing from scapy has side effects such as opening
         # sockets
         from scapy import (  # pylint: disable=import-outside-toplevel,unused-import  # noqa: F401
@@ -319,7 +323,7 @@ class DHCPWatcher(WatcherBase):
         conf.sniff_promisc = 0
 
         try:
-            await self.hass.async_add_executor_job(_verify_l2socket_setup, FILTER)
+            _verify_l2socket_setup(FILTER)
         except (Scapy_Exception, OSError) as ex:
             if os.geteuid() == 0:
                 _LOGGER.error("Cannot watch for dhcp packets: %s", ex)
@@ -330,7 +334,7 @@ class DHCPWatcher(WatcherBase):
             return
 
         try:
-            await self.hass.async_add_executor_job(_verify_working_pcap, FILTER)
+            _verify_working_pcap(FILTER)
         except (Scapy_Exception, ImportError) as ex:
             _LOGGER.error(
                 "Cannot watch for dhcp packets without a functional packet filter: %s",

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "requirements": [
-    "home-assistant-frontend==20211007.0"
+    "home-assistant-frontend==20211007.1"
   ],
   "dependencies": [
     "api",

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -205,21 +205,18 @@ async def async_setup_entry(
     # Load platforms for the devices in the ISY controller that we support.
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
-    def _start_auto_update() -> None:
-        """Start isy auto update."""
-        _LOGGER.debug("ISY Starting Event Stream and automatic updates")
-        isy.websocket.start()
-
-    def _stop_auto_update(event) -> None:
+    @callback
+    def _async_stop_auto_update(event) -> None:
         """Stop the isy auto update on Home Assistant Shutdown."""
         _LOGGER.debug("ISY Stopping Event Stream and automatic updates")
         isy.websocket.stop()
 
-    await hass.async_add_executor_job(_start_auto_update)
+    _LOGGER.debug("ISY Starting Event Stream and automatic updates")
+    isy.websocket.start()
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     entry.async_on_unload(
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _stop_auto_update)
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_auto_update)
     )
 
     # Register Integration-wide Services:

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -35,7 +35,7 @@ DEVICE_ICONS = {
     0: "mdi:access-point-network",  # Router (Orbi ...)
     1: "mdi:book-open-variant",  # Amazon Kindle
     2: "mdi:android",  # Android Device
-    3: "mdi:cellphone-android",  # Android Phone
+    3: "mdi:cellphone",  # Android Phone
     4: "mdi:tablet-android",  # Android Tablet
     5: "mdi:router-wireless",  # Apple Airport Express
     6: "mdi:disc-player",  # Blu-ray Player
@@ -46,15 +46,15 @@ DEVICE_ICONS = {
     11: "mdi:play-network",  # DVR
     12: "mdi:gamepad-variant",  # Gaming Console
     13: "mdi:desktop-mac",  # iMac
-    14: "mdi:tablet-ipad",  # iPad
-    15: "mdi:tablet-ipad",  # iPad Mini
-    16: "mdi:cellphone-iphone",  # iPhone 5/5S/5C
-    17: "mdi:cellphone-iphone",  # iPhone
+    14: "mdi:tablet",  # iPad
+    15: "mdi:tablet",  # iPad Mini
+    16: "mdi:cellphone",  # iPhone 5/5S/5C
+    17: "mdi:cellphone",  # iPhone
     18: "mdi:ipod",  # iPod Touch
     19: "mdi:linux",  # Linux PC
     20: "mdi:apple-finder",  # Mac Mini
     21: "mdi:desktop-tower",  # Mac Pro
-    22: "mdi:laptop-mac",  # MacBook
+    22: "mdi:laptop",  # MacBook
     23: "mdi:play-network",  # Media Device
     24: "mdi:network",  # Network Device
     25: "mdi:play-network",  # Other STB
@@ -71,7 +71,7 @@ DEVICE_ICONS = {
     36: "mdi:tablet",  # Tablet
     37: "mdi:desktop-classic",  # UNIX PC
     38: "mdi:desktop-tower-monitor",  # Windows PC
-    39: "mdi:laptop-windows",  # Surface
+    39: "mdi:laptop",  # Surface
     40: "mdi:access-point-network",  # Wifi Extender
-    41: "mdi:apple-airplay",  # Apple TV
+    41: "mdi:cast-variant",  # Apple TV
 }

--- a/homeassistant/components/nws/manifest.json
+++ b/homeassistant/components/nws/manifest.json
@@ -3,7 +3,7 @@
   "name": "National Weather Service (NWS)",
   "documentation": "https://www.home-assistant.io/integrations/nws",
   "codeowners": ["@MatthewFlamm"],
-  "requirements": ["pynws==1.3.1"],
+  "requirements": ["pynws==1.3.2"],
   "quality_scale": "platinum",
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -156,8 +156,9 @@ def register_services(hass):
             vol.Required(ATTR_GW_ID): vol.All(
                 cv.string, vol.In(hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS])
             ),
-            vol.Optional(ATTR_DATE, default=date.today()): cv.date,
-            vol.Optional(ATTR_TIME, default=datetime.now().time()): cv.time,
+            # pylint: disable=unnecessary-lambda
+            vol.Optional(ATTR_DATE, default=lambda: date.today()): cv.date,
+            vol.Optional(ATTR_TIME, default=lambda: datetime.now().time()): cv.time,
         }
     )
     service_set_control_setpoint_schema = vol.Schema(

--- a/homeassistant/components/opentherm_gw/services.yaml
+++ b/homeassistant/components/opentherm_gw/services.yaml
@@ -54,7 +54,7 @@ set_clock:
       selector:
         text:
     time:
-      name: Name
+      name: Time
       description: Optional time in 24h format which will be provided to the thermostat. Defaults to the current time.
       example: "19:34"
       selector:

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -275,7 +275,7 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
                 if block.type != "device":
                     continue
 
-                if block.wakeupEvent[0] == "button":
+                if len(block.wakeupEvent) == 1 and block.wakeupEvent[0] == "button":
                     self._last_input_events_count[1] = -1
 
                 break

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -21,6 +21,11 @@ LIGHT_TRANSITION_MIN_FIRMWARE_DATE: Final = 20210226
 # max light transition time in milliseconds
 MAX_TRANSITION_TIME: Final = 5000
 
+RGBW_MODELS: Final = (
+    "SHBLB-1",
+    "SHRGBW2",
+)
+
 MODELS_SUPPORTING_LIGHT_TRANSITION: Final = (
     "SHBDUO-1",
     "SHCB-1",

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -46,6 +46,7 @@ from .const import (
     LIGHT_TRANSITION_MIN_FIRMWARE_DATE,
     MAX_TRANSITION_TIME,
     MODELS_SUPPORTING_LIGHT_TRANSITION,
+    RGBW_MODELS,
     RPC,
     SHBLB_1_RGB_EFFECTS,
     STANDARD_RGB_EFFECTS,
@@ -143,7 +144,7 @@ class BlockShellyLight(ShellyBlockEntity, LightEntity):
 
         if hasattr(block, "red") and hasattr(block, "green") and hasattr(block, "blue"):
             self._min_kelvin = KELVIN_MIN_VALUE_COLOR
-            if hasattr(block, "white"):
+            if wrapper.model in RGBW_MODELS:
                 self._supported_color_modes.add(COLOR_MODE_RGBW)
             else:
                 self._supported_color_modes.add(COLOR_MODE_RGB)

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -133,6 +133,10 @@ def is_block_momentary_input(settings: dict[str, Any], block: Block) -> bool:
     if settings["device"]["type"] in SHBTN_MODELS:
         return True
 
+    if settings.get("mode") == "roller":
+        button_type = settings["rollers"][0]["button_type"]
+        return button_type in ["momentary", "momentary_on_release"]
+
     button = settings.get("relays") or settings.get("lights") or settings.get("inputs")
     if button is None:
         return False

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -2,7 +2,7 @@
   "domain": "switchbot",
   "name": "SwitchBot",
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "requirements": ["PySwitchbot==0.11.0"],
+  "requirements": ["PySwitchbot==0.12.0"],
   "config_flow": true,
   "codeowners": ["@danielhiversen", "@RenierM26"],
   "iot_class": "local_polling"

--- a/homeassistant/components/version/manifest.json
+++ b/homeassistant/components/version/manifest.json
@@ -3,7 +3,7 @@
   "name": "Version",
   "documentation": "https://www.home-assistant.io/integrations/version",
   "requirements": [
-    "pyhaversion==21.7.0"
+    "pyhaversion==21.10.0"
   ],
   "codeowners": [
     "@fabaff",

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -36,8 +36,8 @@ from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
-STATE_CHANGE_TIME = 0.25  # seconds
-
+STATE_CHANGE_TIME = 0.40  # seconds
+POWER_STATE_CHANGE_TIME = 1  # seconds
 
 DOMAIN = "yeelight"
 DATA_YEELIGHT = DOMAIN

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -2,7 +2,7 @@
   "domain": "zeroconf",
   "name": "Zero-configuration networking (zeroconf)",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
-  "requirements": ["zeroconf==0.36.7"],
+  "requirements": ["zeroconf==0.36.8"],
   "dependencies": ["network", "api"],
   "codeowners": ["@bdraco"],
   "quality_scale": "internal",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 10
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -32,7 +32,7 @@ sqlalchemy==1.4.23
 voluptuous-serialize==2.4.0
 voluptuous==0.12.2
 yarl==1.6.3
-zeroconf==0.36.7
+zeroconf==0.36.8
 
 pycryptodome>=3.6.6
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -15,7 +15,7 @@ ciso8601==2.2.0
 cryptography==3.4.8
 emoji==1.5.0
 hass-nabucasa==0.50.0
-home-assistant-frontend==20211007.0
+home-assistant-frontend==20211007.1
 httpx==0.19.0
 ifaddr==0.1.7
 jinja2==3.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -49,7 +49,7 @@ PyRMVtransport==0.3.2
 PySocks==1.7.1
 
 # homeassistant.components.switchbot
-# PySwitchbot==0.11.0
+# PySwitchbot==0.12.0
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2474,7 +2474,7 @@ youtube_dl==2021.04.26
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.36.7
+zeroconf==0.36.8
 
 # homeassistant.components.zha
 zha-quirks==0.0.62

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1514,7 +1514,7 @@ pygtfs==0.1.6
 pygti==0.9.2
 
 # homeassistant.components.version
-pyhaversion==21.7.0
+pyhaversion==21.10.0
 
 # homeassistant.components.heos
 pyheos==0.7.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1670,7 +1670,7 @@ pynuki==1.4.1
 pynut2==2.1.2
 
 # homeassistant.components.nws
-pynws==1.3.1
+pynws==1.3.2
 
 # homeassistant.components.nx584
 pynx584==0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -810,7 +810,7 @@ hole==0.5.1
 holidays==0.11.3.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20211007.0
+home-assistant-frontend==20211007.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -485,7 +485,7 @@ hole==0.5.1
 holidays==0.11.3.1
 
 # homeassistant.components.frontend
-home-assistant-frontend==20211007.0
+home-assistant-frontend==20211007.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1409,7 +1409,7 @@ yeelight==0.7.7
 youless-api==0.13
 
 # homeassistant.components.zeroconf
-zeroconf==0.36.7
+zeroconf==0.36.8
 
 # homeassistant.components.zha
 zha-quirks==0.0.62

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -986,7 +986,7 @@ pynuki==1.4.1
 pynut2==2.1.2
 
 # homeassistant.components.nws
-pynws==1.3.1
+pynws==1.3.2
 
 # homeassistant.components.nx584
 pynx584==0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -881,7 +881,7 @@ pygatt[GATTTOOL]==4.0.5
 pygti==0.9.2
 
 # homeassistant.components.version
-pyhaversion==21.7.0
+pyhaversion==21.10.0
 
 # homeassistant.components.heos
 pyheos==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -24,7 +24,7 @@ PyQRCode==1.2.1
 PyRMVtransport==0.3.2
 
 # homeassistant.components.switchbot
-# PySwitchbot==0.11.0
+# PySwitchbot==0.12.0
 
 # homeassistant.components.transport_nsw
 PyTransportNSW==0.1.1

--- a/tests/components/efergy/test_sensor.py
+++ b/tests/components/efergy/test_sensor.py
@@ -1,9 +1,15 @@
 """The tests for Efergy sensor platform."""
 
+import asyncio
+from datetime import timedelta
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
-from tests.common import load_fixture
+from tests.common import async_fire_time_changed, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 token = "9p6QGJ7dpZfO3fqPTBk1fyEmjV1cGoLT"
@@ -30,9 +36,14 @@ MULTI_SENSOR_CONFIG = {
 }
 
 
-def mock_responses(aioclient_mock: AiohttpClientMocker):
+def mock_responses(aioclient_mock: AiohttpClientMocker, error: bool = False):
     """Mock responses for Efergy."""
     base_url = "https://engage.efergy.com/mobile_proxy/"
+    if error:
+        aioclient_mock.get(
+            f"{base_url}getCurrentValuesSummary?token={token}", exc=asyncio.TimeoutError
+        )
+        return
     aioclient_mock.get(
         f"{base_url}getInstant?token={token}",
         text=load_fixture("efergy/efergy_instant.json"),
@@ -64,7 +75,9 @@ async def test_single_sensor_readings(
 ):
     """Test for successfully setting up the Efergy platform."""
     mock_responses(aioclient_mock)
-    assert await async_setup_component(hass, "sensor", {"sensor": ONE_SENSOR_CONFIG})
+    assert await async_setup_component(
+        hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: ONE_SENSOR_CONFIG}
+    )
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.energy_consumed").state == "38.21"
@@ -79,9 +92,44 @@ async def test_multi_sensor_readings(
 ):
     """Test for multiple sensors in one household."""
     mock_responses(aioclient_mock)
-    assert await async_setup_component(hass, "sensor", {"sensor": MULTI_SENSOR_CONFIG})
+    assert await async_setup_component(
+        hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: MULTI_SENSOR_CONFIG}
+    )
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.efergy_728386").state == "218"
     assert hass.states.get("sensor.efergy_0").state == "1808"
     assert hass.states.get("sensor.efergy_728387").state == "312"
+
+
+async def test_failed_getting_sids(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+):
+    """Test failed gettings sids."""
+    mock_responses(aioclient_mock, error=True)
+    assert await async_setup_component(
+        hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: ONE_SENSOR_CONFIG}
+    )
+    assert not hass.states.async_all("sensor")
+
+
+async def test_failed_update_and_reconnection(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+):
+    """Test failed update and reconnection."""
+    mock_responses(aioclient_mock)
+    assert await async_setup_component(
+        hass, SENSOR_DOMAIN, {SENSOR_DOMAIN: ONE_SENSOR_CONFIG}
+    )
+    aioclient_mock.clear_requests()
+    mock_responses(aioclient_mock, error=True)
+    next_update = dt_util.utcnow() + timedelta(seconds=3)
+    async_fire_time_changed(hass, next_update)
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.efergy_728386").state == STATE_UNAVAILABLE
+    aioclient_mock.clear_requests()
+    mock_responses(aioclient_mock)
+    next_update = dt_util.utcnow() + timedelta(seconds=30)
+    async_fire_time_changed(hass, next_update)
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.efergy_728386").state == "1628"

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from kasa import SmartBulb, SmartPlug, SmartStrip
+from kasa import SmartBulb, SmartDimmer, SmartPlug, SmartStrip
 from kasa.exceptions import SmartDeviceException
 from kasa.protocol import TPLinkSmartHomeProtocol
 
@@ -46,6 +46,33 @@ def _mocked_bulb() -> SmartBulb:
     bulb.set_color_temp = AsyncMock()
     bulb.protocol = _mock_protocol()
     return bulb
+
+
+def _mocked_dimmer() -> SmartDimmer:
+    dimmer = MagicMock(auto_spec=SmartDimmer)
+    dimmer.update = AsyncMock()
+    dimmer.mac = MAC_ADDRESS
+    dimmer.alias = ALIAS
+    dimmer.model = MODEL
+    dimmer.host = IP_ADDRESS
+    dimmer.brightness = 50
+    dimmer.color_temp = 4000
+    dimmer.is_color = True
+    dimmer.is_strip = False
+    dimmer.is_plug = False
+    dimmer.is_dimmer = True
+    dimmer.hsv = (10, 30, 5)
+    dimmer.device_id = MAC_ADDRESS
+    dimmer.valid_temperature_range.min = 4000
+    dimmer.valid_temperature_range.max = 9000
+    dimmer.hw_info = {"sw_ver": "1.0.0"}
+    dimmer.turn_off = AsyncMock()
+    dimmer.turn_on = AsyncMock()
+    dimmer.set_brightness = AsyncMock()
+    dimmer.set_hsv = AsyncMock()
+    dimmer.set_color_temp = AsyncMock()
+    dimmer.protocol = _mock_protocol()
+    return dimmer
 
 
 def _mocked_plug() -> SmartPlug:

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -4,14 +4,23 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from homeassistant import setup
 from homeassistant.components import tplink
 from homeassistant.components.tplink.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from . import IP_ADDRESS, MAC_ADDRESS, _patch_discovery, _patch_single_discovery
+from . import (
+    IP_ADDRESS,
+    MAC_ADDRESS,
+    _mocked_dimmer,
+    _patch_discovery,
+    _patch_single_discovery,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -63,3 +72,73 @@ async def test_config_entry_retry(hass):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
         assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
+
+
+async def test_dimmer_switch_unique_id_fix_original_entity_was_deleted(
+    hass: HomeAssistant, entity_reg: EntityRegistry
+):
+    """Test that roll out unique id entity id changed to the original unique id."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=MAC_ADDRESS)
+    config_entry.add_to_hass(hass)
+    dimmer = _mocked_dimmer()
+    rollout_unique_id = MAC_ADDRESS.replace(":", "").upper()
+    original_unique_id = tplink.legacy_device_id(dimmer)
+    rollout_dimmer_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=rollout_unique_id,
+        original_name="Rollout dimmer",
+    )
+
+    with _patch_discovery(device=dimmer), _patch_single_discovery(device=dimmer):
+        await setup.async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    migrated_dimmer_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=original_unique_id,
+        original_name="Migrated dimmer",
+    )
+    assert migrated_dimmer_entity_reg.entity_id == rollout_dimmer_entity_reg.entity_id
+
+
+async def test_dimmer_switch_unique_id_fix_original_entity_still_exists(
+    hass: HomeAssistant, entity_reg: EntityRegistry
+):
+    """Test no migration happens if the original entity id still exists."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=MAC_ADDRESS)
+    config_entry.add_to_hass(hass)
+    dimmer = _mocked_dimmer()
+    rollout_unique_id = MAC_ADDRESS.replace(":", "").upper()
+    original_unique_id = tplink.legacy_device_id(dimmer)
+    original_dimmer_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=original_unique_id,
+        original_name="Original dimmer",
+    )
+    rollout_dimmer_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=rollout_unique_id,
+        original_name="Rollout dimmer",
+    )
+
+    with _patch_discovery(device=dimmer), _patch_single_discovery(device=dimmer):
+        await setup.async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    migrated_dimmer_entity_reg = entity_reg.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="light",
+        unique_id=original_unique_id,
+        original_name="Migrated dimmer",
+    )
+    assert migrated_dimmer_entity_reg.entity_id == original_dimmer_entity_reg.entity_id
+    assert migrated_dimmer_entity_reg.entity_id != rollout_dimmer_entity_reg.entity_id


### PR DESCRIPTION
- Catch errors for efergy ([@tkdrob] - [#57326]) ([efergy docs])
- Use switch format unique ids for tplink dimmers ([@bdraco] - [#57346]) ([tplink docs])
- Fix Shelly RGB/W supported color mode detection ([@thecode] - [#57359]) ([shelly docs])
- Bump pynws to 1.3.2 ([@MatthewFlamm] - [#57361]) ([nws docs])
- Bump Switchbot library ([@RenierM26] - [#57367]) ([switchbot docs])
- Bump pyhaversion to 21.10.0 ([@ludeeus] - [#57377]) ([version docs])
- Update frontend to 20211007.1 ([@bramkragten] - [#57385]) ([frontend docs])
- Do all of dhcp scapy startup in the executor ([@bdraco] - [#57392]) ([dhcp docs])
- Remove executor calls in isy994 as its fully async ([@bdraco] - [#57394]) ([isy994 docs])
- Fix default parameter values for service opentherm_gw.set_clock ([@mvn23] - [#57397]) ([opentherm_gw docs])
- Fix `opentherm_gw.set_clock` `time` parameter name ([@mvn23] - [#57398]) ([opentherm_gw docs])
- Restore yeelight workaround for failing to update state after on/off ([@bdraco] - [#57400]) ([yeelight docs])
- Fix Shelly button filter empty event ([@thecode] - [#57427]) ([shelly docs])
- Fix Shelly button type in roller mode ([@thecode] - [#57429]) ([shelly docs])
- Bump zeroconf to 0.36.8 ([@bdraco] - [#57451]) ([zeroconf docs])
- Fix netgear renamed mdi icons ([@thecode] - [#57431]) ([netgear docs])

[#57326]: https://github.com/home-assistant/core/pull/57326
[#57346]: https://github.com/home-assistant/core/pull/57346
[#57359]: https://github.com/home-assistant/core/pull/57359
[#57361]: https://github.com/home-assistant/core/pull/57361
[#57367]: https://github.com/home-assistant/core/pull/57367
[#57377]: https://github.com/home-assistant/core/pull/57377
[#57385]: https://github.com/home-assistant/core/pull/57385
[#57392]: https://github.com/home-assistant/core/pull/57392
[#57394]: https://github.com/home-assistant/core/pull/57394
[#57397]: https://github.com/home-assistant/core/pull/57397
[#57398]: https://github.com/home-assistant/core/pull/57398
[#57400]: https://github.com/home-assistant/core/pull/57400
[#57427]: https://github.com/home-assistant/core/pull/57427
[#57429]: https://github.com/home-assistant/core/pull/57429
[#57431]: https://github.com/home-assistant/core/pull/57431
[#57451]: https://github.com/home-assistant/core/pull/57451
[@MatthewFlamm]: https://github.com/MatthewFlamm
[@RenierM26]: https://github.com/RenierM26
[@bdraco]: https://github.com/bdraco
[@bramkragten]: https://github.com/bramkragten
[@ludeeus]: https://github.com/ludeeus
[@mvn23]: https://github.com/mvn23
[@thecode]: https://github.com/thecode
[@tkdrob]: https://github.com/tkdrob
[dhcp docs]: https://www.home-assistant.io/integrations/dhcp/
[efergy docs]: https://www.home-assistant.io/integrations/efergy/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[isy994 docs]: https://www.home-assistant.io/integrations/isy994/
[netgear docs]: https://www.home-assistant.io/integrations/netgear/
[nws docs]: https://www.home-assistant.io/integrations/nws/
[opentherm_gw docs]: https://www.home-assistant.io/integrations/opentherm_gw/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[switchbot docs]: https://www.home-assistant.io/integrations/switchbot/
[tplink docs]: https://www.home-assistant.io/integrations/tplink/
[version docs]: https://www.home-assistant.io/integrations/version/
[yeelight docs]: https://www.home-assistant.io/integrations/yeelight/
[zeroconf docs]: https://www.home-assistant.io/integrations/zeroconf/