### PR TITLE
Don't override methods marked as final

### DIFF
--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -211,7 +211,7 @@ class Alert(ToggleEntity):
         )
 
     @property
-    def state(self):
+    def state(self):  # pylint: disable=overridden-final-method
         """Return the alert status."""
         if self._firing:
             if self._ack:

--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -211,7 +211,7 @@ class Alert(ToggleEntity):
         )
 
     @property
-    def state(self):  # pylint: disable=overridden-final-method
+    def state(self):
         """Return the alert status."""
         if self._firing:
             if self._ack:

--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -36,11 +36,6 @@ class BleBoxCoverEntity(BleBoxEntity, CoverEntity):
         self._attr_supported_features = position | stop | SUPPORT_OPEN | SUPPORT_CLOSE
 
     @property
-    def state(self):
-        """Return the equivalent HA cover state."""
-        return BLEBOX_TO_HASS_COVER_STATES[self._feature.state]
-
-    @property
     def current_cover_position(self):
         """Return the current cover position."""
         position = self._feature.current
@@ -83,5 +78,5 @@ class BleBoxCoverEntity(BleBoxEntity, CoverEntity):
         await self._feature.async_stop()
 
     def _is_state(self, state_name):
-        value = self.state
+        value = BLEBOX_TO_HASS_COVER_STATES[self._feature.state]
         return None if value is None else value == state_name

--- a/homeassistant/components/deluge/switch.py
+++ b/homeassistant/components/deluge/switch.py
@@ -69,11 +69,6 @@ class DelugeSwitch(ToggleEntity):
         return self._name
 
     @property
-    def state(self):
-        """Return the state of the device."""
-        return self._state
-
-    @property
     def is_on(self):
         """Return true if device is on."""
         return self._state == STATE_ON

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -60,11 +60,6 @@ class EvoDHW(EvoChild, WaterHeaterEntity):
         self._supported_features = SUPPORT_AWAY_MODE | SUPPORT_OPERATION_MODE
 
     @property
-    def state(self):
-        """Return the current state."""
-        return EVO_STATE_TO_HA[self._evo_device.stateStatus["state"]]
-
-    @property
     def current_operation(self) -> str:
         """Return the current operating mode (Auto, On, or Off)."""
         if self._evo_device.stateStatus["mode"] == EVO_FOLLOW:

--- a/homeassistant/components/generic_hygrostat/humidifier.py
+++ b/homeassistant/components/generic_hygrostat/humidifier.py
@@ -204,14 +204,11 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
         return self._active
 
     @property
-    def state_attributes(self):
+    def extra_state_attributes(self):
         """Return the optional state attributes."""
-        data = super().state_attributes
-
         if self._saved_target_humidity:
-            data[ATTR_SAVED_HUMIDITY] = self._saved_target_humidity
-
-        return data
+            return {ATTR_SAVED_HUMIDITY: self._saved_target_humidity}
+        return None
 
     @property
     def should_poll(self):

--- a/homeassistant/components/hikvisioncam/switch.py
+++ b/homeassistant/components/hikvisioncam/switch.py
@@ -74,11 +74,6 @@ class HikvisionMotionSwitch(SwitchEntity):
         return self._name
 
     @property
-    def state(self):
-        """Return the state of the device if any."""
-        return self._state
-
-    @property
     def is_on(self):
         """Return true if device is on."""
         return self._state == STATE_ON

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -73,7 +73,7 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverEntity):
         return SUPPORT_OPEN | SUPPORT_CLOSE
 
     @property
-    def state(self):
+    def _state(self):
         """Return the current state of the garage door."""
         value = self.service.value(CharacteristicsTypes.DOOR_STATE_CURRENT)
         return CURRENT_GARAGE_STATE_MAP[value]
@@ -81,17 +81,17 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverEntity):
     @property
     def is_closed(self):
         """Return true if cover is closed, else False."""
-        return self.state == STATE_CLOSED
+        return self._state == STATE_CLOSED
 
     @property
     def is_closing(self):
         """Return if the cover is closing or not."""
-        return self.state == STATE_CLOSING
+        return self._state == STATE_CLOSING
 
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
-        return self.state == STATE_OPENING
+        return self._state == STATE_OPENING
 
     async def async_open_cover(self, **kwargs):
         """Send open command."""

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -17,7 +17,7 @@ from homeassistant.components.vacuum import (
     SUPPORT_STATUS,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
-    VacuumEntity,
+    StateVacuumEntity,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF
@@ -76,7 +76,7 @@ async def async_setup_entry(
     )
 
 
-class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
+class LitterRobotCleaner(LitterRobotControlEntity, StateVacuumEntity):
     """Litter-Robot "Vacuum" Cleaner."""
 
     @property

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -48,11 +48,6 @@ class TransmissionSwitch(ToggleEntity):
         return f"{self._tm_client.api.host}-{self.name}"
 
     @property
-    def state(self):
-        """Return the state of the device."""
-        return self._state
-
-    @property
     def should_poll(self):
         """Poll for status regularly."""
         return False


### PR DESCRIPTION
## Proposed change
Preview for the next `pylint` version which adds a new check `overridden-final-method` to detect methods that override a method decorated with `@final`.

For Home Assistant there are a few integrations which overwrite the `state` method at the moment.

Pylint PR which added the check: https://github.com/PyCQA/pylint/pull/5133

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
