### PR TITLE
Bump `nettigo_air_monitor` library to version 1.1.1

### DIFF
--- a/homeassistant/components/nam/const.py
+++ b/homeassistant/components/nam/const.py
@@ -34,6 +34,8 @@ SUFFIX_P4: Final = "_p4"
 ATTR_BME280_HUMIDITY: Final = "bme280_humidity"
 ATTR_BME280_PRESSURE: Final = "bme280_pressure"
 ATTR_BME280_TEMPERATURE: Final = "bme280_temperature"
+ATTR_BMP180_PRESSURE: Final = "bmp180_pressure"
+ATTR_BMP180_TEMPERATURE: Final = "bmp180_temperature"
 ATTR_BMP280_PRESSURE: Final = "bmp280_pressure"
 ATTR_BMP280_TEMPERATURE: Final = "bmp280_temperature"
 ATTR_DHT22_HUMIDITY: Final = "dht22_humidity"
@@ -82,6 +84,20 @@ SENSORS: Final[tuple[SensorEntityDescription, ...]] = (
     SensorEntityDescription(
         key=ATTR_BME280_TEMPERATURE,
         name=f"{DEFAULT_NAME} BME280 Temperature",
+        native_unit_of_measurement=TEMP_CELSIUS,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key=ATTR_BMP180_PRESSURE,
+        name=f"{DEFAULT_NAME} BMP180 Pressure",
+        native_unit_of_measurement=PRESSURE_HPA,
+        device_class=DEVICE_CLASS_PRESSURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key=ATTR_BMP180_TEMPERATURE,
+        name=f"{DEFAULT_NAME} BMP180 Temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=DEVICE_CLASS_TEMPERATURE,
         state_class=STATE_CLASS_MEASUREMENT,

--- a/homeassistant/components/nam/manifest.json
+++ b/homeassistant/components/nam/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nettigo Air Monitor",
   "documentation": "https://www.home-assistant.io/integrations/nam",
   "codeowners": ["@bieniu"],
-  "requirements": ["nettigo-air-monitor==1.1.0"],
+  "requirements": ["nettigo-air-monitor==1.1.1"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1050,7 +1050,7 @@ netdisco==3.0.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==1.1.0
+nettigo-air-monitor==1.1.1
 
 # homeassistant.components.neurio_energy
 neurio==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -621,7 +621,7 @@ netdisco==3.0.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==1.1.0
+nettigo-air-monitor==1.1.1
 
 # homeassistant.components.nexia
 nexia==0.9.11

--- a/tests/components/nam/__init__.py
+++ b/tests/components/nam/__init__.py
@@ -24,6 +24,8 @@ nam_data = {
         {"value_type": "BME280_temperature", "value": "7.56"},
         {"value_type": "BME280_humidity", "value": "45.69"},
         {"value_type": "BME280_pressure", "value": "101101.17"},
+        {"value_type": "BMP_temperature", "value": "7.56"},
+        {"value_type": "BMP_pressure", "value": "103201.18"},
         {"value_type": "BMP280_temperature", "value": "5.56"},
         {"value_type": "BMP280_pressure", "value": "102201.18"},
         {"value_type": "SHT3X_temperature", "value": "6.28"},

--- a/tests/components/nam/test_sensor.py
+++ b/tests/components/nam/test_sensor.py
@@ -97,6 +97,28 @@ async def test_sensor(hass):
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-bme280_pressure"
 
+    state = hass.states.get("sensor.nettigo_air_monitor_bmp180_temperature")
+    assert state
+    assert state.state == "7.6"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
+
+    entry = registry.async_get("sensor.nettigo_air_monitor_bmp180_temperature")
+    assert entry
+    assert entry.unique_id == "aa:bb:cc:dd:ee:ff-bmp180_temperature"
+
+    state = hass.states.get("sensor.nettigo_air_monitor_bmp180_pressure")
+    assert state
+    assert state.state == "1032"
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_PRESSURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PRESSURE_HPA
+
+    entry = registry.async_get("sensor.nettigo_air_monitor_bmp180_pressure")
+    assert entry
+    assert entry.unique_id == "aa:bb:cc:dd:ee:ff-bmp180_pressure"
+
     state = hass.states.get("sensor.nettigo_air_monitor_bmp280_temperature")
     assert state
     assert state.state == "5.6"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `nettigo_air_monitor` library to add support for BMP180 sensor.

Changelog: https://github.com/bieniu/nettigo-air-monitor/releases/tag/1.1.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
