### PR TITLE
Add reauth for Netatmo when token or token scope is invalid

### DIFF
--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -246,7 +246,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    if unload_ok:
+    if unload_ok and entry.entry_id in hass.data[DOMAIN]:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/netatmo/config_flow.py
+++ b/homeassistant/components/netatmo/config_flow.py
@@ -23,7 +23,10 @@ from .const import (
     CONF_UUID,
     CONF_WEATHER_AREAS,
     DOMAIN,
+    NETATMO_SCOPES,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class NetatmoFlowHandler(
@@ -49,30 +52,45 @@ class NetatmoFlowHandler(
     @property
     def extra_authorize_data(self) -> dict:
         """Extra data that needs to be appended to the authorize url."""
-        scopes = [
-            "access_camera",
-            "access_presence",
-            "read_camera",
-            "read_homecoach",
-            "read_presence",
-            "read_smokedetector",
-            "read_station",
-            "read_thermostat",
-            "write_camera",
-            "write_presence",
-            "write_thermostat",
-        ]
-
-        return {"scope": " ".join(scopes)}
+        return {"scope": " ".join(NETATMO_SCOPES)}
 
     async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
         """Handle a flow start."""
         await self.async_set_unique_id(DOMAIN)
 
-        if self._async_current_entries():
+        if (
+            self.source != config_entries.SOURCE_REAUTH
+            and self._async_current_entries()
+        ):
             return self.async_abort(reason="single_instance_allowed")
 
         return await super().async_step_user(user_input)
+
+    async def async_step_reauth(self, user_input: dict | None = None) -> FlowResult:
+        """Perform reauth upon an API authentication error."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict | None = None
+    ) -> FlowResult:
+        """Dialog that informs the user that reauth is required."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=vol.Schema({}),
+            )
+
+        return await self.async_step_user()
+
+    async def async_oauth_create_entry(self, data: dict) -> FlowResult:
+        """Create an oauth config entry or update existing entry for reauth."""
+        existing_entry = await self.async_set_unique_id(DOMAIN)
+        if existing_entry:
+            self.hass.config_entries.async_update_entry(existing_entry, data=data)
+            await self.hass.config_entries.async_reload(existing_entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+
+        return await super().async_oauth_create_entry(data)
 
 
 class NetatmoOptionsFlowHandler(config_entries.OptionsFlow):

--- a/homeassistant/components/netatmo/const.py
+++ b/homeassistant/components/netatmo/const.py
@@ -13,6 +13,20 @@ DEFAULT_ATTRIBUTION = f"Data provided by {MANUFACTURER}"
 
 PLATFORMS = [CAMERA_DOMAIN, CLIMATE_DOMAIN, LIGHT_DOMAIN, SELECT_DOMAIN, SENSOR_DOMAIN]
 
+NETATMO_SCOPES = [
+    "access_camera",
+    "access_presence",
+    "read_camera",
+    "read_homecoach",
+    "read_presence",
+    "read_smokedetector",
+    "read_station",
+    "read_thermostat",
+    "write_camera",
+    "write_presence",
+    "write_thermostat",
+]
+
 MODEL_NAPLUG = "Relay"
 MODEL_NATHERM1 = "Smart Thermostat"
 MODEL_NRV = "Smart Radiator Valves"

--- a/homeassistant/components/netatmo/light.py
+++ b/homeassistant/components/netatmo/light.py
@@ -33,12 +33,6 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Netatmo camera light platform."""
-    if "access_camera" not in entry.data["token"]["scope"]:
-        _LOGGER.info(
-            "Cameras are currently not supported with this authentication method"
-        )
-        return
-
     data_handler = hass.data[DOMAIN][entry.entry_id][DATA_HANDLER]
 
     await data_handler.register_data_class(

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -3,13 +3,18 @@
     "step": {
       "pick_implementation": {
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The Nettmo integration needs to re-authenticate your account"
       }
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
-      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]"
+      "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -6,7 +6,7 @@
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "The Nettmo integration needs to re-authenticate your account"
+        "description": "The Netatmo integration needs to re-authenticate your account"
       }
     },
     "abort": {

--- a/homeassistant/components/netatmo/translations/en.json
+++ b/homeassistant/components/netatmo/translations/en.json
@@ -6,7 +6,7 @@
           },
           "reauth_confirm": {
             "title": "[%key:common::config_flow::title::reauth%]",
-            "description": "The Nettmo integration needs to re-authenticate your account"
+            "description": "The Netatmo integration needs to re-authenticate your account"
           }
         },
         "abort": {

--- a/homeassistant/components/netatmo/translations/en.json
+++ b/homeassistant/components/netatmo/translations/en.json
@@ -1,18 +1,23 @@
 {
     "config": {
+        "step": {
+          "pick_implementation": {
+            "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+          },
+          "reauth_confirm": {
+            "title": "[%key:common::config_flow::title::reauth%]",
+            "description": "The Nettmo integration needs to re-authenticate your account"
+          }
+        },
         "abort": {
-            "authorize_url_timeout": "Timeout generating authorize URL.",
-            "missing_configuration": "The component is not configured. Please follow the documentation.",
-            "no_url_available": "No URL available. For information about this error, [check the help section]({docs_url})",
-            "single_instance_allowed": "Already configured. Only a single configuration possible."
+          "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+          "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+          "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+          "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",
+          "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
         },
         "create_entry": {
-            "default": "Successfully authenticated"
-        },
-        "step": {
-            "pick_implementation": {
-                "title": "Pick Authentication Method"
-            }
+          "default": "[%key:common::config_flow::create_entry::authenticated%]"
         }
     },
     "device_automation": {

--- a/tests/components/netatmo/conftest.py
+++ b/tests/components/netatmo/conftest.py
@@ -22,7 +22,7 @@ def mock_config_entry_fixture(hass):
                 "type": "Bearer",
                 "expires_in": 60,
                 "expires_at": time() + 1000,
-                "scope": " ".join(ALL_SCOPES),
+                "scope": ALL_SCOPES,
             },
         },
         options={

--- a/tests/components/netatmo/conftest.py
+++ b/tests/components/netatmo/conftest.py
@@ -53,7 +53,7 @@ def mock_config_entry_fixture(hass):
     return mock_entry
 
 
-@pytest.fixture
+@pytest.fixture(name="netatmo_auth")
 def netatmo_auth():
     """Restrict loaded platforms to list given."""
     with patch(

--- a/tests/components/netatmo/test_config_flow.py
+++ b/tests/components/netatmo/test_config_flow.py
@@ -13,6 +13,8 @@ from homeassistant.components.netatmo.const import (
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
+from .common import ALL_SCOPES
+
 from tests.common import MockConfigEntry
 
 CLIENT_ID = "1234"
@@ -67,21 +69,7 @@ async def test_full_flow(
         },
     )
 
-    scope = "+".join(
-        [
-            "access_camera",
-            "access_presence",
-            "read_camera",
-            "read_homecoach",
-            "read_presence",
-            "read_smokedetector",
-            "read_station",
-            "read_thermostat",
-            "write_camera",
-            "write_presence",
-            "write_thermostat",
-        ]
-    )
+    scope = "+".join(sorted(ALL_SCOPES))
 
     assert result["url"] == (
         f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
@@ -227,3 +215,110 @@ async def test_option_flow_wrong_coordinates(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     for k, v in expected_result.items():
         assert config_entry.options[CONF_WEATHER_AREAS]["Home"][k] == v
+
+
+async def test_reauth(
+    hass, hass_client_no_auth, aioclient_mock, current_request_with_host
+):
+    """Test initialization of the reauth flow."""
+    assert await setup.async_setup_component(
+        hass,
+        "netatmo",
+        {
+            "netatmo": {CONF_CLIENT_ID: CLIENT_ID, CONF_CLIENT_SECRET: CLIENT_SECRET},
+            "http": {"base_url": "https://example.com"},
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        "netatmo", context={"source": config_entries.SOURCE_USER}
+    )
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+
+    scope = "+".join(sorted(ALL_SCOPES))
+
+    assert result["url"] == (
+        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
+        "&redirect_uri=https://example.com/auth/external/callback"
+        f"&state={state}&scope={scope}"
+    )
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.netatmo.async_setup_entry", return_value=True
+    ) as mock_setup:
+        await hass.config_entries.flow.async_configure(result["flow_id"])
+        await hass.async_block_till_done()
+
+    new_entry = hass.config_entries.async_entries(DOMAIN)[0]
+
+    assert new_entry.state == config_entries.ConfigEntryState.LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert len(mock_setup.mock_calls) == 1
+
+    # Should show form
+    result = await hass.config_entries.flow.async_init(
+        "netatmo", context={"source": config_entries.SOURCE_REAUTH}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    # Confirm reauth flow
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    # Update entry
+    with patch(
+        "homeassistant.components.netatmo.async_setup_entry", return_value=True
+    ) as mock_setup:
+        result3 = await hass.config_entries.flow.async_configure(result2["flow_id"])
+        await hass.async_block_till_done()
+
+    new_entry2 = hass.config_entries.async_entries(DOMAIN)[0]
+
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result3["reason"] == "reauth_successful"
+    assert new_entry2.state == config_entries.ConfigEntryState.LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert len(mock_setup.mock_calls) == 1

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
 from .common import (
+    ALL_SCOPES,
     FAKE_WEBHOOK_ACTIVATION,
     fake_post_request,
     selected_platforms,
@@ -61,7 +62,7 @@ async def test_setup_component(hass):
                 "type": "Bearer",
                 "expires_in": 60,
                 "expires_at": time() + 1000,
-                "scope": "read_station",
+                "scope": " ".join(ALL_SCOPES),
             },
         },
     )
@@ -248,7 +249,7 @@ async def test_setup_with_cloudhook(hass):
                 "type": "Bearer",
                 "expires_in": 60,
                 "expires_at": time() + 1000,
-                "scope": "read_station",
+                "scope": " ".join(ALL_SCOPES),
             },
         },
     )
@@ -310,7 +311,7 @@ async def test_setup_component_api_error(hass):
                 "type": "Bearer",
                 "expires_in": 60,
                 "expires_at": time() + 1000,
-                "scope": "read_station",
+                "scope": " ".join(ALL_SCOPES),
             },
         },
     )
@@ -349,7 +350,7 @@ async def test_setup_component_api_timeout(hass):
                 "type": "Bearer",
                 "expires_in": 60,
                 "expires_at": time() + 1000,
-                "scope": "read_station",
+                "scope": " ".join(ALL_SCOPES),
             },
         },
     )

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -234,7 +234,7 @@ async def test_setup_with_cloudhook(hass):
                 "type": "Bearer",
                 "expires_in": 60,
                 "expires_at": time() + 1000,
-                "scope": " ".join(ALL_SCOPES),
+                "scope": ALL_SCOPES,
             },
         },
     )

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -50,24 +50,8 @@ FAKE_WEBHOOK = {
 }
 
 
-async def test_setup_component(hass):
+async def test_setup_component(hass, config_entry):
     """Test setup and teardown of the netatmo component."""
-    config_entry = MockConfigEntry(
-        domain="netatmo",
-        data={
-            "auth_implementation": "cloud",
-            "token": {
-                "refresh_token": "mock-refresh-token",
-                "access_token": "mock-access-token",
-                "type": "Bearer",
-                "expires_in": 60,
-                "expires_at": time() + 1000,
-                "scope": " ".join(ALL_SCOPES),
-            },
-        },
-    )
-    config_entry.add_to_hass(hass)
-
     with patch(
         "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth",
     ) as mock_auth, patch(
@@ -299,24 +283,8 @@ async def test_setup_with_cloudhook(hass):
         assert not hass.config_entries.async_entries(DOMAIN)
 
 
-async def test_setup_component_api_error(hass):
+async def test_setup_component_api_error(hass, config_entry):
     """Test error on setup of the netatmo component."""
-    config_entry = MockConfigEntry(
-        domain="netatmo",
-        data={
-            "auth_implementation": "cloud",
-            "token": {
-                "refresh_token": "mock-refresh-token",
-                "access_token": "mock-access-token",
-                "type": "Bearer",
-                "expires_in": 60,
-                "expires_at": time() + 1000,
-                "scope": " ".join(ALL_SCOPES),
-            },
-        },
-    )
-    config_entry.add_to_hass(hass)
-
     with patch(
         "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth",
     ) as mock_auth, patch(
@@ -338,24 +306,8 @@ async def test_setup_component_api_error(hass):
     mock_impl.assert_called_once()
 
 
-async def test_setup_component_api_timeout(hass):
+async def test_setup_component_api_timeout(hass, config_entry):
     """Test timeout on setup of the netatmo component."""
-    config_entry = MockConfigEntry(
-        domain="netatmo",
-        data={
-            "auth_implementation": "cloud",
-            "token": {
-                "refresh_token": "mock-refresh-token",
-                "access_token": "mock-access-token",
-                "type": "Bearer",
-                "expires_in": 60,
-                "expires_at": time() + 1000,
-                "scope": " ".join(ALL_SCOPES),
-            },
-        },
-    )
-    config_entry.add_to_hass(hass)
-
     with patch(
         "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth",
     ) as mock_auth, patch(

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -382,3 +382,54 @@ async def test_setup_component_with_delay(hass, config_entry):
 
         await hass.async_stop()
         mock_dropwebhook.assert_called_once()
+
+
+async def test_setup_component_invalid_token_scope(hass):
+    """Test handling of invalid token scope."""
+    config_entry = MockConfigEntry(
+        domain="netatmo",
+        data={
+            "auth_implementation": "cloud",
+            "token": {
+                "refresh_token": "mock-refresh-token",
+                "access_token": "mock-access-token",
+                "type": "Bearer",
+                "expires_in": 60,
+                "expires_at": time() + 1000,
+                "scope": " ".join(
+                    [
+                        "read_smokedetector",
+                        "read_thermostat",
+                        "write_thermostat",
+                    ]
+                ),
+            },
+        },
+        options={},
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth",
+    ) as mock_auth, patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.async_get_config_entry_implementation",
+    ) as mock_impl, patch(
+        "homeassistant.components.webhook.async_generate_url"
+    ) as mock_webhook:
+        mock_auth.return_value.async_post_request.side_effect = fake_post_request
+        mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
+        mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
+        assert await async_setup_component(hass, "netatmo", {})
+
+    await hass.async_block_till_done()
+
+    mock_auth.assert_not_called()
+    mock_impl.assert_called_once()
+    mock_webhook.assert_not_called()
+
+    assert config_entry.state is config_entries.ConfigEntryState.SETUP_ERROR
+    assert hass.config_entries.async_entries(DOMAIN)
+    assert len(hass.states.async_all()) > 0
+
+    for config_entry in hass.config_entries.async_entries("netatmo"):
+        await hass.config_entries.async_remove(config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Trigger reauthentication for Netatmo when token or token scope is invalid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #57409
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
