### PR TITLE
Warn user if Gateway is already paired

### DIFF
--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -176,6 +176,10 @@ async def authenticate(
     try:
         with async_timeout.timeout(5):
             key = await api_factory.generate_psk(security_code)
+            if key is None:
+                raise AuthError(
+                    "Cannot authenticate, is Gateway paired with another server?"
+                )
     except RequestError as err:
         raise AuthError("invalid_security_code") from err
     except asyncio.TimeoutError as err:

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -176,17 +176,14 @@ async def authenticate(
     try:
         with async_timeout.timeout(5):
             key = await api_factory.generate_psk(security_code)
-            if key is None:
-                raise AuthError(
-                    "Cannot authenticate, is Gateway paired with another server?"
-                )
     except RequestError as err:
         raise AuthError("invalid_security_code") from err
     except asyncio.TimeoutError as err:
         raise AuthError("timeout") from err
     finally:
         await api_factory.shutdown()
-
+    if key is None:
+        raise AuthError("Cannot authenticate, is Gateway paired with another server?")
     return await get_gateway_info(hass, host, identity, key)
 
 

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -183,7 +183,7 @@ async def authenticate(
     finally:
         await api_factory.shutdown()
     if key is None:
-        raise AuthError("Cannot authenticate, is Gateway paired with another server?")
+        raise AuthError("cannot_authenticate")
     return await get_gateway_info(hass, host, identity, key)
 
 

--- a/homeassistant/components/tradfri/strings.json
+++ b/homeassistant/components/tradfri/strings.json
@@ -13,7 +13,8 @@
     "error": {
       "invalid_key": "Failed to register with provided key. If this keeps happening, try restarting the gateway.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "timeout": "Timeout validating the code."
+      "timeout": "Timeout validating the code.",
+      "cannot_authenticate": "Cannot authenticate, is Gateway paired with another server?"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/tradfri/strings.json
+++ b/homeassistant/components/tradfri/strings.json
@@ -14,7 +14,7 @@
       "invalid_key": "Failed to register with provided key. If this keeps happening, try restarting the gateway.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "timeout": "Timeout validating the code.",
-      "cannot_authenticate": "Cannot authenticate, is Gateway paired with another server?"
+      "cannot_authenticate": "Cannot authenticate, is Gateway paired with another server like e.g. Homekit?"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the Tradfri config flow."""
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -16,6 +16,26 @@ def mock_auth():
         "homeassistant.components.tradfri.config_flow.authenticate"
     ) as mock_auth:
         yield mock_auth
+
+
+async def test_already_paired(hass, mock_entry_setup):
+    """Test Gateway already paired."""
+    with patch(
+        "homeassistant.components.tradfri.config_flow.APIFactory",
+        autospec=True,
+    ) as mock_lib:
+        mx = AsyncMock()
+        mx.generate_psk.return_value = None
+        mock_lib.init.return_value = mx
+        flow = await hass.config_entries.flow.async_init(
+            "tradfri", context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"], {"host": "123.123.123.123", "security_code": "abcd"}
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "cannot_authenticate"}
 
 
 async def test_user_connection_successful(hass, mock_auth, mock_entry_setup):

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -27,11 +27,11 @@ async def test_already_paired(hass, mock_entry_setup):
         mx = AsyncMock()
         mx.generate_psk.return_value = None
         mock_lib.init.return_value = mx
-        flow = await hass.config_entries.flow.async_init(
+        result = await hass.config_entries.flow.async_init(
             "tradfri", context={"source": config_entries.SOURCE_USER}
         )
         result = await hass.config_entries.flow.async_configure(
-            flow["flow_id"], {"host": "123.123.123.123", "security_code": "abcd"}
+            result["flow_id"], {"host": "123.123.123.123", "security_code": "abcd"}
         )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the IKEA Gateway is already paired with e.g. homekit, pytradfri makes a stack trace and the user does not get a clue.

This PR gives the user a clue.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
There is a PR in pytradfri for a new release, since the problem is already solved on master.

Please see

https://github.com/home-assistant-libs/pytradfri/pull/358

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
#57421
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
