### PR TITLE
Rationalize command_line template usage

### DIFF
--- a/homeassistant/components/command_line/binary_sensor.py
+++ b/homeassistant/components/command_line/binary_sensor.py
@@ -25,8 +25,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.reload import setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from . import CommandData
 from .const import CONF_COMMAND_TIMEOUT, DEFAULT_TIMEOUT, DOMAIN, PLATFORMS
-from .sensor import CommandSensorData
 
 DEFAULT_NAME = "Binary Command Sensor"
 DEFAULT_PAYLOAD_ON = "ON"
@@ -37,7 +37,7 @@ SCAN_INTERVAL = timedelta(seconds=60)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_COMMAND): cv.string,
+        vol.Required(CONF_COMMAND): cv.template,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
         vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
@@ -69,7 +69,7 @@ def setup_platform(
     unique_id = config.get(CONF_UNIQUE_ID)
     if value_template is not None:
         value_template.hass = hass
-    data = CommandSensorData(hass, command, command_timeout)
+    data = CommandData(hass, command, command_timeout)
 
     add_entities(
         [
@@ -130,7 +130,7 @@ class CommandBinarySensor(BinarySensorEntity):
 
     def update(self):
         """Get the latest data and updates the state."""
-        self.data.update()
+        self.data.update(True)
         value = self.data.value
 
         if self._value_template is not None:

--- a/homeassistant/components/command_line/cover.py
+++ b/homeassistant/components/command_line/cover.py
@@ -103,22 +103,13 @@ class CommandCover(CoverEntity):
         self._hass = hass
         self._name = name
         self._state = None
-        self._command_open = (
-            CommandData(hass, command_open, timeout) if command_open else command_open
-        )
-        self._command_close = (
-            CommandData(hass, command_close, timeout)
-            if command_close
-            else command_close
-        )
-        self._command_stop = (
-            CommandData(hass, command_stop, timeout) if command_stop else command_stop
-        )
-        self._command_state = (
-            CommandData(hass, command_state, timeout)
-            if command_state
-            else command_state
-        )
+        self._command_open = CommandData(hass, command_open, timeout)
+        self._command_close = CommandData(hass, command_close, timeout)
+        self._command_stop = CommandData(hass, command_stop, timeout)
+        if command_state:
+            self._command_state = CommandData(hass, command_state, timeout)
+        else:
+            self._command_state = None
         self._value_template = value_template
         self._timeout = timeout
         self._attr_unique_id = unique_id

--- a/homeassistant/components/command_line/switch.py
+++ b/homeassistant/components/command_line/switch.py
@@ -26,16 +26,16 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.reload import setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import call_shell_with_timeout, check_output_or_log
+from . import CommandData
 from .const import CONF_COMMAND_TIMEOUT, DEFAULT_TIMEOUT, DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
 SWITCH_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_COMMAND_OFF, default="true"): cv.string,
-        vol.Optional(CONF_COMMAND_ON, default="true"): cv.string,
-        vol.Optional(CONF_COMMAND_STATE): cv.string,
+        vol.Optional(CONF_COMMAND_OFF, default="true"): cv.template,
+        vol.Optional(CONF_COMMAND_ON, default="true"): cv.template,
+        vol.Optional(CONF_COMMAND_STATE, default=None): vol.Any(cv.template, None),
         vol.Optional(CONF_FRIENDLY_NAME): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_ICON_TEMPLATE): cv.template,
@@ -115,36 +115,31 @@ class CommandSwitch(SwitchEntity):
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
         self._name = friendly_name
         self._state = False
-        self._command_on = command_on
-        self._command_off = command_off
-        self._command_state = command_state
+        self._command_on = (
+            CommandData(hass, command_on, timeout) if command_on else command_on
+        )
+        self._command_off = (
+            CommandData(hass, command_off, timeout) if command_off else command_off
+        )
+        self._command_state = (
+            CommandData(hass, command_state, timeout)
+            if command_state
+            else command_state
+        )
         self._icon_template = icon_template
         self._value_template = value_template
         self._timeout = timeout
         self._attr_unique_id = unique_id
 
-    def _switch(self, command):
+    @classmethod
+    def _switch(cls, command):
         """Execute the actual commands."""
-        _LOGGER.info("Running command: %s", command)
-
-        success = call_shell_with_timeout(command, self._timeout) == 0
+        success = command.update(False) == 0
 
         if not success:
             _LOGGER.error("Command failed: %s", command)
 
         return success
-
-    def _query_state_value(self, command):
-        """Execute state command for return value."""
-        _LOGGER.info("Running state value command: %s", command)
-        return check_output_or_log(command, self._timeout)
-
-    def _query_state_code(self, command):
-        """Execute state command for return code."""
-        _LOGGER.info("Running state code command: %s", command)
-        return (
-            call_shell_with_timeout(command, self._timeout, log_return_code=False) == 0
-        )
 
     @property
     def should_poll(self):
@@ -169,8 +164,8 @@ class CommandSwitch(SwitchEntity):
     def _query_state(self):
         """Query for state."""
         if self._value_template:
-            return self._query_state_value(self._command_state)
-        return self._query_state_code(self._command_state)
+            return self._command_state.update(True)
+        return self._command_state.update(False) == 0
 
     def update(self):
         """Update device state."""

--- a/homeassistant/components/command_line/switch.py
+++ b/homeassistant/components/command_line/switch.py
@@ -115,17 +115,12 @@ class CommandSwitch(SwitchEntity):
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
         self._name = friendly_name
         self._state = False
-        self._command_on = (
-            CommandData(hass, command_on, timeout) if command_on else command_on
-        )
-        self._command_off = (
-            CommandData(hass, command_off, timeout) if command_off else command_off
-        )
-        self._command_state = (
-            CommandData(hass, command_state, timeout)
-            if command_state
-            else command_state
-        )
+        self._command_on = CommandData(hass, command_on, timeout)
+        self._command_off = CommandData(hass, command_off, timeout)
+        if command_state:
+            self._command_state = CommandData(hass, command_state, timeout)
+        else:
+            self._command_state = None
         self._icon_template = icon_template
         self._value_template = value_template
         self._timeout = timeout

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -77,6 +77,20 @@ async def test_template_render(hass: HomeAssistant) -> None:
     assert entity_state.state == "template_value"
 
 
+async def test_template_render_full(hass: HomeAssistant) -> None:
+    """Ensure command with leading templates get rendered properly."""
+
+    await setup_test_entities(
+        hass,
+        {
+            "command": "VAL='{{ states.sensor.template_sensor.state }}'; echo ${VAL}",
+        },
+    )
+    entity_state = hass.states.get("sensor.test")
+    assert entity_state
+    assert entity_state.state == "template_value"
+
+
 async def test_template_render_with_quote(hass: HomeAssistant) -> None:
     """Ensure command with templates and quotes get rendered properly."""
 
@@ -98,13 +112,26 @@ async def test_template_render_with_quote(hass: HomeAssistant) -> None:
         )
 
 
-async def test_bad_template_render(caplog: Any, hass: HomeAssistant) -> None:
+async def test_bad_template_render_1(caplog: Any, hass: HomeAssistant) -> None:
     """Test rendering a broken template."""
 
     await setup_test_entities(
         hass,
         {
             "command": "echo {{ this template doesn't parse",
+        },
+    )
+
+    assert "invalid template" in caplog.text
+
+
+async def test_bad_template_render_2(caplog: Any, hass: HomeAssistant) -> None:
+    """Test rendering a broken template."""
+
+    await setup_test_entities(
+        hass,
+        {
+            "command": "echo {{ foobar + 1 }}",
         },
     )
 

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -79,6 +79,27 @@ async def test_state_none(hass: HomeAssistant) -> None:
         assert entity_state.state == STATE_OFF
 
 
+async def test_state_off_without_log(caplog: Any, hass: HomeAssistant) -> None:
+    """Test with none state."""
+    with tempfile.TemporaryDirectory() as tempdirname:
+        path = os.path.join(tempdirname, "switch_status")
+        await setup_test_entity(
+            hass,
+            {
+                "test": {
+                    "command_on": f"echo 1 > {path}",
+                    "command_off": f"echo 0 > {path}",
+                    "command_state": "foobar",
+                }
+            },
+        )
+
+        entity_state = hass.states.get("switch.test")
+        assert entity_state
+        assert entity_state.state == STATE_OFF
+        assert "Command failed" not in caplog.text
+
+
 async def test_state_value(hass: HomeAssistant) -> None:
     """Test with state value."""
     with tempfile.TemporaryDirectory() as tempdirname:

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -8,6 +8,8 @@ import tempfile
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import setup
 from homeassistant.components.switch import DOMAIN, SCAN_INTERVAL
 from homeassistant.const import (
@@ -79,7 +81,9 @@ async def test_state_none(hass: HomeAssistant) -> None:
         assert entity_state.state == STATE_OFF
 
 
-async def test_state_off_without_log(caplog: pytest.LogCaptureFixture, hass: HomeAssistant) -> None:
+async def test_state_off_without_log(
+    caplog: pytest.LogCaptureFixture, hass: HomeAssistant
+) -> None:
     """Test with none state."""
     with tempfile.TemporaryDirectory() as tempdirname:
         path = os.path.join(tempdirname, "switch_status")

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -79,7 +79,7 @@ async def test_state_none(hass: HomeAssistant) -> None:
         assert entity_state.state == STATE_OFF
 
 
-async def test_state_off_without_log(caplog: Any, hass: HomeAssistant) -> None:
+async def test_state_off_without_log(caplog: pytest.LogCaptureFixture, hass: HomeAssistant) -> None:
     """Test with none state."""
     with tempfile.TemporaryDirectory() as tempdirname:
         path = os.path.join(tempdirname, "switch_status")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, template handling of the commands is not consistent amongst the different platforms of the `command_line` integration. 
Only the sensor one is supporting it, and then again in a strange fashion. Only arguments can be templatized, argument being defined as everything after the first blank in the command.

This:
- Enable templates for all `command_*` of the integration
- Uses a single template for the whole command (so allowing the templating of the first "chunk" of the command as well, e.g.

```yaml
sensor:
  - platform: command_line
    name: Test cli template
    command: >
      TZ="{{ states("input_text.test_tz") }}" date +"%z"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20059

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
