### PR TITLE
Refactor Tuya device handling

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -52,7 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     # Project type has been renamed to auth type in the upstream Tuya IoT SDK.
-    # This migrates existing config entries to reflect that name change.π
+    # This migrates existing config entries to reflect that name change.
     if CONF_PROJECT_TYPE in entry.data:
         data = {**entry.data, CONF_AUTH_TYPE: entry.data[CONF_PROJECT_TYPE]}
         data.pop(CONF_PROJECT_TYPE)
@@ -106,12 +106,11 @@ async def _init_tuya_sdk(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     listener = DeviceListener(hass, device_manager, device_ids)
     device_manager.add_device_listener(listener)
 
-    hass_data = HomeAssistantTuyaData(
+    hass.data[DOMAIN][entry.entry_id] = HomeAssistantTuyaData(
         device_listener=listener,
         device_manager=device_manager,
         home_manager=home_manager,
     )
-    hass.data[DOMAIN][entry.entry_id] = hass_data
 
     # Get devices & clean up device entities
     await hass.async_add_executor_job(home_manager.update_device_cache)

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -1,7 +1,8 @@
 """Support for Tuya Smart devices."""
+from __future__ import annotations
 
-import itertools
 import logging
+from typing import NamedTuple
 
 from tuya_iot import (
     AuthType,
@@ -30,27 +31,28 @@ from .const import (
     CONF_USERNAME,
     DOMAIN,
     PLATFORMS,
-    TUYA_DEVICE_MANAGER,
     TUYA_DISCOVERY_NEW,
-    TUYA_HA_DEVICES,
     TUYA_HA_SIGNAL_UPDATE_ENTITY,
-    TUYA_HA_TUYA_MAP,
-    TUYA_HOME_MANAGER,
-    TUYA_MQTT_LISTENER,
+    TUYA_SUPPORTED_PRODUCT_CATEGORIES,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 
+class HomeAssistantTuyaData(NamedTuple):
+    """Tuya data stored in the Home Assistant data object."""
+
+    device_listener: TuyaDeviceListener
+    device_manager: TuyaDeviceManager
+    home_manager: TuyaHomeManager
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Async setup hass config entry."""
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        TUYA_HA_TUYA_MAP: {},
-        TUYA_HA_DEVICES: set(),
-    }
+    hass.data.setdefault(DOMAIN, {})
 
     # Project type has been renamed to auth type in the upstream Tuya IoT SDK.
-    # This migrates existing config entries to reflect that name change.
+    # This migrates existing config entries to reflect that name change.π
     if CONF_PROJECT_TYPE in entry.data:
         data = {**entry.data, CONF_AUTH_TYPE: entry.data[CONF_PROJECT_TYPE]}
         data.pop(CONF_PROJECT_TYPE)
@@ -98,25 +100,29 @@ async def _init_tuya_sdk(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     tuya_mq = TuyaOpenMQ(api)
     tuya_mq.start()
 
+    device_ids: set[str] = set()
     device_manager = TuyaDeviceManager(api, tuya_mq)
-
-    # Get device list
     home_manager = TuyaHomeManager(api, tuya_mq, device_manager)
-    await hass.async_add_executor_job(home_manager.update_device_cache)
-    hass.data[DOMAIN][entry.entry_id][TUYA_HOME_MANAGER] = home_manager
-
-    listener = DeviceListener(hass, entry)
-    hass.data[DOMAIN][entry.entry_id][TUYA_MQTT_LISTENER] = listener
+    listener = DeviceListener(hass, device_manager, device_ids)
     device_manager.add_device_listener(listener)
-    hass.data[DOMAIN][entry.entry_id][TUYA_DEVICE_MANAGER] = device_manager
 
-    # Clean up device entities
+    hass_data = HomeAssistantTuyaData(
+        device_listener=listener,
+        device_manager=device_manager,
+        home_manager=home_manager,
+    )
+    hass.data[DOMAIN][entry.entry_id] = hass_data
+
+    # Get devices & clean up device entities
+    await hass.async_add_executor_job(home_manager.update_device_cache)
     await cleanup_device_registry(hass, device_manager)
 
-    _LOGGER.debug("init support type->%s", PLATFORMS)
+    # Register known device IDs
+    for device in device_manager.device_map.values():
+        if device.category in TUYA_SUPPORTED_PRODUCT_CATEGORIES:
+            device_ids.add(device.id)
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-
     return True
 
 
@@ -134,17 +140,13 @@ async def cleanup_device_registry(
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unloading the Tuya platforms."""
-    _LOGGER.debug("integration unload")
     unload = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload:
-        device_manager = hass.data[DOMAIN][entry.entry_id][TUYA_DEVICE_MANAGER]
-        device_manager.mq.stop()
-        device_manager.remove_device_listener(
-            hass.data[DOMAIN][entry.entry_id][TUYA_MQTT_LISTENER]
-        )
+        hass_data: HomeAssistantTuyaData = hass.data[DOMAIN][entry.entry_id]
+        hass_data.device_manager.mq.stop()
+        hass_data.device_manager.remove_device_listener(hass_data.device_listener)
 
         hass.data[DOMAIN].pop(entry.entry_id)
-
         if not hass.data[DOMAIN]:
             hass.data.pop(DOMAIN)
 
@@ -154,14 +156,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class DeviceListener(TuyaDeviceListener):
     """Device Update Listener."""
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        device_manager: TuyaDeviceManager,
+        device_ids: set[str],
+    ) -> None:
         """Init DeviceListener."""
         self.hass = hass
-        self.entry = entry
+        self.device_manager = device_manager
+        self.device_ids = device_ids
 
     def update_device(self, device: TuyaDevice) -> None:
         """Update device status."""
-        if device.id in self.hass.data[DOMAIN][self.entry.entry_id][TUYA_HA_DEVICES]:
+        if device.id in self.device_ids:
             _LOGGER.debug(
                 "_update-->%s;->>%s",
                 self,
@@ -171,33 +179,14 @@ class DeviceListener(TuyaDeviceListener):
 
     def add_device(self, device: TuyaDevice) -> None:
         """Add device added listener."""
-        device_add = False
-
-        if device.category in itertools.chain(
-            *self.hass.data[DOMAIN][self.entry.entry_id][TUYA_HA_TUYA_MAP].values()
-        ):
-            ha_tuya_map = self.hass.data[DOMAIN][self.entry.entry_id][TUYA_HA_TUYA_MAP]
+        if device.category in TUYA_SUPPORTED_PRODUCT_CATEGORIES:
+            # Ensure the device isn't present stale
             self.hass.add_job(self.async_remove_device, device.id)
 
-            for domain, tuya_list in ha_tuya_map.items():
-                if device.category in tuya_list:
-                    device_add = True
-                    _LOGGER.debug(
-                        "Add device category->%s; domain-> %s",
-                        device.category,
-                        domain,
-                    )
-                    self.hass.data[DOMAIN][self.entry.entry_id][TUYA_HA_DEVICES].add(
-                        device.id
-                    )
-                    dispatcher_send(
-                        self.hass, TUYA_DISCOVERY_NEW.format(domain), [device.id]
-                    )
+            self.device_ids.add(device.id)
+            dispatcher_send(self.hass, TUYA_DISCOVERY_NEW, [device.id])
 
-        if device_add:
-            device_manager = self.hass.data[DOMAIN][self.entry.entry_id][
-                TUYA_DEVICE_MANAGER
-            ]
+            device_manager = self.device_manager
             device_manager.mq.stop()
             tuya_mq = TuyaOpenMQ(device_manager.api)
             tuya_mq.start()
@@ -207,18 +196,16 @@ class DeviceListener(TuyaDeviceListener):
 
     def remove_device(self, device_id: str) -> None:
         """Add device removed listener."""
-        _LOGGER.debug("tuya remove device:%s", device_id)
         self.hass.add_job(self.async_remove_device, device_id)
 
     @callback
     def async_remove_device(self, device_id: str) -> None:
         """Remove device from Home Assistant."""
+        _LOGGER.debug("Remove device: %s", device_id)
         device_registry_object = device_registry.async_get(self.hass)
         device_entry = device_registry_object.async_get_device(
             identifiers={(DOMAIN, device_id)}
         )
         if device_entry is not None:
             device_registry_object.async_remove_device(device_entry.id)
-            self.hass.data[DOMAIN][self.entry.entry_id][TUYA_HA_DEVICES].discard(
-                device_id
-            )
+            self.device_ids.discard(device_id)

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -15,12 +15,8 @@ CONF_PASSWORD = "password"
 CONF_COUNTRY_CODE = "country_code"
 CONF_APP_TYPE = "tuya_app_type"
 
-TUYA_DISCOVERY_NEW = "tuya_discovery_new_{}"
-TUYA_DEVICE_MANAGER = "tuya_device_manager"
-TUYA_HOME_MANAGER = "tuya_home_manager"
-TUYA_MQTT_LISTENER = "tuya_mqtt_listener"
-TUYA_HA_TUYA_MAP = "tuya_ha_tuya_map"
-TUYA_HA_DEVICES = "tuya_ha_devices"
+TUYA_DISCOVERY_NEW = "tuya_discovery_new"
+TUYA_HA_SIGNAL_UPDATE_ENTITY = "tuya_entry_update"
 
 TUYA_RESPONSE_CODE = "code"
 TUYA_RESPONSE_RESULT = "result"
@@ -28,7 +24,29 @@ TUYA_RESPONSE_MSG = "msg"
 TUYA_RESPONSE_SUCCESS = "success"
 TUYA_RESPONSE_PLATFROM_URL = "platform_url"
 
-TUYA_HA_SIGNAL_UPDATE_ENTITY = "tuya_entry_update"
+TUYA_SUPPORTED_PRODUCT_CATEGORIES = (
+    "bh",  # Smart Kettle
+    "cwysj",  # Pet Water Feeder
+    "cz",  # Socket
+    "dc",  # Light string
+    "dd",  # Light strip
+    "dj",  # Light
+    "dlq",  # Breaker
+    "fs",  # Fan
+    "fs",  # Fan
+    "fwl",  # Ambient light
+    "jsq",  # Humidifier's light
+    "kg",  # Switch
+    "kj",  # Air Purifier
+    "kj",  # Air Purifier
+    "kt",  # Air conditioner
+    "pc",  # Power Strip
+    "qn",  # Heater
+    "wk",  # Thermostat
+    "xdd",  # Ceiling Light
+    "xxj",  # Diffuser
+    "xxj",  # Diffuser's light
+)
 
 TUYA_SMART_APP = "tuyaSmart"
 SMARTLIFE_APP = "smartlife"

--- a/homeassistant/components/tuya/scene.py
+++ b/homeassistant/components/tuya/scene.py
@@ -1,7 +1,6 @@
 """Support for Tuya scenes."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from tuya_iot import TuyaHomeManager, TuyaScene
@@ -9,40 +8,33 @@ from tuya_iot import TuyaHomeManager, TuyaScene
 from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, TUYA_HOME_MANAGER
-
-_LOGGER = logging.getLogger(__name__)
+from . import HomeAssistantTuyaData
+from .const import DOMAIN
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up tuya scenes."""
-    home_manager = hass.data[DOMAIN][entry.entry_id][TUYA_HOME_MANAGER]
-    scenes = await hass.async_add_executor_job(home_manager.query_scenes)
-    async_add_entities(TuyaHAScene(home_manager, scene) for scene in scenes)
+    """Set up Tuya scenes."""
+    hass_data: HomeAssistantTuyaData = hass.data[DOMAIN][entry.entry_id]
+    scenes = await hass.async_add_executor_job(hass_data.home_manager.query_scenes)
+    async_add_entities(TuyaHAScene(hass_data.home_manager, scene) for scene in scenes)
 
 
 class TuyaHAScene(Scene):
     """Tuya Scene Remote."""
 
+    _should_poll = False
+
     def __init__(self, home_manager: TuyaHomeManager, scene: TuyaScene) -> None:
         """Init Tuya Scene."""
         super().__init__()
+        self._attr_unique_id = f"tys{scene.scene_id}"
         self.home_manager = home_manager
         self.scene = scene
-
-    @property
-    def should_poll(self) -> bool:
-        """Hass should not poll."""
-        return False
-
-    @property
-    def unique_id(self) -> str | None:
-        """Return a unique ID."""
-        return f"tys{self.scene.scene_id}"
 
     @property
     def name(self) -> str | None:
@@ -50,14 +42,14 @@ class TuyaHAScene(Scene):
         return self.scene.name
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return a device description for device registry."""
-        return {
-            "identifiers": {(DOMAIN, f"{self.unique_id}")},
-            "manufacturer": "tuya",
-            "name": self.scene.name,
-            "model": "Tuya Scene",
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self.unique_id}")},
+            manufacturer="tuya",
+            name=self.scene.name,
+            model="Tuya Scene",
+        )
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR refactors the Tuya device handling.

- Removes the need for `TUYA_HA_TUYA_MAP` (which contained cross-platform device mapping in hass data)
- Device IDs are now only tracked within the listener handling device changes
- When a new device is announced, all platforms are notified, it is up to the platform to do something with that notification or not.
- Platforms are no longer responsible for ensuring device IDs are tracked.
- Replaced contents of hass data with a typed NamedTuple
- Small things like some typing in some places and things like that (only related to the changed/touched code).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
