### PR TITLE
Replace all Tuya device property constants with an Enum

### DIFF
--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -1,5 +1,6 @@
 """Constants for the Tuya integration."""
 from dataclasses import dataclass
+from enum import Enum
 
 from tuya_iot import TuyaCloudOpenAPIEndpoint
 
@@ -52,6 +53,45 @@ TUYA_SMART_APP = "tuyaSmart"
 SMARTLIFE_APP = "smartlife"
 
 PLATFORMS = ["climate", "fan", "light", "scene", "switch"]
+
+
+class DPCode(str, Enum):
+    """Device Property Codes used by Tuya.
+
+    https://developer.tuya.com/en/docs/iot/standarddescription?id=K9i5ql6waswzq
+    """
+
+    ANION = "anion"  # Ionizer unit
+    BRIGHT_VALUE = "bright_value"  # Brightness
+    C_F = "c_f"  # Temperature unit switching
+    COLOUR_DATA = "colour_data"  # Colored light mode
+    COLOUR_DATA_V2 = "colour_data_v2"  # Colored light mode
+    FAN_DIRECTION = "fan_direction"  # Fan direction
+    FAN_SPEED_ENUM = "fan_speed_enum"  # Speed mode
+    FAN_SPEED_PERCENT = "fan_speed_percent"  # Stepless speed
+    FILTER_RESET = "filter_reset"  # Filter (cartridge) reset
+    HUMIDITY_CURRENT = "humidity_current"  # Current humidity
+    HUMIDITY_SET = "humidity_set"  # Humidity setting
+    LIGHT = "light"  # Light
+    LOCK = "lock"  # Lock / Child lock
+    MODE = "mode"  # Working mode / Mode
+    PUMP_RESET = "pump_reset"  # Water pump reset
+    SPEED = "speed"  # Speed level
+    START = "start"  # Start
+    SWITCH = "switch"  # Switch
+    SWITCH_HORIZONTAL = "switch_horizontal"  # Horizontal swing flap switch
+    SWITCH_LED = "switch_led"  # Switch
+    SWITCH_VERTICAL = "switch_vertical"  # Vertical swing flap switch
+    TEMP_CURRENT = "temp_current"  # Current temperature in °C
+    TEMP_CURRENT_F = "temp_current_f"  # Current temperature in °F
+    TEMP_SET = "temp_set"  # Set the temperature in °C
+    TEMP_SET_F = "temp_set_f"  # Set the temperature in °F
+    TEMP_UNIT_CONVERT = "temp_unit_convert"  # Temperature unit switching
+    TEMP_VALUE = "temp_value"  # Color temperature
+    UV = "uv"  # UV sterilization
+    WATER_RESET = "water_reset"  # Resetting of water usage days
+    WET = "wet"  # Humidification
+    WORK_MODE = "work_mode"  # Working mode
 
 
 @dataclass


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is to further clean up the Tuya integration by aggregating all device property constants into a single Enum. This reduces duplicate definitions across multiple platforms while keeping imports small.

This is in preparation for using EntityDescriptions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
