### PR TITLE
New service reconnect_client for UniFi integration

### DIFF
--- a/homeassistant/components/unifi/services.py
+++ b/homeassistant/components/unifi/services.py
@@ -54,10 +54,10 @@ def async_unload_services(hass) -> None:
 async def async_reconnect_client(hass, data) -> None:
     """Try to get wireless client to reconnect to Wi-Fi."""
     device_registry = await hass.helpers.device_registry.async_get_registry()
-    entry = device_registry.async_get(data[ATTR_DEVICE_ID])
+    device_entry = device_registry.async_get(data[ATTR_DEVICE_ID])
 
     mac = ""
-    for connection in entry.connections:
+    for connection in device_entry.connections:
         if connection[0] == CONNECTION_NETWORK_MAC:
             mac = connection[1]
             break
@@ -68,8 +68,7 @@ async def async_reconnect_client(hass, data) -> None:
     for controller in hass.data[UNIFI_DOMAIN].values():
         if (
             not controller.available
-            or controller.config_entry_id not in entry.config_entries
-            or (client := controller.api.clients.get(mac)) is None
+            or (client := controller.api.clients[mac]) is None
             or client.is_wired
         ):
             continue

--- a/homeassistant/components/unifi/services.yaml
+++ b/homeassistant/components/unifi/services.yaml
@@ -1,3 +1,15 @@
+reconnect_client:
+  name: Reconnect wireless client
+  description: Try to get wireless client to reconnect to UniFi network
+  fields:
+    device_id:
+      name: Device
+      description: Try reconnect client to wireless network
+      required: true
+      selector:
+        device:
+          integration: unifi
+
 remove_clients:
   name: Remove clients from the UniFi Controller
   description: Clean up clients that has only been associated with the controller for a short period of time.

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -4,9 +4,12 @@ from unittest.mock import patch
 
 from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
 from homeassistant.components.unifi.services import (
+    SERVICE_RECONNECT_CLIENT,
     SERVICE_REMOVE_CLIENTS,
     SUPPORTED_SERVICES,
 )
+from homeassistant.const import ATTR_DEVICE_ID
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from .test_controller import setup_unifi_integration
 
@@ -39,6 +42,156 @@ async def test_service_setup_and_unload_not_called_if_multiple_integrations_dete
     remove_service_mock.assert_not_called()
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     assert remove_service_mock.call_count == 2
+
+
+async def test_reconnect_client(hass, aioclient_mock):
+    """Verify call to reconnect client is performed as expected."""
+    clients = [
+        {
+            "is_wired": False,
+            "mac": "00:00:00:00:00:01",
+        }
+    ]
+    config_entry = await setup_unifi_integration(
+        hass, aioclient_mock, clients_response=clients
+    )
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        f"https://{controller.host}:1234/api/s/{controller.site}/cmd/stamgr",
+    )
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(CONNECTION_NETWORK_MAC, clients[0]["mac"])},
+    )
+
+    await hass.services.async_call(
+        UNIFI_DOMAIN,
+        SERVICE_RECONNECT_CLIENT,
+        service_data={ATTR_DEVICE_ID: device_entry.id},
+        blocking=True,
+    )
+    assert aioclient_mock.call_count == 1
+
+
+async def test_reconnect_device_without_mac(hass, aioclient_mock):
+    """Verify no call is made if device does not have a known mac."""
+    config_entry = await setup_unifi_integration(hass, aioclient_mock)
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        f"https://{controller.host}:1234/api/s/{controller.site}/cmd/stamgr",
+    )
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={("other connection", "not mac")},
+    )
+
+    await hass.services.async_call(
+        UNIFI_DOMAIN,
+        SERVICE_RECONNECT_CLIENT,
+        service_data={ATTR_DEVICE_ID: device_entry.id},
+        blocking=True,
+    )
+    assert aioclient_mock.call_count == 0
+
+
+async def test_reconnect_client_controller_unavailable(hass, aioclient_mock):
+    """Verify no call is made if controller is unavailable."""
+    clients = [
+        {
+            "is_wired": False,
+            "mac": "00:00:00:00:00:01",
+        }
+    ]
+    config_entry = await setup_unifi_integration(
+        hass, aioclient_mock, clients_response=clients
+    )
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+    controller.available = False
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        f"https://{controller.host}:1234/api/s/{controller.site}/cmd/stamgr",
+    )
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(CONNECTION_NETWORK_MAC, clients[0]["mac"])},
+    )
+
+    await hass.services.async_call(
+        UNIFI_DOMAIN,
+        SERVICE_RECONNECT_CLIENT,
+        service_data={ATTR_DEVICE_ID: device_entry.id},
+        blocking=True,
+    )
+    assert aioclient_mock.call_count == 0
+
+
+async def test_reconnect_client_unknown_mac(hass, aioclient_mock):
+    """Verify no call is made if trying to reconnect a mac unknown to controller."""
+    config_entry = await setup_unifi_integration(hass, aioclient_mock)
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        f"https://{controller.host}:1234/api/s/{controller.site}/cmd/stamgr",
+    )
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(CONNECTION_NETWORK_MAC, "mac unknown to controller")},
+    )
+
+    await hass.services.async_call(
+        UNIFI_DOMAIN,
+        SERVICE_RECONNECT_CLIENT,
+        service_data={ATTR_DEVICE_ID: device_entry.id},
+        blocking=True,
+    )
+    assert aioclient_mock.call_count == 0
+
+
+async def test_reconnect_wired_client(hass, aioclient_mock):
+    """Verify no call is made if client is wired."""
+    clients = [
+        {
+            "is_wired": True,
+            "mac": "00:00:00:00:00:01",
+        }
+    ]
+    config_entry = await setup_unifi_integration(
+        hass, aioclient_mock, clients_response=clients
+    )
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(
+        f"https://{controller.host}:1234/api/s/{controller.site}/cmd/stamgr",
+    )
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(CONNECTION_NETWORK_MAC, clients[0]["mac"])},
+    )
+
+    await hass.services.async_call(
+        UNIFI_DOMAIN,
+        SERVICE_RECONNECT_CLIENT,
+        service_data={ATTR_DEVICE_ID: device_entry.id},
+        blocking=True,
+    )
+    assert aioclient_mock.call_count == 0
 
 
 async def test_remove_clients(hass, aioclient_mock):

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -3,7 +3,10 @@
 from unittest.mock import patch
 
 from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
-from homeassistant.components.unifi.services import SERVICE_REMOVE_CLIENTS
+from homeassistant.components.unifi.services import (
+    SERVICE_REMOVE_CLIENTS,
+    SUPPORTED_SERVICES,
+)
 
 from .test_controller import setup_unifi_integration
 
@@ -11,10 +14,12 @@ from .test_controller import setup_unifi_integration
 async def test_service_setup_and_unload(hass, aioclient_mock):
     """Verify service setup works."""
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
-    assert hass.services.has_service(UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS)
+    for service in SUPPORTED_SERVICES:
+        assert hass.services.has_service(UNIFI_DOMAIN, service)
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
-    assert not hass.services.has_service(UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS)
+    for service in SUPPORTED_SERVICES:
+        assert not hass.services.has_service(UNIFI_DOMAIN, service)
 
 
 @patch("homeassistant.core.ServiceRegistry.async_remove")
@@ -33,7 +38,7 @@ async def test_service_setup_and_unload_not_called_if_multiple_integrations_dete
     assert await hass.config_entries.async_unload(config_entry_2.entry_id)
     remove_service_mock.assert_not_called()
     assert await hass.config_entries.async_unload(config_entry.entry_id)
-    remove_service_mock.assert_called_once()
+    assert remove_service_mock.call_count == 2
 
 
 async def test_remove_clients(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Try to get a wireless client to reconnect to the network.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19738

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
