### PR TITLE
Optimize update calls for AVM Fritz!Smarthome devices

### DIFF
--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -66,9 +66,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             devices = fritz.get_devices()
 
         data = {}
+        fritz.update_devices()
         for device in devices:
-            device.update()
-
             # assume device as unavailable, see #55799
             if (
                 device.has_powermeter

--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -77,6 +77,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 and device.power <= 0
                 and device.energy <= 0
             ):
+                LOGGER.debug("Assume device %s as unavailable", device.name)
                 device.present = False
 
             data[device.ain] = device

--- a/tests/components/fritzbox/test_binary_sensor.py
+++ b/tests/components/fritzbox/test_binary_sensor.py
@@ -70,14 +70,14 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
         hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
     )
 
-    assert device.update.call_count == 1
+    assert fritz().update_devices.call_count == 1
     assert fritz().login.call_count == 1
 
     next_update = dt_util.utcnow() + timedelta(seconds=200)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()
 
-    assert device.update.call_count == 2
+    assert fritz().update_devices.call_count == 2
     assert fritz().login.call_count == 1
 
 
@@ -89,12 +89,12 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock):
         hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
     )
 
-    assert device.update.call_count == 1
+    assert fritz().update_devices.call_count == 1
     assert fritz().login.call_count == 1
 
     next_update = dt_util.utcnow() + timedelta(seconds=200)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()
 
-    assert device.update.call_count == 2
+    assert fritz().update_devices.call_count == 2
     assert fritz().login.call_count == 1

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -134,7 +134,7 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
     await hass.async_block_till_done()
     state = hass.states.get(ENTITY_ID)
 
-    assert device.update.call_count == 2
+    assert fritz().update_devices.call_count == 2
     assert state
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 19
     assert state.attributes[ATTR_TEMPERATURE] == 20
@@ -143,19 +143,19 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
 async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceClimateMock()
-    device.update.side_effect = HTTPError("Boom")
+    fritz().update_devices.side_effect = HTTPError("Boom")
     assert not await setup_config_entry(
         hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
     )
 
-    assert device.update.call_count == 1
+    assert fritz().update_devices.call_count == 1
     assert fritz().login.call_count == 1
 
     next_update = dt_util.utcnow() + timedelta(seconds=200)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()
 
-    assert device.update.call_count == 2
+    assert fritz().update_devices.call_count == 2
     assert fritz().login.call_count == 2
 
 
@@ -299,7 +299,7 @@ async def test_preset_mode_update(hass: HomeAssistant, fritz: Mock):
     await hass.async_block_till_done()
     state = hass.states.get(ENTITY_ID)
 
-    assert device.update.call_count == 2
+    assert fritz().update_devices.call_count == 2
     assert state
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_COMFORT
 
@@ -310,6 +310,6 @@ async def test_preset_mode_update(hass: HomeAssistant, fritz: Mock):
     await hass.async_block_till_done()
     state = hass.states.get(ENTITY_ID)
 
-    assert device.update.call_count == 3
+    assert fritz().update_devices.call_count == 3
     assert state
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_ECO

--- a/tests/components/fritzbox/test_sensor.py
+++ b/tests/components/fritzbox/test_sensor.py
@@ -70,30 +70,30 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
     assert await setup_config_entry(
         hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
     )
-    assert device.update.call_count == 1
+    assert fritz().update_devices.call_count == 1
     assert fritz().login.call_count == 1
 
     next_update = dt_util.utcnow() + timedelta(seconds=200)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()
 
-    assert device.update.call_count == 2
+    assert fritz().update_devices.call_count == 2
     assert fritz().login.call_count == 1
 
 
 async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceSensorMock()
-    device.update.side_effect = HTTPError("Boom")
+    fritz().update_devices.side_effect = HTTPError("Boom")
     assert not await setup_config_entry(
         hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
     )
-    assert device.update.call_count == 1
+    assert fritz().update_devices.call_count == 1
     assert fritz().login.call_count == 1
 
     next_update = dt_util.utcnow() + timedelta(seconds=200)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()
 
-    assert device.update.call_count == 2
+    assert fritz().update_devices.call_count == 2
     assert fritz().login.call_count == 2

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -114,32 +114,32 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
     assert await setup_config_entry(
         hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
     )
-    assert device.update.call_count == 1
+    assert fritz().update_devices.call_count == 1
     assert fritz().login.call_count == 1
 
     next_update = dt_util.utcnow() + timedelta(seconds=200)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()
 
-    assert device.update.call_count == 2
+    assert fritz().update_devices.call_count == 2
     assert fritz().login.call_count == 1
 
 
 async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceSwitchMock()
-    device.update.side_effect = HTTPError("Boom")
+    fritz().update_devices.side_effect = HTTPError("Boom")
     assert not await setup_config_entry(
         hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
     )
-    assert device.update.call_count == 1
+    assert fritz().update_devices.call_count == 1
     assert fritz().login.call_count == 1
 
     next_update = dt_util.utcnow() + timedelta(seconds=200)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()
 
-    assert device.update.call_count == 2
+    assert fritz().update_devices.call_count == 2
     assert fritz().login.call_count == 2
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will massively reduce the update calls to FritzBox.
Furthermore this will fix the workaround from #56542

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #55799
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
