### PR TITLE
Refresh the bond token if it has changed and available

### DIFF
--- a/homeassistant/components/bond/config_flow.py
+++ b/homeassistant/components/bond/config_flow.py
@@ -106,9 +106,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if entry.unique_id != bond_id:
                 continue
             updates = {CONF_HOST: host}
-            if entry.state == ConfigEntryState.SETUP_ERROR:
-                if token := await async_get_token(self.hass, host):
-                    updates[CONF_ACCESS_TOKEN] = token
+            if entry.state == ConfigEntryState.SETUP_ERROR and (
+                token := await async_get_token(self.hass, host)
+            ):
+                updates[CONF_ACCESS_TOKEN] = token
             self.hass.config_entries.async_update_entry(
                 entry, data={**entry.data, **updates}
             )

--- a/homeassistant/components/bond/config_flow.py
+++ b/homeassistant/components/bond/config_flow.py
@@ -9,6 +9,7 @@ from bond_api import Bond
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_HOST,
@@ -31,6 +32,16 @@ USER_SCHEMA = vol.Schema(
 )
 DISCOVERY_SCHEMA = vol.Schema({vol.Required(CONF_ACCESS_TOKEN): str})
 TOKEN_SCHEMA = vol.Schema({})
+
+
+async def async_get_token(hass: HomeAssistant, host: str) -> str | None:
+    """Try to fetch the token from the bond device."""
+    bond = Bond(host, "", session=async_get_clientsession(hass))
+    try:
+        response: dict[str, str] = await bond.token()
+    except ClientConnectionError:
+        return None
+    return response.get("token")
 
 
 async def _validate_input(hass: HomeAssistant, data: dict[str, Any]) -> tuple[str, str]:
@@ -75,16 +86,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         online longer then the allowed setup period, and we will
         instead ask them to manually enter the token.
         """
-        bond = Bond(
-            self._discovered[CONF_HOST], "", session=async_get_clientsession(self.hass)
-        )
-        try:
-            response = await bond.token()
-        except ClientConnectionError:
-            return
-
-        token = response.get("token")
-        if token is None:
+        host = self._discovered[CONF_HOST]
+        if not (token := await async_get_token(self.hass, host)):
             return
 
         self._discovered[CONF_ACCESS_TOKEN] = token
@@ -99,7 +102,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         host: str = discovery_info[CONF_HOST]
         bond_id = name.partition(".")[0]
         await self.async_set_unique_id(bond_id)
-        self._abort_if_unique_id_configured({CONF_HOST: host})
+        for entry in self._async_current_entries():
+            if entry.unique_id != bond_id:
+                continue
+            updates = {CONF_HOST: host}
+            if entry.state == ConfigEntryState.SETUP_ERROR:
+                if token := await async_get_token(self.hass, host):
+                    updates[CONF_ACCESS_TOKEN] = token
+            self._abort_if_unique_id_configured(updates)
 
         self._discovered = {CONF_HOST: host, CONF_NAME: bond_id}
         await self._async_try_automatic_configure()

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -311,19 +311,18 @@ async def test_zeroconf_already_configured(hass: core.HomeAssistant):
 
 async def test_zeroconf_already_configured_refresh_token(hass: core.HomeAssistant):
     """Test starting a flow from zeroconf when already configured and the token is out of date."""
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="already-registered-bond-id",
-        data={CONF_HOST: "stored-host", CONF_ACCESS_TOKEN: "incorrect-token"},
-    )
-    entry.add_to_hass(hass)
     entry2 = MockConfigEntry(
         domain=DOMAIN,
         unique_id="not-the-same-bond-id",
         data={CONF_HOST: "stored-host", CONF_ACCESS_TOKEN: "correct-token"},
     )
     entry2.add_to_hass(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="already-registered-bond-id",
+        data={CONF_HOST: "stored-host", CONF_ACCESS_TOKEN: "incorrect-token"},
+    )
+    entry.add_to_hass(hass)
 
     with patch_bond_version(
         side_effect=ClientResponseError(MagicMock(), MagicMock(), status=401)

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -318,6 +318,12 @@ async def test_zeroconf_already_configured_refresh_token(hass: core.HomeAssistan
         data={CONF_HOST: "stored-host", CONF_ACCESS_TOKEN: "incorrect-token"},
     )
     entry.add_to_hass(hass)
+    entry2 = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="not-the-same-bond-id",
+        data={CONF_HOST: "stored-host", CONF_ACCESS_TOKEN: "correct-token"},
+    )
+    entry2.add_to_hass(hass)
 
     with patch_bond_version(
         side_effect=ClientResponseError(MagicMock(), MagicMock(), status=401)
@@ -342,6 +348,8 @@ async def test_zeroconf_already_configured_refresh_token(hass: core.HomeAssistan
     assert result["reason"] == "already_configured"
     assert entry.data["host"] == "updated-host"
     assert entry.data[CONF_ACCESS_TOKEN] == "discovered-token"
+    # entry2 should not get changed
+    assert entry2.data[CONF_ACCESS_TOKEN] == "correct-token"
     assert len(mock_setup_entry.mock_calls) == 1
 
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refresh the bond token if it has changed and available

When the device boots up, the token endpoint is available for a few
minutes. If the config entry is in a failed state, we attempt to refresh
the token.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
