### PR TITLE
Add support for multiple Whirlpool air conditioners

### DIFF
--- a/homeassistant/components/whirlpool/climate.py
+++ b/homeassistant/components/whirlpool/climate.py
@@ -71,8 +71,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     # the whirlpool library needs to be updated to be able to support more
     # than one device, so we use only the first one for now
-    aircon = AirConEntity(said_list[0], auth)
-    async_add_entities([aircon], True)
+    aircons = [AirConEntity(said, auth) for said in said_list]
+    async_add_entities(aircons, True)
 
 
 class AirConEntity(ClimateEntity):

--- a/tests/components/whirlpool/conftest.py
+++ b/tests/components/whirlpool/conftest.py
@@ -4,8 +4,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 import whirlpool
+import whirlpool.aircon
 
-MOCK_SAID = "said1"
+MOCK_SAID1 = "said1"
+MOCK_SAID2 = "said2"
 
 
 @pytest.fixture(name="mock_auth_api")
@@ -14,28 +16,53 @@ def fixture_mock_auth_api():
     with mock.patch("homeassistant.components.whirlpool.Auth") as mock_auth:
         mock_auth.return_value.do_auth = AsyncMock()
         mock_auth.return_value.is_access_token_valid.return_value = True
-        mock_auth.return_value.get_said_list.return_value = [MOCK_SAID]
+        mock_auth.return_value.get_said_list.return_value = [MOCK_SAID1, MOCK_SAID2]
         yield mock_auth
 
 
-@pytest.fixture(name="mock_aircon_api", autouse=True)
-def fixture_mock_aircon_api(mock_auth_api):
+def get_aircon_mock(said):
+    """Get a mock of an air conditioner."""
+    mock_aircon = mock.Mock(said=said)
+    mock_aircon.connect = AsyncMock()
+    mock_aircon.fetch_name = AsyncMock(return_value="TestZone")
+    mock_aircon.get_online.return_value = True
+    mock_aircon.get_power_on.return_value = True
+    mock_aircon.get_mode.return_value = whirlpool.aircon.Mode.Cool
+    mock_aircon.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.Auto
+    mock_aircon.get_current_temp.return_value = 15
+    mock_aircon.get_temp.return_value = 20
+    mock_aircon.get_current_humidity.return_value = 80
+    mock_aircon.get_humidity.return_value = 50
+    mock_aircon.get_h_louver_swing.return_value = True
+
+    mock_aircon.set_power_on = AsyncMock()
+    mock_aircon.set_mode = AsyncMock()
+    mock_aircon.set_temp = AsyncMock()
+    mock_aircon.set_humidity = AsyncMock()
+    mock_aircon.set_mode = AsyncMock()
+    mock_aircon.set_fanspeed = AsyncMock()
+    mock_aircon.set_h_louver_swing = AsyncMock()
+
+    return mock_aircon
+
+
+@pytest.fixture(name="mock_aircon1_api", autouse=True)
+def fixture_mock_aircon1_api(mock_auth_api):
+    """Set up air conditioner API fixture."""
+    yield get_aircon_mock(MOCK_SAID1)
+
+
+@pytest.fixture(name="mock_aircon2_api", autouse=True)
+def fixture_mock_aircon2_api(mock_auth_api):
+    """Set up air conditioner API fixture."""
+    yield get_aircon_mock(MOCK_SAID2)
+
+
+@pytest.fixture(name="mock_aircon_api_instances", autouse=True)
+def fixture_mock_aircon_api_instances(mock_aircon1_api, mock_aircon2_api):
     """Set up air conditioner API fixture."""
     with mock.patch(
         "homeassistant.components.whirlpool.climate.Aircon"
     ) as mock_aircon_api:
-        mock_aircon_api.return_value.connect = AsyncMock()
-        mock_aircon_api.return_value.fetch_name = AsyncMock(return_value="TestZone")
-        mock_aircon_api.return_value.said = MOCK_SAID
-        mock_aircon_api.return_value.get_online.return_value = True
-        mock_aircon_api.return_value.get_power_on.return_value = True
-        mock_aircon_api.return_value.get_mode.return_value = whirlpool.aircon.Mode.Cool
-        mock_aircon_api.return_value.get_fanspeed.return_value = (
-            whirlpool.aircon.FanSpeed.Auto
-        )
-        mock_aircon_api.return_value.get_current_temp.return_value = 15
-        mock_aircon_api.return_value.get_temp.return_value = 20
-        mock_aircon_api.return_value.get_current_humidity.return_value = 80
-        mock_aircon_api.return_value.get_humidity.return_value = 50
-        mock_aircon_api.return_value.get_h_louver_swing.return_value = True
+        mock_aircon_api.side_effect = [mock_aircon1_api, mock_aircon2_api]
         yield mock_aircon_api

--- a/tests/components/whirlpool/test_climate.py
+++ b/tests/components/whirlpool/test_climate.py
@@ -2,6 +2,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
+from attr import dataclass
 import pytest
 import whirlpool
 
@@ -55,12 +56,19 @@ from homeassistant.helpers import entity_registry as er
 from . import init_integration
 
 
-async def update_ac_state(hass: HomeAssistant, mock_aircon_api: MagicMock):
+async def update_ac_state(
+    hass: HomeAssistant,
+    entity_id: str,
+    mock_aircon_api_instances: MagicMock,
+    mock_instance_idx: int,
+):
     """Simulate an update trigger from the API."""
-    update_ha_state_cb = mock_aircon_api.call_args.args[2]
+    update_ha_state_cb = mock_aircon_api_instances.call_args_list[
+        mock_instance_idx
+    ].args[2]
     update_ha_state_cb()
     await hass.async_block_till_done()
-    return hass.states.get("climate.said1")
+    return hass.states.get(entity_id)
 
 
 async def test_no_appliances(hass: HomeAssistant, mock_auth_api: MagicMock):
@@ -71,297 +79,337 @@ async def test_no_appliances(hass: HomeAssistant, mock_auth_api: MagicMock):
 
 
 async def test_name_fallback_on_exception(
-    hass: HomeAssistant, mock_aircon_api: MagicMock
+    hass: HomeAssistant, mock_aircon1_api: MagicMock
 ):
     """Test name property."""
-    mock_aircon_api.return_value.fetch_name = AsyncMock(
-        side_effect=aiohttp.ClientError()
-    )
+    mock_aircon1_api.fetch_name = AsyncMock(side_effect=aiohttp.ClientError())
 
     await init_integration(hass)
     state = hass.states.get("climate.said1")
     assert state.attributes[ATTR_FRIENDLY_NAME] == "said1"
 
 
-async def test_static_attributes(hass: HomeAssistant, mock_aircon_api: MagicMock):
+async def test_static_attributes(hass: HomeAssistant, mock_aircon1_api: MagicMock):
     """Test static climate attributes."""
     await init_integration(hass)
 
-    entry = er.async_get(hass).async_get("climate.said1")
-    assert entry
-    assert entry.unique_id == "said1"
+    for entity_id in ("climate.said1", "climate.said2"):
+        entry = er.async_get(hass).async_get(entity_id)
+        assert entry
+        assert entry.unique_id == entity_id.split(".")[1]
 
-    state = hass.states.get("climate.said1")
-    assert state is not None
-    assert state.state != STATE_UNAVAILABLE
-    assert state.state == HVAC_MODE_COOL
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state != STATE_UNAVAILABLE
+        assert state.state == HVAC_MODE_COOL
 
-    attributes = state.attributes
-    assert attributes[ATTR_FRIENDLY_NAME] == "TestZone"
+        attributes = state.attributes
+        assert attributes[ATTR_FRIENDLY_NAME] == "TestZone"
 
-    assert (
-        attributes[ATTR_SUPPORTED_FEATURES]
-        == SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE
-    )
-    assert attributes[ATTR_HVAC_MODES] == [
-        HVAC_MODE_COOL,
-        HVAC_MODE_HEAT,
-        HVAC_MODE_FAN_ONLY,
-        HVAC_MODE_OFF,
-    ]
-    assert attributes[ATTR_FAN_MODES] == [
-        FAN_AUTO,
-        FAN_HIGH,
-        FAN_MEDIUM,
-        FAN_LOW,
-        FAN_OFF,
-    ]
-    assert attributes[ATTR_SWING_MODES] == [SWING_HORIZONTAL, SWING_OFF]
-    assert attributes[ATTR_TARGET_TEMP_STEP] == 1
-    assert attributes[ATTR_MIN_TEMP] == 16
-    assert attributes[ATTR_MAX_TEMP] == 30
+        assert (
+            attributes[ATTR_SUPPORTED_FEATURES]
+            == SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE
+        )
+        assert attributes[ATTR_HVAC_MODES] == [
+            HVAC_MODE_COOL,
+            HVAC_MODE_HEAT,
+            HVAC_MODE_FAN_ONLY,
+            HVAC_MODE_OFF,
+        ]
+        assert attributes[ATTR_FAN_MODES] == [
+            FAN_AUTO,
+            FAN_HIGH,
+            FAN_MEDIUM,
+            FAN_LOW,
+            FAN_OFF,
+        ]
+        assert attributes[ATTR_SWING_MODES] == [SWING_HORIZONTAL, SWING_OFF]
+        assert attributes[ATTR_TARGET_TEMP_STEP] == 1
+        assert attributes[ATTR_MIN_TEMP] == 16
+        assert attributes[ATTR_MAX_TEMP] == 30
 
 
-async def test_dynamic_attributes(hass: HomeAssistant, mock_aircon_api: MagicMock):
+async def test_dynamic_attributes(
+    hass: HomeAssistant,
+    mock_aircon_api_instances: MagicMock,
+    mock_aircon1_api: MagicMock,
+    mock_aircon2_api: MagicMock,
+):
     """Test dynamic attributes."""
     await init_integration(hass)
 
-    state = hass.states.get("climate.said1")
-    assert state is not None
-    assert state.state == HVAC_MODE_COOL
+    @dataclass
+    class ClimateTestInstance:
+        """Helper class for multiple climate and mock instances."""
 
-    mock_aircon_api.return_value.get_power_on.return_value = False
-    state = await update_ac_state(hass, mock_aircon_api)
-    assert state.state == HVAC_MODE_OFF
+        entity_id: str
+        mock_instance: MagicMock
+        mock_instance_idx: int
 
-    mock_aircon_api.return_value.get_online.return_value = False
-    state = await update_ac_state(hass, mock_aircon_api)
-    assert state.state == STATE_UNAVAILABLE
+    for clim_test_instance in (
+        ClimateTestInstance("climate.said1", mock_aircon1_api, 0),
+        ClimateTestInstance("climate.said2", mock_aircon2_api, 1),
+    ):
+        entity_id = clim_test_instance.entity_id
+        mock_instance = clim_test_instance.mock_instance
+        mock_instance_idx = clim_test_instance.mock_instance_idx
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == HVAC_MODE_COOL
 
-    mock_aircon_api.return_value.get_power_on.return_value = True
-    mock_aircon_api.return_value.get_online.return_value = True
-    state = await update_ac_state(hass, mock_aircon_api)
-    assert state.state == HVAC_MODE_COOL
+        mock_instance.get_power_on.return_value = False
+        state = await update_ac_state(
+            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+        )
+        assert state.state == HVAC_MODE_OFF
 
-    mock_aircon_api.return_value.get_mode.return_value = whirlpool.aircon.Mode.Heat
-    state = await update_ac_state(hass, mock_aircon_api)
-    assert state.state == HVAC_MODE_HEAT
+        mock_instance.get_online.return_value = False
+        state = await update_ac_state(
+            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+        )
+        assert state.state == STATE_UNAVAILABLE
 
-    mock_aircon_api.return_value.get_mode.return_value = whirlpool.aircon.Mode.Fan
-    state = await update_ac_state(hass, mock_aircon_api)
-    assert state.state == HVAC_MODE_FAN_ONLY
+        mock_instance.get_power_on.return_value = True
+        mock_instance.get_online.return_value = True
+        state = await update_ac_state(
+            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+        )
+        assert state.state == HVAC_MODE_COOL
 
-    mock_aircon_api.return_value.get_fanspeed.return_value = (
-        whirlpool.aircon.FanSpeed.Auto
-    )
-    state = await update_ac_state(hass, mock_aircon_api)
-    assert state.attributes[ATTR_FAN_MODE] == HVAC_MODE_AUTO
+        mock_instance.get_mode.return_value = whirlpool.aircon.Mode.Heat
+        state = await update_ac_state(
+            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+        )
+        assert state.state == HVAC_MODE_HEAT
 
-    mock_aircon_api.return_value.get_fanspeed.return_value = (
-        whirlpool.aircon.FanSpeed.Low
-    )
-    state = await update_ac_state(hass, mock_aircon_api)
-    assert state.attributes[ATTR_FAN_MODE] == FAN_LOW
+        mock_instance.get_mode.return_value = whirlpool.aircon.Mode.Fan
+        state = await update_ac_state(
+            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+        )
+        assert state.state == HVAC_MODE_FAN_ONLY
 
-    mock_aircon_api.return_value.get_fanspeed.return_value = (
-        whirlpool.aircon.FanSpeed.Medium
-    )
-    state = await update_ac_state(hass, mock_aircon_api)
-    assert state.attributes[ATTR_FAN_MODE] == FAN_MEDIUM
+        mock_instance.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.Auto
+        state = await update_ac_state(
+            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+        )
+        assert state.attributes[ATTR_FAN_MODE] == HVAC_MODE_AUTO
 
-    mock_aircon_api.return_value.get_fanspeed.return_value = (
-        whirlpool.aircon.FanSpeed.High
-    )
-    state = await update_ac_state(hass, mock_aircon_api)
-    assert state.attributes[ATTR_FAN_MODE] == FAN_HIGH
+        mock_instance.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.Low
+        state = await update_ac_state(
+            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+        )
+        assert state.attributes[ATTR_FAN_MODE] == FAN_LOW
 
-    mock_aircon_api.return_value.get_fanspeed.return_value = (
-        whirlpool.aircon.FanSpeed.Off
-    )
-    state = await update_ac_state(hass, mock_aircon_api)
-    assert state.attributes[ATTR_FAN_MODE] == FAN_OFF
+        mock_instance.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.Medium
+        state = await update_ac_state(
+            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+        )
+        assert state.attributes[ATTR_FAN_MODE] == FAN_MEDIUM
 
-    mock_aircon_api.return_value.get_current_temp.return_value = 15
-    mock_aircon_api.return_value.get_temp.return_value = 20
-    mock_aircon_api.return_value.get_current_humidity.return_value = 80
-    mock_aircon_api.return_value.get_h_louver_swing.return_value = True
-    attributes = (await update_ac_state(hass, mock_aircon_api)).attributes
-    assert attributes[ATTR_CURRENT_TEMPERATURE] == 15
-    assert attributes[ATTR_TEMPERATURE] == 20
-    assert attributes[ATTR_CURRENT_HUMIDITY] == 80
-    assert attributes[ATTR_SWING_MODE] == SWING_HORIZONTAL
+        mock_instance.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.High
+        state = await update_ac_state(
+            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+        )
+        assert state.attributes[ATTR_FAN_MODE] == FAN_HIGH
 
-    mock_aircon_api.return_value.get_current_temp.return_value = 16
-    mock_aircon_api.return_value.get_temp.return_value = 21
-    mock_aircon_api.return_value.get_current_humidity.return_value = 70
-    mock_aircon_api.return_value.get_h_louver_swing.return_value = False
-    attributes = (await update_ac_state(hass, mock_aircon_api)).attributes
-    assert attributes[ATTR_CURRENT_TEMPERATURE] == 16
-    assert attributes[ATTR_TEMPERATURE] == 21
-    assert attributes[ATTR_CURRENT_HUMIDITY] == 70
-    assert attributes[ATTR_SWING_MODE] == SWING_OFF
+        mock_instance.get_fanspeed.return_value = whirlpool.aircon.FanSpeed.Off
+        state = await update_ac_state(
+            hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+        )
+        assert state.attributes[ATTR_FAN_MODE] == FAN_OFF
+
+        mock_instance.get_current_temp.return_value = 15
+        mock_instance.get_temp.return_value = 20
+        mock_instance.get_current_humidity.return_value = 80
+        mock_instance.get_h_louver_swing.return_value = True
+        attributes = (
+            await update_ac_state(
+                hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+            )
+        ).attributes
+        assert attributes[ATTR_CURRENT_TEMPERATURE] == 15
+        assert attributes[ATTR_TEMPERATURE] == 20
+        assert attributes[ATTR_CURRENT_HUMIDITY] == 80
+        assert attributes[ATTR_SWING_MODE] == SWING_HORIZONTAL
+
+        mock_instance.get_current_temp.return_value = 16
+        mock_instance.get_temp.return_value = 21
+        mock_instance.get_current_humidity.return_value = 70
+        mock_instance.get_h_louver_swing.return_value = False
+        attributes = (
+            await update_ac_state(
+                hass, entity_id, mock_aircon_api_instances, mock_instance_idx
+            )
+        ).attributes
+        assert attributes[ATTR_CURRENT_TEMPERATURE] == 16
+        assert attributes[ATTR_TEMPERATURE] == 21
+        assert attributes[ATTR_CURRENT_HUMIDITY] == 70
+        assert attributes[ATTR_SWING_MODE] == SWING_OFF
 
 
-async def test_service_calls(hass: HomeAssistant, mock_aircon_api: MagicMock):
+async def test_service_calls(
+    hass: HomeAssistant, mock_aircon1_api: MagicMock, mock_aircon2_api: MagicMock
+):
     """Test controlling the entity through service calls."""
     await init_integration(hass)
-    mock_aircon_api.return_value.set_power_on = AsyncMock()
-    mock_aircon_api.return_value.set_mode = AsyncMock()
-    mock_aircon_api.return_value.set_temp = AsyncMock()
-    mock_aircon_api.return_value.set_humidity = AsyncMock()
-    mock_aircon_api.return_value.set_mode = AsyncMock()
-    mock_aircon_api.return_value.set_fanspeed = AsyncMock()
-    mock_aircon_api.return_value.set_h_louver_swing = AsyncMock()
 
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "climate.said1"},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_power_on.assert_called_once_with(False)
+    @dataclass
+    class ClimateInstancesData:
+        """Helper class for multiple climate and mock instances."""
 
-    mock_aircon_api.return_value.set_power_on.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "climate.said1"},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_power_on.assert_called_once_with(True)
+        entity_id: str
+        mock_instance: MagicMock
 
-    mock_aircon_api.return_value.set_power_on.reset_mock()
-    mock_aircon_api.return_value.get_power_on.return_value = False
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_HVAC_MODE: HVAC_MODE_COOL},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_power_on.assert_called_once_with(True)
+    for clim_test_instance in (
+        ClimateInstancesData("climate.said1", mock_aircon1_api),
+        ClimateInstancesData("climate.said2", mock_aircon2_api),
+    ):
+        mock_instance = clim_test_instance.mock_instance
+        entity_id = clim_test_instance.entity_id
 
-    mock_aircon_api.return_value.set_temp.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_TEMPERATURE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_TEMPERATURE: 15},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_temp.assert_called_once_with(15)
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+        mock_instance.set_power_on.assert_called_once_with(False)
 
-    mock_aircon_api.return_value.set_mode.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_HVAC_MODE: HVAC_MODE_COOL},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_mode.assert_called_once_with(
-        whirlpool.aircon.Mode.Cool
-    )
+        mock_instance.set_power_on.reset_mock()
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+        mock_instance.set_power_on.assert_called_once_with(True)
 
-    mock_aircon_api.return_value.set_mode.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_HVAC_MODE: HVAC_MODE_HEAT},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_mode.assert_called_once_with(
-        whirlpool.aircon.Mode.Heat
-    )
-
-    mock_aircon_api.return_value.set_mode.reset_mock()
-    # HVAC_MODE_DRY is not supported
-    with pytest.raises(ValueError):
+        mock_instance.set_power_on.reset_mock()
+        mock_instance.get_power_on.return_value = False
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,
-            {ATTR_ENTITY_ID: "climate.said1", ATTR_HVAC_MODE: HVAC_MODE_DRY},
+            {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: HVAC_MODE_COOL},
             blocking=True,
         )
-    mock_aircon_api.return_value.set_mode.assert_not_called()
+        mock_instance.set_power_on.assert_called_once_with(True)
 
-    mock_aircon_api.return_value.set_mode.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_HVAC_MODE: HVAC_MODE_FAN_ONLY},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_mode.assert_called_once_with(
-        whirlpool.aircon.Mode.Fan
-    )
+        mock_instance.set_temp.reset_mock()
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_TEMPERATURE: 15},
+            blocking=True,
+        )
+        mock_instance.set_temp.assert_called_once_with(15)
 
-    mock_aircon_api.return_value.set_fanspeed.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_FAN_MODE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_FAN_MODE: FAN_AUTO},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_fanspeed.assert_called_once_with(
-        whirlpool.aircon.FanSpeed.Auto
-    )
+        mock_instance.set_mode.reset_mock()
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: HVAC_MODE_COOL},
+            blocking=True,
+        )
+        mock_instance.set_mode.assert_called_once_with(whirlpool.aircon.Mode.Cool)
 
-    mock_aircon_api.return_value.set_fanspeed.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_FAN_MODE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_FAN_MODE: FAN_LOW},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_fanspeed.assert_called_once_with(
-        whirlpool.aircon.FanSpeed.Low
-    )
+        mock_instance.set_mode.reset_mock()
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: HVAC_MODE_HEAT},
+            blocking=True,
+        )
+        mock_instance.set_mode.assert_called_once_with(whirlpool.aircon.Mode.Heat)
 
-    mock_aircon_api.return_value.set_fanspeed.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_FAN_MODE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_FAN_MODE: FAN_MEDIUM},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_fanspeed.assert_called_once_with(
-        whirlpool.aircon.FanSpeed.Medium
-    )
+        mock_instance.set_mode.reset_mock()
+        # HVAC_MODE_DRY is not supported
+        with pytest.raises(ValueError):
+            await hass.services.async_call(
+                CLIMATE_DOMAIN,
+                SERVICE_SET_HVAC_MODE,
+                {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: HVAC_MODE_DRY},
+                blocking=True,
+            )
+        mock_instance.set_mode.assert_not_called()
 
-    mock_aircon_api.return_value.set_fanspeed.reset_mock()
-    # FAN_MIDDLE is not supported
-    with pytest.raises(ValueError):
+        mock_instance.set_mode.reset_mock()
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: HVAC_MODE_FAN_ONLY},
+            blocking=True,
+        )
+        mock_instance.set_mode.assert_called_once_with(whirlpool.aircon.Mode.Fan)
+
+        mock_instance.set_fanspeed.reset_mock()
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_FAN_MODE,
-            {ATTR_ENTITY_ID: "climate.said1", ATTR_FAN_MODE: FAN_MIDDLE},
+            {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: FAN_AUTO},
             blocking=True,
         )
-    mock_aircon_api.return_value.set_fanspeed.assert_not_called()
+        mock_instance.set_fanspeed.assert_called_once_with(
+            whirlpool.aircon.FanSpeed.Auto
+        )
 
-    mock_aircon_api.return_value.set_fanspeed.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_FAN_MODE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_FAN_MODE: FAN_HIGH},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_fanspeed.assert_called_once_with(
-        whirlpool.aircon.FanSpeed.High
-    )
+        mock_instance.set_fanspeed.reset_mock()
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: FAN_LOW},
+            blocking=True,
+        )
+        mock_instance.set_fanspeed.assert_called_once_with(
+            whirlpool.aircon.FanSpeed.Low
+        )
 
-    mock_aircon_api.return_value.set_h_louver_swing.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_SWING_MODE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_SWING_MODE: SWING_HORIZONTAL},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_h_louver_swing.assert_called_with(True)
+        mock_instance.set_fanspeed.reset_mock()
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: FAN_MEDIUM},
+            blocking=True,
+        )
+        mock_instance.set_fanspeed.assert_called_once_with(
+            whirlpool.aircon.FanSpeed.Medium
+        )
 
-    mock_aircon_api.return_value.set_h_louver_swing.reset_mock()
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_SWING_MODE,
-        {ATTR_ENTITY_ID: "climate.said1", ATTR_SWING_MODE: SWING_OFF},
-        blocking=True,
-    )
-    mock_aircon_api.return_value.set_h_louver_swing.assert_called_with(False)
+        mock_instance.set_fanspeed.reset_mock()
+        # FAN_MIDDLE is not supported
+        with pytest.raises(ValueError):
+            await hass.services.async_call(
+                CLIMATE_DOMAIN,
+                SERVICE_SET_FAN_MODE,
+                {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: FAN_MIDDLE},
+                blocking=True,
+            )
+        mock_instance.set_fanspeed.assert_not_called()
+
+        mock_instance.set_fanspeed.reset_mock()
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: FAN_HIGH},
+            blocking=True,
+        )
+        mock_instance.set_fanspeed.assert_called_once_with(
+            whirlpool.aircon.FanSpeed.High
+        )
+
+        mock_instance.set_h_louver_swing.reset_mock()
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_SWING_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_SWING_MODE: SWING_HORIZONTAL},
+            blocking=True,
+        )
+        mock_instance.set_h_louver_swing.assert_called_with(True)
+
+        mock_instance.set_h_louver_swing.reset_mock()
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_SWING_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_SWING_MODE: SWING_OFF},
+            blocking=True,
+        )
+        mock_instance.set_h_louver_swing.assert_called_with(False)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support for multiple air conditioners on the Whirlpool integration. The initial version supported only a single aircon, since I had no way to test that the lib was working fine with multiple aircons. I was now able to find a tester for this and I'm confident to update the integration now.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
