### PR TITLE
Avoid setting up harmony websocket from discovery

### DIFF
--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -43,8 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     cancel_stop = hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, _async_on_stop)
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         HARMONY_DATA: data,
         CANCEL_LISTENER: cancel_listener,
         CANCEL_STOP: cancel_stop,

--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -1,12 +1,10 @@
 """The Logitech Harmony Hub integration."""
-import asyncio
 import logging
 
 from homeassistant.components.remote import ATTR_ACTIVITY, ATTR_DELAY_SECS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -34,13 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     address = entry.data[CONF_HOST]
     name = entry.data[CONF_NAME]
     data = HarmonyData(hass, address, name, entry.unique_id)
-    try:
-        connected_ok = await data.connect()
-    except (asyncio.TimeoutError, ValueError, AttributeError) as err:
-        raise ConfigEntryNotReady from err
-
-    if not connected_ok:
-        raise ConfigEntryNotReady
+    await data.connect()
 
     await _migrate_old_unique_ids(hass, entry.entry_id, data)
 

--- a/homeassistant/components/harmony/config_flow.py
+++ b/homeassistant/components/harmony/config_flow.py
@@ -104,6 +104,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )  # pylint: disable=protected-access
         except aiohttp.ClientError:
             return self.async_abort(reason="cannot_connect")
+        finally:
+            if connector._aiohttp_session:  # pylint: disable=protected-access
+                await connector._aiohttp_session.close()  # pylint: disable=protected-access
 
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured(

--- a/homeassistant/components/harmony/config_flow.py
+++ b/homeassistant/components/harmony/config_flow.py
@@ -1,7 +1,10 @@
 """Config flow for Logitech Harmony Hub integration."""
+import asyncio
 import logging
 from urllib.parse import urlparse
 
+from aioharmony.hubconnector_websocket import HubConnector
+import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
@@ -94,16 +97,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_NAME: friendly_name,
         }
 
-        harmony = await get_harmony_client_if_available(parsed_url.hostname)
+        connector = HubConnector(parsed_url.hostname, asyncio.Queue())
+        try:
+            unique_id = (
+                await connector._get_remote_id()
+            )  # pylint: disable=protected-access
+        except aiohttp.ClientError:
+            return self.async_abort(reason="cannot_connect")
 
-        if harmony:
-            unique_id = find_unique_id_for_remote(harmony)
-            await self.async_set_unique_id(unique_id)
-            self._abort_if_unique_id_configured(
-                updates={CONF_HOST: self.harmony_config[CONF_HOST]}
-            )
-            self.harmony_config[UNIQUE_ID] = unique_id
-
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured(
+            updates={CONF_HOST: self.harmony_config[CONF_HOST]}
+        )
+        self.harmony_config[UNIQUE_ID] = unique_id
         return await self.async_step_link()
 
     async def async_step_link(self, user_input=None):

--- a/homeassistant/components/harmony/config_flow.py
+++ b/homeassistant/components/harmony/config_flow.py
@@ -99,14 +99,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         connector = HubConnector(parsed_url.hostname, asyncio.Queue())
         try:
-            unique_id = (
-                await connector._get_remote_id()
-            )  # pylint: disable=protected-access
+            unique_id = await connector.get_remote_id()
         except aiohttp.ClientError:
             return self.async_abort(reason="cannot_connect")
         finally:
-            if connector._aiohttp_session:  # pylint: disable=protected-access
-                await connector._aiohttp_session.close()  # pylint: disable=protected-access
+            await connector.async_close_session()
 
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured(

--- a/homeassistant/components/harmony/config_flow.py
+++ b/homeassistant/components/harmony/config_flow.py
@@ -99,13 +99,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         connector = HubConnector(parsed_url.hostname, asyncio.Queue())
         try:
-            unique_id = await connector.get_remote_id()
+            remote_id = await connector.get_remote_id()
         except aiohttp.ClientError:
             return self.async_abort(reason="cannot_connect")
         finally:
             await connector.async_close_session()
 
-        await self.async_set_unique_id(unique_id)
+        unique_id = str(remote_id)
+        await self.async_set_unique_id(str(unique_id))
         self._abort_if_unique_id_configured(
             updates={CONF_HOST: self.harmony_config[CONF_HOST]}
         )

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -115,7 +115,7 @@ class HarmonyData(HarmonySubscriberMixin):
         connected = False
         try:
             connected = await self._client.connect()
-        except (asyncio.TimeoutError, aioexc.TimeOut):
+        except (asyncio.TimeoutError, aioexc.TimeOut) as err:
             await self._client.close()
             raise ConfigEntryNotReady(
                 f"{self._name}: Connection timed-out to {self._address}:8088"

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -111,11 +111,18 @@ class HarmonyData(HarmonySubscriberMixin):
 
         try:
             if not await self._client.connect():
-                _LOGGER.warning("%s: Unable to connect to HUB", self._name)
+                _LOGGER.warning(
+                    "%s: Unable to connect to HUB at: %s:%s",
+                    self._name,
+                    self._address,
+                    8088,
+                )
                 await self._client.close()
                 return False
         except aioexc.TimeOut:
-            _LOGGER.warning("%s: Connection timed-out", self._name)
+            _LOGGER.warning(
+                "%s: Connection timed-out to %s:%s", self._name, self._address, 8088
+            )
             return False
 
         return True

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -119,7 +119,7 @@ class HarmonyData(HarmonySubscriberMixin):
             await self._client.close()
             raise ConfigEntryNotReady(
                 f"{self._name}: Connection timed-out to {self._address}:8088"
-            )
+            ) from err
         except (ValueError, AttributeError) as err:
             await self._client.close()
             raise ConfigEntryNotReady(

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -1,12 +1,15 @@
 """Harmony data object which contains the Harmony Client."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterable
 import logging
 
 from aioharmony.const import ClientCallbackType, SendCommandDevice
 import aioharmony.exceptions as aioexc
 from aioharmony.harmonyapi import HarmonyAPI as HarmonyClient
+
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import ACTIVITY_POWER_OFF
 from .subscriber import HarmonySubscriberMixin
@@ -109,23 +112,24 @@ class HarmonyData(HarmonySubscriberMixin):
             ip_address=self._address, callbacks=ClientCallbackType(**callbacks)
         )
 
+        connected = False
         try:
-            if not await self._client.connect():
-                _LOGGER.warning(
-                    "%s: Unable to connect to HUB at: %s:%s",
-                    self._name,
-                    self._address,
-                    8088,
-                )
-                await self._client.close()
-                return False
-        except aioexc.TimeOut:
-            _LOGGER.warning(
-                "%s: Connection timed-out to %s:%s", self._name, self._address, 8088
+            connected = await self._client.connect()
+        except (asyncio.TimeoutError, aioexc.TimeOut):
+            await self._client.close()
+            raise ConfigEntryNotReady(
+                f"{self._name}: Connection timed-out to {self._address}:8088"
             )
-            return False
-
-        return True
+        except (ValueError, AttributeError) as err:
+            await self._client.close()
+            raise ConfigEntryNotReady(
+                f"{self._name}: Error {err} while connected HUB at: {self._address}:8088"
+            )
+        if not connected:
+            await self._client.close()
+            raise ConfigEntryNotReady(
+                f"{self._name}: Unable to connect to HUB at: {self._address}:8088"
+            )
 
     async def shutdown(self):
         """Close connection on shutdown."""

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -124,7 +124,7 @@ class HarmonyData(HarmonySubscriberMixin):
             await self._client.close()
             raise ConfigEntryNotReady(
                 f"{self._name}: Error {err} while connected HUB at: {self._address}:8088"
-            )
+            ) from err
         if not connected:
             await self._client.close()
             raise ConfigEntryNotReady(

--- a/homeassistant/components/harmony/manifest.json
+++ b/homeassistant/components/harmony/manifest.json
@@ -2,7 +2,7 @@
   "domain": "harmony",
   "name": "Logitech Harmony Hub",
   "documentation": "https://www.home-assistant.io/integrations/harmony",
-  "requirements": ["aioharmony==0.2.7"],
+  "requirements": ["aioharmony==0.2.8"],
   "codeowners": [
     "@ehendrix23",
     "@bramkragten",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -176,7 +176,7 @@ aiogithubapi==21.8.0
 aioguardian==1.0.8
 
 # homeassistant.components.harmony
-aioharmony==0.2.7
+aioharmony==0.2.8
 
 # homeassistant.components.homekit_controller
 aiohomekit==0.6.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -118,7 +118,7 @@ aioflo==0.4.1
 aioguardian==1.0.8
 
 # homeassistant.components.harmony
-aioharmony==0.2.7
+aioharmony==0.2.8
 
 # homeassistant.components.homekit_controller
 aiohomekit==0.6.3

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the Logitech Harmony Hub config flow."""
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
+
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.harmony.config_flow import CannotConnect
 from homeassistant.components.harmony.const import DOMAIN, PREVIOUS_ACTIVE_ACTIVITY
@@ -49,11 +51,9 @@ async def test_user_form(hass):
 async def test_form_ssdp(hass):
     """Test we get the form with ssdp source."""
 
-    harmonyapi = _get_mock_harmonyapi(connect=True)
-
     with patch(
-        "homeassistant.components.harmony.util.HarmonyAPI",
-        return_value=harmonyapi,
+        "homeassistant.components.harmony.config_flow.HubConnector._get_remote_id",
+        return_value=1234,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -75,6 +75,8 @@ async def test_form_ssdp(hass):
     assert progress[0]["flow_id"] == result["flow_id"]
     assert progress[0]["context"]["confirm_only"] is True
 
+    harmonyapi = _get_mock_harmonyapi(connect=True)
+
     with patch(
         "homeassistant.components.harmony.util.HarmonyAPI",
         return_value=harmonyapi,
@@ -92,6 +94,25 @@ async def test_form_ssdp(hass):
     assert result2["title"] == "Harmony Hub"
     assert result2["data"] == {"host": "192.168.1.12", "name": "Harmony Hub"}
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_ssdp_fails_to_get_remote_id(hass):
+    """Test we abort if we cannot get the remote id."""
+
+    with patch(
+        "homeassistant.components.harmony.config_flow.HubConnector._get_remote_id",
+        side_effect=aiohttp.ClientError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_SSDP},
+            data={
+                "friendlyName": "Harmony Hub",
+                "ssdp_location": "http://192.168.1.12:8088/description",
+            },
+        )
+    assert result["type"] == "abort"
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_form_ssdp_aborts_before_checking_remoteid_if_host_known(hass):

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -52,7 +52,7 @@ async def test_form_ssdp(hass):
     """Test we get the form with ssdp source."""
 
     with patch(
-        "homeassistant.components.harmony.config_flow.HubConnector._get_remote_id",
+        "homeassistant.components.harmony.config_flow.HubConnector.get_remote_id",
         return_value=1234,
     ):
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -100,7 +100,7 @@ async def test_form_ssdp_fails_to_get_remote_id(hass):
     """Test we abort if we cannot get the remote id."""
 
     with patch(
-        "homeassistant.components.harmony.config_flow.HubConnector._get_remote_id",
+        "homeassistant.components.harmony.config_flow.HubConnector.get_remote_id",
         side_effect=aiohttp.ClientError,
     ):
         result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Probing for the remote id would connect the websocket which could overload the device if there were too many re-discoveries.

Fixes #57542

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
