### PR TITLE
Guard linking credential that is already linked

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -276,6 +276,12 @@ class AuthManager:
         self, user: models.User, credentials: models.Credentials
     ) -> None:
         """Link credentials to an existing user."""
+        linked_user = await self.async_get_user_by_credentials(credentials)
+        if linked_user == user:
+            return
+        if linked_user is not None:
+            raise ValueError("Credential is already linked to a user")
+
         await self._store.async_link_user(user, credentials)
 
     async def async_remove_user(self, user: models.User) -> None:

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -412,7 +412,15 @@ class LinkUserView(HomeAssistantView):
         if credentials is None:
             return self.json_message("Invalid code", status_code=HTTPStatus.BAD_REQUEST)
 
-        await hass.auth.async_link_user(user, credentials)
+        linked_user = await hass.auth.async_get_user_by_credentials(credentials)
+        if linked_user != user and linked_user is not None:
+            return self.json_message(
+                "Credential already linked", status_code=HTTPStatus.BAD_REQUEST
+            )
+
+        # No-op if credential is already linked to the user it will be linked to
+        if linked_user != user:
+            await hass.auth.async_link_user(user, credentials)
         return self.json_message("User linked")
 
 

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -282,6 +282,16 @@ async def test_linking_user_to_two_auth_providers(hass, hass_storage):
     await manager.async_link_user(user, new_credential)
     assert len(user.credentials) == 2
 
+    # Linking it again to same user is a no-op
+    await manager.async_link_user(user, new_credential)
+    assert len(user.credentials) == 2
+
+    # Linking a credential to a user while the credential is already linked to another user should raise
+    user_2 = await manager.async_create_user("User 2")
+    with pytest.raises(ValueError):
+        await manager.async_link_user(user_2, new_credential)
+    assert len(user_2.credentials) == 0
+
 
 async def test_saving_loading(hass, hass_storage):
     """Test storing and saving data.

--- a/tests/components/auth/test_init_link_user.py
+++ b/tests/components/auth/test_init_link_user.py
@@ -127,7 +127,7 @@ async def test_link_user_invalid_auth(hass, aiohttp_client):
 
 
 async def test_link_user_already_linked_same_user(hass, aiohttp_client):
-    """Test linking a user to new credentials."""
+    """Test linking a user to a credential it's already linked to."""
     info = await async_get_code(hass, aiohttp_client)
     client = info["client"]
     code = info["code"]
@@ -148,7 +148,7 @@ async def test_link_user_already_linked_same_user(hass, aiohttp_client):
 
 
 async def test_link_user_already_linked_other_user(hass, aiohttp_client):
-    """Test linking a user to new credentials."""
+    """Test linking a user to a credential already linked to other user."""
     info = await async_get_code(hass, aiohttp_client)
     client = info["client"]
     code = info["code"]

--- a/tests/components/auth/test_init_link_user.py
+++ b/tests/components/auth/test_init_link_user.py
@@ -1,4 +1,6 @@
 """Tests for the link user flow."""
+from unittest.mock import patch
+
 from . import async_setup_auth
 
 from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI
@@ -122,3 +124,48 @@ async def test_link_user_invalid_auth(hass, aiohttp_client):
 
     assert resp.status == 401
     assert len(info["user"].credentials) == 0
+
+
+async def test_link_user_already_linked_same_user(hass, aiohttp_client):
+    """Test linking a user to new credentials."""
+    info = await async_get_code(hass, aiohttp_client)
+    client = info["client"]
+    code = info["code"]
+
+    # Link user
+    with patch.object(
+        hass.auth, "async_get_user_by_credentials", return_value=info["user"]
+    ):
+        resp = await client.post(
+            "/auth/link_user",
+            json={"client_id": CLIENT_ID, "code": code},
+            headers={"authorization": f"Bearer {info['access_token']}"},
+        )
+
+    assert resp.status == 200
+    # The credential was not added because it saw that it was already linked
+    assert len(info["user"].credentials) == 0
+
+
+async def test_link_user_already_linked_other_user(hass, aiohttp_client):
+    """Test linking a user to new credentials."""
+    info = await async_get_code(hass, aiohttp_client)
+    client = info["client"]
+    code = info["code"]
+
+    another_user = await hass.auth.async_create_user(name="Another")
+
+    # Link user
+    with patch.object(
+        hass.auth, "async_get_user_by_credentials", return_value=another_user
+    ):
+        resp = await client.post(
+            "/auth/link_user",
+            json={"client_id": CLIENT_ID, "code": code},
+            headers={"authorization": f"Bearer {info['access_token']}"},
+        )
+
+    assert resp.status == 400
+    # The credential was not added because it saw that it was already linked
+    assert len(info["user"].credentials) == 0
+    assert len(another_user.credentials) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It was possible to link a credential to two users. This would put auth in an invalid state because login would always be linked to first user found with the credential.

The credential linking code is not used at the moment but noticed this issue while reviewing the code for something else.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
