### PR TITLE
Log unhandled loop exception traces when asyncio debug is on

### DIFF
--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -5,6 +5,7 @@ import asyncio
 import dataclasses
 import logging
 import threading
+import traceback
 from typing import Any
 
 from homeassistant import bootstrap
@@ -87,9 +88,15 @@ def _async_loop_exception_handler(_: Any, context: dict[str, Any]) -> None:
     if exception:
         kwargs["exc_info"] = (type(exception), exception, exception.__traceback__)
 
-    logging.getLogger(__package__).error(
-        "Error doing job: %s", context["message"], **kwargs  # type: ignore
-    )
+    logger = logging.getLogger(__package__)
+    if source_traceback := context.get("source_traceback"):
+        stack_summary = "".join(traceback.format_list(source_traceback))
+        logger.error(
+            "Error doing job: %s: %s", context["message"], stack_summary, **kwargs  # type: ignore
+        )
+        return
+
+    logger.error("Error doing job: %s", context["message"], **kwargs)  # type: ignore
 
 
 async def setup_and_run_hass(runtime_config: RuntimeConfig) -> int:

--- a/tests/ignore_uncaught_exceptions.py
+++ b/tests/ignore_uncaught_exceptions.py
@@ -1,6 +1,12 @@
 """List of tests that have uncaught exceptions today. Will be shrunk over time."""
 IGNORE_UNCAUGHT_EXCEPTIONS = [
     (
+        # This test explicitly throws an uncaught exception
+        # and should not be removed.
+        "tests.test_runner",
+        "test_unhandled_exception_traceback",
+    ),
+    (
         "test_homeassistant_bridge",
         "test_homeassistant_bridge_fan_setup",
     ),

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -117,3 +117,23 @@ def test_run_does_not_block_forever_with_shielded_task(hass, tmpdir, caplog):
     assert (
         "Task could not be canceled and was still running after shutdown" in caplog.text
     )
+
+
+async def test_unhandled_exception_traceback(hass, caplog):
+    """Test an unhandled exception get a traceback in debug mode."""
+
+    async def _unhandled_exception():
+        raise Exception("This is unhandled")
+
+    try:
+        hass.loop.set_debug(True)
+        asyncio.create_task(_unhandled_exception())
+    finally:
+        hass.loop.set_debug(False)
+
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert "Task exception was never retrieved" in caplog.text
+    assert "This is unhandled" in caplog.text
+    assert "_unhandled_exception" in caplog.text

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -120,7 +120,7 @@ def test_run_does_not_block_forever_with_shielded_task(hass, tmpdir, caplog):
 
 
 async def test_unhandled_exception_traceback(hass, caplog):
-    """Test an unhandled exception get a traceback in debug mode."""
+    """Test an unhandled exception gets a traceback in debug mode."""
 
     async def _unhandled_exception():
         raise Exception("This is unhandled")


### PR DESCRIPTION
Before
```
2021-10-12 23:01:57 ERROR (MainThread) [homeassistant] Error doing job: Unclosed client session
```

After
```
2021-10-12 23:01:57 ERROR (MainThread) [homeassistant] Error doing job: Unclosed client session:   File "/Users/bdraco/home-assistant/venv/bin/hass", line 33, in <module>
    sys.exit(load_entry_point('homeassistant', 'console_scripts', 'hass')())
  File "/Users/bdraco/home-assistant/homeassistant/__main__.py", line 318, in main
    exit_code = runner.run(runtime_conf)
  File "/Users/bdraco/home-assistant/homeassistant/runner.py", line 122, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 629, in run_until_complete
    self.run_forever()
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 596, in run_forever
    self._run_once()
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 1882, in _run_once
    handle._run()
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/bdraco/home-assistant/homeassistant/data_entry_flow.py", line 191, in _async_init
    result = await self._async_handle_step(flow, flow.init_step, data, init_done)
  File "/Users/bdraco/home-assistant/homeassistant/data_entry_flow.py", line 270, in _async_handle_step
    result: FlowResult = await getattr(flow, method)(user_input)
  File "/Users/bdraco/home-assistant/homeassistant/components/harmony/config_flow.py", line 103, in async_step_ssdp
    await connector._get_remote_id()
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aioharmony/hubconnector_websocket.py", line 105, in _get_remote_id
    response = await self._retrieve_hub_info()
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aioharmony/hubconnector_websocket.py", line 427, in _retrieve_hub_info
    response = await self.hub_post(url, json_request, headers)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aioharmony/hubconnector_websocket.py", line 322, in hub_post
    async with self._session.post(
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aioharmony/hubconnector_websocket.py", line 96, in _session
    self._aiohttp_session = aiohttp.ClientSession(connector=conn,

```

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
