### PR TITLE
Improve warning prints for sensor statistics

### DIFF
--- a/homeassistant/components/energy/sensor.py
+++ b/homeassistant/components/energy/sensor.py
@@ -330,6 +330,7 @@ class EnergyCostSensor(SensorEntity):
             cast(str, self._config[self._adapter.entity_energy_key]),
             energy,
             float(self._last_energy_sensor_state.state),
+            self._last_energy_sensor_state,
         ):
             # Energy meter was reset, reset cost sensor too
             energy_state_copy = copy.copy(energy_state)

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -560,8 +560,8 @@ def _compile_statistics(  # noqa: C901
                         ):
                             reset = True
                             _LOGGER.info(
-                                "Detected new cycle for %s, value dropped from %s to %s. "
-                                "Triggered by state with last_updated set to %s.",
+                                "Detected new cycle for %s, value dropped from %s to %s, "
+                                "triggered by state with last_updated set to %s",
                                 entity_id,
                                 new_state,
                                 state.last_updated.isoformat(),

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -287,7 +287,7 @@ def _suggest_report_issue(hass: HomeAssistant, entity_id: str) -> str:
     return report_issue
 
 
-def warn_dip(hass: HomeAssistant, entity_id: str) -> None:
+def warn_dip(hass: HomeAssistant, entity_id: str, state: State) -> None:
     """Log a warning once if a sensor with state_class_total has a decreasing value.
 
     The log will be suppressed until two dips have been seen to prevent warning due to
@@ -308,14 +308,17 @@ def warn_dip(hass: HomeAssistant, entity_id: str) -> None:
             return
         _LOGGER.warning(
             "Entity %s %shas state class total_increasing, but its state is "
-            "not strictly increasing. Please %s",
+            "not strictly increasing. Triggered by state %s with last_updated set to %s. "
+            "Please %s",
             entity_id,
             f"from integration {domain} " if domain else "",
+            state.state,
+            state.last_updated.isoformat(),
             _suggest_report_issue(hass, entity_id),
         )
 
 
-def warn_negative(hass: HomeAssistant, entity_id: str) -> None:
+def warn_negative(hass: HomeAssistant, entity_id: str, state: State) -> None:
     """Log a warning once if a sensor with state_class_total has a negative value."""
     if WARN_NEGATIVE not in hass.data:
         hass.data[WARN_NEGATIVE] = set()
@@ -324,28 +327,34 @@ def warn_negative(hass: HomeAssistant, entity_id: str) -> None:
         domain = entity_sources(hass).get(entity_id, {}).get("domain")
         _LOGGER.warning(
             "Entity %s %shas state class total_increasing, but its state is "
-            "negative. Please %s",
+            "negative. Triggered by state %s with last_updated set to %s. Please %s",
             entity_id,
             f"from integration {domain} " if domain else "",
+            state.state,
+            state.last_updated.isoformat(),
             _suggest_report_issue(hass, entity_id),
         )
 
 
 def reset_detected(
-    hass: HomeAssistant, entity_id: str, state: float, previous_state: float | None
+    hass: HomeAssistant,
+    entity_id: str,
+    fstate: float,
+    previous_fstate: float | None,
+    state: State,
 ) -> bool:
     """Test if a total_increasing sensor has been reset."""
-    if previous_state is None:
+    if previous_fstate is None:
         return False
 
-    if 0.9 * previous_state <= state < previous_state:
-        warn_dip(hass, entity_id)
+    if 0.9 * previous_fstate <= fstate < previous_fstate:
+        warn_dip(hass, entity_id, state)
 
-    if state < 0:
-        warn_negative(hass, entity_id)
+    if fstate < 0:
+        warn_negative(hass, entity_id, state)
         raise HomeAssistantError
 
-    return state < 0.9 * previous_state
+    return fstate < 0.9 * previous_fstate
 
 
 def _wanted_statistics(sensor_states: list[State]) -> dict[str, set[str]]:
@@ -547,13 +556,15 @@ def _compile_statistics(  # noqa: C901
                 elif state_class == STATE_CLASS_TOTAL_INCREASING:
                     try:
                         if old_state is None or reset_detected(
-                            hass, entity_id, fstate, new_state
+                            hass, entity_id, fstate, new_state, state
                         ):
                             reset = True
                             _LOGGER.info(
-                                "Detected new cycle for %s, value dropped from %s to %s",
+                                "Detected new cycle for %s, value dropped from %s to %s. "
+                                "Triggered by state with last_updated set to %s.",
                                 entity_id,
                                 new_state,
+                                state.last_updated.isoformat(),
                                 fstate,
                             )
                     except HomeAssistantError:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve warning prints for sensor statistics to make it easier to locate the offending states in the recorder database

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
