### PR TITLE
Refurbish deluge sensors using transmission as a blueprint

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -190,6 +190,8 @@ omit =
     homeassistant/components/decora/light.py
     homeassistant/components/decora_wifi/light.py
     homeassistant/components/delijn/*
+    homeassistant/components/deluge/const.py
+    homeassistant/components/deluge/errors.py
     homeassistant/components/deluge/sensor.py
     homeassistant/components/deluge/switch.py
     homeassistant/components/denon/media_player.py

--- a/homeassistant/components/deluge/__init__.py
+++ b/homeassistant/components/deluge/__init__.py
@@ -1,1 +1,290 @@
-"""The deluge component."""
+"""Support for the Deluge BitTorrent client API."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from deluge_client import DelugeRPCClient, FailedToReconnectException
+import voluptuous as vol
+
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
+
+from .const import (
+    DATA_UPDATED,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+from .errors import AuthenticationError, CannotConnect, UnknownError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+DELUGE_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Required(CONF_HOST): cv.string,
+            vol.Required(CONF_PASSWORD): cv.string,
+            vol.Required(CONF_USERNAME): cv.string,
+            vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(
+                CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+            ): cv.time_period,
+        }
+    )
+)
+
+CONFIG_SCHEMA = vol.Schema(
+    vol.All(cv.deprecated(DOMAIN), {DOMAIN: vol.All(cv.ensure_list, [DELUGE_SCHEMA])}),
+    extra=vol.ALLOW_EXTRA,
+)
+
+PLATFORMS = ["sensor", "switch"]
+
+
+async def async_setup(hass, config):
+    """Import the Deluge Component from config."""
+    if DOMAIN in config:
+        for entry in config[DOMAIN]:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=entry
+                )
+            )
+
+    return True
+
+
+async def async_setup_entry(hass, config_entry):
+    """Set up the Deluge Component."""
+    client = DelugeClient(hass, config_entry)
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = client
+
+    if not await client.async_setup():
+        return False
+
+    return True
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload Deluge Entry from config_entry."""
+    client = hass.data[DOMAIN].pop(config_entry.entry_id)
+    if client.unsub_timer:
+        client.unsub_timer()
+
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        config_entry, PLATFORMS
+    )
+
+    return unload_ok
+
+
+async def get_client(hass, entry):
+    """Get Deluge client."""
+    host = entry[CONF_HOST]
+    port = entry[CONF_PORT]
+    username = entry.get(CONF_USERNAME)
+    password = entry.get(CONF_PASSWORD)
+
+    try:
+        client = await hass.async_add_executor_job(
+            _make_client, host, port, username, password
+        )
+        _LOGGER.debug("Successfully connected to %s", host)
+        return client
+
+    except ConnectionError as error:
+        _LOGGER.error("Connecting to the Deluge client %s failed", host)
+        raise CannotConnect from error
+
+    except Exception as error:
+        if type(error).__name__ == 'BadLoginError':
+            _LOGGER.error("Credentials for Deluge client are not valid")
+            raise AuthenticationError from error
+
+        _LOGGER.error(error)
+        raise UnknownError from error
+
+
+def _make_client(host, port, username, password):
+    client = DelugeRPCClient(host, port, username, password)
+    client.connect()
+    return client
+
+
+class DelugeClient:
+    """Deluge Client Object."""
+
+    def __init__(self, hass, config_entry):
+        """Initialize the Deluge RPC API."""
+        self.hass = hass
+        self.config_entry = config_entry
+        self.deluge_client: DelugeRPCClient = None
+        self._deluge_state: DelugeState = None
+        self.unsub_timer = None
+
+    @property
+    def state(self) -> DelugeState:
+        """Return the DelugeData object."""
+        return self._deluge_state
+
+    async def async_setup(self):
+        """Set up the Deluge client."""
+
+        try:
+            self.deluge_client = await get_client(self.hass, self.config_entry.data)
+        except CannotConnect as error:
+            raise ConfigEntryNotReady from error
+        except (AuthenticationError, UnknownError):
+            return False
+
+        self._deluge_state = DelugeState(
+            self.hass, self.config_entry, self.deluge_client
+        )
+
+        await self.hass.async_add_executor_job(self._deluge_state.init_torrents)
+        await self.hass.async_add_executor_job(self._deluge_state.update)
+        self.add_options()
+        self.set_scan_interval(self.config_entry.options[CONF_SCAN_INTERVAL])
+
+        self.hass.config_entries.async_setup_platforms(self.config_entry, PLATFORMS)
+
+        self.config_entry.add_update_listener(self.async_options_updated)
+
+        return True
+
+    def add_options(self):
+        """Add options for entry."""
+        if self.config_entry.options:
+            return
+        scan_interval = self.config_entry.data.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
+        options = {
+            CONF_SCAN_INTERVAL: scan_interval,
+        }
+
+        self.hass.config_entries.async_update_entry(self.config_entry, options=options)
+
+    def set_scan_interval(self, scan_interval):
+        """Update scan interval."""
+
+        def refresh(_):
+            """Get the latest data from Deluge."""
+            self._deluge_state.update()
+
+        if self.unsub_timer is not None:
+            self.unsub_timer()
+        self.unsub_timer = async_track_time_interval(
+            self.hass, refresh, timedelta(seconds=scan_interval)
+        )
+
+    @staticmethod
+    async def async_options_updated(hass, entry):
+        """Triggered by config entry options updates."""
+        deluge_client = hass.data[DOMAIN][entry.entry_id]
+        deluge_client.set_scan_interval(entry.options[CONF_SCAN_INTERVAL])
+        await hass.async_add_executor_job(deluge_client.api.update)
+
+
+class DelugeState:
+    """Get the latest data and update the states."""
+
+    def __init__(self, hass, config, client: DelugeRPCClient):
+        """Initialize the Deluge RPC API."""
+        self.hass = hass
+        self.config = config
+        self.available: bool = True
+        self._client: DelugeRPCClient = client
+        self._session: dict = {}
+        self._torrents: list[dict] = []
+
+    @property
+    def host(self):
+        """Return the host name."""
+        return self.config.data[CONF_HOST]
+
+    @property
+    def signal_update(self):
+        """Update signal per Deluge entry."""
+        return f"{DATA_UPDATED}-{self.host}"
+
+    @property
+    def session(self):
+        """Get the session data."""
+        return self._session
+
+    @property
+    def torrents(self):
+        """Get the list of torrents."""
+        return self._torrents
+
+    def init_torrents(self):
+        """Initialize torrent list."""
+        self._torrents = self._get_torrents_status()
+
+    def update(self):
+        """Get the latest data from Deluge instance."""
+        try:
+            self._session = self._get_session_status()
+            self._torrents = self._get_torrents_status()
+
+            _LOGGER.debug("Torrent Data for %s Updated", self.host)
+            self.available = True
+
+        except FailedToReconnectException:
+            self.available = False
+            _LOGGER.error("Unable to connect to Deluge client %s", self.host)
+
+        dispatcher_send(self.hass, self.signal_update)
+
+    def resume_torrents(self):
+        """Start all torrents."""
+        if not self._torrents:
+            return
+        torrent_ids = [torrent[b"id"] for torrent in self._torrents]
+        self._client.call("core.resume_torrent", torrent_ids)
+
+    def pause_torrents(self):
+        """Stop all active torrents."""
+        if not self._torrents:
+            return
+        torrent_ids = [torrent[b"id"] for torrent in self._torrents]
+        self._client.call("core.pause_torrent", torrent_ids)
+
+    def _get_session_status(self):
+        session_status = self._client.call(
+            "core.get_session_status",
+            [
+                "dht_download_rate",
+                "dht_upload_rate",
+                "download_rate",
+                "upload_rate",
+            ],
+        )
+        session_status[b"free_space"] = self._client.call("core.get_free_space")
+        return session_status
+
+    def _get_torrents_status(self, states=None):
+        torrents_status = self._client.call(
+            "core.get_torrents_status",
+            {"state": states} if states else None,
+            ["eta", "name", "progress", "ratio", "state", "time_added"],
+        )
+        for torrent_id, torrent_info in torrents_status.items():
+            torrent_info[b"id"] = torrent_id
+        return list(torrents_status.values())

--- a/homeassistant/components/deluge/config_flow.py
+++ b/homeassistant/components/deluge/config_flow.py
@@ -1,0 +1,110 @@
+"""Config flow for Deluge Bittorent Client."""
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+from homeassistant.core import callback
+
+from . import get_client
+from .const import (
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+from .errors import AuthenticationError, CannotConnect, UnknownError
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+    }
+)
+
+
+class DelugeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle Deluge config flow."""
+
+    VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return DelugeOptionsFlowHandler(config_entry)
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        errors = {}
+
+        if user_input is not None:
+
+            for entry in self._async_current_entries():
+                if (
+                    entry.data[CONF_HOST] == user_input[CONF_HOST]
+                    and entry.data[CONF_PORT] == user_input[CONF_PORT]
+                ):
+                    return self.async_abort(reason="already_configured")
+                if entry.data[CONF_NAME] == user_input[CONF_NAME]:
+                    errors[CONF_NAME] = "name_exists"
+                    break
+            try:
+                await get_client(self.hass, user_input)
+
+            except AuthenticationError:
+                errors[CONF_USERNAME] = "invalid_auth"
+                errors[CONF_PASSWORD] = "invalid_auth"
+            except (CannotConnect, UnknownError):
+                errors["base"] = "cannot_connect"
+
+            if not errors:
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME], data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_import(self, import_config):
+        """Import from Deluge client config."""
+        import_config[CONF_SCAN_INTERVAL] = import_config[
+            CONF_SCAN_INTERVAL
+        ].total_seconds()
+        return await self.async_step_user(user_input=import_config)
+
+
+class DelugeOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Deluge client options."""
+
+    def __init__(self, config_entry):
+        """Initialize Deluge options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the Deluge options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        options = {
+            vol.Optional(
+                CONF_SCAN_INTERVAL,
+                default=self.config_entry.options.get(
+                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                ),
+            ): int,
+        }
+
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/deluge/config_flow.py
+++ b/homeassistant/components/deluge/config_flow.py
@@ -7,16 +7,13 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
-    CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
-from homeassistant.core import callback
 
 from . import get_client
 from .const import (
     DEFAULT_NAME,
     DEFAULT_PORT,
-    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
 from .errors import AuthenticationError, CannotConnect, UnknownError
@@ -36,12 +33,6 @@ class DelugeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle Deluge config flow."""
 
     VERSION = 1
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Get the options flow for this handler."""
-        return DelugeOptionsFlowHandler(config_entry)
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
@@ -77,34 +68,3 @@ class DelugeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=DATA_SCHEMA,
             errors=errors,
         )
-
-    async def async_step_import(self, import_config):
-        """Import from Deluge client config."""
-        import_config[CONF_SCAN_INTERVAL] = import_config[
-            CONF_SCAN_INTERVAL
-        ].total_seconds()
-        return await self.async_step_user(user_input=import_config)
-
-
-class DelugeOptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle Deluge client options."""
-
-    def __init__(self, config_entry):
-        """Initialize Deluge options flow."""
-        self.config_entry = config_entry
-
-    async def async_step_init(self, user_input=None):
-        """Manage the Deluge options."""
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
-
-        options = {
-            vol.Optional(
-                CONF_SCAN_INTERVAL,
-                default=self.config_entry.options.get(
-                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-                ),
-            ): int,
-        }
-
-        return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/deluge/const.py
+++ b/homeassistant/components/deluge/const.py
@@ -1,0 +1,10 @@
+"""Constants for the Deluge Bittorent Client component."""
+DOMAIN = "deluge"
+
+DEFAULT_NAME = "Deluge"
+DEFAULT_PORT = 58846
+DEFAULT_SCAN_INTERVAL = 120
+
+STATE_ATTR_FREE_SPACE = "free_space"
+
+DATA_UPDATED = "deluge_data_updated"

--- a/homeassistant/components/deluge/errors.py
+++ b/homeassistant/components/deluge/errors.py
@@ -1,0 +1,14 @@
+"""Errors for the Transmission component."""
+from homeassistant.exceptions import HomeAssistantError
+
+
+class AuthenticationError(HomeAssistantError):
+    """Wrong Username or Password."""
+
+
+class CannotConnect(HomeAssistantError):
+    """Unable to connect to client."""
+
+
+class UnknownError(HomeAssistantError):
+    """Unknown Error."""

--- a/homeassistant/components/deluge/manifest.json
+++ b/homeassistant/components/deluge/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "deluge",
   "name": "Deluge",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deluge",
   "requirements": ["deluge-client==1.7.1"],
   "codeowners": [],

--- a/homeassistant/components/deluge/sensor.py
+++ b/homeassistant/components/deluge/sensor.py
@@ -1,150 +1,133 @@
 """Support for monitoring the Deluge BitTorrent client API."""
 from __future__ import annotations
 
-import logging
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import CONF_NAME, DATA_RATE_MEGABYTES_PER_SECOND, STATE_IDLE
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from deluge_client import DelugeRPCClient, FailedToReconnectException
-import voluptuous as vol
-
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA,
-    SensorEntity,
-    SensorEntityDescription,
-)
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_MONITORED_VARIABLES,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_USERNAME,
-    DATA_RATE_KILOBYTES_PER_SECOND,
-    STATE_IDLE,
-)
-from homeassistant.exceptions import PlatformNotReady
-import homeassistant.helpers.config_validation as cv
-
-_LOGGER = logging.getLogger(__name__)
-_THROTTLED_REFRESH = None
-
-DEFAULT_NAME = "Deluge"
-DEFAULT_PORT = 58846
-DHT_UPLOAD = 1000
-DHT_DOWNLOAD = 1000
-SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
-        key="current_status",
-        name="Status",
-    ),
-    SensorEntityDescription(
-        key="download_speed",
-        name="Down Speed",
-        native_unit_of_measurement=DATA_RATE_KILOBYTES_PER_SECOND,
-    ),
-    SensorEntityDescription(
-        key="upload_speed",
-        name="Up Speed",
-        native_unit_of_measurement=DATA_RATE_KILOBYTES_PER_SECOND,
-    ),
-)
-
-SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_MONITORED_VARIABLES, default=[]): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_KEYS)]
-        ),
-    }
+from . import DelugeClient
+from .const import (
+    DOMAIN,
+    STATE_ATTR_FREE_SPACE,
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Deluge sensors."""
 
-    name = config[CONF_NAME]
-    host = config[CONF_HOST]
-    username = config[CONF_USERNAME]
-    password = config[CONF_PASSWORD]
-    port = config[CONF_PORT]
+    deluge_client = hass.data[DOMAIN][config_entry.entry_id]
+    name = config_entry.data[CONF_NAME]
 
-    deluge_api = DelugeRPCClient(host, port, username, password)
-    try:
-        deluge_api.connect()
-    except ConnectionRefusedError as err:
-        _LOGGER.error("Connection to Deluge Daemon failed")
-        raise PlatformNotReady from err
-    monitored_variables = config[CONF_MONITORED_VARIABLES]
     entities = [
-        DelugeSensor(deluge_api, name, description)
-        for description in SENSOR_TYPES
-        if description.key in monitored_variables
+        DelugeSpeedSensor(deluge_client, name, "Down Speed", "download"),
+        DelugeSpeedSensor(deluge_client, name, "Up Speed", "upload"),
+        DelugeStatusSensor(deluge_client, name, "Status"),
     ]
 
-    add_entities(entities)
+    async_add_entities(entities, True)
 
 
 class DelugeSensor(SensorEntity):
-    """Representation of a Deluge sensor."""
+    """A base class for all Deluge sensors."""
 
-    def __init__(
-        self, deluge_client, client_name, description: SensorEntityDescription
-    ):
+    @staticmethod
+    def _get_session_speeds(session):
+        return (
+            session[b"download_rate"] - session[b"dht_download_rate"],
+            session[b"upload_rate"] - session[b"dht_upload_rate"],
+        )
+
+    def __init__(self, deluge_client, client_name, sensor_name, sub_type=None):
         """Initialize the sensor."""
-        self.entity_description = description
-        self.client = deluge_client
-        self.data = None
+        self._deluge_client: DelugeClient = deluge_client
+        self._client_name = client_name
+        self._name = sensor_name
+        self._sub_type = sub_type
+        self._state = None
 
-        self._attr_available = False
-        self._attr_name = f"{client_name} {description.name}"
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{self._client_name} {self._name}"
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the entity."""
+        return f"{self._deluge_client.state.host}-{self.name}"
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def should_poll(self):
+        """Return the polling requirement for this sensor."""
+        return False
+
+    @property
+    def available(self):
+        """Could the device be accessed during the last update call."""
+        return self._deluge_client.state.available
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+
+        @callback
+        def update():
+            """Update the state."""
+            self.async_schedule_update_ha_state(True)
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, self._deluge_client.state.signal_update, update
+            )
+        )
+
+
+class DelugeSpeedSensor(DelugeSensor):
+    """Representation of a Deluge speed sensor."""
+
+    @property
+    def native_unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return DATA_RATE_MEGABYTES_PER_SECOND
 
     def update(self):
         """Get the latest data from Deluge and updates the state."""
+        session = self._deluge_client.state.session
+        if session:
+            download, upload = self._get_session_speeds(session)
+            value = float(download if self._sub_type == "download" else upload)
+            value = value / 1024 / 1024  # Convert from bytes to MiB
+            self._state = round(value, 2 if value < 0.1 else 1)
+        else:
+            self._state = None
 
-        try:
-            self.data = self.client.call(
-                "core.get_session_status",
-                [
-                    "upload_rate",
-                    "download_rate",
-                    "dht_upload_rate",
-                    "dht_download_rate",
-                ],
-            )
-            self._attr_available = True
-        except FailedToReconnectException:
-            _LOGGER.error("Connection to Deluge Daemon Lost")
-            self._attr_available = False
-            return
 
-        upload = self.data[b"upload_rate"] - self.data[b"dht_upload_rate"]
-        download = self.data[b"download_rate"] - self.data[b"dht_download_rate"]
+class DelugeStatusSensor(DelugeSensor):
+    """Representation of a Deluge status sensor."""
 
-        sensor_type = self.entity_description.key
-        if sensor_type == "current_status":
-            if self.data:
-                if upload > 0 and download > 0:
-                    self._attr_native_value = "Up/Down"
-                elif upload > 0 and download == 0:
-                    self._attr_native_value = "Seeding"
-                elif upload == 0 and download > 0:
-                    self._attr_native_value = "Downloading"
-                else:
-                    self._attr_native_value = STATE_IDLE
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes, if any."""
+        session = self._deluge_client.state.session
+        value = session[b"free_space"] / 1024 / 1024 / 1024  # Convert from bytes to GiB
+        return {STATE_ATTR_FREE_SPACE: round(value, 2 if value < 0.1 else 1)}
+
+    def update(self):
+        """Get the latest data from Deluge and updates the state."""
+        session = self._deluge_client.state.session
+        if session:
+            download, upload = self._get_session_speeds(session)
+            if download > 0 and upload > 0:
+                self._state = "Up/Down"
+            elif download == 0 and upload > 0:
+                self._state = "Seeding"
+            elif download > 0 and upload == 0:
+                self._state = "Downloading"
             else:
-                self._attr_native_value = None
-
-        if self.data:
-            if sensor_type == "download_speed":
-                kb_spd = float(download)
-                kb_spd = kb_spd / 1024
-                self._attr_native_value = round(kb_spd, 2 if kb_spd < 0.1 else 1)
-            elif sensor_type == "upload_speed":
-                kb_spd = float(upload)
-                kb_spd = kb_spd / 1024
-                self._attr_native_value = round(kb_spd, 2 if kb_spd < 0.1 else 1)
+                self._state = STATE_IDLE
+        else:
+            self._state = None

--- a/homeassistant/components/deluge/strings.json
+++ b/homeassistant/components/deluge/strings.json
@@ -1,0 +1,34 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Setup Deluge Client",
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        }
+      }
+    },
+    "error": {
+      "name_exists": "[%key:common::config_flow::data::name%] already exists",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure options for Deluge",
+        "data": {
+          "scan_interval": "Update frequency"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/deluge/switch.py
+++ b/homeassistant/components/deluge/switch.py
@@ -1,109 +1,101 @@
 """Support for setting the Deluge BitTorrent client in Pause."""
 import logging
 
-from deluge_client import DelugeRPCClient, FailedToReconnectException
-import voluptuous as vol
-
-from homeassistant.components.switch import PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_USERNAME,
-    STATE_OFF,
-    STATE_ON,
-)
-from homeassistant.exceptions import PlatformNotReady
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import ToggleEntity
 
-_LOGGER = logging.getLogger(__name__)
+from . import DelugeClient
+from .const import DOMAIN
 
-DEFAULT_NAME = "Deluge Switch"
-DEFAULT_PORT = 58846
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    }
-)
+_LOGGING = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Deluge switch."""
 
-    name = config[CONF_NAME]
-    host = config[CONF_HOST]
-    username = config[CONF_USERNAME]
-    password = config[CONF_PASSWORD]
-    port = config[CONF_PORT]
+    deluge_client = hass.data[DOMAIN][config_entry.entry_id]
+    name = config_entry.data[CONF_NAME]
 
-    deluge_api = DelugeRPCClient(host, port, username, password)
-    try:
-        deluge_api.connect()
-    except ConnectionRefusedError as err:
-        _LOGGER.error("Connection to Deluge Daemon failed")
-        raise PlatformNotReady from err
+    entities = [
+        DelugeSwitch("Switch", deluge_client, name),
+    ]
 
-    add_entities([DelugeSwitch(deluge_api, name)])
+    async_add_entities(entities, True)
 
 
 class DelugeSwitch(ToggleEntity):
     """Representation of a Deluge switch."""
 
-    def __init__(self, deluge_client, name):
+    def __init__(self, switch_name, deluge_client, name):
         """Initialize the Deluge switch."""
-        self._name = name
-        self.deluge_client = deluge_client
+        self._name = switch_name
+        self._deluge_client: DelugeClient = deluge_client
+        self.client_name = name
         self._state = STATE_OFF
-        self._available = False
+        self.unsub_update = None
 
     @property
     def name(self):
         """Return the name of the switch."""
-        return self._name
+        return f"{self.client_name} {self._name}"
 
     @property
-    def is_on(self):
-        """Return true if device is on."""
+    def unique_id(self):
+        """Return the unique id of the entity."""
+        return f"{self._deluge_client.state.host}-{self.name}"
+
+    @property
+    def should_poll(self) -> bool:
+        """Poll for status regularly."""
+        return False
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is on."""
         return self._state == STATE_ON
 
     @property
     def available(self):
-        """Return true if device is available."""
-        return self._available
+        """Could the device be accessed during the last update call."""
+        return self._deluge_client.state.available
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        torrent_ids = self.deluge_client.call("core.get_session_state")
-        self.deluge_client.call("core.resume_torrent", torrent_ids)
+        _LOGGING.debug("Starting all torrents")
+        self._deluge_client.state.resume_torrents()
+        self._deluge_client.state.update()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        torrent_ids = self.deluge_client.call("core.get_session_state")
-        self.deluge_client.call("core.pause_torrent", torrent_ids)
+        _LOGGING.debug("Stopping all torrents")
+        self._deluge_client.state.pause_torrents()
+        self._deluge_client.state.update()
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        self.unsub_update = async_dispatcher_connect(
+            self.hass,
+            self._deluge_client.state.signal_update,
+            self._schedule_immediate_update,
+        )
+
+    @callback
+    def _schedule_immediate_update(self):
+        self.async_schedule_update_ha_state(True)
+
+    async def will_remove_from_hass(self):
+        """Unsubscribe from update dispatcher."""
+        if self.unsub_update:
+            self.unsub_update()
+            self.unsub_update = None
 
     def update(self):
-        """Get the latest data from deluge and updates the state."""
-
-        try:
-            torrent_list = self.deluge_client.call(
-                "core.get_torrents_status", {}, ["paused"]
-            )
-            self._available = True
-        except FailedToReconnectException:
-            _LOGGER.error("Connection to Deluge Daemon Lost")
-            self._available = False
+        """Get the latest data from Deluge and updates the state."""
+        torrents = self._deluge_client.state.torrents
+        if not torrents:
             return
-        for torrent in torrent_list.values():
-            item = torrent.popitem()
-            if not item[1]:
-                self._state = STATE_ON
-                return
 
-        self._state = STATE_OFF
+        all_torrents_paused = all(torrent[b"state"] == "paused" for torrent in torrents)
+        self._state = STATE_OFF if all_torrents_paused else STATE_ON

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -57,6 +57,7 @@ FLOWS = [
     "crownstone",
     "daikin",
     "deconz",
+    "deluge",
     "denonavr",
     "devolo_home_control",
     "dexcom",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -323,6 +323,9 @@ debugpy==1.5.0
 # homeassistant.components.ohmconnect
 defusedxml==0.7.1
 
+# homeassistant.components.deluge
+deluge-client==1.7.1
+
 # homeassistant.components.denonavr
 denonavr==0.10.9
 

--- a/tests/components/deluge/__init__.py
+++ b/tests/components/deluge/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Deluge."""

--- a/tests/components/deluge/test_config_flow.py
+++ b/tests/components/deluge/test_config_flow.py
@@ -1,0 +1,255 @@
+"""Tests for Deluge config flow."""
+from datetime import timedelta
+from unittest.mock import patch
+
+from deluge_client import FailedToReconnectException
+import pytest
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components import deluge
+from homeassistant.components.deluge import config_flow
+from homeassistant.components.deluge.const import (
+    CONF_LIMIT,
+    CONF_ORDER,
+    DEFAULT_LIMIT,
+    DEFAULT_NAME,
+    DEFAULT_ORDER,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+
+from tests.common import MockConfigEntry
+
+NAME = "Deluge"
+HOST = "192.168.1.100"
+USERNAME = "username"
+PASSWORD = "password"
+PORT = 9091
+SCAN_INTERVAL = 10
+
+MOCK_ENTRY = {
+    CONF_NAME: NAME,
+    CONF_HOST: HOST,
+    CONF_USERNAME: USERNAME,
+    CONF_PASSWORD: PASSWORD,
+    CONF_PORT: PORT,
+}
+
+
+@pytest.fixture(name="api")
+def mock_deluge_api():
+    """Mock an api."""
+    with patch("deluge_client.DelugeRPCClient"):
+        yield
+
+
+@pytest.fixture(name="unknown_error")
+def mock_api_unknown_error():
+    """Mock an api."""
+    with patch("deluge_client.DelugeRPCClient", side_effect=FailedToReconnectException):
+        yield
+
+
+@pytest.fixture(name="deluge_setup", autouse=True)
+def deluge_setup_fixture():
+    """Mock Deluge entry setup."""
+    with patch("homeassistant.components.deluge.async_setup_entry", return_value=True):
+        yield
+
+
+def init_config_flow(hass):
+    """Init a configuration flow."""
+    flow = config_flow.DelugeFlowHandler()
+    flow.hass = hass
+    return flow
+
+
+async def test_flow_user_config(hass, api):
+    """Test user config."""
+    result = await hass.config_entries.flow.async_init(
+        deluge.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+
+async def test_flow_required_fields(hass, api):
+    """Test with required fields only."""
+    result = await hass.config_entries.flow.async_init(
+        deluge.DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_NAME: NAME, CONF_HOST: HOST, CONF_PORT: PORT},
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == NAME
+    assert result["data"][CONF_NAME] == NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == PORT
+
+
+async def test_flow_all_provided(hass, api):
+    """Test with all provided."""
+    result = await hass.config_entries.flow.async_init(
+        deluge.DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=MOCK_ENTRY,
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == NAME
+    assert result["data"][CONF_NAME] == NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_PORT] == PORT
+
+
+async def test_options(hass):
+    """Test updating options."""
+    entry = MockConfigEntry(
+        domain=deluge.DOMAIN,
+        title=CONF_NAME,
+        data=MOCK_ENTRY,
+        options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
+    )
+    flow = init_config_flow(hass)
+    options_flow = flow.async_get_options_flow(entry)
+
+    result = await options_flow.async_step_init()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+    result = await options_flow.async_step_init({CONF_SCAN_INTERVAL: 10})
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"][CONF_SCAN_INTERVAL] == 10
+
+
+async def test_import(hass, api):
+    """Test import step."""
+    flow = init_config_flow(hass)
+
+    # import with minimum fields only
+    result = await flow.async_step_import(
+        {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_HOST: HOST,
+            CONF_PORT: DEFAULT_PORT,
+            CONF_SCAN_INTERVAL: timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+            CONF_LIMIT: DEFAULT_LIMIT,
+            CONF_ORDER: DEFAULT_ORDER,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+    assert result["data"][CONF_NAME] == DEFAULT_NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_PORT] == DEFAULT_PORT
+    assert result["data"][CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
+
+    # import with all
+    result = await flow.async_step_import(
+        {
+            CONF_NAME: NAME,
+            CONF_HOST: HOST,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_PORT: PORT,
+            CONF_SCAN_INTERVAL: timedelta(seconds=SCAN_INTERVAL),
+            CONF_LIMIT: DEFAULT_LIMIT,
+            CONF_ORDER: DEFAULT_ORDER,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == NAME
+    assert result["data"][CONF_NAME] == NAME
+    assert result["data"][CONF_HOST] == HOST
+    assert result["data"][CONF_USERNAME] == USERNAME
+    assert result["data"][CONF_PASSWORD] == PASSWORD
+    assert result["data"][CONF_PORT] == PORT
+    assert result["data"][CONF_SCAN_INTERVAL] == SCAN_INTERVAL
+
+
+async def test_host_already_configured(hass, api):
+    """Test host is already configured."""
+    entry = MockConfigEntry(
+        domain=deluge.DOMAIN,
+        data=MOCK_ENTRY,
+        options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
+    )
+    entry.add_to_hass(hass)
+
+    mock_entry_unique_name = MOCK_ENTRY.copy()
+    mock_entry_unique_name[CONF_NAME] = "Deluge 1"
+    result = await hass.config_entries.flow.async_init(
+        deluge.DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=mock_entry_unique_name,
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+    mock_entry_unique_port = MOCK_ENTRY.copy()
+    mock_entry_unique_port[CONF_PORT] = 9092
+    mock_entry_unique_port[CONF_NAME] = "Deluge 2"
+    result = await hass.config_entries.flow.async_init(
+        deluge.DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=mock_entry_unique_port,
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    mock_entry_unique_host = MOCK_ENTRY.copy()
+    mock_entry_unique_host[CONF_HOST] = "192.168.1.101"
+    mock_entry_unique_host[CONF_NAME] = "Deluge 3"
+    result = await hass.config_entries.flow.async_init(
+        deluge.DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=mock_entry_unique_host,
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+async def test_name_already_configured(hass, api):
+    """Test name is already configured."""
+    entry = MockConfigEntry(
+        domain=deluge.DOMAIN,
+        data=MOCK_ENTRY,
+        options={CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL},
+    )
+    entry.add_to_hass(hass)
+
+    mock_entry = MOCK_ENTRY.copy()
+    mock_entry[CONF_HOST] = "0.0.0.0"
+    result = await hass.config_entries.flow.async_init(
+        deluge.DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=mock_entry,
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_NAME: "name_exists"}
+
+
+async def test_error_on_unknown_error(hass, unknown_error):
+    """Test when connection to host fails."""
+    flow = init_config_flow(hass)
+
+    result = await flow.async_step_user(
+        {
+            CONF_NAME: NAME,
+            CONF_HOST: HOST,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+            CONF_PORT: PORT,
+        }
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "cannot_connect"}

--- a/tests/components/deluge/test_init.py
+++ b/tests/components/deluge/test_init.py
@@ -1,0 +1,92 @@
+"""Tests for Deluge init."""
+
+from unittest.mock import patch
+
+from deluge_client import FailedToReconnectException
+import pytest
+
+from homeassistant.components import deluge
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry, mock_coro
+
+MOCK_ENTRY = MockConfigEntry(
+    domain=deluge.DOMAIN,
+    data={
+        deluge.CONF_NAME: "Deluge",
+        deluge.CONF_HOST: "0.0.0.0",
+        deluge.CONF_USERNAME: "user",
+        deluge.CONF_PASSWORD: "pass",
+        deluge.CONF_PORT: 9091,
+    },
+)
+
+
+@pytest.fixture(name="api")
+def mock_deluge_api():
+    """Mock an api."""
+    with patch("deluge_client.DelugeRPCClient"):
+        yield
+
+
+@pytest.fixture(name="unknown_error")
+def mock_api_unknown_error():
+    """Mock an api."""
+    with patch("deluge_client.DelugeRPCClient", side_effect=FailedToReconnectException):
+        yield
+
+
+async def test_setup_with_no_config(hass):
+    """Test that we do not discover anything or try to set up a Deluge client."""
+    assert await async_setup_component(hass, deluge.DOMAIN, {}) is True
+    assert deluge.DOMAIN not in hass.data
+
+
+async def test_setup_with_config(hass, api):
+    """Test that we import the config and setup the client."""
+    config = {
+        deluge.DOMAIN: {
+            deluge.CONF_NAME: "Deluge",
+            deluge.CONF_HOST: "0.0.0.0",
+            deluge.CONF_USERNAME: "user",
+            deluge.CONF_PASSWORD: "pass",
+            deluge.CONF_PORT: 9091,
+        },
+        deluge.DOMAIN: {
+            deluge.CONF_NAME: "Deluge 2",
+            deluge.CONF_HOST: "0.0.0.1",
+            deluge.CONF_USERNAME: "user",
+            deluge.CONF_PASSWORD: "pass",
+            deluge.CONF_PORT: 9091,
+        },
+    }
+    assert await async_setup_component(hass, deluge.DOMAIN, config) is True
+
+
+async def test_successful_config_entry(hass, api):
+    """Test that configured Deluge is configured successfully."""
+
+    entry = MOCK_ENTRY
+    entry.add_to_hass(hass)
+
+    assert await deluge.async_setup_entry(hass, entry) is True
+    assert entry.options == {
+        deluge.CONF_SCAN_INTERVAL: deluge.DEFAULT_SCAN_INTERVAL,
+        deluge.CONF_LIMIT: deluge.DEFAULT_LIMIT,
+        deluge.CONF_ORDER: deluge.DEFAULT_ORDER,
+    }
+
+
+async def test_unload_entry(hass, api):
+    """Test removing Deluge client."""
+    entry = MOCK_ENTRY
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        hass.config_entries, "async_forward_entry_unload", return_value=mock_coro(True)
+    ) as unload_entry:
+        assert await deluge.async_setup_entry(hass, entry)
+
+        assert await deluge.async_unload_entry(hass, entry)
+        assert unload_entry.call_count == 2
+        assert entry.entry_id not in hass.data[deluge.DOMAIN]


### PR DESCRIPTION
Improves status sensor and adds new torrent sensors:
* Configuration flow
* Status (with free_space attribute [New!])

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Complete rewrite of the Deluge sensors. Also adding a configuration flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19732
- Related to PR: https://github.com/home-assistant/core/pull/57534

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
