### PR TITLE
Port unmerged fixes from tuya_v2 

### DIFF
--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -326,6 +326,12 @@ class TuyaHaLight(TuyaHaEntity, LightEntity):
         return self.tuya_device.status.get(DPCode.WORK_MODE, "")
 
     def _get_hsv(self) -> dict[str, int]:
+        if (
+            self.dp_code_colour not in self.tuya_device.status
+            or len(self.tuya_device.status[self.dp_code_colour]) == 0
+        ):
+            return {"h": 0, "s": 0, "v": 0}
+
         return json.loads(self.tuya_device.status[self.dp_code_colour])
 
     @property

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -239,6 +239,14 @@ class TuyaHaLight(TuyaHaEntity, LightEntity):
         return bright_value.get("min", 0), bright_value.get("max", 255)
 
     @property
+    def color_mode(self) -> str:
+        """Return the color_mode of the light."""
+        work_mode = self._work_mode()
+        if work_mode == WORK_MODE_WHITE:
+            return COLOR_MODE_COLOR_TEMP
+        return COLOR_MODE_HS
+
+    @property
     def hs_color(self) -> tuple[float, float] | None:
         """Return the hs_color of the light."""
         colour_json = self.tuya_device.status.get(self.dp_code_colour)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is a port from tuya/tuya-home-assistant#486 which fixes several problems identified in the tuya_v2 integration before that was merged through #56820.

Fixes tuya/tuya-home-assistant#314
Fixes tuya/tuya-home-assistant#316
Fixes tuya/tuya-home-assistant#412
Fixes tuya/tuya-home-assistant#484

### Fix tuya/light turn_on parameter setting
    
When brightness and hs_color were passed together two colour_data commands would be sent, one setting the new brightness on the old color, and one setting the new color with the old brightness.  The second would take effect so the requested brightness would be ignored.

Cache work_mode once, updating it if a new working mode was implicitly selected by a color keyword argument.  Ensure that brightness and color-related instructions are not sent when the working mode is neither colour nor white.

Refactor so that hs_color and color_temp are handled first.  Since only one will be provided, use if/elif to only test the correct code.

If color_temp is used, send the standard brightness instruction; otherwise after handling hs_color apply brightness to the updated colour_data.  Send colour_data only if a kw argument caused it to be updated.

Uniformly use the named constants for string literals like "colour" and "white".


### Fix tuya/light when light has no color
    
Some lights don't support color, and the support code test suggests that even when they do the status property might not be available. Make _get_hsv() return something sensible in that case so turn_on has a basic structure to work with.

### Fix tuya/light loss of color mode
    
While properties allowed the core to be informed of the current color setting, work_mode was not translated into its corresponding Light property color_mode.  As a result the icon for a light reconfigured from a dark red to a warm white would remain dark red, and the UI variant for changing light status would always start on the color wheel rather than the color temperature.

Implement the property getter for color_mode to fix this.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
