### PR TITLE
Update xknx to version 0.18.10

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -359,15 +359,8 @@ class KNXModule:
     async def connection_state_changed_cb(self, state: XknxConnectionState) -> None:
         """Call invoked after a KNX connection state change was received."""
         self.connected = state == XknxConnectionState.CONNECTED
-        if tasks := [*device.after_update() for device in self.xknx.devices]:
+        if tasks := [device.after_update() for device in self.xknx.devices]:
             await asyncio.gather(*tasks)
-
-        self.hass.bus.async_fire(
-            "knx_connection_state_change",
-            {
-                "connection_state": state.name,
-            },
-        )
 
     def register_callback(self) -> TelegramQueue.Callback:
         """Register callback within XKNX TelegramQueue."""

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -359,8 +359,8 @@ class KNXModule:
     async def connection_state_changed_cb(self, state: XknxConnectionState) -> None:
         """Call invoked after a KNX connection state change was received."""
         self.connected = state == XknxConnectionState.CONNECTED
-        for device in self.xknx.devices:
-            await device.after_update()
+        if tasks := [*device.after_update() for device in self.xknx.devices]:
+            await asyncio.gather(*tasks)
 
         self.hass.bus.async_fire(
             "knx_connection_state_change",

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -2,7 +2,7 @@
   "domain": "knx",
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.18.9"],
+  "requirements": ["xknx==0.18.10"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
   "quality_scale": "silver",
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2436,7 +2436,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.knx
-xknx==0.18.9
+xknx==0.18.10
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1395,7 +1395,7 @@ wolf_smartset==0.1.11
 xbox-webapi==2.0.11
 
 # homeassistant.components.knx
-xknx==0.18.9
+xknx==0.18.10
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/tests/components/knx/conftest.py
+++ b/tests/components/knx/conftest.py
@@ -153,6 +153,7 @@ class KNXTestKit:
                 source_address=IndividualAddress(self.INDIVIDUAL_ADDRESS),
             )
         )
+        await self.xknx.telegrams.join()
         await self.hass.async_block_till_done()
 
     async def receive_read(

--- a/tests/components/knx/test_binary_sensor.py
+++ b/tests/components/knx/test_binary_sensor.py
@@ -37,7 +37,6 @@ async def test_binary_sensor(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_read("2/2/2")
     await knx.receive_response("1/1/1", True)
     await knx.receive_response("2/2/2", False)
-    await hass.async_block_till_done()
     state_normal = hass.states.get("binary_sensor.test_normal")
     state_invert = hass.states.get("binary_sensor.test_invert")
     assert state_normal.state is STATE_ON
@@ -46,7 +45,6 @@ async def test_binary_sensor(hass: HomeAssistant, knx: KNXTestKit):
     # receive OFF telegram
     await knx.receive_write("1/1/1", False)
     await knx.receive_write("2/2/2", True)
-    await hass.async_block_till_done()
     state_normal = hass.states.get("binary_sensor.test_normal")
     state_invert = hass.states.get("binary_sensor.test_invert")
     assert state_normal.state is STATE_OFF
@@ -55,7 +53,6 @@ async def test_binary_sensor(hass: HomeAssistant, knx: KNXTestKit):
     # receive ON telegram
     await knx.receive_write("1/1/1", True)
     await knx.receive_write("2/2/2", False)
-    await hass.async_block_till_done()
     state_normal = hass.states.get("binary_sensor.test_normal")
     state_invert = hass.states.get("binary_sensor.test_invert")
     assert state_normal.state is STATE_ON
@@ -130,7 +127,7 @@ async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit):
                 {
                     CONF_NAME: "test",
                     CONF_STATE_ADDRESS: "2/2/2",
-                    BinarySensorSchema.CONF_CONTEXT_TIMEOUT: 0.1,
+                    BinarySensorSchema.CONF_CONTEXT_TIMEOUT: 0.001,
                     CONF_SYNC_STATE: False,
                 },
             ]
@@ -148,19 +145,22 @@ async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit):
     state = hass.states.get("binary_sensor.test")
     assert state.state is STATE_OFF
     assert state.attributes.get("counter") == 0
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=0.1))
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=0.001))
     await hass.async_block_till_done()
-    await asyncio.sleep(0.2)
+    await asyncio.sleep(0.002)
     # state changed twice after context timeout - once to ON with counter 1 and once to counter 0
     state = hass.states.get("binary_sensor.test")
     assert state.state is STATE_ON
     assert state.attributes.get("counter") == 0
     # additional async_block_till_done needed event capture
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
     assert len(events) == 2
-    assert events.pop(0).data.get("new_state").attributes.get("counter") == 1
-    assert events.pop(0).data.get("new_state").attributes.get("counter") == 0
+    event = events.pop(0).data
+    assert event.get("new_state").attributes.get("counter") == 1
+    assert event.get("old_state").attributes.get("counter") == 0
+    event = events.pop(0).data
+    assert event.get("new_state").attributes.get("counter") == 0
+    assert event.get("old_state").attributes.get("counter") == 1
 
     # receive 2 telegrams in context
     await knx.receive_write("2/2/2", True)

--- a/tests/components/knx/test_binary_sensor.py
+++ b/tests/components/knx/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test KNX binary sensor."""
+import asyncio
 from datetime import timedelta
 
 from homeassistant.components.knx.const import CONF_STATE_ADDRESS, CONF_SYNC_STATE
@@ -36,6 +37,7 @@ async def test_binary_sensor(hass: HomeAssistant, knx: KNXTestKit):
     await knx.assert_read("2/2/2")
     await knx.receive_response("1/1/1", True)
     await knx.receive_response("2/2/2", False)
+    await hass.async_block_till_done()
     state_normal = hass.states.get("binary_sensor.test_normal")
     state_invert = hass.states.get("binary_sensor.test_invert")
     assert state_normal.state is STATE_ON
@@ -44,6 +46,7 @@ async def test_binary_sensor(hass: HomeAssistant, knx: KNXTestKit):
     # receive OFF telegram
     await knx.receive_write("1/1/1", False)
     await knx.receive_write("2/2/2", True)
+    await hass.async_block_till_done()
     state_normal = hass.states.get("binary_sensor.test_normal")
     state_invert = hass.states.get("binary_sensor.test_invert")
     assert state_normal.state is STATE_OFF
@@ -52,6 +55,7 @@ async def test_binary_sensor(hass: HomeAssistant, knx: KNXTestKit):
     # receive ON telegram
     await knx.receive_write("1/1/1", True)
     await knx.receive_write("2/2/2", False)
+    await hass.async_block_till_done()
     state_normal = hass.states.get("binary_sensor.test_normal")
     state_invert = hass.states.get("binary_sensor.test_invert")
     assert state_normal.state is STATE_ON
@@ -126,7 +130,7 @@ async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit):
                 {
                     CONF_NAME: "test",
                     CONF_STATE_ADDRESS: "2/2/2",
-                    BinarySensorSchema.CONF_CONTEXT_TIMEOUT: 1,
+                    BinarySensorSchema.CONF_CONTEXT_TIMEOUT: 0.1,
                     CONF_SYNC_STATE: False,
                 },
             ]
@@ -144,13 +148,15 @@ async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit):
     state = hass.states.get("binary_sensor.test")
     assert state.state is STATE_OFF
     assert state.attributes.get("counter") == 0
-    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=0.1))
     await hass.async_block_till_done()
+    await asyncio.sleep(0.2)
     # state changed twice after context timeout - once to ON with counter 1 and once to counter 0
     state = hass.states.get("binary_sensor.test")
     assert state.state is STATE_ON
     assert state.attributes.get("counter") == 0
     # additional async_block_till_done needed event capture
+    await hass.async_block_till_done()
     await hass.async_block_till_done()
     assert len(events) == 2
     assert events.pop(0).data.get("new_state").attributes.get("counter") == 1
@@ -170,9 +176,11 @@ async def test_binary_sensor_counter(hass: HomeAssistant, knx: KNXTestKit):
     assert state.state is STATE_ON
     assert state.attributes.get("counter") == 0
     await hass.async_block_till_done()
-    assert len(events) == 2
-    assert events.pop(0).data.get("new_state").attributes.get("counter") == 2
-    assert events.pop(0).data.get("new_state").attributes.get("counter") == 0
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    event = events.pop(0).data
+    assert event.get("new_state").attributes.get("counter") == 2
+    assert event.get("old_state").attributes.get("counter") == 0
 
 
 async def test_binary_sensor_reset(hass: HomeAssistant, knx: KNXTestKit):
@@ -199,6 +207,7 @@ async def test_binary_sensor_reset(hass: HomeAssistant, knx: KNXTestKit):
     state = hass.states.get("binary_sensor.test")
     assert state.state is STATE_ON
     async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
     await hass.async_block_till_done()
     # state reset after after timeout
     state = hass.states.get("binary_sensor.test")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates the xknx library used by the KNX integration to version 0.18.10. Changelog: https://github.com/XKNX/xknx/releases/tag/0.18.10

One of the changes included is that users will now see in the UI if the KNX connection is currently working or if the connectivity to the gateway is interrupted (based on the available property).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #57072
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
