### PR TITLE
Remove YAML configuration from nfandroidtv

### DIFF
--- a/homeassistant/components/nfandroidtv/__init__.py
+++ b/homeassistant/components/nfandroidtv/__init__.py
@@ -2,32 +2,15 @@
 from notifications_android_tv.notifications import ConnectError, Notifications
 
 from homeassistant.components.notify import DOMAIN as NOTIFY
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PLATFORM
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import discovery
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 
 PLATFORMS = [NOTIFY]
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the NFAndroidTV component."""
-    hass.data.setdefault(DOMAIN, {})
-    # Iterate all entries for notify to only get nfandroidtv
-    if NOTIFY in config:
-        for entry in config[NOTIFY]:
-            if entry[CONF_PLATFORM] == DOMAIN:
-                hass.async_create_task(
-                    hass.config_entries.flow.async_init(
-                        DOMAIN, context={"source": SOURCE_IMPORT}, data=entry
-                    )
-                )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/nfandroidtv/config_flow.py
+++ b/homeassistant/components/nfandroidtv/config_flow.py
@@ -50,19 +50,6 @@ class NFAndroidTVFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_import(self, import_config):
-        """Import a config entry from configuration.yaml."""
-        for entry in self._async_current_entries():
-            if entry.data[CONF_HOST] == import_config[CONF_HOST]:
-                _LOGGER.warning(
-                    "Already configured. This yaml configuration has already been imported. Please remove it"
-                )
-                return self.async_abort(reason="already_configured")
-        if CONF_NAME not in import_config:
-            import_config[CONF_NAME] = f"{DEFAULT_NAME} {import_config[CONF_HOST]}"
-
-        return await self.async_step_user(import_config)
-
     async def _async_try_connect(self, host):
         """Try connecting to Android TV / Fire TV."""
         try:

--- a/homeassistant/components/nfandroidtv/const.py
+++ b/homeassistant/components/nfandroidtv/const.py
@@ -1,11 +1,5 @@
 """Constants for the NFAndroidTV integration."""
 DOMAIN: str = "nfandroidtv"
-CONF_DURATION = "duration"
-CONF_FONTSIZE = "fontsize"
-CONF_POSITION = "position"
-CONF_TRANSPARENCY = "transparency"
-CONF_COLOR = "color"
-CONF_INTERRUPT = "interrupt"
 
 DEFAULT_NAME = "Android TV / Fire TV"
 DEFAULT_TIMEOUT = 5
@@ -15,7 +9,6 @@ ATTR_FONTSIZE = "fontsize"
 ATTR_POSITION = "position"
 ATTR_TRANSPARENCY = "transparency"
 ATTR_COLOR = "color"
-ATTR_BKGCOLOR = "bkgcolor"
 ATTR_INTERRUPT = "interrupt"
 ATTR_FILE = "file"
 # Attributes contained in file

--- a/homeassistant/components/nfandroidtv/notify.py
+++ b/homeassistant/components/nfandroidtv/notify.py
@@ -10,10 +10,9 @@ from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TITLE,
     ATTR_TITLE_DEFAULT,
-    PLATFORM_SCHEMA,
     BaseNotificationService,
 )
-from homeassistant.const import ATTR_ICON, CONF_HOST, CONF_TIMEOUT
+from homeassistant.const import ATTR_ICON, CONF_HOST
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 
@@ -31,36 +30,10 @@ from .const import (
     ATTR_INTERRUPT,
     ATTR_POSITION,
     ATTR_TRANSPARENCY,
-    CONF_COLOR,
-    CONF_DURATION,
-    CONF_FONTSIZE,
-    CONF_INTERRUPT,
-    CONF_POSITION,
-    CONF_TRANSPARENCY,
     DEFAULT_TIMEOUT,
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-# Deprecated in Home Assistant 2021.8
-PLATFORM_SCHEMA = cv.deprecated(
-    vol.All(
-        PLATFORM_SCHEMA.extend(
-            {
-                vol.Required(CONF_HOST): cv.string,
-                vol.Optional(CONF_DURATION): vol.Coerce(int),
-                vol.Optional(CONF_FONTSIZE): vol.In(Notifications.FONTSIZES.keys()),
-                vol.Optional(CONF_POSITION): vol.In(Notifications.POSITIONS.keys()),
-                vol.Optional(CONF_TRANSPARENCY): vol.In(
-                    Notifications.TRANSPARENCIES.keys()
-                ),
-                vol.Optional(CONF_COLOR): vol.In(Notifications.BKG_COLORS.keys()),
-                vol.Optional(CONF_TIMEOUT): vol.Coerce(int),
-                vol.Optional(CONF_INTERRUPT): cv.boolean,
-            }
-        ),
-    )
-)
 
 
 async def async_get_service(hass: HomeAssistant, config, discovery_info=None):

--- a/tests/components/nfandroidtv/test_config_flow.py
+++ b/tests/components/nfandroidtv/test_config_flow.py
@@ -4,8 +4,7 @@ from unittest.mock import patch
 from notifications_android_tv.notifications import ConnectError
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.nfandroidtv.const import DEFAULT_NAME, DOMAIN
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.components.nfandroidtv.const import DOMAIN
 
 from . import (
     CONF_CONFIG_FLOW,
@@ -95,41 +94,3 @@ async def test_flow_user_unknown_error(hass):
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {"base": "unknown"}
-
-
-async def test_flow_import(hass):
-    """Test an import flow."""
-    mocked_tv = await _create_mocked_tv(True)
-    with _patch_config_flow_tv(mocked_tv), _patch_setup():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=CONF_CONFIG_FLOW,
-        )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["data"] == CONF_DATA
-
-    with _patch_config_flow_tv(mocked_tv), _patch_setup():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=CONF_CONFIG_FLOW,
-        )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "already_configured"
-
-
-async def test_flow_import_missing_optional(hass):
-    """Test an import flow with missing options."""
-    mocked_tv = await _create_mocked_tv(True)
-    with _patch_config_flow_tv(mocked_tv), _patch_setup():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={CONF_HOST: HOST},
-        )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["data"] == {CONF_HOST: HOST, CONF_NAME: f"{DEFAULT_NAME} {HOST}"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The previously deprecated YAML configuration of the Notifications for Android TV / Fire TV integration has been removed.

Notifications for Android TV / Fire TV is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
