### PR TITLE
Nut: Use coordinator data, code cleanup and add test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -731,7 +731,6 @@ omit =
     homeassistant/components/nuki/const.py
     homeassistant/components/nuki/binary_sensor.py
     homeassistant/components/nuki/lock.py
-    homeassistant/components/nut/sensor.py
     homeassistant/components/nx584/alarm_control_panel.py
     homeassistant/components/nzbget/coordinator.py
     homeassistant/components/obihai/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -361,7 +361,7 @@ homeassistant/components/nsw_rural_fire_service_feed/* @exxamalte
 homeassistant/components/nuki/* @pschmitt @pvizeli @pree
 homeassistant/components/numato/* @clssn
 homeassistant/components/number/* @home-assistant/core @Shulyaka
-homeassistant/components/nut/* @bdraco
+homeassistant/components/nut/* @bdraco @ollo69
 homeassistant/components/nws/* @MatthewFlamm
 homeassistant/components/nzbget/* @chriscla
 homeassistant/components/obihai/* @dshokouhi

--- a/homeassistant/components/nut/const.py
+++ b/homeassistant/components/nut/const.py
@@ -45,7 +45,6 @@ PYNUT_UNIQUE_ID = "unique_id"
 PYNUT_MANUFACTURER = "manufacturer"
 PYNUT_MODEL = "model"
 PYNUT_FIRMWARE = "firmware"
-PYNUT_NAME = "name"
 
 SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     "ups.status.display": SensorEntityDescription(

--- a/homeassistant/components/nut/manifest.json
+++ b/homeassistant/components/nut/manifest.json
@@ -3,7 +3,7 @@
   "name": "Network UPS Tools (NUT)",
   "documentation": "https://www.home-assistant.io/integrations/nut",
   "requirements": ["pynut2==2.1.2"],
-  "codeowners": ["@bdraco"],
+  "codeowners": ["@bdraco", "@ollo69"],
   "config_flow": true,
   "zeroconf": ["_nut._tcp.local."],
   "iot_class": "local_polling"

--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -20,7 +20,6 @@ from .const import (
     PYNUT_FIRMWARE,
     PYNUT_MANUFACTURER,
     PYNUT_MODEL,
-    PYNUT_NAME,
     PYNUT_UNIQUE_ID,
     SENSOR_TYPES,
     STATE_TYPES,
@@ -37,10 +36,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     manufacturer = pynut_data[PYNUT_MANUFACTURER]
     model = pynut_data[PYNUT_MODEL]
     firmware = pynut_data[PYNUT_FIRMWARE]
-    name = pynut_data[PYNUT_NAME]
     coordinator = pynut_data[COORDINATOR]
     data = pynut_data[PYNUT_DATA]
-    status = data.status
+    status = coordinator.data
 
     enabled_resources = [
         resource.lower() for resource in config_entry.data[CONF_RESOURCES]
@@ -55,7 +53,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         NUTSensor(
             coordinator,
             data,
-            name.title(),
             SENSOR_TYPES[sensor_type],
             unique_id,
             manufacturer,
@@ -76,7 +73,6 @@ class NUTSensor(CoordinatorEntity, SensorEntity):
         self,
         coordinator: DataUpdateCoordinator,
         data: PyNUTData,
-        name: str,
         sensor_description: SensorEntityDescription,
         unique_id: str,
         manufacturer: str | None,
@@ -90,20 +86,16 @@ class NUTSensor(CoordinatorEntity, SensorEntity):
         self._manufacturer = manufacturer
         self._firmware = firmware
         self._model = model
-        self._device_name = name
-        self._data = data
+        self._device_name = data.name.title()
         self._unique_id = unique_id
-        self._attr_entity_registry_enabled_default = enabled_default
 
-        self._attr_name = f"{name} {sensor_description.name}"
-        if unique_id is not None:
-            self._attr_unique_id = f"{unique_id}_{sensor_description.key}"
+        self._attr_entity_registry_enabled_default = enabled_default
+        self._attr_name = f"{self._device_name} {sensor_description.name}"
+        self._attr_unique_id = f"{unique_id}_{sensor_description.key}"
 
     @property
     def device_info(self):
         """Device info for the ups."""
-        if not self._unique_id:
-            return None
         device_info = {
             "identifiers": {(DOMAIN, self._unique_id)},
             "name": self._device_name,
@@ -119,17 +111,14 @@ class NUTSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         """Return entity state from ups."""
-        if not self._data.status:
-            return None
+        status = self.coordinator.data
         if self.entity_description.key == KEY_STATUS_DISPLAY:
-            return _format_display_state(self._data.status)
-        return self._data.status.get(self.entity_description.key)
+            return _format_display_state(status)
+        return status.get(self.entity_description.key)
 
 
 def _format_display_state(status):
     """Return UPS display state."""
-    if status is None:
-        return STATE_TYPES["OFF"]
     try:
         return " ".join(STATE_TYPES[state] for state in status[KEY_STATUS].split())
     except KeyError:

--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -1,9 +1,20 @@
 """The sensor tests for the nut platform."""
 
-from homeassistant.const import PERCENTAGE
+from unittest.mock import patch
+
+from homeassistant.components.nut.const import DOMAIN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_RESOURCES,
+    PERCENTAGE,
+    STATE_UNKNOWN,
+)
 from homeassistant.helpers import entity_registry as er
 
-from .util import async_init_integration
+from .util import _get_mock_pynutclient, async_init_integration
+
+from tests.common import MockConfigEntry
 
 
 async def test_pr3000rt2u(hass):
@@ -202,6 +213,64 @@ async def test_blazer_usb(hass):
     assert all(
         state.attributes[key] == expected_attributes[key] for key in expected_attributes
     )
+
+
+async def test_state_sensors(hass):
+    """Test creation of status display sensors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "mock",
+            CONF_PORT: "mock",
+            CONF_RESOURCES: ["ups.status", "ups.status.display"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    mock_pynut = _get_mock_pynutclient(
+        list_ups={"ups1": "UPS 1"}, list_vars={"ups.status": "OL"}
+    )
+
+    with patch(
+        "homeassistant.components.nut.PyNUTClient",
+        return_value=mock_pynut,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state1 = hass.states.get("sensor.ups1_status")
+        state2 = hass.states.get("sensor.ups1_status_data")
+        assert state1.state == "Online"
+        assert state2.state == "OL"
+
+
+async def test_unknown_state_sensors(hass):
+    """Test creation of unknown status display sensors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "mock",
+            CONF_PORT: "mock",
+            CONF_RESOURCES: ["ups.status", "ups.status.display"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    mock_pynut = _get_mock_pynutclient(
+        list_ups={"ups1": "UPS 1"}, list_vars={"ups.status": "OQ"}
+    )
+
+    with patch(
+        "homeassistant.components.nut.PyNUTClient",
+        return_value=mock_pynut,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state1 = hass.states.get("sensor.ups1_status")
+        state2 = hass.states.get("sensor.ups1_status_data")
+        assert state1.state == STATE_UNKNOWN
+        assert state2.state == "OQ"
 
 
 async def test_stale_options(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I did some code clean-up for Nut integration, removing useless code and improving tests. To simplify approval process I will split changes in 2 or 3 PR.
On this PR:
- Implemented use of `coordinator.data` to store and fetch Nut status
- Removed unreachable or useless codes
- Added tests for sensor module (removed exclusion from `.coveragerc`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
