### PR TITLE
Add kodi attributes for the state of DPMS and screensaver

### DIFF
--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -282,6 +282,8 @@ class KodiEntity(MediaPlayerEntity):
         self._app_properties = {}
         self._media_position_updated_at = None
         self._media_position = None
+        self._dpms = None
+        self._screensaver = None
 
     def _reset_state(self, players=None):
         self._players = players
@@ -321,6 +323,30 @@ class KodiEntity(MediaPlayerEntity):
             return
 
         self._reset_state([])
+        self.async_write_ha_state()
+
+    @callback
+    def async_on_dpms_on(self, sender, data):
+        """Handle the activation of display power management."""
+        self._dpms = True
+        self.async_write_ha_state()
+
+    @callback
+    def async_on_dpms_off(self, sender, data):
+        """Handle the activation of display power management."""
+        self._dpms = False
+        self.async_write_ha_state()
+
+    @callback
+    def async_on_screensaver_on(self, sender, data):
+        """Handle the activation of the screensaver."""
+        self._screensaver = True
+        self.async_write_ha_state()
+
+    @callback
+    def async_on_screensaver_off(self, sender, data):
+        """Handle the activation of the screensaver."""
+        self._screensaver = False
         self.async_write_ha_state()
 
     @callback
@@ -404,6 +430,7 @@ class KodiEntity(MediaPlayerEntity):
         device = dev_reg.async_get_device({(DOMAIN, self.unique_id)})
         dev_reg.async_update_device(device.id, sw_version=sw_version)
 
+        await self.async_query_display_status()
         self.async_schedule_update_ha_state(True)
 
     async def _async_ws_connect(self):
@@ -442,9 +469,29 @@ class KodiEntity(MediaPlayerEntity):
         self._connection.server.Application.OnVolumeChanged = (
             self.async_on_volume_changed
         )
+        self._connection.server.GUI.OnDPMSActivated = self.async_on_dpms_on
+        self._connection.server.GUI.OnDPMSDeactivated = self.async_on_dpms_off
+        self._connection.server.GUI.OnScreensaverActivated = (
+            self.async_on_screensaver_on
+        )
+        self._connection.server.GUI.OnScreensaverDeactivated = (
+            self.async_on_screensaver_off
+        )
         self._connection.server.System.OnQuit = self.async_on_quit
         self._connection.server.System.OnRestart = self.async_on_quit
         self._connection.server.System.OnSleep = self.async_on_quit
+
+    @cmd
+    async def async_query_display_status(self):
+        """Retrieve display properties."""
+        display_properties = {
+            "booleans": ["System.DPMSActive", "System.ScreenSaverActive"]
+        }
+        display_status = await self._kodi.call_method(
+            "XBMC.GetInfoBooleans", **display_properties
+        )
+        self._dpms = display_status["System.DPMSActive"]
+        self._screensaver = display_status["System.ScreenSaverActive"]
 
     @cmd
     async def async_update(self):
@@ -500,6 +547,11 @@ class KodiEntity(MediaPlayerEntity):
     def should_poll(self):
         """Return True if entity has to be polled for state."""
         return not self._connection.can_subscribe
+
+    @property
+    def extra_state_attributes(self):
+        """Return the DPMS and screensaver status."""
+        return {"display_dpms": self._dpms, "screensaver": self._screensaver}
 
     @property
     def volume_level(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Provides status of external display power management and internal screensaver as attributes, can be used to prevent a playback automation from starting, as the output device may be unable to render audio or video, or be used to automate the power-on of an output device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
