### PR TITLE
Don't add indirectly referenced config entities to service calls

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -61,7 +61,7 @@ async def async_setup(hass: ha.HomeAssistant, config: ConfigType) -> bool:  # no
 
     async def async_handle_turn_service(service):
         """Handle calls to homeassistant.turn_on/off."""
-        referenced = await async_extract_referenced_entity_ids(hass, service)
+        referenced = async_extract_referenced_entity_ids(hass, service)
         all_referenced = referenced.referenced | referenced.indirectly_referenced
 
         # Generic turn on/off method requires entity id

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -396,7 +396,7 @@ def _async_register_events_and_services(hass: HomeAssistant):
 
     async def async_handle_homekit_unpair(service):
         """Handle unpair HomeKit service call."""
-        referenced = await async_extract_referenced_entity_ids(hass, service)
+        referenced = async_extract_referenced_entity_ids(hass, service)
         dev_reg = device_registry.async_get(hass)
         for device_id in referenced.referenced_devices:
             dev_reg_ent = dev_reg.async_get(device_id)

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -113,11 +113,25 @@ def area_mock(hass):
         platform="test",
         area_id="own-area",
     )
+    config_entity_in_own_area = ent_reg.RegistryEntry(
+        entity_id="light.config_in_own_area",
+        unique_id="config-in-own-area-id",
+        platform="test",
+        area_id="own-area",
+        entity_category="config",
+    )
     entity_in_area = ent_reg.RegistryEntry(
         entity_id="light.in_area",
         unique_id="in-area-id",
         platform="test",
         device_id=device_in_area.id,
+    )
+    config_entity_in_area = ent_reg.RegistryEntry(
+        entity_id="light.config_in_area",
+        unique_id="config-in-area-id",
+        platform="test",
+        device_id=device_in_area.id,
+        entity_category="config",
     )
     entity_in_other_area = ent_reg.RegistryEntry(
         entity_id="light.in_other_area",
@@ -138,6 +152,13 @@ def area_mock(hass):
         unique_id="no-area-id",
         platform="test",
         device_id=device_no_area.id,
+    )
+    config_entity_no_area = ent_reg.RegistryEntry(
+        entity_id="light.config_no_area",
+        unique_id="config-no-area-id",
+        platform="test",
+        device_id=device_no_area.id,
+        entity_category="config",
     )
     entity_diff_area = ent_reg.RegistryEntry(
         entity_id="light.diff_area",
@@ -163,10 +184,13 @@ def area_mock(hass):
         hass,
         {
             entity_in_own_area.entity_id: entity_in_own_area,
+            config_entity_in_own_area.entity_id: config_entity_in_own_area,
             entity_in_area.entity_id: entity_in_area,
+            config_entity_in_area.entity_id: config_entity_in_area,
             entity_in_other_area.entity_id: entity_in_other_area,
             entity_assigned_to_area.entity_id: entity_assigned_to_area,
             entity_no_area.entity_id: entity_no_area,
+            config_entity_no_area.entity_id: config_entity_no_area,
             entity_diff_area.entity_id: entity_diff_area,
             entity_in_area_a.entity_id: entity_in_area_a,
             entity_in_area_b.entity_id: entity_in_area_b,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Entities which have their `entity_category` set to `config` or `diagnostic` will not be targeted by service calls with a device or area target.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't add config and diagnostic entities indirectly referenced by a device or area to service calls

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
