### PR TITLE
Bump spiderpy to 1.4.3

### DIFF
--- a/homeassistant/components/spider/manifest.json
+++ b/homeassistant/components/spider/manifest.json
@@ -2,7 +2,7 @@
   "domain": "spider",
   "name": "Itho Daalderop Spider",
   "documentation": "https://www.home-assistant.io/integrations/spider",
-  "requirements": ["spiderpy==1.4.2"],
+  "requirements": ["spiderpy==1.4.3"],
   "codeowners": ["@peternijssen"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2202,7 +2202,7 @@ speak2mary==1.4.0
 speedtest-cli==2.1.3
 
 # homeassistant.components.spider
-spiderpy==1.4.2
+spiderpy==1.4.3
 
 # homeassistant.components.spotify
 spotipy==2.18.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1269,7 +1269,7 @@ speak2mary==1.4.0
 speedtest-cli==2.1.3
 
 # homeassistant.components.spider
-spiderpy==1.4.2
+spiderpy==1.4.3
 
 # homeassistant.components.spotify
 spotipy==2.18.0


### PR DESCRIPTION
## Proposed change
This updates the dependency of spiderpy to 1.4.3, which contains a fix for logging in. Would love to see this PR go in the next minor release of HA.


Changes: https://github.com/peternijssen/spiderpy/compare/1.4.2...1.4.3


## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #57664
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
