### PR TITLE
Swap order of int template helper kwargs

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1463,7 +1463,7 @@ def forgiving_float_filter(value, default=_SENTINEL):
         return default
 
 
-def forgiving_int(value, default=_SENTINEL, base=10):
+def forgiving_int(value, base=10, default=_SENTINEL):
     """Try to convert value to an int, and warn if it fails."""
     result = jinja2.filters.do_int(value, default=default, base=base)
     if result is _SENTINEL:
@@ -1472,7 +1472,7 @@ def forgiving_int(value, default=_SENTINEL, base=10):
     return result
 
 
-def forgiving_int_filter(value, default=_SENTINEL, base=10):
+def forgiving_int_filter(value, base=10, default=_SENTINEL):
     """Try to convert value to an int, and warn if it fails."""
     result = jinja2.filters.do_int(value, default=default, base=base)
     if result is _SENTINEL:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -250,7 +250,7 @@ def test_int_filter(hass):
     assert render(hass, "{{ states.sensor.temperature.state | int(base=16) }}") == 16
 
     assert render(hass, "{{ 'bad' | int }}") == 0
-    assert render(hass, "{{ 'bad' | int(1) }}") == 1
+    assert render(hass, "{{ 'bad' | int(10, 1) }}") == 1
     assert render(hass, "{{ 'bad' | int(default=1) }}") == 1
 
 
@@ -264,7 +264,7 @@ def test_int_function(hass):
     assert render(hass, "{{ int(states.sensor.temperature.state, base=16) }}") == 16
 
     assert render(hass, "{{ int('bad') }}") == "bad"
-    assert render(hass, "{{ int('bad', 1) }}") == 1
+    assert render(hass, "{{ int('bad', 10, 1) }}") == 1
     assert render(hass, "{{ int('bad', default=1) }}") == 1
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -248,6 +248,11 @@ def test_int_filter(hass):
 
     hass.states.async_set("sensor.temperature", "0x10")
     assert render(hass, "{{ states.sensor.temperature.state | int(base=16) }}") == 16
+    assert render(hass, "{{ states.sensor.temperature.state | int(16) }}") == 16
+
+    hass.states.async_set("sensor.temperature", "1111")
+    assert render(hass, "{{ states.sensor.temperature.state | int(base=2) }}") == 15
+    assert render(hass, "{{ states.sensor.temperature.state | int(2) }}") == 15
 
     assert render(hass, "{{ 'bad' | int }}") == 0
     assert render(hass, "{{ 'bad' | int(10, 1) }}") == 1
@@ -262,6 +267,11 @@ def test_int_function(hass):
 
     hass.states.async_set("sensor.temperature", "0x10")
     assert render(hass, "{{ int(states.sensor.temperature.state, base=16) }}") == 16
+    assert render(hass, "{{ int(states.sensor.temperature.state, 16) }}") == 16
+
+    hass.states.async_set("sensor.temperature", "1111")
+    assert render(hass, "{{ int(states.sensor.temperature.state, base=2) }}") == 15
+    assert render(hass, "{{ int(states.sensor.temperature.state, 2) }}") == 15
 
     assert render(hass, "{{ int('bad') }}") == "bad"
     assert render(hass, "{{ int('bad', 10, 1) }}") == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
swap the order of the kwargs for the int function/filter.  Without it swapped it's going to break all non base 10 uses.  

I.e.  No error will be produced because they are providing a default but the int is now changed from a base n to base 10.
I'd think we'd rather put the default as the 3rd argument so that they'll get warnings and nothing will silently break.
i.e.
```
int('1111', 2)
```
the default will be 2 now, and int will return 1111 instead of 15.

So with this change

```
int('1111', 2)
```
will still return 15 and produce the 'no default' warning.  Users will always have to use
```
int('xyz', default=0)
'xyz' | int(default=0)
```
if they want to keep the integer base 10 and provide a default

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
