### PR TITLE
Add auto slider/box mode to number entity

### DIFF
--- a/homeassistant/components/demo/number.py
+++ b/homeassistant/components/demo/number.py
@@ -1,7 +1,10 @@
 """Demo platform that offers a fake Number entity."""
 from __future__ import annotations
 
+from typing import Literal
+
 from homeassistant.components.number import NumberEntity
+from homeassistant.components.number.const import MODE_AUTO, MODE_BOX, MODE_SLIDER
 from homeassistant.const import DEVICE_DEFAULT_NAME
 
 from . import DOMAIN
@@ -17,6 +20,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 42.0,
                 "mdi:volume-high",
                 False,
+                mode=MODE_SLIDER,
             ),
             DemoNumber(
                 "pwm1",
@@ -27,6 +31,27 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 0.0,
                 1.0,
                 0.01,
+                MODE_BOX,
+            ),
+            DemoNumber(
+                "large_range",
+                "Large Range",
+                500,
+                "mdi:square-wave",
+                False,
+                1,
+                1000,
+                1,
+            ),
+            DemoNumber(
+                "small_range",
+                "Small Range",
+                128,
+                "mdi:square-wave",
+                False,
+                1,
+                255,
+                1,
             ),
         ]
     )
@@ -51,7 +76,8 @@ class DemoNumber(NumberEntity):
         assumed: bool,
         min_value: float | None = None,
         max_value: float | None = None,
-        step=None,
+        step: float | None = None,
+        mode: Literal["auto", "box", "slider"] = MODE_AUTO,
     ) -> None:
         """Initialize the Demo Number entity."""
         self._attr_assumed_state = assumed
@@ -59,6 +85,7 @@ class DemoNumber(NumberEntity):
         self._attr_name = name or DEVICE_DEFAULT_NAME
         self._attr_unique_id = unique_id
         self._attr_value = state
+        self._attr_mode = mode
 
         if min_value is not None:
             self._attr_min_value = min_value

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any, final
+from typing import Any, Literal, final
 
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_MODE
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
@@ -27,6 +28,7 @@ from .const import (
     DEFAULT_MIN_VALUE,
     DEFAULT_STEP,
     DOMAIN,
+    MODE_AUTO,
     SERVICE_SET_VALUE,
 )
 
@@ -90,6 +92,7 @@ class NumberEntity(Entity):
     _attr_min_value: float = DEFAULT_MIN_VALUE
     _attr_state: None = None
     _attr_step: float
+    _attr_mode: Literal["auto", "slider", "box"] = MODE_AUTO
     _attr_value: float
 
     @property
@@ -99,6 +102,7 @@ class NumberEntity(Entity):
             ATTR_MIN: self.min_value,
             ATTR_MAX: self.max_value,
             ATTR_STEP: self.step,
+            ATTR_MODE: self.mode,
         }
 
     @property
@@ -122,6 +126,11 @@ class NumberEntity(Entity):
             while value_range <= step:
                 step /= 10.0
         return step
+
+    @property
+    def mode(self) -> Literal["auto", "slider", "box"]:
+        """Return the mode of the entity."""
+        return self._attr_mode
 
     @property
     @final

--- a/homeassistant/components/number/const.py
+++ b/homeassistant/components/number/const.py
@@ -1,9 +1,15 @@
 """Provides the constants needed for the component."""
 
+from typing import Final
+
 ATTR_VALUE = "value"
 ATTR_MIN = "min"
 ATTR_MAX = "max"
 ATTR_STEP = "step"
+
+MODE_AUTO: Final = "auto"
+MODE_BOX: Final = "box"
+MODE_SLIDER: Final = "slider"
 
 DEFAULT_MIN_VALUE = 0.0
 DEFAULT_MAX_VALUE = 100.0

--- a/tests/components/demo/test_number.py
+++ b/tests/components/demo/test_number.py
@@ -9,13 +9,18 @@ from homeassistant.components.number.const import (
     ATTR_STEP,
     ATTR_VALUE,
     DOMAIN,
+    MODE_AUTO,
+    MODE_BOX,
+    MODE_SLIDER,
     SERVICE_SET_VALUE,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
 from homeassistant.setup import async_setup_component
 
 ENTITY_VOLUME = "number.volume"
 ENTITY_PWM = "number.pwm_1"
+ENTITY_LARGE_RANGE = "number.large_range"
+ENTITY_SMALL_RANGE = "number.small_range"
 
 
 @pytest.fixture(autouse=True)
@@ -37,11 +42,25 @@ def test_default_setup_params(hass):
     assert state.attributes.get(ATTR_MIN) == 0.0
     assert state.attributes.get(ATTR_MAX) == 100.0
     assert state.attributes.get(ATTR_STEP) == 1.0
+    assert state.attributes.get(ATTR_MODE) == MODE_SLIDER
 
     state = hass.states.get(ENTITY_PWM)
     assert state.attributes.get(ATTR_MIN) == 0.0
     assert state.attributes.get(ATTR_MAX) == 1.0
     assert state.attributes.get(ATTR_STEP) == 0.01
+    assert state.attributes.get(ATTR_MODE) == MODE_BOX
+
+    state = hass.states.get(ENTITY_LARGE_RANGE)
+    assert state.attributes.get(ATTR_MIN) == 1.0
+    assert state.attributes.get(ATTR_MAX) == 1000.0
+    assert state.attributes.get(ATTR_STEP) == 1.0
+    assert state.attributes.get(ATTR_MODE) == MODE_AUTO
+
+    state = hass.states.get(ENTITY_SMALL_RANGE)
+    assert state.attributes.get(ATTR_MIN) == 1.0
+    assert state.attributes.get(ATTR_MAX) == 255.0
+    assert state.attributes.get(ATTR_STEP) == 1.0
+    assert state.attributes.get(ATTR_MODE) == MODE_AUTO
 
 
 async def test_set_value_bad_attr(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This extends the `number` entity with an optional mode, it provides a hint to the UI on how to represent this number entity in either a slider or box, similar to how we do it with `input_number`.

The difference is the `auto` mode, which is the default. This should cover almost all cases out there and will be instantly applied to all existing `number` entities.

When in `auto` mode: If the range of possible positions on the `number` is 256 positions or smaller, it will become a `slider`, else a `box` is automatically picked.

The demo platform has been extended, the 2 existing entities (volume, PWM) have a fixed mode, while the large and small range entities have the default `auto` mode.

![image](https://user-images.githubusercontent.com/195327/137409311-6fa559e7-4af4-4f3f-8d42-bbb8f8ae7c6c.png)


Frontend PR: https://github.com/home-assistant/frontend/pull/10272

Related #56862

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
