### PR TITLE
Consolidate ESPHome icon-handling code into EsphomeEntity

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -874,6 +874,9 @@ class EsphomeEnumMapper(Generic[_EnumT, _ValT]):
         return self._inverse[value]
 
 
+ICON_SCHEMA = vol.Schema(cv.icon)
+
+
 class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     """Define a base esphome entity."""
 
@@ -997,6 +1000,14 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     def name(self) -> str:
         """Return the name of the entity."""
         return self._static_info.name
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon."""
+        if not self._static_info.icon:
+            return None
+
+        return cast(str, ICON_SCHEMA(self._static_info.icon))
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/esphome/number.py
+++ b/homeassistant/components/esphome/number.py
@@ -2,20 +2,15 @@
 from __future__ import annotations
 
 import math
-from typing import cast
 
 from aioesphomeapi import NumberInfo, NumberState
-import voluptuous as vol
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import EsphomeEntity, esphome_state_property, platform_async_setup_entry
-
-ICON_SCHEMA = vol.Schema(cv.icon)
 
 
 async def async_setup_entry(
@@ -41,13 +36,6 @@ async def async_setup_entry(
 
 class EsphomeNumber(EsphomeEntity[NumberInfo, NumberState], NumberEntity):
     """A number implementation for esphome."""
-
-    @property
-    def icon(self) -> str | None:
-        """Return the icon."""
-        if not self._static_info.icon:
-            return None
-        return cast(str, ICON_SCHEMA(self._static_info.icon))
 
     @property
     def min_value(self) -> float:

--- a/homeassistant/components/esphome/select.py
+++ b/homeassistant/components/esphome/select.py
@@ -1,20 +1,14 @@
 """Support for esphome selects."""
 from __future__ import annotations
 
-from typing import cast
-
 from aioesphomeapi import SelectInfo, SelectState
-import voluptuous as vol
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import EsphomeEntity, esphome_state_property, platform_async_setup_entry
-
-ICON_SCHEMA = vol.Schema(cv.icon)
 
 
 async def async_setup_entry(
@@ -40,13 +34,6 @@ async def async_setup_entry(
 
 class EsphomeSelect(EsphomeEntity[SelectInfo, SelectState], SelectEntity):
     """A select implementation for esphome."""
-
-    @property
-    def icon(self) -> str | None:
-        """Return the icon."""
-        if not self._static_info.icon:
-            return None
-        return cast(str, ICON_SCHEMA(self._static_info.icon))
 
     @property
     def options(self) -> list[str]:

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import math
-from typing import cast
 
 from aioesphomeapi import (
     SensorInfo,
@@ -12,7 +11,6 @@ from aioesphomeapi import (
     TextSensorState,
 )
 from aioesphomeapi.model import LastResetType
-import voluptuous as vol
 
 from homeassistant.components.sensor import (
     DEVICE_CLASS_TIMESTAMP,
@@ -23,7 +21,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt
 
@@ -33,8 +30,6 @@ from . import (
     esphome_state_property,
     platform_async_setup_entry,
 )
-
-ICON_SCHEMA = vol.Schema(cv.icon)
 
 
 async def async_setup_entry(
@@ -76,13 +71,6 @@ _STATE_CLASSES: EsphomeEnumMapper[SensorStateClass, str | None] = EsphomeEnumMap
 
 class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
     """A sensor implementation for esphome."""
-
-    @property
-    def icon(self) -> str | None:
-        """Return the icon."""
-        if not self._static_info.icon or self._static_info.device_class:
-            return None
-        return cast(str, ICON_SCHEMA(self._static_info.icon))
 
     @property
     def force_update(self) -> bool:
@@ -132,11 +120,6 @@ class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
 
 class EsphomeTextSensor(EsphomeEntity[TextSensorInfo, TextSensorState], SensorEntity):
     """A text sensor implementation for ESPHome."""
-
-    @property
-    def icon(self) -> str:
-        """Return the icon."""
-        return self._static_info.icon
 
     @esphome_state_property
     def native_value(self) -> str | None:

--- a/homeassistant/components/esphome/switch.py
+++ b/homeassistant/components/esphome/switch.py
@@ -36,11 +36,6 @@ class EsphomeSwitch(EsphomeEntity[SwitchInfo, SwitchState], SwitchEntity):
     """A switch implementation for ESPHome."""
 
     @property
-    def icon(self) -> str:
-        """Return the icon."""
-        return self._static_info.icon
-
-    @property
     def assumed_state(self) -> bool:
         """Return true if we do optimistic updates."""
         return self._static_info.assumed_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exposes the `icon` property for all entities supported by ESPHome via the ESPHome Native API. This is achieved by moving icon-handling code into the EsphomeEntity base class, and removing redundant code from its subclasses.

Further information: in esphome/esphome#2418, properties that are common to all entities were consolidated into a single base class. Since the `icon` property was moved into this base class, support for it has been implicitly added for all ESPHome entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
