### PR TITLE
Identify onetime listeners

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -819,6 +819,7 @@ class EventBus:
         filterable_job: tuple[HassJob, Callable | None] | None = None
 
         @callback
+        @functools.wraps(listener)
         def _onetime_listener(event: Event) -> None:
             """Remove listener from event bus and then fire listener."""
             nonlocal filterable_job

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -819,7 +819,6 @@ class EventBus:
         filterable_job: tuple[HassJob, Callable | None] | None = None
 
         @callback
-        @functools.wraps(listener)
         def _onetime_listener(event: Event) -> None:
             """Remove listener from event bus and then fire listener."""
             nonlocal filterable_job
@@ -834,6 +833,10 @@ class EventBus:
             assert filterable_job is not None
             self._async_remove_listener(event_type, filterable_job)
             self._hass.async_run_job(listener, event)
+
+        functools.update_wrapper(
+            _onetime_listener, listener, ("__name__", "__qualname__", "__module__"), []
+        )
 
         filterable_job = (HassJob(_onetime_listener), None)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #57600

Identify the one time listener as the listener it is wrapping.

Helps identify when things go wrong.

Before:

```
2021-10-14 20:43:44 ERROR (MainThread) [homeassistant.core] Unable to remove unknown job listener (<Job HassJobType.Callback <function EventBus.async_listen_once.<locals>._onetime_listener at 0x107a473a0>>, None)
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/homeassistant/core.py", line 850, in _async_remove_listener
    self._listeners[event_type].remove(filterable_job)
KeyError: 'homeassistant_stop'
```

After:

```
2021-10-14 23:13:46 ERROR (MainThread) [homeassistant.core] Unable to remove unknown job listener (<Job HassJobType.Callback <function WLEDDataUpdateCoordinator._use_websocket.<locals>.close_websocket at 0x10f7bd310>>, None)
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/homeassistant/core.py", line 851, in _async_remove_listener
    self._listeners[event_type].remove(filterable_job)
KeyError: 'homeassistant_stop'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
