### PR TITLE
Remove YAML import from UptimeRobot

### DIFF
--- a/homeassistant/components/uptimerobot/binary_sensor.py
+++ b/homeassistant/components/uptimerobot/binary_sensor.py
@@ -1,42 +1,18 @@
 """UptimeRobot binary_sensor platform."""
 from __future__ import annotations
 
-import voluptuous as vol
-
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,
-    PLATFORM_SCHEMA,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_API_KEY
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
 from .entity import UptimeRobotEntity
-
-PLATFORM_SCHEMA = cv.deprecated(
-    vol.All(PLATFORM_SCHEMA.extend({vol.Required(CONF_API_KEY): cv.string}))
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the UptimeRobot binary_sensor platform."""
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
-    )
 
 
 async def async_setup_entry(

--- a/homeassistant/components/uptimerobot/config_flow.py
+++ b/homeassistant/components/uptimerobot/config_flow.py
@@ -111,21 +111,3 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reauth_confirm", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
-
-    async def async_step_import(self, import_config: ConfigType) -> FlowResult:
-        """Import a config entry from configuration.yaml."""
-        for entry in self._async_current_entries():
-            if entry.data[CONF_API_KEY] == import_config[CONF_API_KEY]:
-                LOGGER.warning(
-                    "Already configured. This YAML configuration has already been imported. Please remove it"
-                )
-                return self.async_abort(reason="already_configured")
-
-        imported_config = {CONF_API_KEY: import_config[CONF_API_KEY]}
-
-        _, account = await self._validate_input(imported_config)
-        if account:
-            await self.async_set_unique_id(str(account.user_id))
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=account.email, data=imported_config)
-        return self.async_abort(reason="unknown")

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -22,7 +22,6 @@
             "reauth_failed_matching_account": "The API key you provided does not match the account ID for existing configuration."
         },
         "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
             "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
             "reauth_failed_existing": "Could not update the config entry, please remove the integration and set it up again.",
             "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/homeassistant/components/uptimerobot/strings.json
+++ b/homeassistant/components/uptimerobot/strings.json
@@ -22,6 +22,7 @@
             "reauth_failed_matching_account": "The API key you provided does not match the account ID for existing configuration."
         },
         "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
             "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
             "reauth_failed_existing": "Could not update the config entry, please remove the integration and set it up again.",
             "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/tests/components/uptimerobot/test_binary_sensor.py
+++ b/tests/components/uptimerobot/test_binary_sensor.py
@@ -8,48 +8,18 @@ from homeassistant.components.binary_sensor import DEVICE_CLASS_CONNECTIVITY
 from homeassistant.components.uptimerobot.const import (
     ATTRIBUTION,
     COORDINATOR_UPDATE_INTERVAL,
-    DOMAIN,
 )
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
 from .common import (
-    MOCK_UPTIMEROBOT_API_KEY,
     MOCK_UPTIMEROBOT_MONITOR,
     UPTIMEROBOT_TEST_ENTITY,
-    MockApiResponseKey,
-    mock_uptimerobot_api_response,
     setup_uptimerobot_integration,
 )
 
 from tests.common import async_fire_time_changed
-
-
-async def test_config_import(hass: HomeAssistant) -> None:
-    """Test importing YAML configuration."""
-    config = {
-        "binary_sensor": {
-            "platform": DOMAIN,
-            "api_key": MOCK_UPTIMEROBOT_API_KEY,
-        }
-    }
-    with patch(
-        "pyuptimerobot.UptimeRobot.async_get_account_details",
-        return_value=mock_uptimerobot_api_response(key=MockApiResponseKey.ACCOUNT),
-    ), patch(
-        "pyuptimerobot.UptimeRobot.async_get_monitors",
-        return_value=mock_uptimerobot_api_response(),
-    ):
-        assert await async_setup_component(hass, "binary_sensor", config)
-        await hass.async_block_till_done()
-
-    config_entries = hass.config_entries.async_entries(DOMAIN)
-
-    assert len(config_entries) == 1
-    config_entry = config_entries[0]
-    assert config_entry.source == "import"
 
 
 async def test_presentation(hass: HomeAssistant) -> None:

--- a/tests/components/uptimerobot/test_config_flow.py
+++ b/tests/components/uptimerobot/test_config_flow.py
@@ -102,66 +102,6 @@ async def test_form_api_error(hass: HomeAssistant, caplog: LogCaptureFixture) ->
     assert "test error from API." in caplog.text
 
 
-async def test_flow_import(
-    hass: HomeAssistant,
-) -> None:
-    """Test an import flow."""
-    with patch(
-        "pyuptimerobot.UptimeRobot.async_get_account_details",
-        return_value=mock_uptimerobot_api_response(key=MockApiResponseKey.ACCOUNT),
-    ), patch(
-        "homeassistant.components.uptimerobot.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={"platform": DOMAIN, CONF_API_KEY: MOCK_UPTIMEROBOT_API_KEY},
-        )
-        await hass.async_block_till_done()
-
-        assert len(mock_setup_entry.mock_calls) == 1
-        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-        assert result["data"] == {CONF_API_KEY: MOCK_UPTIMEROBOT_API_KEY}
-
-    with patch(
-        "pyuptimerobot.UptimeRobot.async_get_account_details",
-        return_value=mock_uptimerobot_api_response(key=MockApiResponseKey.ACCOUNT),
-    ), patch(
-        "homeassistant.components.uptimerobot.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={"platform": DOMAIN, CONF_API_KEY: MOCK_UPTIMEROBOT_API_KEY},
-        )
-        await hass.async_block_till_done()
-
-        assert len(mock_setup_entry.mock_calls) == 0
-        assert result["type"] == RESULT_TYPE_ABORT
-        assert result["reason"] == "already_configured"
-
-    with patch(
-        "pyuptimerobot.UptimeRobot.async_get_account_details",
-        return_value=mock_uptimerobot_api_response(
-            key=MockApiResponseKey.ACCOUNT, data={}
-        ),
-    ), patch(
-        "homeassistant.components.uptimerobot.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={"platform": DOMAIN, CONF_API_KEY: "12345"},
-        )
-        await hass.async_block_till_done()
-
-        assert result["type"] == RESULT_TYPE_ABORT
-        assert result["reason"] == "unknown"
-
-
 async def test_user_unique_id_already_exists(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The UptimeRobot integration will no longer import configured YAML.
If you still have this configured with YAML in your configuration, you need to remove it. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Removes all parts of the YAML import in the UptimeRobot integration.
Config flow and import were added in 2021.9 
<https://www.home-assistant.io/blog/2021/09/01/release-20219/#breaking-changes>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
