### PR TITLE
Fix mode_callerid attributes

### DIFF
--- a/homeassistant/components/modem_callerid/sensor.py
+++ b/homeassistant/components/modem_callerid/sensor.py
@@ -106,18 +106,11 @@ class ModemCalleridSensor(SensorEntity):
     @callback
     def _async_incoming_call(self, new_state) -> None:
         """Handle new states."""
-        if new_state == PhoneModem.STATE_RING:
-            if self.native_value == PhoneModem.STATE_IDLE:
-                self._attr_extra_state_attributes = {
-                    CID.CID_NUMBER: "",
-                    CID.CID_NAME: "",
-                }
-        elif new_state == PhoneModem.STATE_CALLERID:
-            self._attr_extra_state_attributes = {
-                CID.CID_NUMBER: self.api.cid_number,
-                CID.CID_NAME: self.api.cid_name,
-            }
-        self._attr_extra_state_attributes[CID.CID_TIME] = self.api.cid_time
+        self._attr_extra_state_attributes = {
+            CID.CID_NUMBER: self.api.cid_number,
+            CID.CID_NAME: self.api.cid_name,
+            CID.CID_TIME: self.api.cid_time,
+        }
         self._attr_native_value = self.api.state
         self.async_write_ha_state()
 

--- a/homeassistant/components/modem_callerid/sensor.py
+++ b/homeassistant/components/modem_callerid/sensor.py
@@ -106,11 +106,13 @@ class ModemCalleridSensor(SensorEntity):
     @callback
     def _async_incoming_call(self, new_state) -> None:
         """Handle new states."""
-        self._attr_extra_state_attributes = {
-            CID.CID_NAME: self.api.cid_name if self.api.cid_name else None,
-            CID.CID_NUMBER: self.api.cid_number if self.api.cid_number else None,
-            CID.CID_TIME: self.api.cid_time if self.api.cid_time else None,
-        }
+        self._attr_extra_state_attributes = {}
+        if self.api.cid_name:
+            self._attr_extra_state_attributes[CID.CID_NAME] = self.api.cid_name
+        if self.api.cid_number:
+            self._attr_extra_state_attributes[CID.CID_NUMBER] = self.api.cid_number
+        if self.api.cid_time:
+            self._attr_extra_state_attributes[CID.CID_TIME] = self.api.cid_time
         self._attr_native_value = self.api.state
         self.async_write_ha_state()
 

--- a/homeassistant/components/modem_callerid/sensor.py
+++ b/homeassistant/components/modem_callerid/sensor.py
@@ -107,9 +107,9 @@ class ModemCalleridSensor(SensorEntity):
     def _async_incoming_call(self, new_state) -> None:
         """Handle new states."""
         self._attr_extra_state_attributes = {
-            CID.CID_NAME: self.api.cid_name,
-            CID.CID_NUMBER: self.api.cid_number,
-            CID.CID_TIME: self.api.cid_time,
+            CID.CID_NAME: self.api.cid_name if self.api.cid_name else None,
+            CID.CID_NUMBER: self.api.cid_number if self.api.cid_number else None,
+            CID.CID_TIME: self.api.cid_time if self.api.cid_time else None,
         }
         self._attr_native_value = self.api.state
         self.async_write_ha_state()

--- a/homeassistant/components/modem_callerid/sensor.py
+++ b/homeassistant/components/modem_callerid/sensor.py
@@ -107,8 +107,8 @@ class ModemCalleridSensor(SensorEntity):
     def _async_incoming_call(self, new_state) -> None:
         """Handle new states."""
         self._attr_extra_state_attributes = {
-            CID.CID_NUMBER: self.api.cid_number,
             CID.CID_NAME: self.api.cid_name,
+            CID.CID_NUMBER: self.api.cid_number,
             CID.CID_TIME: self.api.cid_time,
         }
         self._attr_native_value = self.api.state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The sensor state attributes of modem_callerid are now only populated when the values are known. Users need to handle missing attributes in templates in automations and scripts.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow mode_callerid to display incomplete callerid info.
Some countries  or devices may have different standards that do not support `cid_name`. This PR will at least allow the `cid_number` to be displayed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/57765
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
