### PR TITLE
2021.10.5

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -404,8 +404,8 @@ class DlnaDmrEntity(MediaPlayerEntity):
         try:
             do_ping = self.poll_availability or self.check_available
             await self._device.async_update(do_ping=do_ping)
-        except UpnpError:
-            _LOGGER.debug("Device unavailable")
+        except UpnpError as err:
+            _LOGGER.debug("Device unavailable: %r", err)
             await self._device_disconnect()
             return
         finally:

--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -1,7 +1,7 @@
 """Support for testing internet speed via Fast.com."""
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 from typing import Any
 
@@ -67,7 +67,7 @@ class SpeedtestData:
         self.data: dict[str, Any] | None = None
         self._hass = hass
 
-    def update(self) -> None:
+    def update(self, now: datetime | None = None) -> None:
         """Get the latest data from fast.com."""
 
         _LOGGER.debug("Executing fast.com speedtest")

--- a/homeassistant/components/mill/manifest.json
+++ b/homeassistant/components/mill/manifest.json
@@ -2,7 +2,7 @@
   "domain": "mill",
   "name": "Mill",
   "documentation": "https://www.home-assistant.io/integrations/mill",
-  "requirements": ["millheater==0.6.1"],
+  "requirements": ["millheater==0.6.2"],
   "codeowners": ["@danielhiversen"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/notion/__init__.py
+++ b/homeassistant/components/notion/__init__.py
@@ -151,7 +151,7 @@ class NotionEntity(CoordinatorEntity):
             "identifiers": {(DOMAIN, sensor["hardware_id"])},
             "manufacturer": "Silicon Labs",
             "model": sensor["hardware_revision"],
-            "name": sensor["name"],
+            "name": str(sensor["name"]),
             "sw_version": sensor["firmware_version"],
             "via_device": (DOMAIN, bridge.get("hardware_id")),
         }

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -311,7 +311,9 @@ def setup_connection_for_dialect(
             result = query_on_connection(dbapi_connection, "SELECT VERSION()")
             version = result[0][0]
             major, minor, _patch = version.split(".", 2)
-            if int(major) == 5 and int(minor) < 8:
+            if (int(major) == 5 and int(minor) < 8) or (
+                int(major) == 10 and int(minor) < 2
+            ):
                 instance._db_supports_row_number = (  # pylint: disable=[protected-access]
                     False
                 )

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -182,7 +182,7 @@ SENSORS: Final = {
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_HUMIDITY,
         state_class=sensor.STATE_CLASS_MEASUREMENT,
-        available=lambda block: cast(int, block.extTemp) != 999,
+        available=lambda block: cast(int, block.humidity) != 999,
     ),
     ("sensor", "luminosity"): BlockAttributeDescription(
         name="Luminosity",

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==11.0.6"],
+  "requirements": ["simplisafe-python==11.0.7"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/spider/manifest.json
+++ b/homeassistant/components/spider/manifest.json
@@ -2,7 +2,7 @@
   "domain": "spider",
   "name": "Itho Daalderop Spider",
   "documentation": "https://www.home-assistant.io/integrations/spider",
-  "requirements": ["spiderpy==1.4.2"],
+  "requirements": ["spiderpy==1.4.3"],
   "codeowners": ["@peternijssen"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -264,5 +264,5 @@ class UpnpEntity(CoordinatorEntity):
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and (
-            self.coordinator.data.get(self.entity_description.key) or False
+            self.coordinator.data.get(self.entity_description.key) is not None
         )

--- a/homeassistant/components/upnp/sensor.py
+++ b/homeassistant/components/upnp/sensor.py
@@ -190,7 +190,10 @@ class DerivedUpnpSensor(UpnpSensor):
 
         # Calculate derivative.
         delta_value = current_value - self._last_value
-        if self.entity_description.native_unit_of_measurement == DATA_BYTES:
+        if (
+            self.entity_description.native_unit_of_measurement
+            == DATA_RATE_KIBIBYTES_PER_SECOND
+        ):
             delta_value /= KIBIBYTE
         delta_time = current_timestamp - self._last_timestamp
         if delta_time.total_seconds() == 0:

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -631,7 +631,11 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         """Set bulb's color."""
         if not hs_color or COLOR_MODE_HS not in self.supported_color_modes:
             return
-        if self.color_mode == COLOR_MODE_HS and self.hs_color == hs_color:
+        if (
+            not self.device.is_color_flow_enabled
+            and self.color_mode == COLOR_MODE_HS
+            and self.hs_color == hs_color
+        ):
             _LOGGER.debug("HS already set to: %s", hs_color)
             # Already set, and since we get pushed updates
             # we avoid setting it again to ensure we do not
@@ -648,7 +652,11 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
         """Set bulb's color."""
         if not rgb or COLOR_MODE_RGB not in self.supported_color_modes:
             return
-        if self.color_mode == COLOR_MODE_RGB and self.rgb_color == rgb:
+        if (
+            not self.device.is_color_flow_enabled
+            and self.color_mode == COLOR_MODE_RGB
+            and self.rgb_color == rgb
+        ):
             _LOGGER.debug("RGB already set to: %s", rgb)
             # Already set, and since we get pushed updates
             # we avoid setting it again to ensure we do not
@@ -667,7 +675,11 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
             return
         temp_in_k = mired_to_kelvin(colortemp)
 
-        if self.color_mode == COLOR_MODE_COLOR_TEMP and self.color_temp == colortemp:
+        if (
+            not self.device.is_color_flow_enabled
+            and self.color_mode == COLOR_MODE_COLOR_TEMP
+            and self.color_temp == colortemp
+        ):
             _LOGGER.debug("Color temp already set to: %s", temp_in_k)
             # Already set, and since we get pushed updates
             # we avoid setting it again to ensure we do not

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -2,7 +2,7 @@
   "domain": "yeelight",
   "name": "Yeelight",
   "documentation": "https://www.home-assistant.io/integrations/yeelight",
-  "requirements": ["yeelight==0.7.7", "async-upnp-client==0.22.8"],
+  "requirements": ["yeelight==0.7.8", "async-upnp-client==0.22.8"],
   "codeowners": ["@rytilahti", "@zewelor", "@shenxn", "@starkillerOG"],
   "config_flow": true,
   "dependencies": ["network"],

--- a/homeassistant/components/youless/sensor.py
+++ b/homeassistant/components/youless/sensor.py
@@ -5,6 +5,7 @@ from youless_api.youless_sensor import YoulessSensor
 
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL,
     STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
 )
@@ -40,9 +41,9 @@ async def async_setup_entry(
     async_add_entities(
         [
             GasSensor(coordinator, device),
-            PowerMeterSensor(coordinator, device, "low"),
-            PowerMeterSensor(coordinator, device, "high"),
-            PowerMeterSensor(coordinator, device, "total"),
+            PowerMeterSensor(coordinator, device, "low", STATE_CLASS_TOTAL_INCREASING),
+            PowerMeterSensor(coordinator, device, "high", STATE_CLASS_TOTAL_INCREASING),
+            PowerMeterSensor(coordinator, device, "total", STATE_CLASS_TOTAL),
             CurrentPowerSensor(coordinator, device),
             DeliveryMeterSensor(coordinator, device, "low"),
             DeliveryMeterSensor(coordinator, device, "high"),
@@ -168,7 +169,11 @@ class PowerMeterSensor(YoulessBaseSensor):
     _attr_state_class = STATE_CLASS_TOTAL_INCREASING
 
     def __init__(
-        self, coordinator: DataUpdateCoordinator, device: str, dev_type: str
+        self,
+        coordinator: DataUpdateCoordinator,
+        device: str,
+        dev_type: str,
+        state_class: str,
     ) -> None:
         """Instantiate a power meter sensor."""
         super().__init__(
@@ -177,6 +182,7 @@ class PowerMeterSensor(YoulessBaseSensor):
         self._device = device
         self._type = dev_type
         self._attr_name = f"Power {dev_type}"
+        self._attr_state_class = state_class
 
     @property
     def get_sensor(self) -> YoulessSensor | None:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 10
-PATCH_VERSION: Final = "4"
+PATCH_VERSION: Final = "5"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2149,7 +2149,7 @@ simplehound==0.3
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==11.0.6
+simplisafe-python==11.0.7
 
 # homeassistant.components.sisyphus
 sisyphus-control==3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1005,7 +1005,7 @@ micloud==0.3
 miflora==0.7.0
 
 # homeassistant.components.mill
-millheater==0.6.1
+millheater==0.6.2
 
 # homeassistant.components.minio
 minio==4.0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2459,7 +2459,7 @@ yalesmartalarmclient==0.3.4
 yalexs==1.1.13
 
 # homeassistant.components.yeelight
-yeelight==0.7.7
+yeelight==0.7.8
 
 # homeassistant.components.yeelightsunflower
 yeelightsunflower==0.0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2214,7 +2214,7 @@ speak2mary==1.4.0
 speedtest-cli==2.1.3
 
 # homeassistant.components.spider
-spiderpy==1.4.2
+spiderpy==1.4.3
 
 # homeassistant.components.spotify
 spotipy==2.18.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1263,7 +1263,7 @@ speak2mary==1.4.0
 speedtest-cli==2.1.3
 
 # homeassistant.components.spider
-spiderpy==1.4.2
+spiderpy==1.4.3
 
 # homeassistant.components.spotify
 spotipy==2.18.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -585,7 +585,7 @@ mficlient==0.3.0
 micloud==0.3
 
 # homeassistant.components.mill
-millheater==0.6.1
+millheater==0.6.2
 
 # homeassistant.components.minio
 minio==4.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1224,7 +1224,7 @@ sharkiqpy==0.1.8
 simplehound==0.3
 
 # homeassistant.components.simplisafe
-simplisafe-python==11.0.6
+simplisafe-python==11.0.7
 
 # homeassistant.components.slack
 slackclient==2.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1403,7 +1403,7 @@ yalesmartalarmclient==0.3.4
 yalexs==1.1.13
 
 # homeassistant.components.yeelight
-yeelight==0.7.7
+yeelight==0.7.8
 
 # homeassistant.components.youless
 youless-api==0.14

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -125,7 +125,8 @@ async def test_last_run_was_recently_clean(hass):
 @pytest.mark.parametrize(
     "mysql_version, db_supports_row_number",
     [
-        ("10.0.0", True),
+        ("10.2.0", True),
+        ("10.1.0", False),
         ("5.8.0", True),
         ("5.7.0", False),
     ],

--- a/tests/components/upnp/test_binary_sensor.py
+++ b/tests/components/upnp/test_binary_sensor.py
@@ -1,0 +1,42 @@
+"""Tests for UPnP/IGD binary_sensor."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from homeassistant.components.upnp.const import (
+    DOMAIN,
+    ROUTER_IP,
+    ROUTER_UPTIME,
+    WAN_STATUS,
+)
+from homeassistant.core import HomeAssistant
+import homeassistant.util.dt as dt_util
+
+from .conftest import MockDevice
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_upnp_binary_sensors(
+    hass: HomeAssistant, setup_integration: MockConfigEntry
+):
+    """Test normal sensors."""
+    mock_device: MockDevice = hass.data[DOMAIN][setup_integration.entry_id].device
+
+    # First poll.
+    wan_status_state = hass.states.get("binary_sensor.mock_name_wan_status")
+    assert wan_status_state.state == "on"
+
+    # Second poll.
+    mock_device.async_get_status = AsyncMock(
+        return_value={
+            WAN_STATUS: "Disconnected",
+            ROUTER_UPTIME: 100,
+            ROUTER_IP: "",
+        }
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+
+    wan_status_state = hass.states.get("binary_sensor.mock_name_wan_status")
+    assert wan_status_state.state == "off"

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -25,6 +25,7 @@ from .conftest import (
     TEST_ST,
     TEST_UDN,
     TEST_USN,
+    MockDevice,
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -196,7 +197,7 @@ async def test_options_flow(hass: HomeAssistant):
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id) is True
     await hass.async_block_till_done()
-    mock_device = hass.data[DOMAIN][config_entry.entry_id].device
+    mock_device: MockDevice = hass.data[DOMAIN][config_entry.entry_id].device
 
     # Reset.
     mock_device.traffic_times_polled = 0

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -9,7 +9,6 @@ from homeassistant.components.upnp.const import (
     DOMAIN,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ST, TEST_UDN
 
@@ -27,10 +26,6 @@ async def test_async_setup_entry_default(hass: HomeAssistant):
             CONFIG_ENTRY_ST: TEST_ST,
         },
     )
-
-    # Initialisation of component, no device discovered.
-    await async_setup_component(hass, DOMAIN, {})
-    await hass.async_block_till_done()
 
     # Load config_entry.
     entry.add_to_hass(hass)

--- a/tests/components/upnp/test_sensor.py
+++ b/tests/components/upnp/test_sensor.py
@@ -1,0 +1,114 @@
+"""Tests for UPnP/IGD sensor."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from homeassistant.components.upnp.const import (
+    BYTES_RECEIVED,
+    BYTES_SENT,
+    DOMAIN,
+    PACKETS_RECEIVED,
+    PACKETS_SENT,
+    ROUTER_IP,
+    ROUTER_UPTIME,
+    TIMESTAMP,
+    UPDATE_INTERVAL,
+    WAN_STATUS,
+)
+from homeassistant.core import HomeAssistant
+import homeassistant.util.dt as dt_util
+
+from .conftest import MockDevice
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_upnp_sensors(hass: HomeAssistant, setup_integration: MockConfigEntry):
+    """Test normal sensors."""
+    mock_device: MockDevice = hass.data[DOMAIN][setup_integration.entry_id].device
+
+    # First poll.
+    b_received_state = hass.states.get("sensor.mock_name_b_received")
+    b_sent_state = hass.states.get("sensor.mock_name_b_sent")
+    packets_received_state = hass.states.get("sensor.mock_name_packets_received")
+    packets_sent_state = hass.states.get("sensor.mock_name_packets_sent")
+    external_ip_state = hass.states.get("sensor.mock_name_external_ip")
+    wan_status_state = hass.states.get("sensor.mock_name_wan_status")
+    assert b_received_state.state == "0"
+    assert b_sent_state.state == "0"
+    assert packets_received_state.state == "0"
+    assert packets_sent_state.state == "0"
+    assert external_ip_state.state == "8.9.10.11"
+    assert wan_status_state.state == "Connected"
+
+    # Second poll.
+    mock_device.async_get_traffic_data = AsyncMock(
+        return_value={
+            TIMESTAMP: dt_util.utcnow() + UPDATE_INTERVAL,
+            BYTES_RECEIVED: 10240,
+            BYTES_SENT: 20480,
+            PACKETS_RECEIVED: 30,
+            PACKETS_SENT: 40,
+        }
+    )
+    mock_device.async_get_status = AsyncMock(
+        return_value={
+            WAN_STATUS: "Disconnected",
+            ROUTER_UPTIME: 100,
+            ROUTER_IP: "",
+        }
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+
+    b_received_state = hass.states.get("sensor.mock_name_b_received")
+    b_sent_state = hass.states.get("sensor.mock_name_b_sent")
+    packets_received_state = hass.states.get("sensor.mock_name_packets_received")
+    packets_sent_state = hass.states.get("sensor.mock_name_packets_sent")
+    external_ip_state = hass.states.get("sensor.mock_name_external_ip")
+    wan_status_state = hass.states.get("sensor.mock_name_wan_status")
+    assert b_received_state.state == "10240"
+    assert b_sent_state.state == "20480"
+    assert packets_received_state.state == "30"
+    assert packets_sent_state.state == "40"
+    assert external_ip_state.state == ""
+    assert wan_status_state.state == "Disconnected"
+
+
+async def test_derived_upnp_sensors(
+    hass: HomeAssistant, setup_integration: MockConfigEntry
+):
+    """Test derived sensors."""
+    mock_device: MockDevice = hass.data[DOMAIN][setup_integration.entry_id].device
+
+    # First poll.
+    kib_s_received_state = hass.states.get("sensor.mock_name_kib_s_received")
+    kib_s_sent_state = hass.states.get("sensor.mock_name_kib_s_sent")
+    packets_s_received_state = hass.states.get("sensor.mock_name_packets_s_received")
+    packets_s_sent_state = hass.states.get("sensor.mock_name_packets_s_sent")
+    assert kib_s_received_state.state == "unknown"
+    assert kib_s_sent_state.state == "unknown"
+    assert packets_s_received_state.state == "unknown"
+    assert packets_s_sent_state.state == "unknown"
+
+    # Second poll.
+    mock_device.async_get_traffic_data = AsyncMock(
+        return_value={
+            TIMESTAMP: dt_util.utcnow() + UPDATE_INTERVAL,
+            BYTES_RECEIVED: int(10240 * UPDATE_INTERVAL.total_seconds()),
+            BYTES_SENT: int(20480 * UPDATE_INTERVAL.total_seconds()),
+            PACKETS_RECEIVED: int(30 * UPDATE_INTERVAL.total_seconds()),
+            PACKETS_SENT: int(40 * UPDATE_INTERVAL.total_seconds()),
+        }
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+
+    kib_s_received_state = hass.states.get("sensor.mock_name_kib_s_received")
+    kib_s_sent_state = hass.states.get("sensor.mock_name_kib_s_sent")
+    packets_s_received_state = hass.states.get("sensor.mock_name_packets_s_received")
+    packets_s_sent_state = hass.states.get("sensor.mock_name_packets_s_sent")
+    assert kib_s_received_state.state == "10.0"
+    assert kib_s_sent_state.state == "20.0"
+    assert packets_s_received_state.state == "30.0"
+    assert packets_s_sent_state.state == "40.0"

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -625,6 +625,22 @@ async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant):
     assert mocked_bulb.async_set_brightness.mock_calls == []
     mocked_bulb.async_set_rgb.reset_mock()
 
+    mocked_bulb.last_properties["flowing"] = "1"
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_RGB_COLOR: (red, green, blue)},
+        blocking=True,
+    )
+    assert mocked_bulb.async_set_hsv.mock_calls == []
+    assert mocked_bulb.async_set_rgb.mock_calls == [
+        call(255, 0, 0, duration=350, light_type=ANY)
+    ]
+    assert mocked_bulb.async_set_color_temp.mock_calls == []
+    assert mocked_bulb.async_set_brightness.mock_calls == []
+    mocked_bulb.async_set_rgb.reset_mock()
+    mocked_bulb.last_properties["flowing"] = "0"
+
     await hass.services.async_call(
         "light",
         SERVICE_TURN_ON,
@@ -666,6 +682,22 @@ async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant):
     assert mocked_bulb.async_set_color_temp.mock_calls == []
     assert mocked_bulb.async_set_brightness.mock_calls == []
 
+    mocked_bulb.last_properties["flowing"] = "1"
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_COLOR_TEMP: 250},
+        blocking=True,
+    )
+    assert mocked_bulb.async_set_hsv.mock_calls == []
+    assert mocked_bulb.async_set_rgb.mock_calls == []
+    assert mocked_bulb.async_set_color_temp.mock_calls == [
+        call(4000, duration=350, light_type=ANY)
+    ]
+    assert mocked_bulb.async_set_brightness.mock_calls == []
+    mocked_bulb.async_set_color_temp.reset_mock()
+    mocked_bulb.last_properties["flowing"] = "0"
+
     mocked_bulb.last_properties["color_mode"] = 3
     # This last change should generate a call even though
     # the color mode is the same since the HSV has changed
@@ -681,6 +713,33 @@ async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant):
     assert mocked_bulb.async_set_rgb.mock_calls == []
     assert mocked_bulb.async_set_color_temp.mock_calls == []
     assert mocked_bulb.async_set_brightness.mock_calls == []
+    mocked_bulb.async_set_hsv.reset_mock()
+
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_HS_COLOR: (100, 35)},
+        blocking=True,
+    )
+    assert mocked_bulb.async_set_hsv.mock_calls == []
+    assert mocked_bulb.async_set_rgb.mock_calls == []
+    assert mocked_bulb.async_set_color_temp.mock_calls == []
+    assert mocked_bulb.async_set_brightness.mock_calls == []
+
+    mocked_bulb.last_properties["flowing"] = "1"
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_HS_COLOR: (100, 35)},
+        blocking=True,
+    )
+    assert mocked_bulb.async_set_hsv.mock_calls == [
+        call(100.0, 35.0, duration=350, light_type=ANY)
+    ]
+    assert mocked_bulb.async_set_rgb.mock_calls == []
+    assert mocked_bulb.async_set_color_temp.mock_calls == []
+    assert mocked_bulb.async_set_brightness.mock_calls == []
+    mocked_bulb.last_properties["flowing"] = "0"
 
 
 async def test_device_types(hass: HomeAssistant, caplog):


### PR DESCRIPTION
- Log reason for DLNA-DMR device becoming unavailable ([@chishm] - [#57516]) ([dlna_dmr docs])
- Bump Mill library to 0.6.2 ([@Danielhiversen] - [#57533]) ([mill docs])
- Fix Fast.com autoupdate ([@Z1ni] - [#57552]) ([fastdotcom docs])
- Bump simplisafe-python to 11.0.7 ([@bachya] - [#57573]) ([simplisafe docs])
- Correct detection of row_number support for MariaDB ([@emontnemery] - [#57663]) ([recorder docs])
- Ensure Notion device name is stored as a string ([@bachya] - [#57670]) ([notion docs])
- Bump spiderpy to 1.4.3 ([@peternijssen] - [#57675]) ([spider docs])
- Fix Shelly humidity sensor available condition ([@thecode] - [#57721]) ([shelly docs])
- Reconnect and retry yeelight commands after previous wifi drop out ([@bdraco] - [#57741]) ([yeelight docs])
- Always send color/temp when switching from an effect in yeelight ([@bdraco] - [#57745]) ([yeelight docs])
- Fix Youless state class for power total sensor ([@gjong] - [#57758]) ([youless docs])
- Fix broken upnp derived sensors reporting b/s instead of kb/s ([@StevenLooman] - [#57681]) ([upnp docs])

[#57516]: https://github.com/home-assistant/core/pull/57516
[#57533]: https://github.com/home-assistant/core/pull/57533
[#57552]: https://github.com/home-assistant/core/pull/57552
[#57573]: https://github.com/home-assistant/core/pull/57573
[#57663]: https://github.com/home-assistant/core/pull/57663
[#57670]: https://github.com/home-assistant/core/pull/57670
[#57675]: https://github.com/home-assistant/core/pull/57675
[#57681]: https://github.com/home-assistant/core/pull/57681
[#57721]: https://github.com/home-assistant/core/pull/57721
[#57741]: https://github.com/home-assistant/core/pull/57741
[#57745]: https://github.com/home-assistant/core/pull/57745
[#57758]: https://github.com/home-assistant/core/pull/57758
[@Danielhiversen]: https://github.com/Danielhiversen
[@StevenLooman]: https://github.com/StevenLooman
[@Z1ni]: https://github.com/Z1ni
[@bachya]: https://github.com/bachya
[@bdraco]: https://github.com/bdraco
[@chishm]: https://github.com/chishm
[@emontnemery]: https://github.com/emontnemery
[@gjong]: https://github.com/gjong
[@peternijssen]: https://github.com/peternijssen
[@thecode]: https://github.com/thecode
[dlna_dmr docs]: https://www.home-assistant.io/integrations/dlna_dmr/
[fastdotcom docs]: https://www.home-assistant.io/integrations/fastdotcom/
[mill docs]: https://www.home-assistant.io/integrations/mill/
[notion docs]: https://www.home-assistant.io/integrations/notion/
[recorder docs]: https://www.home-assistant.io/integrations/recorder/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[simplisafe docs]: https://www.home-assistant.io/integrations/simplisafe/
[spider docs]: https://www.home-assistant.io/integrations/spider/
[upnp docs]: https://www.home-assistant.io/integrations/upnp/
[yeelight docs]: https://www.home-assistant.io/integrations/yeelight/
[youless docs]: https://www.home-assistant.io/integrations/youless/