### PR TITLE
Add command_line sensor json_attributes_path config option

### DIFF
--- a/homeassistant/components/command_line/const.py
+++ b/homeassistant/components/command_line/const.py
@@ -1,6 +1,9 @@
 """Allows to configure custom shell commands to turn a value for a sensor."""
 
 CONF_COMMAND_TIMEOUT = "command_timeout"
+CONF_JSON_ATTRIBUTES = "json_attributes"
+CONF_JSON_ATTRIBUTES_PATH = "json_attributes_path"
+
 DEFAULT_TIMEOUT = 15
 DOMAIN = "command_line"
 PLATFORMS = ["binary_sensor", "cover", "sensor", "switch"]

--- a/homeassistant/components/command_line/manifest.json
+++ b/homeassistant/components/command_line/manifest.json
@@ -2,6 +2,7 @@
   "domain": "command_line",
   "name": "Command Line",
   "documentation": "https://www.home-assistant.io/integrations/command_line",
+  "requirements": ["jsonpath==0.82"],
   "codeowners": [],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -887,6 +887,7 @@ iperf3==0.1.11
 # homeassistant.components.gogogate2
 ismartgate==4.0.0
 
+# homeassistant.components.command_line
 # homeassistant.components.rest
 jsonpath==0.82
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -539,6 +539,7 @@ iotawattpy==0.1.0
 # homeassistant.components.gogogate2
 ismartgate==4.0.0
 
+# homeassistant.components.command_line
 # homeassistant.components.rest
 jsonpath==0.82
 

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -223,3 +223,30 @@ async def test_update_with_unnecessary_json_attrs(caplog, hass: HomeAssistant) -
     assert entity_state.attributes["key"] == "some_json_value"
     assert entity_state.attributes["another_key"] == "another_json_value"
     assert "key_three" not in entity_state.attributes
+
+
+async def test_update_with_json_attrs_with_json_attrs_path(hass: HomeAssistant) -> None:
+    """Test attributes get extracted from a JSON result with a path to those attributes."""
+
+    await setup_test_entities(
+        hass,
+        {
+            "command": 'echo \
+                {\
+                    \\"top_level\\": {\
+                        \\"second_level\\": {\
+                            \\"key\\": \\"some_json_value\\",\
+                            \\"another_key\\": \\"another_json_value\\",\
+                            \\"key_three\\": \\"value_three\\"\
+                        }\
+                    }\
+                }',
+            "json_attributes": ["key", "another_key", "key_three"],
+            "json_attributes_path": "$.top_level.second_level",
+        },
+    )
+    entity_state = hass.states.get("sensor.test")
+    assert entity_state
+    assert entity_state.attributes["key"] == "some_json_value"
+    assert entity_state.attributes["another_key"] == "another_json_value"
+    assert entity_state.attributes["key_three"] == "value_three"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds `json_attributes_path` configuration parameter to the command_line sensor integration bringing it up to parity of the available JSON matching capability of the REST sensor. This parameter uses [jsonpath](https://pypi.org/project/jsonpath/) to select an object from somewhere other than the first level to be considered the root dictionary. Without this feature, users who needed this capability had to manually manipulate the JSON in the command, perhaps through `sed` for instance. This might be beyond the capabilities of some users. The implementation used here is the exact same as is used in the REST sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
