### PR TITLE
Make sure Flu Near You data storage conforms to standards

### DIFF
--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -15,13 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    CATEGORY_CDC_REPORT,
-    CATEGORY_USER_REPORT,
-    DATA_COORDINATOR,
-    DOMAIN,
-    LOGGER,
-)
+from .const import CATEGORY_CDC_REPORT, CATEGORY_USER_REPORT, DOMAIN, LOGGER
 
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=30)
 
@@ -33,7 +27,6 @@ PLATFORMS = ["sensor"]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Flu Near You as config entry."""
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {DATA_COORDINATOR: {}}
 
     websession = aiohttp_client.async_get_clientsession(hass)
     client = Client(session=websession)
@@ -71,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         data_init_tasks.append(coordinator.async_refresh())
 
     await asyncio.gather(*data_init_tasks)
-    hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR] = coordinators
+    hass.data[DOMAIN][entry.entry_id] = coordinators
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -32,8 +32,8 @@ PLATFORMS = ["sensor"]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Flu Near You as config entry."""
-    hass.data.setdefault(DOMAIN, {DATA_COORDINATOR: {}})
-    hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id] = {}
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {DATA_COORDINATOR: {}}
 
     websession = aiohttp_client.async_get_clientsession(hass)
     client = Client(session=websession)
@@ -59,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     data_init_tasks = []
     for api_category in (CATEGORY_CDC_REPORT, CATEGORY_USER_REPORT):
-        coordinator = hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][
+        coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR][
             api_category
         ] = DataUpdateCoordinator(
             hass,
@@ -81,6 +81,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload an Flu Near You config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN][DATA_COORDINATOR].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/flunearyou/__init__.py
+++ b/homeassistant/components/flunearyou/__init__.py
@@ -57,11 +57,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         return data
 
+    coordinators = {}
     data_init_tasks = []
+
     for api_category in (CATEGORY_CDC_REPORT, CATEGORY_USER_REPORT):
-        coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR][
-            api_category
-        ] = DataUpdateCoordinator(
+        coordinator = coordinators[api_category] = DataUpdateCoordinator(
             hass,
             LOGGER,
             name=f"{api_category} ({latitude}, {longitude})",
@@ -71,6 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         data_init_tasks.append(coordinator.async_refresh())
 
     await asyncio.gather(*data_init_tasks)
+    hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR] = coordinators
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/flunearyou/const.py
+++ b/homeassistant/components/flunearyou/const.py
@@ -4,7 +4,5 @@ import logging
 DOMAIN = "flunearyou"
 LOGGER = logging.getLogger(__package__)
 
-DATA_COORDINATOR = "coordinator"
-
 CATEGORY_CDC_REPORT = "cdc_report"
 CATEGORY_USER_REPORT = "user_report"

--- a/homeassistant/components/flunearyou/sensor.py
+++ b/homeassistant/components/flunearyou/sensor.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import CATEGORY_CDC_REPORT, CATEGORY_USER_REPORT, DATA_COORDINATOR, DOMAIN
+from .const import CATEGORY_CDC_REPORT, CATEGORY_USER_REPORT, DOMAIN
 
 ATTR_CITY = "city"
 ATTR_REPORTED_DATE = "reported_date"
@@ -122,7 +122,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Flu Near You sensors based on a config entry."""
-    coordinators = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
+    coordinators = hass.data[DOMAIN][entry.entry_id]
 
     sensors: list[CdcSensor | UserSensor] = [
         CdcSensor(coordinators[CATEGORY_CDC_REPORT], entry, description)

--- a/homeassistant/components/flunearyou/sensor.py
+++ b/homeassistant/components/flunearyou/sensor.py
@@ -122,7 +122,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Flu Near You sensors based on a config entry."""
-    coordinators = hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id]
+    coordinators = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
 
     sensors: list[CdcSensor | UserSensor] = [
         CdcSensor(coordinators[CATEGORY_CDC_REPORT], entry, description)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When integrations store data in `hass.data`, the standard is to use the config entry ID as the first key (with sub-keys coming after) – e.g., `hass.data[entry.entry_id][...]`. Flu Near You is doing this backwards (storing sub-keys first). This PR updates things to standard.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
