### PR TITLE
Make sure IQVIA data storage conforms to standards

### DIFF
--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -24,7 +24,6 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import (
     CONF_ZIP_CODE,
-    DATA_COORDINATOR,
     DOMAIN,
     LOGGER,
     TYPE_ALLERGY_FORECAST,
@@ -95,7 +94,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # API calls fail:
         raise ConfigEntryNotReady()
 
-    hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR] = coordinators
+    hass.data[DOMAIN][entry.entry_id] = coordinators
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
@@ -142,7 +141,7 @@ class IQVIAEntity(CoordinatorEntity):
 
         if self.entity_description.key == TYPE_ALLERGY_FORECAST:
             self.async_on_remove(
-                self.hass.data[DOMAIN][self._entry.entry_id][DATA_COORDINATOR][
+                self.hass.data[DOMAIN][self._entry.entry_id][
                     TYPE_ALLERGY_OUTLOOK
                 ].async_add_listener(self._handle_coordinator_update)
             )

--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -45,7 +45,7 @@ PLATFORMS = ["sensor"]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up IQVIA as config entry."""
     hass.data.setdefault(DOMAIN, {})
-    coordinators = {}
+    hass.data[DOMAIN][entry.entry_id] = {}
 
     if not entry.unique_id:
         # If the config entry doesn't already have a unique ID, set one:
@@ -67,7 +67,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         return cast(Dict[str, Any], data)
 
+    coordinators = {}
     init_data_update_tasks = []
+
     for sensor_type, api_coro in (
         (TYPE_ALLERGY_FORECAST, client.allergens.extended),
         (TYPE_ALLERGY_INDEX, client.allergens.current),
@@ -93,7 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # API calls fail:
         raise ConfigEntryNotReady()
 
-    hass.data[DOMAIN].setdefault(DATA_COORDINATOR, {})[entry.entry_id] = coordinators
+    hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR] = coordinators
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
@@ -103,7 +105,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload an OpenUV config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN][DATA_COORDINATOR].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id)
+
     return unload_ok
 
 
@@ -139,7 +142,7 @@ class IQVIAEntity(CoordinatorEntity):
 
         if self.entity_description.key == TYPE_ALLERGY_FORECAST:
             self.async_on_remove(
-                self.hass.data[DOMAIN][DATA_COORDINATOR][self._entry.entry_id][
+                self.hass.data[DOMAIN][self._entry.entry_id][DATA_COORDINATOR][
                     TYPE_ALLERGY_OUTLOOK
                 ].async_add_listener(self._handle_coordinator_update)
             )

--- a/homeassistant/components/iqvia/const.py
+++ b/homeassistant/components/iqvia/const.py
@@ -7,8 +7,6 @@ DOMAIN = "iqvia"
 
 CONF_ZIP_CODE = "zip_code"
 
-DATA_COORDINATOR = "coordinator"
-
 TYPE_ALLERGY_FORECAST = "allergy_average_forecasted"
 TYPE_ALLERGY_INDEX = "allergy_index"
 TYPE_ALLERGY_OUTLOOK = "allergy_outlook"

--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -18,7 +18,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import IQVIAEntity
 from .const import (
-    DATA_COORDINATOR,
     DOMAIN,
     TYPE_ALLERGY_FORECAST,
     TYPE_ALLERGY_INDEX,
@@ -133,7 +132,7 @@ async def async_setup_entry(
     """Set up IQVIA sensors based on a config entry."""
     sensors: list[ForecastSensor | IndexSensor] = [
         ForecastSensor(
-            hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR][
+            hass.data[DOMAIN][entry.entry_id][
                 API_CATEGORY_MAPPING.get(description.key, description.key)
             ],
             entry,
@@ -144,7 +143,7 @@ async def async_setup_entry(
     sensors.extend(
         [
             IndexSensor(
-                hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR][
+                hass.data[DOMAIN][entry.entry_id][
                     API_CATEGORY_MAPPING.get(description.key, description.key)
                 ],
                 entry,
@@ -207,8 +206,8 @@ class ForecastSensor(IQVIAEntity, SensorEntity):
 
         if self.entity_description.key == TYPE_ALLERGY_FORECAST:
             outlook_coordinator = self.hass.data[DOMAIN][self._entry.entry_id][
-                DATA_COORDINATOR
-            ][TYPE_ALLERGY_OUTLOOK]
+                TYPE_ALLERGY_OUTLOOK
+            ]
 
             if not outlook_coordinator.last_update_success:
                 return

--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -133,7 +133,7 @@ async def async_setup_entry(
     """Set up IQVIA sensors based on a config entry."""
     sensors: list[ForecastSensor | IndexSensor] = [
         ForecastSensor(
-            hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][
+            hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR][
                 API_CATEGORY_MAPPING.get(description.key, description.key)
             ],
             entry,
@@ -144,7 +144,7 @@ async def async_setup_entry(
     sensors.extend(
         [
             IndexSensor(
-                hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][
+                hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR][
                     API_CATEGORY_MAPPING.get(description.key, description.key)
                 ],
                 entry,
@@ -206,8 +206,8 @@ class ForecastSensor(IQVIAEntity, SensorEntity):
         )
 
         if self.entity_description.key == TYPE_ALLERGY_FORECAST:
-            outlook_coordinator = self.hass.data[DOMAIN][DATA_COORDINATOR][
-                self._entry.entry_id
+            outlook_coordinator = self.hass.data[DOMAIN][self._entry.entry_id][
+                DATA_COORDINATOR
             ][TYPE_ALLERGY_OUTLOOK]
 
             if not outlook_coordinator.last_update_success:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When integrations store data in `hass.data`, the standard is to use the config entry ID as the first key (with sub-keys coming after) – e.g., `hass.data[entry.entry_id][...]`. IQVIA is doing this backwards (storing sub-keys first). This PR updates things to standard.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
