### PR TITLE
Ensure lutron_caseta triggers can still be attached in setup retry state

### DIFF
--- a/homeassistant/components/lutron_caseta/device_trigger.py
+++ b/homeassistant/components/lutron_caseta/device_trigger.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -257,6 +258,12 @@ async def async_get_triggers(
     return triggers
 
 
+def _device_model_to_type(model: str) -> str:
+    """Convert a lutron_caseta device registry entry model to type."""
+    _, device_type = model.split(" ")
+    return device_type.replace("(", "").replace(")", "")
+
+
 async def async_attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
@@ -264,15 +271,18 @@ async def async_attach_trigger(
     automation_info: AutomationTriggerInfo,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
-    device = get_button_device_by_dr_id(hass, config[CONF_DEVICE_ID])
-    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
-    valid_buttons = DEVICE_TYPE_SUBTYPE_MAP.get(device["type"])
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(config[CONF_DEVICE_ID])
+    device_type = _device_model_to_type(device.model)
+    _, serial = list(device.identifiers)[0]
+    schema = DEVICE_TYPE_SCHEMA_MAP.get(device_type)
+    valid_buttons = DEVICE_TYPE_SUBTYPE_MAP.get(device_type)
     config = schema(config)
     event_config = {
         event_trigger.CONF_PLATFORM: CONF_EVENT,
         event_trigger.CONF_EVENT_TYPE: LUTRON_CASETA_BUTTON_EVENT,
         event_trigger.CONF_EVENT_DATA: {
-            ATTR_SERIAL: device["serial"],
+            ATTR_SERIAL: serial,
             ATTR_BUTTON_NUMBER: valid_buttons[config[CONF_SUBTYPE]],
             ATTR_ACTION: config[CONF_TYPE],
         },


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Avoid having to restart when the lutron hub comes back online.

Fixes
```

2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.turn_on_master_bed_lights_from_picos] Error setting up trigger Turn On Master Bed Lights from Picos
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable
2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.turn_on_master_bed_lights_from_picos] Error setting up trigger Turn On Master Bed Lights from Picos
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable
2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.turn_off_master_bed_lights_from_picos] Error setting up trigger Turn Off Master Bed Lights from Picos
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable
2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.turn_off_master_bed_lights_from_picos] Error setting up trigger Turn Off Master Bed Lights from Picos
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable
2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.dim_master_bed_lights_from_picos] Error setting up trigger Dim Master Bed Lights from Picos
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable
2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.dim_master_bed_lights_from_picos] Error setting up trigger Dim Master Bed Lights from Picos
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable
2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.brighten_master_bed_lights_from_picos] Error setting up trigger Brighten Master Bed Lights from Picos
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable
2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.brighten_master_bed_lights_from_picos] Error setting up trigger Brighten Master Bed Lights from Picos
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable
2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.turn_on_master_bed_aircon_from_pico] Error setting up trigger Turn on Master Bed Aircon from Pico
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable
2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.turn_on_master_bed_aircon_from_pico] Error setting up trigger Turn on Master Bed Aircon from Pico
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable
2021-10-16 07:43:54 ERROR (MainThread) [homeassistant.components.automation.turn_off_master_bed_aircon_from_pico] Error setting up trigger Turn off Master Bed Aircon from Pico
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/device_automation/trigger.py", line 36, in async_attach_trigger
    return await platform.async_attach_trigger(hass, config, action, automation_info)
  File "/usr/src/homeassistant/homeassistant/components/lutron_caseta/device_trigger.py", line 268, in async_attach_trigger
    schema = DEVICE_TYPE_SCHEMA_MAP.get(device["type"])
TypeError: NoneType object is not subscriptable

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
