### PR TITLE
Set `nest` camera always on STATE_STREAMING

### DIFF
--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -76,6 +76,7 @@ class NestCamera(Camera):
         self._event_id: str | None = None
         self._event_image_bytes: bytes | None = None
         self._event_image_cleanup_unsub: Callable[[], None] | None = None
+        self.is_streaming = CameraLiveStreamTrait.NAME in self._device.traits
 
     @property
     def should_poll(self) -> bool:

--- a/tests/components/nest/camera_sdm_test.py
+++ b/tests/components/nest/camera_sdm_test.py
@@ -14,7 +14,7 @@ from google_nest_sdm.event import EventMessage
 import pytest
 
 from homeassistant.components import camera
-from homeassistant.components.camera import STATE_IDLE
+from homeassistant.components.camera import STATE_IDLE, STATE_STREAMING
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -168,7 +168,7 @@ async def test_camera_device(hass):
     assert len(hass.states.async_all()) == 1
     camera = hass.states.get("camera.my_camera")
     assert camera is not None
-    assert camera.state == STATE_IDLE
+    assert camera.state == STATE_STREAMING
 
     registry = er.async_get(hass)
     entry = registry.async_get("camera.my_camera")
@@ -191,7 +191,7 @@ async def test_camera_stream(hass, auth):
     assert len(hass.states.async_all()) == 1
     cam = hass.states.get("camera.my_camera")
     assert cam is not None
-    assert cam.state == STATE_IDLE
+    assert cam.state == STATE_STREAMING
 
     stream_source = await camera.async_get_stream_source(hass, "camera.my_camera")
     assert stream_source == "rtsp://some/url?auth=g.0.streamingToken"
@@ -253,7 +253,7 @@ async def test_refresh_expired_stream_token(hass, auth):
     assert len(hass.states.async_all()) == 1
     cam = hass.states.get("camera.my_camera")
     assert cam is not None
-    assert cam.state == STATE_IDLE
+    assert cam.state == STATE_STREAMING
 
     # Request a stream for the camera entity to exercise nest cam + camera interaction
     # and shutdown on url expiration
@@ -318,7 +318,7 @@ async def test_stream_response_already_expired(hass, auth):
     assert len(hass.states.async_all()) == 1
     cam = hass.states.get("camera.my_camera")
     assert cam is not None
-    assert cam.state == STATE_IDLE
+    assert cam.state == STATE_STREAMING
 
     # The stream is expired, but we return it anyway
     stream_source = await camera.async_get_stream_source(hass, "camera.my_camera")
@@ -342,7 +342,7 @@ async def test_camera_removed(hass, auth):
     assert len(hass.states.async_all()) == 1
     cam = hass.states.get("camera.my_camera")
     assert cam is not None
-    assert cam.state == STATE_IDLE
+    assert cam.state == STATE_STREAMING
 
     # Start a stream, exercising cleanup on remove
     auth.responses = [
@@ -386,7 +386,7 @@ async def test_refresh_expired_stream_failure(hass, auth):
     assert len(hass.states.async_all()) == 1
     cam = hass.states.get("camera.my_camera")
     assert cam is not None
-    assert cam.state == STATE_IDLE
+    assert cam.state == STATE_STREAMING
 
     # Request an HLS stream
     with patch("homeassistant.components.camera.create_stream") as create_stream:
@@ -639,7 +639,7 @@ async def test_camera_web_rtc(hass, auth, hass_ws_client):
     assert len(hass.states.async_all()) == 1
     cam = hass.states.get("camera.my_camera")
     assert cam is not None
-    assert cam.state == STATE_IDLE
+    assert cam.state == STATE_STREAMING
 
     client = await hass_ws_client(hass)
     await client.send_json(
@@ -669,7 +669,7 @@ async def test_camera_web_rtc_unsupported(hass, auth, hass_ws_client):
     assert len(hass.states.async_all()) == 1
     cam = hass.states.get("camera.my_camera")
     assert cam is not None
-    assert cam.state == STATE_IDLE
+    assert cam.state == STATE_STREAMING
 
     client = await hass_ws_client(hass)
     await client.send_json(


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Set the nest cameras that support streaming to always be in the state of
streaming rather than idle, since this is a common point of user confusion.

The SDM API does not expose any notion of on/off, so always assume that any
cam that can stream is streaming since the stream is always available to join.

Tests are updated, though one still exercises the `STATE_IDLE` case of a camera that does not support streaming.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
