### PR TITLE
Restore the previous state of a KNX binary sensor

### DIFF
--- a/homeassistant/components/knx/binary_sensor.py
+++ b/homeassistant/components/knx/binary_sensor.py
@@ -74,7 +74,7 @@ class KNXBinarySensor(KnxEntity, BinarySensorEntity, RestoreEntity):
         if (
             last_state := await self.async_get_last_state()
         ) and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-            self._device.remote_value.value = last_state.state == STATE_ON
+            await self._device.remote_value.update_value(last_state.state == STATE_ON)
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/knx/binary_sensor.py
+++ b/homeassistant/components/knx/binary_sensor.py
@@ -7,9 +7,16 @@ from xknx import XKNX
 from xknx.devices import BinarySensor as XknxBinarySensor
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
+from homeassistant.const import (
+    CONF_DEVICE_CLASS,
+    CONF_NAME,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt
 
@@ -36,7 +43,7 @@ async def async_setup_platform(
     )
 
 
-class KNXBinarySensor(KnxEntity, BinarySensorEntity):
+class KNXBinarySensor(KnxEntity, BinarySensorEntity, RestoreEntity):
     """Representation of a KNX binary sensor."""
 
     _device: XknxBinarySensor
@@ -60,6 +67,14 @@ class KNXBinarySensor(KnxEntity, BinarySensorEntity):
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._attr_force_update = self._device.ignore_internal_state
         self._attr_unique_id = str(self._device.remote_value.group_address_state)
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last state."""
+        await super().async_added_to_hass()
+        if (
+            last_state := await self.async_get_last_state()
+        ) and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            self._device.remote_value.value = last_state.state == STATE_ON
 
     @property
     def is_on(self) -> bool:

--- a/tests/components/knx/test_binary_sensor.py
+++ b/tests/components/knx/test_binary_sensor.py
@@ -246,3 +246,37 @@ async def test_binary_sensor_restore_and_respond(hass, knx):
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.test")
     assert state.state is STATE_OFF
+
+
+async def test_binary_sensor_restore_invert(hass, knx):
+    """Test restoring KNX binary sensor state with invert."""
+    _ADDRESS = "2/2/2"
+    fake_state = State("binary_sensor.test", STATE_ON)
+
+    with patch(
+        "homeassistant.helpers.restore_state.RestoreEntity.async_get_last_state",
+        return_value=fake_state,
+    ):
+        await knx.setup_integration(
+            {
+                BinarySensorSchema.PLATFORM_NAME: [
+                    {
+                        CONF_NAME: "test",
+                        CONF_STATE_ADDRESS: _ADDRESS,
+                        BinarySensorSchema.CONF_INVERT: True,
+                        CONF_SYNC_STATE: False,
+                    },
+                ]
+            }
+        )
+
+    # restored state - doesn't send telegram
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+    await knx.assert_telegram_count(0)
+
+    # inverted is on, make sure the state is off after it
+    await knx.receive_write(_ADDRESS, True)
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.test")
+    assert state.state is STATE_OFF

--- a/tests/components/knx/test_binary_sensor.py
+++ b/tests/components/knx/test_binary_sensor.py
@@ -1,10 +1,11 @@
 """Test KNX binary sensor."""
 from datetime import timedelta
+from unittest.mock import patch
 
 from homeassistant.components.knx.const import CONF_STATE_ADDRESS, CONF_SYNC_STATE
 from homeassistant.components.knx.schema import BinarySensorSchema
 from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.util import dt
 
 from .conftest import KNXTestKit
@@ -211,5 +212,37 @@ async def test_binary_sensor_reset(hass: HomeAssistant, knx: KNXTestKit):
     await hass.async_block_till_done()
     await hass.async_block_till_done()
     # state reset after after timeout
+    state = hass.states.get("binary_sensor.test")
+    assert state.state is STATE_OFF
+
+
+async def test_binary_sensor_restore_and_respond(hass, knx):
+    """Test restoring KNX binary sensor state and respond to read."""
+    _ADDRESS = "2/2/2"
+    fake_state = State("binary_sensor.test", STATE_ON)
+
+    with patch(
+        "homeassistant.helpers.restore_state.RestoreEntity.async_get_last_state",
+        return_value=fake_state,
+    ):
+        await knx.setup_integration(
+            {
+                BinarySensorSchema.PLATFORM_NAME: [
+                    {
+                        CONF_NAME: "test",
+                        CONF_STATE_ADDRESS: _ADDRESS,
+                        CONF_SYNC_STATE: False,
+                    },
+                ]
+            }
+        )
+
+    # restored state - doesn't send telegram
+    state = hass.states.get("binary_sensor.test")
+    assert state.state == STATE_ON
+    await knx.assert_telegram_count(0)
+
+    await knx.receive_write(_ADDRESS, False)
+    await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.test")
     assert state.state is STATE_OFF


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Restores the previous state of a KNX binary sensor after rebooting Home Assistant.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52842
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
