### PR TITLE
Bump `brother` library to version 1.1.0

### DIFF
--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -90,12 +90,14 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_HOST: self.host})
 
         snmp_engine = get_snmp_engine(self.hass)
-        model = discovery_info["properties"]["product"]
+        model = discovery_info.get("properties", {}).get("product")
 
         try:
             self.brother = Brother(self.host, snmp_engine=snmp_engine, model=model)
             await self.brother.async_update()
-        except (ConnectionError, SnmpError, UnsupportedModel):
+        except UnsupportedModel:
+            return self.async_abort(reason="unsupported_model")
+        except (ConnectionError, SnmpError):
             return self.async_abort(reason="cannot_connect")
 
         # Check if already configured

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -60,10 +60,8 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 brother = Brother(user_input[CONF_HOST], snmp_engine=snmp_engine)
                 await brother.async_update()
-
                 await self.async_set_unique_id(brother.serial.lower())
                 self._abort_if_unique_id_configured()
-
                 title = f"{brother.model} {brother.serial}"
                 return self.async_create_entry(title=title, data=user_input)
             except InvalidHost:
@@ -90,9 +88,10 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_HOST: self.host})
 
         snmp_engine = get_snmp_engine(self.hass)
+        model = discovery_info["properties"]["product"]
 
-        self.brother = Brother(self.host, snmp_engine=snmp_engine)
         try:
+            self.brother = Brother(self.host, snmp_engine=snmp_engine, model=model)
             await self.brother.async_update()
         except (ConnectionError, SnmpError, UnsupportedModel):
             return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -60,8 +60,10 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 brother = Brother(user_input[CONF_HOST], snmp_engine=snmp_engine)
                 await brother.async_update()
+
                 await self.async_set_unique_id(brother.serial.lower())
                 self._abort_if_unique_id_configured()
+
                 title = f"{brother.model} {brother.serial}"
                 return self.async_create_entry(title=title, data=user_input)
             except InvalidHost:

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brother Printer",
   "documentation": "https://www.home-assistant.io/integrations/brother",
   "codeowners": ["@bieniu"],
-  "requirements": ["brother==1.0.2"],
+  "requirements": ["brother==1.1.0"],
   "zeroconf": [
     {
       "type": "_printer._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -431,7 +431,7 @@ bravia-tv==1.0.11
 broadlink==0.17.0
 
 # homeassistant.components.brother
-brother==1.0.2
+brother==1.1.0
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -269,7 +269,7 @@ bravia-tv==1.0.11
 broadlink==0.17.0
 
 # homeassistant.components.brother
-brother==1.0.2
+brother==1.1.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -150,6 +150,24 @@ async def test_zeroconf_snmp_error(hass):
         assert result["reason"] == "cannot_connect"
 
 
+async def test_zeroconf_unsupported_model(hass):
+    """Test unsupported printer model error."""
+    with patch("brother.Brother._get_data") as mock_get_data:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data={
+                "hostname": "example.local.",
+                "name": "Brother Printer",
+                "properties": {"product": "MFC-8660DN"},
+            },
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "unsupported_model"
+        assert len(mock_get_data.mock_calls) == 0
+
+
 async def test_zeroconf_device_exists_abort(hass):
     """Test we abort zeroconf flow if Brother printer already configured."""
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `brother` library to version 1.1.0 to check if the printer model is supported during discovery (before trying to fetch data via SNMP). For two very old printer models, fetching data via SNMP restarts the printer and this change fixes the behavior.

Changelog: https://github.com/bieniu/brother/compare/1.0.2...1.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52834
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
