### PR TITLE
Fix order of arguments in rainmachine sensors

### DIFF
--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -115,23 +115,26 @@ async def async_setup_entry(
         if api_category == DATA_PROVISION_SETTINGS:
             return partial(
                 ProvisionSettingsBinarySensor,
+                entry,
                 coordinators[DATA_PROVISION_SETTINGS],
             )
 
         if api_category == DATA_RESTRICTIONS_CURRENT:
             return partial(
                 CurrentRestrictionsBinarySensor,
+                entry,
                 coordinators[DATA_RESTRICTIONS_CURRENT],
             )
 
         return partial(
             UniversalRestrictionsBinarySensor,
+            entry,
             coordinators[DATA_RESTRICTIONS_UNIVERSAL],
         )
 
     async_add_entities(
         [
-            async_get_sensor(description.api_category)(entry, controller, description)
+            async_get_sensor(description.api_category)(controller, description)
             for description in BINARY_SENSOR_DESCRIPTIONS
         ]
     )

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -104,17 +104,19 @@ async def async_setup_entry(
         if api_category == DATA_PROVISION_SETTINGS:
             return partial(
                 ProvisionSettingsSensor,
+                entry,
                 coordinators[DATA_PROVISION_SETTINGS],
             )
 
         return partial(
             UniversalRestrictionsSensor,
+            entry,
             coordinators[DATA_RESTRICTIONS_UNIVERSAL],
         )
 
     async_add_entities(
         [
-            async_get_sensor(description.api_category)(entry, controller, description)
+            async_get_sensor(description.api_category)(controller, description)
             for description in SENSOR_DESCRIPTIONS
         ]
     )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes
```
2021-10-16 07:41:21 ERROR (MainThread) [homeassistant.components.binary_sensor] Error while setting up rainmachine platform for binary_sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 248, in _async_setup_platform
    await asyncio.shield(task)
  File "/usr/src/homeassistant/homeassistant/components/rainmachine/binary_sensor.py", line 133, in async_setup_entry
    [
  File "/usr/src/homeassistant/homeassistant/components/rainmachine/binary_sensor.py", line 134, in <listcomp>
    async_get_sensor(description.api_category)(entry, controller, description)
  File "/usr/src/homeassistant/homeassistant/components/rainmachine/__init__.py", line 336, in __init__
    "configuration_url": f"https://{entry.data[CONF_IP_ADDRESS]}:{entry.data[CONF_PORT]}",
KeyError: ip_address
2021-10-16 07:41:21 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up rainmachine platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 248, in _async_setup_platform
    await asyncio.shield(task)
  File "/usr/src/homeassistant/homeassistant/components/rainmachine/sensor.py", line 116, in async_setup_entry
    [
  File "/usr/src/homeassistant/homeassistant/components/rainmachine/sensor.py", line 117, in <listcomp>
    async_get_sensor(description.api_category)(entry, controller, description)
  File "/usr/src/homeassistant/homeassistant/components/rainmachine/__init__.py", line 336, in __init__
    "configuration_url": f"https://{entry.data[CONF_IP_ADDRESS]}:{entry.data[CONF_PORT]}",
KeyError: ip_address
```






## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
