### PR TITLE
Add MusicCast Sleep Timer Service

### DIFF
--- a/homeassistant/components/yamaha_musiccast/const.py
+++ b/homeassistant/components/yamaha_musiccast/const.py
@@ -18,6 +18,7 @@ ATTR_PRESET = "preset"
 ATTR_MC_LINK = "mc_link"
 ATTR_MAIN_SYNC = "main_sync"
 ATTR_MC_LINK_SOURCES = [ATTR_MC_LINK, ATTR_MAIN_SYNC]
+ATTR_SLEEP_TIME = "sleep_time"
 
 CONF_UPNP_DESC = "upnp_description"
 CONF_SERIAL = "serial"
@@ -42,3 +43,6 @@ MEDIA_CLASS_MAPPING = {
     "directory": MEDIA_CLASS_DIRECTORY,
     "categories": MEDIA_CLASS_DIRECTORY,
 }
+
+SERVICE_SET_TIMER = "set_sleep_timer"
+SERVICE_CLEAR_TIMER = "clear_sleep_timer"

--- a/homeassistant/components/yamaha_musiccast/manifest.json
+++ b/homeassistant/components/yamaha_musiccast/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/yamaha_musiccast",
   "requirements": [
-    "aiomusiccast==0.10.0"
+    "aiomusiccast==0.11.0"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -1,8 +1,9 @@
 """Implementation of the musiccast media player."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
-from typing import Any, Mapping
+from typing import Any
 
 from aiomusiccast import MusicCastGroupException, MusicCastMediaContent
 from aiomusiccast.features import ZoneFeature

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -145,7 +145,7 @@ async def async_setup_entry(
         SERVICE_SET_TIMER,
         {
             vol.Required(ATTR_SLEEP_TIME): vol.All(
-                vol.Coerce(int), vol.Range(min=0, max=120)
+                vol.Coerce(int), vol.Any(30, 60, 90, 120)
             )
         },
         "set_sleep_timer",

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -144,7 +144,7 @@ async def async_setup_entry(
         SERVICE_SET_TIMER,
         {
             vol.Required(ATTR_SLEEP_TIME): vol.All(
-                vol.Coerce(int), vol.Range(min=0, max=86399)
+                vol.Coerce(int), vol.Range(min=0, max=120)
             )
         },
         "set_sleep_timer",
@@ -942,8 +942,6 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
         if ZoneFeature.SLEEP not in self.coordinator.data.zones[self._zone_id].features:
             raise HomeAssistantError("This device does not support sleep timers")
         await self.coordinator.musiccast.set_sleep_timer(self._zone_id, sleep_time)
-        print(self.coordinator.data.zones[self._zone_id].features)
-        print(self.coordinator.data.zones[self._zone_id].__dict__)
 
     async def clear_sleep_timer(self):
         """Disable the sleep timer."""

--- a/homeassistant/components/yamaha_musiccast/services.yaml
+++ b/homeassistant/components/yamaha_musiccast/services.yaml
@@ -1,0 +1,23 @@
+set_sleep_timer:
+  name: Set timer
+  description: Set a MusicCast sleep timer.
+  target:
+    device:
+      integration: yamaha_musiccast
+  fields:
+    sleep_time:
+      name: Sleep Time
+      description: Number of minutes to set the timer.
+      selector:
+        number:
+          min: 30
+          max: 120
+          step: 30
+          unit_of_measurement: minutes
+
+clear_sleep_timer:
+  name: Clear timer
+  description: Clear a MusicCast sleep timer.
+  target:
+    device:
+      integration: yamaha_musiccast

--- a/homeassistant/components/yamaha_musiccast/services.yaml
+++ b/homeassistant/components/yamaha_musiccast/services.yaml
@@ -1,13 +1,13 @@
 set_sleep_timer:
   name: Set timer
-  description: Set a MusicCast sleep timer.
+  description: Set a MusicCast Sleep Timer.
   target:
     device:
       integration: yamaha_musiccast
   fields:
     sleep_time:
       name: Sleep Time
-      description: Number of minutes to set the timer.
+      description: Number of minutes to set the timer to.
       selector:
         number:
           min: 30
@@ -17,7 +17,7 @@ set_sleep_timer:
 
 clear_sleep_timer:
   name: Clear timer
-  description: Clear a MusicCast sleep timer.
+  description: Clear a MusicCast Sleep Timer.
   target:
     device:
       integration: yamaha_musiccast

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -213,7 +213,7 @@ aiolyric==1.0.7
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.10.0
+aiomusiccast==0.11.0
 
 # homeassistant.components.nanoleaf
 aionanoleaf==0.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -143,7 +143,7 @@ aiolyric==1.0.7
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.10.0
+aiomusiccast==0.11.0
 
 # homeassistant.components.nanoleaf
 aionanoleaf==0.0.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some Yamaha MusicCast devices support a sleep timer, which can be set to turn off the device after a defined time. This feature is now also available from Home Assistant using a service.
To implement this feature an update of aiomusiccast was necessary. The changes are documented [here](https://github.com/vigonotion/aiomusiccast/releases/tag/0.11.0).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19817

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
