### PR TITLE
Add unit/device_class validation and normalization to Tuya

### DIFF
--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -1,8 +1,67 @@
 """Constants for the Tuya integration."""
-from dataclasses import dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 from enum import Enum
+from typing import Callable
 
 from tuya_iot import TuyaCloudOpenAPIEndpoint
+
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_PARTS_PER_BILLION,
+    CONCENTRATION_PARTS_PER_MILLION,
+    DEVICE_CLASS_AQI,
+    DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_CO,
+    DEVICE_CLASS_CO2,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_DATE,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_GAS,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_MONETARY,
+    DEVICE_CLASS_NITROGEN_DIOXIDE,
+    DEVICE_CLASS_NITROGEN_MONOXIDE,
+    DEVICE_CLASS_NITROUS_OXIDE,
+    DEVICE_CLASS_OZONE,
+    DEVICE_CLASS_PM1,
+    DEVICE_CLASS_PM10,
+    DEVICE_CLASS_PM25,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_POWER_FACTOR,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_SIGNAL_STRENGTH,
+    DEVICE_CLASS_SULPHUR_DIOXIDE,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_TIMESTAMP,
+    DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS,
+    DEVICE_CLASS_VOLTAGE,
+    ELECTRIC_CURRENT_AMPERE,
+    ELECTRIC_CURRENT_MILLIAMPERE,
+    ELECTRIC_POTENTIAL_MILLIVOLT,
+    ELECTRIC_POTENTIAL_VOLT,
+    ENERGY_KILO_WATT_HOUR,
+    ENERGY_WATT_HOUR,
+    LIGHT_LUX,
+    PERCENTAGE,
+    POWER_KILO_WATT,
+    POWER_WATT,
+    PRESSURE_BAR,
+    PRESSURE_HPA,
+    PRESSURE_INHG,
+    PRESSURE_MBAR,
+    PRESSURE_PA,
+    PRESSURE_PSI,
+    SIGNAL_STRENGTH_DECIBELS,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+    VOLUME_CUBIC_FEET,
+    VOLUME_CUBIC_METERS,
+)
 
 DOMAIN = "tuya"
 
@@ -153,6 +212,212 @@ class DPCode(str, Enum):
     WATER_SET = "water_set"  # Water level
     WET = "wet"  # Humidification
     WORK_MODE = "work_mode"  # Working mode
+
+
+@dataclass
+class UnitOfMeasurement:
+    """Describes a unit of measurement."""
+
+    unit: str
+    device_classes: set[str]
+
+    aliases: set[str] = field(default_factory=set)
+    conversion_unit: str | None = None
+    conversion_fn: Callable[[float], float] | None = None
+
+
+# A tuple of available units of measurements we can work with.
+# Tuya's devices aren't consistent in UOM use, thus this provides
+# a list of aliases for units and possible conversions we can do
+# to make them compatible with our model.
+UNITS = (
+    UnitOfMeasurement(
+        unit="",
+        aliases={" "},
+        device_classes={
+            DEVICE_CLASS_AQI,
+            DEVICE_CLASS_DATE,
+            DEVICE_CLASS_MONETARY,
+            DEVICE_CLASS_TIMESTAMP,
+        },
+    ),
+    UnitOfMeasurement(
+        unit=PERCENTAGE,
+        aliases={"pct", "percent"},
+        device_classes={
+            DEVICE_CLASS_BATTERY,
+            DEVICE_CLASS_HUMIDITY,
+            DEVICE_CLASS_POWER_FACTOR,
+        },
+    ),
+    UnitOfMeasurement(
+        unit=CONCENTRATION_PARTS_PER_MILLION,
+        device_classes={
+            DEVICE_CLASS_CO,
+            DEVICE_CLASS_CO2,
+        },
+    ),
+    UnitOfMeasurement(
+        unit=CONCENTRATION_PARTS_PER_BILLION,
+        device_classes={
+            DEVICE_CLASS_CO,
+            DEVICE_CLASS_CO2,
+        },
+        conversion_unit=CONCENTRATION_PARTS_PER_MILLION,
+        conversion_fn=lambda x: x / 1000,
+    ),
+    UnitOfMeasurement(
+        unit=ELECTRIC_CURRENT_AMPERE,
+        aliases={"a", "ampere"},
+        device_classes={DEVICE_CLASS_CURRENT},
+    ),
+    UnitOfMeasurement(
+        unit=ELECTRIC_CURRENT_MILLIAMPERE,
+        aliases={"a", "ampere"},
+        device_classes={DEVICE_CLASS_CURRENT},
+        conversion_unit=ELECTRIC_CURRENT_AMPERE,
+        conversion_fn=lambda x: x / 1000,
+    ),
+    UnitOfMeasurement(
+        unit=ENERGY_WATT_HOUR,
+        aliases={"wh", "watthour"},
+        device_classes={DEVICE_CLASS_ENERGY},
+    ),
+    UnitOfMeasurement(
+        unit=ENERGY_KILO_WATT_HOUR,
+        aliases={"kwh", "kilowatt-hour"},
+        device_classes={DEVICE_CLASS_ENERGY},
+    ),
+    UnitOfMeasurement(
+        unit=VOLUME_CUBIC_FEET,
+        aliases={"ft3"},
+        device_classes={DEVICE_CLASS_GAS},
+    ),
+    UnitOfMeasurement(
+        unit=VOLUME_CUBIC_METERS,
+        aliases={"m3"},
+        device_classes={DEVICE_CLASS_GAS},
+    ),
+    UnitOfMeasurement(
+        unit=LIGHT_LUX,
+        aliases={"lux"},
+        device_classes={DEVICE_CLASS_ILLUMINANCE},
+    ),
+    UnitOfMeasurement(
+        unit="lm",
+        aliases={"lum", "lumen"},
+        device_classes={DEVICE_CLASS_ILLUMINANCE},
+    ),
+    UnitOfMeasurement(
+        unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        aliases={"ug/m3", "µg/m3", "ug/m³"},
+        device_classes={
+            DEVICE_CLASS_NITROGEN_DIOXIDE,
+            DEVICE_CLASS_NITROGEN_MONOXIDE,
+            DEVICE_CLASS_NITROUS_OXIDE,
+            DEVICE_CLASS_OZONE,
+            DEVICE_CLASS_PM1,
+            DEVICE_CLASS_PM25,
+            DEVICE_CLASS_PM10,
+            DEVICE_CLASS_SULPHUR_DIOXIDE,
+            DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS,
+        },
+    ),
+    UnitOfMeasurement(
+        unit=CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+        aliases={"mg/m3"},
+        device_classes={
+            DEVICE_CLASS_NITROGEN_DIOXIDE,
+            DEVICE_CLASS_NITROGEN_MONOXIDE,
+            DEVICE_CLASS_NITROUS_OXIDE,
+            DEVICE_CLASS_OZONE,
+            DEVICE_CLASS_PM1,
+            DEVICE_CLASS_PM25,
+            DEVICE_CLASS_PM10,
+            DEVICE_CLASS_SULPHUR_DIOXIDE,
+            DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS,
+        },
+        conversion_unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        conversion_fn=lambda x: x * 1000,
+    ),
+    UnitOfMeasurement(
+        unit=POWER_WATT,
+        aliases={"watt"},
+        device_classes={DEVICE_CLASS_POWER},
+    ),
+    UnitOfMeasurement(
+        unit=POWER_KILO_WATT,
+        aliases={"kilowatt"},
+        device_classes={DEVICE_CLASS_POWER},
+    ),
+    UnitOfMeasurement(
+        unit=PRESSURE_BAR,
+        device_classes={DEVICE_CLASS_PRESSURE},
+    ),
+    UnitOfMeasurement(
+        unit=PRESSURE_MBAR,
+        aliases={"millibar"},
+        device_classes={DEVICE_CLASS_PRESSURE},
+    ),
+    UnitOfMeasurement(
+        unit=PRESSURE_HPA,
+        aliases={"hpa", "hectopascal"},
+        device_classes={DEVICE_CLASS_PRESSURE},
+    ),
+    UnitOfMeasurement(
+        unit=PRESSURE_INHG,
+        aliases={"inhg"},
+        device_classes={DEVICE_CLASS_PRESSURE},
+    ),
+    UnitOfMeasurement(
+        unit=PRESSURE_PSI,
+        device_classes={DEVICE_CLASS_PRESSURE},
+    ),
+    UnitOfMeasurement(
+        unit=PRESSURE_PA,
+        device_classes={DEVICE_CLASS_PRESSURE},
+    ),
+    UnitOfMeasurement(
+        unit=SIGNAL_STRENGTH_DECIBELS,
+        aliases={"db"},
+        device_classes={DEVICE_CLASS_SIGNAL_STRENGTH},
+    ),
+    UnitOfMeasurement(
+        unit=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        aliases={"dbm"},
+        device_classes={DEVICE_CLASS_SIGNAL_STRENGTH},
+    ),
+    UnitOfMeasurement(
+        unit=TEMP_CELSIUS,
+        aliases={"°c", "c", "celsius"},
+        device_classes={DEVICE_CLASS_TEMPERATURE},
+    ),
+    UnitOfMeasurement(
+        unit=TEMP_FAHRENHEIT,
+        aliases={"°f", "f", "fahrenheit"},
+        device_classes={DEVICE_CLASS_TEMPERATURE},
+    ),
+    UnitOfMeasurement(
+        unit=ELECTRIC_POTENTIAL_VOLT,
+        aliases={"volt"},
+        device_classes={DEVICE_CLASS_VOLTAGE},
+    ),
+    UnitOfMeasurement(
+        unit=ELECTRIC_POTENTIAL_MILLIVOLT,
+        aliases={"mv", "millivolt"},
+        device_classes={DEVICE_CLASS_VOLTAGE},
+        conversion_unit=ELECTRIC_POTENTIAL_VOLT,
+        conversion_fn=lambda x: x / 1000,
+    ),
+)
+
+
+DEVICE_CLASS_UNITS: dict[str, dict[str, UnitOfMeasurement]] = {}
+for uom in UNITS:
+    for device_class in uom.device_classes:
+        DEVICE_CLASS_UNITS.setdefault(device_class, {})[uom.unit] = uom
+        for unit_alias in uom.aliases:
+            DEVICE_CLASS_UNITS[device_class][unit_alias] = uom
 
 
 @dataclass

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -273,7 +273,7 @@ UNITS = (
     ),
     UnitOfMeasurement(
         unit=ELECTRIC_CURRENT_MILLIAMPERE,
-        aliases={"a", "ampere"},
+        aliases={"ma", "milliampere"},
         device_classes={DEVICE_CLASS_CURRENT},
         conversion_unit=ELECTRIC_CURRENT_AMPERE,
         conversion_fn=lambda x: x / 1000,

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -31,7 +31,13 @@ from homeassistant.helpers.typing import StateType
 
 from . import HomeAssistantTuyaData
 from .base import EnumTypeData, IntegerTypeData, TuyaEntity
-from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode
+from .const import (
+    DEVICE_CLASS_UNITS,
+    DOMAIN,
+    TUYA_DISCOVERY_NEW,
+    DPCode,
+    UnitOfMeasurement,
+)
 
 # All descriptions can be found here. Mostly the Integer data types in the
 # default status set of each category (that don't have a set instruction)
@@ -209,6 +215,7 @@ class TuyaSensorEntity(TuyaEntity, SensorEntity):
 
     _status_range: TuyaDeviceStatusRange | None = None
     _type_data: IntegerTypeData | EnumTypeData | None = None
+    _uom: UnitOfMeasurement | None = None
 
     def __init__(
         self,
@@ -235,6 +242,37 @@ class TuyaSensorEntity(TuyaEntity, SensorEntity):
             elif self._status_range.type == "Enum":
                 self._type_data = EnumTypeData.from_json(self._status_range.values)
 
+        # Logic to ensure the set device class and API received Unit Of Measurement
+        # match Home Assistants requirements.
+        if (
+            self.device_class is not None
+            and description.native_unit_of_measurement is None
+        ):
+            # We cannot have a device class, if the UOM isn't set or the
+            # device class cannot be found in the validation mapping.
+            if (
+                self.unit_of_measurement is None
+                or self.device_class not in DEVICE_CLASS_UNITS
+            ):
+                self._attr_device_class = None
+                return
+
+            uoms = DEVICE_CLASS_UNITS[self.device_class]
+            self._uom = uoms.get(self.unit_of_measurement) or uoms.get(
+                self.unit_of_measurement.lower()
+            )
+
+            # Unknown unit of measurement, device should not be used.
+            if self._uom is None:
+                self._attr_device_class = None
+                return
+
+            # Found unit of measurement, use the standardized Unit
+            # Use the target conversion unit (if set)
+            self._attr_native_unit_of_measurement = (
+                self._uom.conversion_unit or self._uom.unit
+            )
+
     @property
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
@@ -253,7 +291,10 @@ class TuyaSensorEntity(TuyaEntity, SensorEntity):
 
         # Scale integer/float value
         if isinstance(self._type_data, IntegerTypeData):
-            return self._type_data.scale_value(value)
+            scaled_value = self._type_data.scale_value(value)
+            if self._uom and self._uom.conversion_fn is not None:
+                return self._uom.conversion_fn(scaled_value)
+            return scaled_value
 
         # Unexpected enum value
         if (

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -262,7 +262,7 @@ class TuyaSensorEntity(TuyaEntity, SensorEntity):
                 self.unit_of_measurement.lower()
             )
 
-            # Unknown unit of measurement, device should not be used.
+            # Unknown unit of measurement, device class should not be used.
             if self._uom is None:
                 self._attr_device_class = None
                 return


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Based on feedback by @MartinHjelmare.

This PR implementers normalization for units of measurements provided by the Tuya API and therefore can decide if a set device class is valid for the provided unit.

Examples:
- the Tuya API returns `lux` in many cases, we use the `lx` unit.
- the Tuya API can return a non-temperature unit while we have set the temperature device class.
- the Tuya API can return `mV` unit for the device class voltage, which is invalid, but we can convert it to `V` to solve that issue.

The above examples are solved using this PR.
We'll probably learn about more aliases/variants in the future (because they aren't consistently defined in their devices). For now, this should provide a solid base.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
