### PR TITLE
Update naming scheme for Renault entities

### DIFF
--- a/homeassistant/components/renault/renault_entities.py
+++ b/homeassistant/components/renault/renault_entities.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, cast
 
+from homeassistant.const import ATTR_NAME
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -46,3 +47,11 @@ class RenaultDataEntity(CoordinatorEntity[Optional[T]], Entity):
         if self.coordinator.data is None:
             return None
         return cast(StateType, getattr(self.coordinator.data, key))
+
+    @property
+    def name(self) -> str:
+        """Return the name of the entity.
+
+        Overridden to include the description.
+        """
+        return f"{self.vehicle.device_info[ATTR_NAME]} {self.entity_description.name}"

--- a/homeassistant/components/renault/renault_entities.py
+++ b/homeassistant/components/renault/renault_entities.py
@@ -52,6 +52,6 @@ class RenaultDataEntity(CoordinatorEntity[Optional[T]], Entity):
     def name(self) -> str:
         """Return the name of the entity.
 
-        Overridden to include the description.
+        Overridden to include the device name.
         """
         return f"{self.vehicle.device_info[ATTR_NAME]} {self.entity_description.name}"

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -56,9 +56,9 @@ FIXED_ATTRIBUTES = (
 DYNAMIC_ATTRIBUTES = (ATTR_ICON,)
 
 ICON_FOR_EMPTY_VALUES = {
-    "select.charge_mode": "mdi:calendar-remove",
-    "sensor.charge_state": "mdi:flash-off",
-    "sensor.plug_state": "mdi:power-plug-off",
+    "select.reg_number_charge_mode": "mdi:calendar-remove",
+    "sensor.reg_number_charge_state": "mdi:flash-off",
+    "sensor.reg_number_plug_state": "mdi:power-plug-off",
 }
 
 # Mock config data to be used across multiple tests
@@ -93,13 +93,13 @@ MOCK_VEHICLES = {
         },
         BINARY_SENSOR_DOMAIN: [
             {
-                "entity_id": "binary_sensor.plugged_in",
+                "entity_id": "binary_sensor.reg_number_plugged_in",
                 "unique_id": "vf1aaaaa555777999_plugged_in",
                 "result": STATE_ON,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_PLUG,
             },
             {
-                "entity_id": "binary_sensor.charging",
+                "entity_id": "binary_sensor.reg_number_charging",
                 "unique_id": "vf1aaaaa555777999_charging",
                 "result": STATE_ON,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY_CHARGING,
@@ -108,7 +108,7 @@ MOCK_VEHICLES = {
         DEVICE_TRACKER_DOMAIN: [],
         SELECT_DOMAIN: [
             {
-                "entity_id": "select.charge_mode",
+                "entity_id": "select.reg_number_charge_mode",
                 "unique_id": "vf1aaaaa555777999_charge_mode",
                 "result": "always",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_MODE,
@@ -118,7 +118,7 @@ MOCK_VEHICLES = {
         ],
         SENSOR_DOMAIN: [
             {
-                "entity_id": "sensor.battery_autonomy",
+                "entity_id": "sensor.reg_number_battery_autonomy",
                 "unique_id": "vf1aaaaa555777999_battery_autonomy",
                 "result": "141",
                 ATTR_ICON: "mdi:ev-station",
@@ -126,7 +126,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
             },
             {
-                "entity_id": "sensor.battery_available_energy",
+                "entity_id": "sensor.reg_number_battery_available_energy",
                 "unique_id": "vf1aaaaa555777999_battery_available_energy",
                 "result": "31",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
@@ -134,7 +134,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
             },
             {
-                "entity_id": "sensor.battery_level",
+                "entity_id": "sensor.reg_number_battery_level",
                 "unique_id": "vf1aaaaa555777999_battery_level",
                 "result": "60",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY,
@@ -142,14 +142,14 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
             },
             {
-                "entity_id": "sensor.battery_last_activity",
+                "entity_id": "sensor.reg_number_battery_last_activity",
                 "unique_id": "vf1aaaaa555777999_battery_last_activity",
                 "result": "2020-01-12T21:40:16+00:00",
                 "default_disabled": True,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_TIMESTAMP,
             },
             {
-                "entity_id": "sensor.battery_temperature",
+                "entity_id": "sensor.reg_number_battery_temperature",
                 "unique_id": "vf1aaaaa555777999_battery_temperature",
                 "result": "20",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -157,14 +157,14 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
             },
             {
-                "entity_id": "sensor.charge_state",
+                "entity_id": "sensor.reg_number_charge_state",
                 "unique_id": "vf1aaaaa555777999_charge_state",
                 "result": "charge_in_progress",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_STATE,
                 ATTR_ICON: "mdi:flash",
             },
             {
-                "entity_id": "sensor.charging_power",
+                "entity_id": "sensor.reg_number_charging_power",
                 "unique_id": "vf1aaaaa555777999_charging_power",
                 "result": "0.027",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
@@ -172,7 +172,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
             },
             {
-                "entity_id": "sensor.charging_remaining_time",
+                "entity_id": "sensor.reg_number_charging_remaining_time",
                 "unique_id": "vf1aaaaa555777999_charging_remaining_time",
                 "result": "145",
                 ATTR_ICON: "mdi:timer",
@@ -180,7 +180,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: TIME_MINUTES,
             },
             {
-                "entity_id": "sensor.mileage",
+                "entity_id": "sensor.reg_number_mileage",
                 "unique_id": "vf1aaaaa555777999_mileage",
                 "result": "49114",
                 ATTR_ICON: "mdi:sign-direction",
@@ -188,7 +188,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
             },
             {
-                "entity_id": "sensor.outside_temperature",
+                "entity_id": "sensor.reg_number_outside_temperature",
                 "unique_id": "vf1aaaaa555777999_outside_temperature",
                 "result": "8.0",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -196,7 +196,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
             },
             {
-                "entity_id": "sensor.plug_state",
+                "entity_id": "sensor.reg_number_plug_state",
                 "unique_id": "vf1aaaaa555777999_plug_state",
                 "result": "plugged",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_PLUG_STATE,
@@ -227,13 +227,13 @@ MOCK_VEHICLES = {
         },
         BINARY_SENSOR_DOMAIN: [
             {
-                "entity_id": "binary_sensor.plugged_in",
+                "entity_id": "binary_sensor.reg_number_plugged_in",
                 "unique_id": "vf1aaaaa555777999_plugged_in",
                 "result": STATE_OFF,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_PLUG,
             },
             {
-                "entity_id": "binary_sensor.charging",
+                "entity_id": "binary_sensor.reg_number_charging",
                 "unique_id": "vf1aaaaa555777999_charging",
                 "result": STATE_OFF,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY_CHARGING,
@@ -241,7 +241,7 @@ MOCK_VEHICLES = {
         ],
         DEVICE_TRACKER_DOMAIN: [
             {
-                "entity_id": "device_tracker.location",
+                "entity_id": "device_tracker.reg_number_location",
                 "unique_id": "vf1aaaaa555777999_location",
                 "result": STATE_NOT_HOME,
                 ATTR_ICON: "mdi:car",
@@ -249,7 +249,7 @@ MOCK_VEHICLES = {
         ],
         SELECT_DOMAIN: [
             {
-                "entity_id": "select.charge_mode",
+                "entity_id": "select.reg_number_charge_mode",
                 "unique_id": "vf1aaaaa555777999_charge_mode",
                 "result": "schedule_mode",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_MODE,
@@ -259,7 +259,7 @@ MOCK_VEHICLES = {
         ],
         SENSOR_DOMAIN: [
             {
-                "entity_id": "sensor.battery_autonomy",
+                "entity_id": "sensor.reg_number_battery_autonomy",
                 "unique_id": "vf1aaaaa555777999_battery_autonomy",
                 "result": "128",
                 ATTR_ICON: "mdi:ev-station",
@@ -267,7 +267,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
             },
             {
-                "entity_id": "sensor.battery_available_energy",
+                "entity_id": "sensor.reg_number_battery_available_energy",
                 "unique_id": "vf1aaaaa555777999_battery_available_energy",
                 "result": "0",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
@@ -275,7 +275,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
             },
             {
-                "entity_id": "sensor.battery_level",
+                "entity_id": "sensor.reg_number_battery_level",
                 "unique_id": "vf1aaaaa555777999_battery_level",
                 "result": "50",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY,
@@ -283,14 +283,14 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
             },
             {
-                "entity_id": "sensor.battery_last_activity",
+                "entity_id": "sensor.reg_number_battery_last_activity",
                 "unique_id": "vf1aaaaa555777999_battery_last_activity",
                 "result": "2020-11-17T08:06:48+00:00",
                 "default_disabled": True,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_TIMESTAMP,
             },
             {
-                "entity_id": "sensor.battery_temperature",
+                "entity_id": "sensor.reg_number_battery_temperature",
                 "unique_id": "vf1aaaaa555777999_battery_temperature",
                 "result": STATE_UNKNOWN,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -298,14 +298,14 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
             },
             {
-                "entity_id": "sensor.charge_state",
+                "entity_id": "sensor.reg_number_charge_state",
                 "unique_id": "vf1aaaaa555777999_charge_state",
                 "result": "charge_error",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_STATE,
                 ATTR_ICON: "mdi:flash-off",
             },
             {
-                "entity_id": "sensor.charging_power",
+                "entity_id": "sensor.reg_number_charging_power",
                 "unique_id": "vf1aaaaa555777999_charging_power",
                 "result": STATE_UNKNOWN,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_CURRENT,
@@ -313,7 +313,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: ELECTRIC_CURRENT_AMPERE,
             },
             {
-                "entity_id": "sensor.charging_remaining_time",
+                "entity_id": "sensor.reg_number_charging_remaining_time",
                 "unique_id": "vf1aaaaa555777999_charging_remaining_time",
                 "result": STATE_UNKNOWN,
                 ATTR_ICON: "mdi:timer",
@@ -321,7 +321,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: TIME_MINUTES,
             },
             {
-                "entity_id": "sensor.mileage",
+                "entity_id": "sensor.reg_number_mileage",
                 "unique_id": "vf1aaaaa555777999_mileage",
                 "result": "49114",
                 ATTR_ICON: "mdi:sign-direction",
@@ -329,14 +329,14 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
             },
             {
-                "entity_id": "sensor.plug_state",
+                "entity_id": "sensor.reg_number_plug_state",
                 "unique_id": "vf1aaaaa555777999_plug_state",
                 "result": "unplugged",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_PLUG_STATE,
                 ATTR_ICON: "mdi:power-plug-off",
             },
             {
-                "entity_id": "sensor.location_last_activity",
+                "entity_id": "sensor.reg_number_location_last_activity",
                 "unique_id": "vf1aaaaa555777999_location_last_activity",
                 "result": "2020-02-18T16:58:38+00:00",
                 "default_disabled": True,
@@ -367,13 +367,13 @@ MOCK_VEHICLES = {
         },
         BINARY_SENSOR_DOMAIN: [
             {
-                "entity_id": "binary_sensor.plugged_in",
+                "entity_id": "binary_sensor.reg_number_plugged_in",
                 "unique_id": "vf1aaaaa555777123_plugged_in",
                 "result": STATE_ON,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_PLUG,
             },
             {
-                "entity_id": "binary_sensor.charging",
+                "entity_id": "binary_sensor.reg_number_charging",
                 "unique_id": "vf1aaaaa555777123_charging",
                 "result": STATE_ON,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY_CHARGING,
@@ -381,7 +381,7 @@ MOCK_VEHICLES = {
         ],
         DEVICE_TRACKER_DOMAIN: [
             {
-                "entity_id": "device_tracker.location",
+                "entity_id": "device_tracker.reg_number_location",
                 "unique_id": "vf1aaaaa555777123_location",
                 "result": STATE_NOT_HOME,
                 ATTR_ICON: "mdi:car",
@@ -389,7 +389,7 @@ MOCK_VEHICLES = {
         ],
         SELECT_DOMAIN: [
             {
-                "entity_id": "select.charge_mode",
+                "entity_id": "select.reg_number_charge_mode",
                 "unique_id": "vf1aaaaa555777123_charge_mode",
                 "result": "always",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_MODE,
@@ -399,7 +399,7 @@ MOCK_VEHICLES = {
         ],
         SENSOR_DOMAIN: [
             {
-                "entity_id": "sensor.battery_autonomy",
+                "entity_id": "sensor.reg_number_battery_autonomy",
                 "unique_id": "vf1aaaaa555777123_battery_autonomy",
                 "result": "141",
                 ATTR_ICON: "mdi:ev-station",
@@ -407,7 +407,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
             },
             {
-                "entity_id": "sensor.battery_available_energy",
+                "entity_id": "sensor.reg_number_battery_available_energy",
                 "unique_id": "vf1aaaaa555777123_battery_available_energy",
                 "result": "31",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
@@ -415,7 +415,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
             },
             {
-                "entity_id": "sensor.battery_level",
+                "entity_id": "sensor.reg_number_battery_level",
                 "unique_id": "vf1aaaaa555777123_battery_level",
                 "result": "60",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY,
@@ -423,14 +423,14 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
             },
             {
-                "entity_id": "sensor.battery_last_activity",
+                "entity_id": "sensor.reg_number_battery_last_activity",
                 "unique_id": "vf1aaaaa555777123_battery_last_activity",
                 "result": "2020-01-12T21:40:16+00:00",
                 "default_disabled": True,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_TIMESTAMP,
             },
             {
-                "entity_id": "sensor.battery_temperature",
+                "entity_id": "sensor.reg_number_battery_temperature",
                 "unique_id": "vf1aaaaa555777123_battery_temperature",
                 "result": "20",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -438,14 +438,14 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
             },
             {
-                "entity_id": "sensor.charge_state",
+                "entity_id": "sensor.reg_number_charge_state",
                 "unique_id": "vf1aaaaa555777123_charge_state",
                 "result": "charge_in_progress",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_CHARGE_STATE,
                 ATTR_ICON: "mdi:flash",
             },
             {
-                "entity_id": "sensor.charging_power",
+                "entity_id": "sensor.reg_number_charging_power",
                 "unique_id": "vf1aaaaa555777123_charging_power",
                 "result": "27.0",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_CURRENT,
@@ -453,7 +453,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: ELECTRIC_CURRENT_AMPERE,
             },
             {
-                "entity_id": "sensor.charging_remaining_time",
+                "entity_id": "sensor.reg_number_charging_remaining_time",
                 "unique_id": "vf1aaaaa555777123_charging_remaining_time",
                 "result": "145",
                 ATTR_ICON: "mdi:timer",
@@ -461,7 +461,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: TIME_MINUTES,
             },
             {
-                "entity_id": "sensor.fuel_autonomy",
+                "entity_id": "sensor.reg_number_fuel_autonomy",
                 "unique_id": "vf1aaaaa555777123_fuel_autonomy",
                 "result": "35",
                 ATTR_ICON: "mdi:gas-station",
@@ -469,7 +469,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
             },
             {
-                "entity_id": "sensor.fuel_quantity",
+                "entity_id": "sensor.reg_number_fuel_quantity",
                 "unique_id": "vf1aaaaa555777123_fuel_quantity",
                 "result": "3",
                 ATTR_ICON: "mdi:fuel",
@@ -477,7 +477,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: VOLUME_LITERS,
             },
             {
-                "entity_id": "sensor.mileage",
+                "entity_id": "sensor.reg_number_mileage",
                 "unique_id": "vf1aaaaa555777123_mileage",
                 "result": "5567",
                 ATTR_ICON: "mdi:sign-direction",
@@ -485,14 +485,14 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
             },
             {
-                "entity_id": "sensor.plug_state",
+                "entity_id": "sensor.reg_number_plug_state",
                 "unique_id": "vf1aaaaa555777123_plug_state",
                 "result": "plugged",
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_PLUG_STATE,
                 ATTR_ICON: "mdi:power-plug",
             },
             {
-                "entity_id": "sensor.location_last_activity",
+                "entity_id": "sensor.reg_number_location_last_activity",
                 "unique_id": "vf1aaaaa555777123_location_last_activity",
                 "result": "2020-02-18T16:58:38+00:00",
                 "default_disabled": True,
@@ -522,7 +522,7 @@ MOCK_VEHICLES = {
         BINARY_SENSOR_DOMAIN: [],
         DEVICE_TRACKER_DOMAIN: [
             {
-                "entity_id": "device_tracker.location",
+                "entity_id": "device_tracker.reg_number_location",
                 "unique_id": "vf1aaaaa555777123_location",
                 "result": STATE_NOT_HOME,
                 ATTR_ICON: "mdi:car",
@@ -531,7 +531,7 @@ MOCK_VEHICLES = {
         SELECT_DOMAIN: [],
         SENSOR_DOMAIN: [
             {
-                "entity_id": "sensor.fuel_autonomy",
+                "entity_id": "sensor.reg_number_fuel_autonomy",
                 "unique_id": "vf1aaaaa555777123_fuel_autonomy",
                 "result": "35",
                 ATTR_ICON: "mdi:gas-station",
@@ -539,7 +539,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
             },
             {
-                "entity_id": "sensor.fuel_quantity",
+                "entity_id": "sensor.reg_number_fuel_quantity",
                 "unique_id": "vf1aaaaa555777123_fuel_quantity",
                 "result": "3",
                 ATTR_ICON: "mdi:fuel",
@@ -547,7 +547,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: VOLUME_LITERS,
             },
             {
-                "entity_id": "sensor.mileage",
+                "entity_id": "sensor.reg_number_mileage",
                 "unique_id": "vf1aaaaa555777123_mileage",
                 "result": "5567",
                 ATTR_ICON: "mdi:sign-direction",
@@ -555,7 +555,7 @@ MOCK_VEHICLES = {
                 ATTR_UNIT_OF_MEASUREMENT: LENGTH_KILOMETERS,
             },
             {
-                "entity_id": "sensor.location_last_activity",
+                "entity_id": "sensor.reg_number_location_last_activity",
                 "unique_id": "vf1aaaaa555777123_location_last_activity",
                 "result": "2020-02-18T16:58:38+00:00",
                 "default_disabled": True,

--- a/tests/components/renault/test_select.py
+++ b/tests/components/renault/test_select.py
@@ -171,7 +171,7 @@ async def test_select_charge_mode(hass: HomeAssistant):
     await setup_renault_integration_vehicle(hass, "zoe_40")
 
     data = {
-        ATTR_ENTITY_ID: "select.charge_mode",
+        ATTR_ENTITY_ID: "select.reg_number_charge_mode",
         ATTR_OPTION: "always",
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add car plate to entity naming scheme.
Fixes #57371

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #57371
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
