### PR TITLE
Allow setting the nexia run mode with the hvac mode

### DIFF
--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -70,21 +70,17 @@ SET_HUMIDITY_SCHEMA = {
     vol.Required(ATTR_HUMIDITY): vol.All(vol.Coerce(int), vol.Range(min=35, max=65)),
 }
 
-SET_HVAC_RUN_MODE_SCHEMA = {
+SET_HVAC_RUN_MODE_SCHEMA = vol.All(
+    cv.has_at_least_one_key(ATTR_RUN_MODE, ATTR_HVAC_MODE),
     cv.make_entity_service_schema(
-        vol.All(
-            {
-                vol.Optional(ATTR_RUN_MODE): vol.In(
-                    [HOLD_PERMANENT, HOLD_RESUME_SCHEDULE]
-                ),
-                vol.Optional(ATTR_HVAC_MODE): vol.In(
-                    [HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_AUTO]
-                ),
-            },
-            cv.has_at_least_one_key(ATTR_RUN_MODE, ATTR_HVAC_MODE),
-        )
-    )
-}
+        {
+            vol.Optional(ATTR_RUN_MODE): vol.In([HOLD_PERMANENT, HOLD_RESUME_SCHEDULE]),
+            vol.Optional(ATTR_HVAC_MODE): vol.In(
+                [HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_AUTO]
+            ),
+        }
+    ),
+)
 
 #
 # Nexia has two bits to determine hvac mode

--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -71,14 +71,18 @@ SET_HUMIDITY_SCHEMA = {
 }
 
 SET_HVAC_RUN_MODE_SCHEMA = {
-    vol.All(
-        {
-            vol.Optional(ATTR_RUN_MODE): vol.In([HOLD_PERMANENT, HOLD_RESUME_SCHEDULE]),
-            vol.Optional(ATTR_HVAC_MODE): vol.In(
-                [HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_AUTO]
-            ),
-        },
-        cv.has_at_least_one_key(ATTR_RUN_MODE, ATTR_HVAC_MODE),
+    cv.make_entity_service_schema(
+        vol.All(
+            {
+                vol.Optional(ATTR_RUN_MODE): vol.In(
+                    [HOLD_PERMANENT, HOLD_RESUME_SCHEDULE]
+                ),
+                vol.Optional(ATTR_HVAC_MODE): vol.In(
+                    [HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_AUTO]
+                ),
+            },
+            cv.has_at_least_one_key(ATTR_RUN_MODE, ATTR_HVAC_MODE),
+        )
     )
 }
 

--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -216,6 +216,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
                 self._zone.call_return_to_schedule()
         if hvac_mode is not None:
             self._zone.set_mode(mode=HA_TO_NEXIA_HVAC_MODE_MAP[hvac_mode])
+        self._signal_thermostat_update()
 
     @property
     def preset_mode(self):

--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -1,5 +1,7 @@
 """Support for Nexia / Trane XL thermostats."""
 from nexia.const import (
+    HOLD_PERMANENT,
+    HOLD_RESUME_SCHEDULE,
     OPERATION_MODE_AUTO,
     OPERATION_MODE_COOL,
     OPERATION_MODE_HEAT,
@@ -14,6 +16,7 @@ import voluptuous as vol
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_HUMIDITY,
+    ATTR_HVAC_MODE,
     ATTR_MAX_HUMIDITY,
     ATTR_MIN_HUMIDITY,
     ATTR_TARGET_TEMP_HIGH,
@@ -45,6 +48,7 @@ from .const import (
     ATTR_DEHUMIDIFY_SUPPORTED,
     ATTR_HUMIDIFY_SETPOINT,
     ATTR_HUMIDIFY_SUPPORTED,
+    ATTR_RUN_MODE,
     ATTR_ZONE_STATUS,
     DOMAIN,
     SIGNAL_THERMOSTAT_UPDATE,
@@ -56,6 +60,7 @@ from .util import percent_conv
 
 SERVICE_SET_AIRCLEANER_MODE = "set_aircleaner_mode"
 SERVICE_SET_HUMIDIFY_SETPOINT = "set_humidify_setpoint"
+SERVICE_SET_HVAC_RUN_MODE = "set_hvac_run_mode"
 
 SET_AIRCLEANER_SCHEMA = {
     vol.Required(ATTR_AIRCLEANER_MODE): cv.string,
@@ -65,6 +70,17 @@ SET_HUMIDITY_SCHEMA = {
     vol.Required(ATTR_HUMIDITY): vol.All(vol.Coerce(int), vol.Range(min=35, max=65)),
 }
 
+SET_HVAC_RUN_MODE_SCHEMA = {
+    vol.All(
+        {
+            vol.Optional(ATTR_RUN_MODE): vol.In([HOLD_PERMANENT, HOLD_RESUME_SCHEDULE]),
+            vol.Optional(ATTR_HVAC_MODE): vol.In(
+                [HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_AUTO]
+            ),
+        },
+        cv.has_at_least_one_key(ATTR_RUN_MODE, ATTR_HVAC_MODE),
+    )
+}
 
 #
 # Nexia has two bits to determine hvac mode
@@ -101,6 +117,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
     platform.async_register_entity_service(
         SERVICE_SET_AIRCLEANER_MODE, SET_AIRCLEANER_SCHEMA, SERVICE_SET_AIRCLEANER_MODE
+    )
+    platform.async_register_entity_service(
+        SERVICE_SET_HVAC_RUN_MODE, SET_HVAC_RUN_MODE_SCHEMA, SERVICE_SET_HVAC_RUN_MODE
     )
 
     entities = []
@@ -187,6 +206,16 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         """Set new target fan mode."""
         self._thermostat.set_fan_mode(fan_mode)
         self._signal_thermostat_update()
+
+    def set_hvac_run_mode(self, run_mode, hvac_mode):
+        """Set the hvac run mode."""
+        if run_mode is not None:
+            if run_mode == HOLD_PERMANENT:
+                self._zone.call_permanent_hold()
+            else:
+                self._zone.call_return_to_schedule()
+        if hvac_mode is not None:
+            self._zone.set_mode(mode=HA_TO_NEXIA_HVAC_MODE_MAP[hvac_mode])
 
     @property
     def preset_mode(self):

--- a/homeassistant/components/nexia/const.py
+++ b/homeassistant/components/nexia/const.py
@@ -18,6 +18,8 @@ ATTR_DESCRIPTION = "description"
 
 ATTR_AIRCLEANER_MODE = "aircleaner_mode"
 
+ATTR_RUN_MODE = "run_mode"
+
 ATTR_ZONE_STATUS = "zone_status"
 ATTR_HUMIDIFY_SUPPORTED = "humidify_supported"
 ATTR_DEHUMIDIFY_SUPPORTED = "dehumidify_supported"

--- a/homeassistant/components/nexia/services.yaml
+++ b/homeassistant/components/nexia/services.yaml
@@ -34,3 +34,31 @@ set_humidify_setpoint:
           min: 35
           max: 65
           unit_of_measurement: '%'
+
+set_hvac_run_mode:
+  name: Set hvac run mode
+  description: "The hvac run mode."
+  target:
+    entity:
+      integration: nexia
+      domain: climate
+  fields:
+    run_mode:
+      name: Run mode
+      description: 'Run the schedule or hold. If not specified, the current run mode will be used.'
+      required: false
+      selector:
+        select:
+          options:
+            - 'permanent_hold'
+            - 'run_schedule'
+    hvac_mode:
+      name: Hvac mode
+      description: 'The hvac mode to use for the schedule or hold. If not specified, the current hvac mode will be used.'
+      required: false
+      selector:
+        select:
+          options:
+            - 'auto'
+            - 'cool'
+            - 'heat'


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow setting the nexia run mode with the hvac mode

- Users wanted to be able to set auto mode without returning
  to the schedule, or temporarily override the hvac_mode without
  setting a perm hold


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
- Users wanted to be able to set auto mode without returning
  to the schedule, or temporarily override the hvac_mode without
  setting a perm hold