### PR TITLE
2021.10.6

### DIFF
--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -122,7 +122,7 @@ class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, BinarySensorEntity):
             if has_check_control_messages:
                 cbs_list = []
                 for message in check_control_messages:
-                    cbs_list.append(message.description_short)
+                    cbs_list.append(message["ccmDescriptionShort"])
                 result["check_control_messages"] = cbs_list
             else:
                 result["check_control_messages"] = "OK"

--- a/homeassistant/components/bond/manifest.json
+++ b/homeassistant/components/bond/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bond",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/bond",
-  "requirements": ["bond-api==0.1.13"],
+  "requirements": ["bond-api==0.1.14"],
   "zeroconf": ["_bond._tcp.local."],
   "codeowners": ["@prystupa", "@joshs85"],
   "quality_scale": "platinum",

--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -1,12 +1,10 @@
 """The Logitech Harmony Hub integration."""
-import asyncio
 import logging
 
 from homeassistant.components.remote import ATTR_ACTIVITY, ATTR_DELAY_SECS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -34,13 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     address = entry.data[CONF_HOST]
     name = entry.data[CONF_NAME]
     data = HarmonyData(hass, address, name, entry.unique_id)
-    try:
-        connected_ok = await data.connect()
-    except (asyncio.TimeoutError, ValueError, AttributeError) as err:
-        raise ConfigEntryNotReady from err
-
-    if not connected_ok:
-        raise ConfigEntryNotReady
+    await data.connect()
 
     await _migrate_old_unique_ids(hass, entry.entry_id, data)
 
@@ -51,8 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     cancel_stop = hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, _async_on_stop)
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         HARMONY_DATA: data,
         CANCEL_LISTENER: cancel_listener,
         CANCEL_STOP: cancel_stop,

--- a/homeassistant/components/harmony/manifest.json
+++ b/homeassistant/components/harmony/manifest.json
@@ -2,7 +2,7 @@
   "domain": "harmony",
   "name": "Logitech Harmony Hub",
   "documentation": "https://www.home-assistant.io/integrations/harmony",
-  "requirements": ["aioharmony==0.2.7"],
+  "requirements": ["aioharmony==0.2.8"],
   "codeowners": [
     "@ehendrix23",
     "@bramkragten",

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -5,6 +5,7 @@ import logging
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_PRESSURE,
@@ -68,32 +69,32 @@ ENERGY_SENSOR_MAP = {
     "electricity_consumed_interval": [
         "Consumed Power Interval",
         ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
     "electricity_consumed_peak_interval": [
         "Consumed Power Interval",
         ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
     "electricity_consumed_off_peak_interval": [
         "Consumed Power Interval (off peak)",
         ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
     "electricity_produced_interval": [
         "Produced Power Interval",
         ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
     "electricity_produced_peak_interval": [
         "Produced Power Interval",
         ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
     "electricity_produced_off_peak_interval": [
         "Produced Power Interval (off peak)",
         ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
     "electricity_consumed_off_peak_point": [
         "Current Consumed Power (off peak)",
@@ -108,12 +109,12 @@ ENERGY_SENSOR_MAP = {
     "electricity_consumed_off_peak_cumulative": [
         "Cumulative Consumed Power (off peak)",
         ENERGY_KILO_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
     "electricity_consumed_peak_cumulative": [
         "Cumulative Consumed Power",
         ENERGY_KILO_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
     "electricity_produced_off_peak_point": [
         "Current Produced Power (off peak)",
@@ -128,12 +129,12 @@ ENERGY_SENSOR_MAP = {
     "electricity_produced_off_peak_cumulative": [
         "Cumulative Produced Power (off peak)",
         ENERGY_KILO_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
     "electricity_produced_peak_cumulative": [
         "Cumulative Produced Power",
         ENERGY_KILO_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
     "gas_consumed_interval": [
         "Current Consumed Gas Interval",
@@ -145,7 +146,7 @@ ENERGY_SENSOR_MAP = {
     "net_electricity_cumulative": [
         "Cumulative net Power",
         ENERGY_KILO_WATT_HOUR,
-        DEVICE_CLASS_POWER,
+        DEVICE_CLASS_ENERGY,
     ],
 }
 

--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -60,7 +60,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await async_migrate_entries(hass, entry.entry_id, async_migrate_callback)
 
-    websession = aiohttp_client.async_get_clientsession(hass)
+    # Tile's API uses cookies to identify a consumer; in order to allow for multiple
+    # instances of this config entry, we use a new session each time:
+    websession = aiohttp_client.async_create_clientsession(hass)
 
     try:
         client = await async_login(

--- a/homeassistant/components/tile/manifest.json
+++ b/homeassistant/components/tile/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tile",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tile",
-  "requirements": ["pytile==5.2.3"],
+  "requirements": ["pytile==5.2.4"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 10
-PATCH_VERSION: Final = "5"
+PATCH_VERSION: Final = "6"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,7 +179,7 @@ aiogithubapi==21.8.0
 aioguardian==1.0.8
 
 # homeassistant.components.harmony
-aioharmony==0.2.7
+aioharmony==0.2.8
 
 # homeassistant.components.homekit_controller
 aiohomekit==0.6.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -415,7 +415,7 @@ blockchain==1.4.4
 # bme680==1.0.5
 
 # homeassistant.components.bond
-bond-api==0.1.13
+bond-api==0.1.14
 
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.19

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1964,7 +1964,7 @@ python_opendata_transport==0.2.1
 pythonegardia==1.0.40
 
 # homeassistant.components.tile
-pytile==5.2.3
+pytile==5.2.4
 
 # homeassistant.components.touchline
 pytouchline==0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1127,7 +1127,7 @@ python-twitch-client==0.6.0
 python_awair==0.2.1
 
 # homeassistant.components.tile
-pytile==5.2.3
+pytile==5.2.4
 
 # homeassistant.components.traccar
 pytraccar==0.9.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -254,7 +254,7 @@ blebox_uniapi==1.3.3
 blinkpy==0.17.0
 
 # homeassistant.components.bond
-bond-api==0.1.13
+bond-api==0.1.14
 
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.19

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -118,7 +118,7 @@ aioflo==0.4.1
 aioguardian==1.0.8
 
 # homeassistant.components.harmony
-aioharmony==0.2.7
+aioharmony==0.2.8
 
 # homeassistant.components.homekit_controller
 aiohomekit==0.6.3

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the Logitech Harmony Hub config flow."""
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
+
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.harmony.config_flow import CannotConnect
 from homeassistant.components.harmony.const import DOMAIN, PREVIOUS_ACTIVE_ACTIVITY
@@ -50,11 +52,9 @@ async def test_form_ssdp(hass):
     """Test we get the form with ssdp source."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    harmonyapi = _get_mock_harmonyapi(connect=True)
-
     with patch(
-        "homeassistant.components.harmony.util.HarmonyAPI",
-        return_value=harmonyapi,
+        "homeassistant.components.harmony.config_flow.HubConnector.get_remote_id",
+        return_value=1234,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -76,6 +76,8 @@ async def test_form_ssdp(hass):
     assert progress[0]["flow_id"] == result["flow_id"]
     assert progress[0]["context"]["confirm_only"] is True
 
+    harmonyapi = _get_mock_harmonyapi(connect=True)
+
     with patch(
         "homeassistant.components.harmony.util.HarmonyAPI",
         return_value=harmonyapi,
@@ -93,6 +95,25 @@ async def test_form_ssdp(hass):
     assert result2["title"] == "Harmony Hub"
     assert result2["data"] == {"host": "192.168.1.12", "name": "Harmony Hub"}
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_ssdp_fails_to_get_remote_id(hass):
+    """Test we abort if we cannot get the remote id."""
+
+    with patch(
+        "homeassistant.components.harmony.config_flow.HubConnector.get_remote_id",
+        side_effect=aiohttp.ClientError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_SSDP},
+            data={
+                "friendlyName": "Harmony Hub",
+                "ssdp_location": "http://192.168.1.12:8088/description",
+            },
+        )
+    assert result["type"] == "abort"
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_form_ssdp_aborts_before_checking_remoteid_if_host_known(hass):

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -502,6 +502,18 @@ async def test_discovered_by_dhcp_or_homekit(hass, source, data):
     assert mock_async_setup.called
     assert mock_async_setup_entry.called
 
+    with _patch_discovery(
+        no_device=True
+    ), _patch_discovery_timeout(), _patch_discovery_interval(), patch(
+        f"{MODULE_CONFIG_FLOW}.AsyncBulb", side_effect=CannotConnect
+    ):
+        result3 = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": source}, data=data
+        )
+        await hass.async_block_till_done()
+    assert result3["type"] == RESULT_TYPE_ABORT
+    assert result3["reason"] == "already_configured"
+
 
 @pytest.mark.parametrize(
     "source, data",


### PR DESCRIPTION
- Avoid setting up harmony websocket from discovery ([@bdraco] - [#57589]) ([harmony docs])
- Fix device class for energy plugwise sensors ([@squio] - [#57803]) ([plugwise docs])
- Prevent yeelight discovery from overloading the bulb ([@bdraco] - [#57820]) ([yeelight docs])
- Bump bond-api to 0.1.14 ([@bdraco] - [#57874]) ([bond docs])
- Revert "Fix bmw_conntected_drive check_control_message short description" ([@cdce8p] - [#57928]) ([bmw_connected_drive docs])
- Fix bug that prevents multiple instances of Tile ([@bachya] - [#57942]) ([tile docs])

[#57589]: https://github.com/home-assistant/core/pull/57589
[#57803]: https://github.com/home-assistant/core/pull/57803
[#57820]: https://github.com/home-assistant/core/pull/57820
[#57874]: https://github.com/home-assistant/core/pull/57874
[#57928]: https://github.com/home-assistant/core/pull/57928
[#57942]: https://github.com/home-assistant/core/pull/57942
[@bachya]: https://github.com/bachya
[@bdraco]: https://github.com/bdraco
[@cdce8p]: https://github.com/cdce8p
[@squio]: https://github.com/squio
[bmw_connected_drive docs]: https://www.home-assistant.io/integrations/bmw_connected_drive/
[bond docs]: https://www.home-assistant.io/integrations/bond/
[harmony docs]: https://www.home-assistant.io/integrations/harmony/
[plugwise docs]: https://www.home-assistant.io/integrations/plugwise/
[tile docs]: https://www.home-assistant.io/integrations/tile/
[yeelight docs]: https://www.home-assistant.io/integrations/yeelight/