### PR TITLE
Add manual step to Broadlink configuration flow

### DIFF
--- a/homeassistant/components/broadlink/__init__.py
+++ b/homeassistant/components/broadlink/__init__.py
@@ -2,10 +2,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import logging
 
-from .const import DOMAIN
+from homeassistant.const import CONF_TYPE
+
+from .const import CONF_PRODUCT_ID, DOMAIN
 from .device import BroadlinkDevice
 from .heartbeat import BroadlinkHeartbeat
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -47,3 +52,18 @@ async def async_unload_entry(hass, entry):
         data.heartbeat = None
 
     return result
+
+
+async def async_migrate_entry(hass, entry):
+    """Migrate a config entry."""
+    if entry.version == 1:
+        new = {**entry.data}
+
+        new[CONF_PRODUCT_ID] = new.pop(CONF_TYPE)
+
+        entry.data = {**new}
+        entry.version = 2
+
+        _LOGGER.info("Migration to version %s successful", entry.version)
+
+    return True

--- a/homeassistant/components/broadlink/const.py
+++ b/homeassistant/components/broadlink/const.py
@@ -5,6 +5,11 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 
 DOMAIN = "broadlink"
 
+CONF_DEVICE_TYPE = "device_type"
+CONF_PRODUCT_ID = "product_id"
+
+LIBRARY_URL = "https://github.com/mjg59/python-broadlink"
+
 DOMAINS_AND_TYPES = {
     REMOTE_DOMAIN: {"RM4MINI", "RM4PRO", "RMMINI", "RMMINIB", "RMPRO"},
     SENSOR_DOMAIN: {
@@ -34,6 +39,7 @@ DOMAINS_AND_TYPES = {
         "SP4B",
     },
 }
+DEVICE_TYPES = set.union(*DOMAINS_AND_TYPES.values())
 
 DEFAULT_PORT = 80
 DEFAULT_TIMEOUT = 5

--- a/homeassistant/components/broadlink/strings.json
+++ b/homeassistant/components/broadlink/strings.json
@@ -9,6 +9,13 @@
           "timeout": "Timeout"
         }
       },
+      "manual": {
+        "title": "Manual configuration",
+        "description": "Sorry, we don't know what kind of device this is. You can try to configure it manually by selecting an appropriate device type.\n\nIf you can make it work, please open an issue or pull request at {url}.",
+        "data": {
+          "device_type": "Device type"
+        }
+      },
       "auth": {
         "title": "Authenticate to the device"
       },

--- a/homeassistant/components/broadlink/translations/en.json
+++ b/homeassistant/components/broadlink/translations/en.json
@@ -24,6 +24,13 @@
                 },
                 "title": "Choose a name for the device"
             },
+            "manual": {
+                "title": "Manual configuration",
+                "description": "Sorry, we don't know what kind of device this is. You can try to configure it manually by selecting an appropriate device type.\n\nIf you can make it work, please open an issue or pull request at {url}.",
+                "data": {
+                    "device_type": "Device type"
+                }
+            },
             "reset": {
                 "description": "{name} ({model} at {host}) is locked. You need to unlock the device in order to authenticate and complete the configuration. Instructions:\n1. Open the Broadlink app.\n2. Click on the device.\n3. Click `...` in the upper right.\n4. Scroll to the bottom of the page.\n5. Disable the lock.",
                 "title": "Unlock the device"

--- a/tests/components/broadlink/__init__.py
+++ b/tests/components/broadlink/__init__.py
@@ -68,6 +68,16 @@ BROADLINK_DEVICES = {
         57,
         5,
     ),
+    "Attic": (  # Unknown device type.
+        "109.97.99.104",
+        "696e65667265",
+        "",
+        "",
+        "Unknown",
+        0x6E63,
+        107,
+        5,
+    ),
 }
 
 
@@ -84,18 +94,27 @@ class BroadlinkDevice:
     """Representation of a Broadlink device."""
 
     def __init__(
-        self, name, host, mac, model, manufacturer, type_, devtype, fwversion, timeout
-    ):
+        self,
+        name: str,
+        host: str,
+        mac: str,
+        model: str,
+        manufacturer: str,
+        device_type: int,
+        product_id: int,
+        fwversion: int,
+        timeout: int,
+    ) -> None:
         """Initialize the device."""
-        self.name: str = name
-        self.host: str = host
-        self.mac: str = mac
-        self.model: str = model
-        self.manufacturer: str = manufacturer
-        self.type: str = type_
-        self.devtype: int = devtype
-        self.timeout: int = timeout
-        self.fwversion: int = fwversion
+        self.name = name
+        self.host = host
+        self.mac = mac
+        self.model = model
+        self.manufacturer = manufacturer
+        self.type = device_type
+        self.devtype = product_id
+        self.fwversion = fwversion
+        self.timeout = timeout
 
     async def setup_entry(self, hass, mock_api=None, mock_entry=None):
         """Set up the device."""
@@ -128,13 +147,18 @@ class BroadlinkDevice:
         mock_api.get_fwversion.return_value = self.fwversion
         return mock_api
 
-    def get_mock_entry(self):
+    def get_mock_entry(self, extra_config=None):
         """Return a mock config entry."""
+        data = self.get_entry_data()
+        if extra_config is not None:
+            data.update(extra_config)
+
         return MockConfigEntry(
             domain=DOMAIN,
             unique_id=self.mac,
             title=self.name,
-            data=self.get_entry_data(),
+            data=data,
+            version=2,
         )
 
     def get_entry_data(self):
@@ -142,7 +166,7 @@ class BroadlinkDevice:
         return {
             "host": self.host,
             "mac": self.mac,
-            "type": self.devtype,
+            "product_id": self.devtype,
             "timeout": self.timeout,
         }
 

--- a/tests/components/broadlink/test_config_flow.py
+++ b/tests/components/broadlink/test_config_flow.py
@@ -229,6 +229,54 @@ async def test_flow_user_os_error(hass):
     assert result["errors"] == {"base": "unknown"}
 
 
+async def test_flow_manual_works(hass):
+    """Test we allow the user to configure an unknown device."""
+    device = get_device("Attic")
+    mock_api = device.get_mock_api()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(DEVICE_HELLO, return_value=mock_api) as mock_hello:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "manual"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"device_type": "RM4PRO"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "finish"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": device.name},
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == device.name
+    assert result["data"] == {
+        **device.get_entry_data(),
+        "device_type": "RM4PRO",
+    }
+
+    assert mock_hello.call_count == 1
+    assert mock_api.auth.call_count == 1
+
+
 async def test_flow_auth_authentication_error(hass):
     """Test we handle an authentication error in the auth step."""
     device = get_device("Living Room")
@@ -570,7 +618,7 @@ async def test_flow_import_works(hass):
     assert result["title"] == device.name
     assert result["data"]["host"] == device.host
     assert result["data"]["mac"] == device.mac
-    assert result["data"]["type"] == device.devtype
+    assert result["data"]["product_id"] == device.devtype
 
     assert mock_api.auth.call_count == 1
     assert mock_hello.call_count == 1
@@ -637,7 +685,7 @@ async def test_flow_import_mac_already_configured(hass):
 
     assert mock_entry.data["host"] == device.host
     assert mock_entry.data["mac"] == device.mac
-    assert mock_entry.data["type"] == device.devtype
+    assert mock_entry.data["product_id"] == device.devtype
     assert mock_api.auth.call_count == 0
 
 
@@ -827,38 +875,36 @@ async def test_dhcp_can_finish(hass):
     """Test DHCP discovery flow can finish right away."""
 
     device = get_device("Living Room")
-    device.host = "1.2.3.4"
     mock_api = device.get_mock_api()
 
-    with patch(DEVICE_HELLO, return_value=mock_api):
+    with patch(DEVICE_HELLO, return_value=mock_api) as mock_hello:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
             data={
                 HOSTNAME: "broadlink",
-                IP_ADDRESS: "1.2.3.4",
+                IP_ADDRESS: device.host,
                 MAC_ADDRESS: device_registry.format_mac(device.mac),
             },
         )
-        await hass.async_block_till_done()
 
     assert result["type"] == "form"
     assert result["step_id"] == "finish"
+    assert result["errors"] == {}
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {},
+        {"name": device.name},
     )
-    await hass.async_block_till_done()
 
-    assert result2["type"] == "create_entry"
-    assert result2["title"] == "Living Room"
-    assert result2["data"] == {
-        "host": "1.2.3.4",
-        "mac": "34ea34b43b5a",
-        "timeout": 10,
-        "type": 24374,
-    }
+    assert result["type"] == "create_entry"
+    assert result["title"] == device.name
+    assert result["data"]["host"] == device.host
+    assert result["data"]["mac"] == device.mac
+    assert result["data"]["product_id"] == device.devtype
+
+    assert mock_hello.call_count == 1
+    assert mock_api.auth.call_count == 1
 
 
 async def test_dhcp_fails_to_connect(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Bump the config entries to version 2. I added a migration, it's very simple, things won't break, but it's import to mention.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a manual step to Broadlink configuration flow.

We show this step when we encounter an unknown device type. Then we allow the user to configure the device manually by selecting an appropriate device type.

Advantages:
- users don't need to wait for library updates when the type is already supported, but unknown
- users can easily run compatibility tests, they no longer need complicated steps to figure out the right class to control the device

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
