### PR TITLE
Use pytest fixtures on Onewire tests

### DIFF
--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -8,7 +8,6 @@ from pyownet.protocol import ProtocolError
 
 from homeassistant.components.onewire.const import (
     CONF_MOUNT_DIR,
-    CONF_NAMES,
     CONF_TYPE_OWSERVER,
     CONF_TYPE_SYSBUS,
     DEFAULT_SYSBUS_MOUNT_DIR,
@@ -71,30 +70,6 @@ async def setup_onewire_owserver_integration(hass):
         await hass.async_block_till_done()
 
         return config_entry
-
-
-async def setup_onewire_patched_owserver_integration(hass):
-    """Create the 1-Wire integration."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        source=SOURCE_USER,
-        data={
-            CONF_TYPE: CONF_TYPE_OWSERVER,
-            CONF_HOST: "1.2.3.4",
-            CONF_PORT: 1234,
-            CONF_NAMES: {
-                "10.111111111111": "My DS18B20",
-            },
-        },
-        options={},
-        entry_id="2",
-    )
-    config_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    return config_entry
 
 
 def setup_owproxy_mock_devices(owproxy, domain, device_ids) -> None:

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -46,7 +46,7 @@ def setup_owproxy_mock_devices(
 
 
 def setup_sysbus_mock_devices(
-    domain: str, device_ids: list[str]
+    platform: str, device_ids: list[str]
 ) -> tuple[list[str], list[Any]]:
     """Set up mock for sysbus."""
     glob_result = []
@@ -59,7 +59,7 @@ def setup_sysbus_mock_devices(
         glob_result += [f"/{DEFAULT_SYSBUS_MOUNT_DIR}/{device_id}"]
 
         # Setup sub-device reads
-        device_sensors = mock_device.get(domain, [])
+        device_sensors = mock_device.get(platform, [])
         for expected_sensor in device_sensors:
             if isinstance(expected_sensor["injected_value"], list):
                 read_side_effect += expected_sensor["injected_value"]

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -2,77 +2,18 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 from pyownet.protocol import ProtocolError
 
-from homeassistant.components.onewire.const import (
-    CONF_MOUNT_DIR,
-    CONF_TYPE_OWSERVER,
-    CONF_TYPE_SYSBUS,
-    DEFAULT_SYSBUS_MOUNT_DIR,
-    DOMAIN,
-)
-from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
+from homeassistant.components.onewire.const import DEFAULT_SYSBUS_MOUNT_DIR
 
 from .const import MOCK_OWPROXY_DEVICES, MOCK_SYSBUS_DEVICES
 
-from tests.common import MockConfigEntry
 
-
-async def setup_onewire_sysbus_integration(hass):
-    """Create the 1-Wire integration."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        source=SOURCE_USER,
-        data={
-            CONF_TYPE: CONF_TYPE_SYSBUS,
-            CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR,
-            "names": {
-                "10-111111111111": "My DS18B20",
-            },
-        },
-        unique_id=f"{CONF_TYPE_SYSBUS}:{DEFAULT_SYSBUS_MOUNT_DIR}",
-        options={},
-        entry_id="1",
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.onewire.onewirehub.os.path.isdir", return_value=True
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    return config_entry
-
-
-async def setup_onewire_owserver_integration(hass):
-    """Create the 1-Wire integration."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        source=SOURCE_USER,
-        data={
-            CONF_TYPE: CONF_TYPE_OWSERVER,
-            CONF_HOST: "1.2.3.4",
-            CONF_PORT: 1234,
-        },
-        options={},
-        entry_id="2",
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.onewire.onewirehub.protocol.proxy",
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-        return config_entry
-
-
-def setup_owproxy_mock_devices(owproxy, domain, device_ids) -> None:
+def setup_owproxy_mock_devices(
+    owproxy: MagicMock, platform: str, device_ids: list(str)
+) -> None:
     """Set up mock for owproxy."""
     dir_return_value = []
     main_read_side_effect = []
@@ -90,7 +31,7 @@ def setup_owproxy_mock_devices(owproxy, domain, device_ids) -> None:
             main_read_side_effect += mock_device["inject_reads"]
 
         # Setup sub-device reads
-        device_sensors = mock_device.get(domain, [])
+        device_sensors = mock_device.get(platform, [])
         for expected_sensor in device_sensors:
             sub_read_side_effect.append(expected_sensor["injected_value"])
 

--- a/tests/components/onewire/conftest.py
+++ b/tests/components/onewire/conftest.py
@@ -1,11 +1,15 @@
 """Provide common 1-Wire fixtures."""
 from unittest.mock import MagicMock, patch
 
+from pyownet.protocol import ConnError
 import pytest
 
 from homeassistant.components.onewire.const import (
+    CONF_MOUNT_DIR,
     CONF_NAMES,
     CONF_TYPE_OWSERVER,
+    CONF_TYPE_SYSBUS,
+    DEFAULT_SYSBUS_MOUNT_DIR,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER, ConfigEntry
@@ -44,8 +48,48 @@ def get_config_entry(hass: HomeAssistant) -> ConfigEntry:
     return config_entry
 
 
+@pytest.fixture(name="sysbus_config_entry")
+def get_sysbus_config_entry(hass: HomeAssistant) -> ConfigEntry:
+    """Create and register mock config entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data={
+            CONF_TYPE: CONF_TYPE_SYSBUS,
+            CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR,
+            "names": {
+                "10-111111111111": "My DS18B20",
+            },
+        },
+        unique_id=f"{CONF_TYPE_SYSBUS}:{DEFAULT_SYSBUS_MOUNT_DIR}",
+        options={},
+        entry_id="3",
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry
+
+
 @pytest.fixture(name="owproxy")
 def get_owproxy() -> MagicMock:
     """Mock owproxy."""
     with patch("homeassistant.components.onewire.onewirehub.protocol.proxy") as owproxy:
         yield owproxy
+
+
+@pytest.fixture(name="owproxy_with_connerror")
+def get_owproxy_with_connerror() -> MagicMock:
+    """Mock owproxy."""
+    with patch(
+        "homeassistant.components.onewire.onewirehub.protocol.proxy",
+        side_effect=ConnError,
+    ) as owproxy:
+        yield owproxy
+
+
+@pytest.fixture(name="sysbus")
+def get_sysbus() -> MagicMock:
+    """Mock sysbus."""
+    with patch(
+        "homeassistant.components.onewire.onewirehub.os.path.isdir", return_value=True
+    ):
+        yield

--- a/tests/components/onewire/conftest.py
+++ b/tests/components/onewire/conftest.py
@@ -1,0 +1,51 @@
+"""Provide common 1-Wire fixtures."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.onewire.const import (
+    CONF_NAMES,
+    CONF_TYPE_OWSERVER,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER, ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
+from homeassistant.core import HomeAssistant
+
+from .const import MOCK_OWPROXY_DEVICES
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="device_id", params=MOCK_OWPROXY_DEVICES.keys())
+def get_device_id(request: pytest.FixtureRequest) -> str:
+    """Parametrize device id."""
+    return request.param
+
+
+@pytest.fixture(name="config_entry")
+def get_config_entry(hass: HomeAssistant) -> ConfigEntry:
+    """Create and register mock config entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data={
+            CONF_TYPE: CONF_TYPE_OWSERVER,
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 1234,
+            CONF_NAMES: {
+                "10.111111111111": "My DS18B20",
+            },
+        },
+        options={},
+        entry_id="2",
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry
+
+
+@pytest.fixture(name="owproxy")
+def get_owproxy() -> MagicMock:
+    """Mock owproxy."""
+    with patch("homeassistant.components.onewire.onewirehub.protocol.proxy") as owproxy:
+        yield owproxy

--- a/tests/components/onewire/test_binary_sensor.py
+++ b/tests/components/onewire/test_binary_sensor.py
@@ -1,51 +1,52 @@
 """Tests for 1-Wire devices connected on OWServer."""
 import copy
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.onewire.binary_sensor import DEVICE_BINARY_SENSORS
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
-from . import setup_onewire_patched_owserver_integration, setup_owproxy_mock_devices
+from . import setup_owproxy_mock_devices
 from .const import MOCK_OWPROXY_DEVICES
 
 from tests.common import mock_registry
 
-MOCK_BINARY_SENSORS = {
-    key: value
-    for (key, value) in MOCK_OWPROXY_DEVICES.items()
-    if BINARY_SENSOR_DOMAIN in value
-}
+
+@pytest.fixture(autouse=True)
+def override_platforms():
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.onewire.PLATFORMS", [BINARY_SENSOR_DOMAIN]):
+        yield
 
 
-@pytest.mark.parametrize("device_id", MOCK_BINARY_SENSORS.keys())
-@patch("homeassistant.components.onewire.onewirehub.protocol.proxy")
-async def test_owserver_binary_sensor(owproxy, hass, device_id):
+async def test_owserver_binary_sensor(
+    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock, device_id: str
+):
     """Test for 1-Wire binary sensor.
 
     This test forces all entities to be enabled.
     """
-
     entity_registry = mock_registry(hass)
 
     setup_owproxy_mock_devices(owproxy, BINARY_SENSOR_DOMAIN, [device_id])
 
-    mock_device = MOCK_BINARY_SENSORS[device_id]
-    expected_entities = mock_device[BINARY_SENSOR_DOMAIN]
+    mock_device = MOCK_OWPROXY_DEVICES[device_id]
+    expected_entities = mock_device.get(BINARY_SENSOR_DOMAIN, [])
 
     # Force enable binary sensors
     patch_device_binary_sensors = copy.deepcopy(DEVICE_BINARY_SENSORS)
-    for item in patch_device_binary_sensors[device_id[0:2]]:
-        item.entity_registry_enabled_default = True
+    if device_binary_sensor := patch_device_binary_sensors.get(device_id[0:2]):
+        for item in device_binary_sensor:
+            item.entity_registry_enabled_default = True
 
-    with patch(
-        "homeassistant.components.onewire.PLATFORMS", [BINARY_SENSOR_DOMAIN]
-    ), patch.dict(
+    with patch.dict(
         "homeassistant.components.onewire.binary_sensor.DEVICE_BINARY_SENSORS",
         patch_device_binary_sensors,
     ):
-        await setup_onewire_patched_owserver_integration(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     assert len(entity_registry.entities) == len(expected_entities)

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -1,89 +1,61 @@
 """Tests for 1-Wire config flow."""
 from unittest.mock import MagicMock, patch
 
-from pyownet.protocol import ConnError, OwnetError
+import pytest
 
-from homeassistant.components.onewire.const import CONF_TYPE_OWSERVER, DOMAIN
+from homeassistant.components.onewire.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.config_entries import SOURCE_USER, ConfigEntry, ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from . import (
-    setup_onewire_owserver_integration,
-    setup_onewire_sysbus_integration,
-    setup_owproxy_mock_devices,
-)
+from . import setup_owproxy_mock_devices
 
-from tests.common import MockConfigEntry, mock_device_registry, mock_registry
+from tests.common import mock_device_registry, mock_registry
 
 
-async def test_owserver_connect_failure(hass):
+@pytest.mark.usefixtures("owproxy_with_connerror")
+async def test_owserver_connect_failure(hass: HomeAssistant, config_entry: ConfigEntry):
     """Test connection failure raises ConfigEntryNotReady."""
-    config_entry_owserver = MockConfigEntry(
-        domain=DOMAIN,
-        source=SOURCE_USER,
-        data={
-            CONF_TYPE: CONF_TYPE_OWSERVER,
-            CONF_HOST: "1.2.3.4",
-            CONF_PORT: "1234",
-        },
-        options={},
-        entry_id="2",
-    )
-    config_entry_owserver.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.onewire.onewirehub.protocol.proxy",
-        side_effect=ConnError,
-    ):
-        await hass.config_entries.async_setup(config_entry_owserver.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert config_entry_owserver.state is ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
     assert not hass.data.get(DOMAIN)
 
 
-async def test_failed_owserver_listing(hass):
-    """Create the 1-Wire integration."""
-    config_entry_owserver = MockConfigEntry(
-        domain=DOMAIN,
-        source=SOURCE_USER,
-        data={
-            CONF_TYPE: CONF_TYPE_OWSERVER,
-            CONF_HOST: "1.2.3.4",
-            CONF_PORT: "1234",
-        },
-        options={},
-        entry_id="2",
-    )
-    config_entry_owserver.add_to_hass(hass)
-
-    with patch("homeassistant.components.onewire.onewirehub.protocol.proxy") as owproxy:
-        owproxy.return_value.dir.side_effect = OwnetError
-        await hass.config_entries.async_setup(config_entry_owserver.entry_id)
-        await hass.async_block_till_done()
-
-        return config_entry_owserver
-
-
-async def test_unload_entry(hass):
+@pytest.mark.usefixtures("owproxy")
+async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Test being able to unload an entry."""
-    config_entry_owserver = await setup_onewire_owserver_integration(hass)
-    config_entry_sysbus = await setup_onewire_sysbus_integration(hass)
-
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
-    assert config_entry_owserver.state is ConfigEntryState.LOADED
-    assert config_entry_sysbus.state is ConfigEntryState.LOADED
-
-    assert await hass.config_entries.async_unload(config_entry_owserver.entry_id)
-    assert await hass.config_entries.async_unload(config_entry_sysbus.entry_id)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry_owserver.state is ConfigEntryState.NOT_LOADED
-    assert config_entry_sysbus.state is ConfigEntryState.NOT_LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert not hass.data.get(DOMAIN)
+
+
+@pytest.mark.usefixtures("sysbus")
+async def test_unload_sysbus_entry(
+    hass: HomeAssistant, sysbus_config_entry: ConfigEntry
+):
+    """Test being able to unload an entry."""
+    await hass.config_entries.async_setup(sysbus_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert sysbus_config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(sysbus_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert sysbus_config_entry.state is ConfigEntryState.NOT_LOADED
     assert not hass.data.get(DOMAIN)
 
 
@@ -117,9 +89,8 @@ async def test_registry_cleanup(
     assert len(dr.async_entries_for_config_entry(device_registry, "2")) == 2
 
     # Second item has disappeared from bus, and was removed manually from the front-end
-    with patch("homeassistant.components.onewire.PLATFORMS", [SENSOR_DOMAIN]):
-        await hass.config_entries.async_reload("2")
-        await hass.async_block_till_done()
+    await hass.config_entries.async_reload("2")
+    await hass.async_block_till_done()
 
     assert len(er.async_entries_for_config_entry(entity_registry, "2")) == 1
     assert len(dr.async_entries_for_config_entry(device_registry, "2")) == 1

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -1,15 +1,12 @@
 """Tests for 1-Wire sensor platform."""
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from pyownet.protocol import Error as ProtocolError
 import pytest
 
-from homeassistant.components.onewire.const import (
-    DEFAULT_SYSBUS_MOUNT_DIR,
-    DOMAIN,
-    PLATFORMS,
-)
+from homeassistant.components.onewire.const import DEFAULT_SYSBUS_MOUNT_DIR, DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS, DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_MANUFACTURER,
@@ -17,10 +14,10 @@ from homeassistant.const import (
     ATTR_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import (
-    setup_onewire_patched_owserver_integration,
     setup_onewire_sysbus_integration,
     setup_owproxy_mock_devices,
     setup_sysbus_mock_devices,
@@ -34,7 +31,14 @@ MOCK_COUPLERS = {
 }
 
 
-async def test_setup_minimum(hass):
+@pytest.fixture(autouse=True)
+def override_platforms():
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.onewire.PLATFORMS", [SENSOR_DOMAIN]):
+        yield
+
+
+async def test_setup_minimum(hass: HomeAssistant):
     """Test old platform setup with minimum configuration."""
     config = {"sensor": {"platform": "onewire"}}
     with assert_setup_component(1, "sensor"):
@@ -42,7 +46,7 @@ async def test_setup_minimum(hass):
     await hass.async_block_till_done()
 
 
-async def test_setup_sysbus(hass):
+async def test_setup_sysbus(hass: HomeAssistant):
     """Test old platform setup with SysBus configuration."""
     config = {
         "sensor": {
@@ -55,7 +59,7 @@ async def test_setup_sysbus(hass):
     await hass.async_block_till_done()
 
 
-async def test_setup_owserver(hass):
+async def test_setup_owserver(hass: HomeAssistant):
     """Test old platform setup with OWServer configuration."""
     config = {"sensor": {"platform": "onewire", "host": "localhost"}}
     with assert_setup_component(1, "sensor"):
@@ -63,7 +67,7 @@ async def test_setup_owserver(hass):
     await hass.async_block_till_done()
 
 
-async def test_setup_owserver_with_port(hass):
+async def test_setup_owserver_with_port(hass: HomeAssistant):
     """Test old platform setup with OWServer configuration."""
     config = {"sensor": {"platform": "onewire", "host": "localhost", "port": "1234"}}
     with assert_setup_component(1, "sensor"):
@@ -72,8 +76,9 @@ async def test_setup_owserver_with_port(hass):
 
 
 @pytest.mark.parametrize("device_id", ["1F.111111111111"])
-@patch("homeassistant.components.onewire.onewirehub.protocol.proxy")
-async def test_sensors_on_owserver_coupler(owproxy, hass, device_id):
+async def test_sensors_on_owserver_coupler(
+    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock, device_id: str
+):
     """Test for 1-Wire sensors connected to DS2409 coupler."""
 
     entity_registry = mock_registry(hass)
@@ -111,9 +116,8 @@ async def test_sensors_on_owserver_coupler(owproxy, hass, device_id):
     owproxy.return_value.dir.side_effect = dir_side_effect
     owproxy.return_value.read.side_effect = read_side_effect
 
-    with patch("homeassistant.components.onewire.PLATFORMS", [SENSOR_DOMAIN]):
-        await setup_onewire_patched_owserver_integration(hass)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(entity_registry.entities) == len(expected_sensors)
 
@@ -130,26 +134,23 @@ async def test_sensors_on_owserver_coupler(owproxy, hass, device_id):
         assert state.attributes["device_file"] == expected_sensor["device_file"]
 
 
-@pytest.mark.parametrize("device_id", MOCK_OWPROXY_DEVICES.keys())
-@pytest.mark.parametrize("platform", PLATFORMS)
-@patch("homeassistant.components.onewire.onewirehub.protocol.proxy")
-async def test_owserver_setup_valid_device(owproxy, hass, device_id, platform):
+async def test_owserver_setup_valid_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock, device_id: str
+):
     """Test for 1-Wire device.
 
     As they would be on a clean setup: all binary-sensors and switches disabled.
     """
-
     entity_registry = mock_registry(hass)
     device_registry = mock_device_registry(hass)
 
-    setup_owproxy_mock_devices(owproxy, platform, [device_id])
+    setup_owproxy_mock_devices(owproxy, SENSOR_DOMAIN, [device_id])
 
     mock_device = MOCK_OWPROXY_DEVICES[device_id]
-    expected_entities = mock_device.get(platform, [])
+    expected_entities = mock_device.get(SENSOR_DOMAIN, [])
 
-    with patch("homeassistant.components.onewire.PLATFORMS", [platform]):
-        await setup_onewire_patched_owserver_integration(hass)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(entity_registry.entities) == len(expected_entities)
 
@@ -181,8 +182,8 @@ async def test_owserver_setup_valid_device(owproxy, hass, device_id, platform):
             )
 
 
-@pytest.mark.parametrize("device_id", MOCK_SYSBUS_DEVICES.keys())
-async def test_onewiredirect_setup_valid_device(hass, device_id):
+@pytest.mark.parametrize("device_id", MOCK_SYSBUS_DEVICES.keys(), indirect=True)
+async def test_onewiredirect_setup_valid_device(hass: HomeAssistant, device_id: str):
     """Test that sysbus config entry works correctly."""
 
     entity_registry = mock_registry(hass)

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -1,51 +1,52 @@
 """Tests for 1-Wire devices connected on OWServer."""
 import copy
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from homeassistant.components.onewire.switch import DEVICE_SWITCHES
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TOGGLE, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 
-from . import setup_onewire_patched_owserver_integration, setup_owproxy_mock_devices
+from . import setup_owproxy_mock_devices
 from .const import MOCK_OWPROXY_DEVICES
 
 from tests.common import mock_registry
 
-MOCK_SWITCHES = {
-    key: value
-    for (key, value) in MOCK_OWPROXY_DEVICES.items()
-    if SWITCH_DOMAIN in value
-}
+
+@pytest.fixture(autouse=True)
+def override_platforms():
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.onewire.PLATFORMS", [SWITCH_DOMAIN]):
+        yield
 
 
-@pytest.mark.parametrize("device_id", MOCK_SWITCHES.keys())
-@patch("homeassistant.components.onewire.onewirehub.protocol.proxy")
-async def test_owserver_switch(owproxy, hass, device_id):
+async def test_owserver_switch(
+    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock, device_id: str
+):
     """Test for 1-Wire switch.
 
     This test forces all entities to be enabled.
     """
-
     entity_registry = mock_registry(hass)
 
     setup_owproxy_mock_devices(owproxy, SWITCH_DOMAIN, [device_id])
 
-    mock_device = MOCK_SWITCHES[device_id]
-    expected_entities = mock_device[SWITCH_DOMAIN]
+    mock_device = MOCK_OWPROXY_DEVICES[device_id]
+    expected_entities = mock_device.get(SWITCH_DOMAIN, [])
 
     # Force enable switches
     patch_device_switches = copy.deepcopy(DEVICE_SWITCHES)
-    for item in patch_device_switches[device_id[0:2]]:
-        item.entity_registry_enabled_default = True
+    if device_switch := patch_device_switches.get(device_id[0:2]):
+        for item in device_switch:
+            item.entity_registry_enabled_default = True
 
-    with patch(
-        "homeassistant.components.onewire.PLATFORMS", [SWITCH_DOMAIN]
-    ), patch.dict(
+    with patch.dict(
         "homeassistant.components.onewire.switch.DEVICE_SWITCHES", patch_device_switches
     ):
-        await setup_onewire_patched_owserver_integration(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
     assert len(entity_registry.entities) == len(expected_entities)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reworked tests to make use of pytest fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
