### PR TITLE
Fix issue parsing color effect None in flux_led

### DIFF
--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -214,6 +214,9 @@ async def async_setup_platform(
             host,
         )
         custom_effects = device_config.get(CONF_CUSTOM_EFFECT, {})
+        custom_effect_colors = None
+        if CONF_COLORS in custom_effects:
+            custom_effect_colors = str(custom_effects[CONF_COLORS])
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
@@ -224,7 +227,7 @@ async def async_setup_platform(
                     CONF_NAME: device_config[CONF_NAME],
                     CONF_PROTOCOL: device_config.get(CONF_PROTOCOL),
                     CONF_MODE: device_config.get(ATTR_MODE, MODE_AUTO),
-                    CONF_CUSTOM_EFFECT_COLORS: str(custom_effects.get(CONF_COLORS)),
+                    CONF_CUSTOM_EFFECT_COLORS: custom_effect_colors,
                     CONF_CUSTOM_EFFECT_SPEED_PCT: custom_effects.get(
                         CONF_SPEED_PCT, DEFAULT_EFFECT_SPEED
                     ),

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -254,9 +254,9 @@ async def async_setup_entry(
     options = entry.options
 
     try:
-        custom_effect_colors = ast.literal_eval(
-            options.get(CONF_CUSTOM_EFFECT_COLORS) or "[]"
-        )
+        custom_effect_colors = (
+            ast.literal_eval(options.get(CONF_CUSTOM_EFFECT_COLORS) or "[]") or []
+        )  # The text inside this option may be "None"
     except (ValueError, TypeError, SyntaxError, MemoryError) as ex:
         _LOGGER.warning(
             "Could not parse custom effect colors for %s: %s", entry.unique_id, ex

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -257,9 +257,9 @@ async def async_setup_entry(
     options = entry.options
 
     try:
-        custom_effect_colors = (
-            ast.literal_eval(options.get(CONF_CUSTOM_EFFECT_COLORS) or "[]") or []
-        )  # The text inside this option may be "None"
+        custom_effect_colors = ast.literal_eval(
+            options.get(CONF_CUSTOM_EFFECT_COLORS) or "[]"
+        )
     except (ValueError, TypeError, SyntaxError, MemoryError) as ex:
         _LOGGER.warning(
             "Could not parse custom effect colors for %s: %s", entry.unique_id, ex

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -741,7 +741,10 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
     assert attributes[ATTR_EFFECT] == "custom"
 
 
-async def test_rgb_light_custom_effects_invalid_colors(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize("effect_colors", [":: CANNOT BE PARSED ::", "None"])
+async def test_rgb_light_custom_effects_invalid_colors(
+    hass: HomeAssistant, effect_colors: str
+) -> None:
     """Test an rgb light with a invalid effect."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -749,7 +752,7 @@ async def test_rgb_light_custom_effects_invalid_colors(hass: HomeAssistant) -> N
         unique_id=MAC_ADDRESS,
         options={
             CONF_MODE: MODE_AUTO,
-            CONF_CUSTOM_EFFECT_COLORS: ":: CANNOT BE PARSED ::",
+            CONF_CUSTOM_EFFECT_COLORS: effect_colors,
             CONF_CUSTOM_EFFECT_SPEED_PCT: 88,
             CONF_CUSTOM_EFFECT_TRANSITION: TRANSITION_JUMP,
         },

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -832,7 +832,7 @@ async def test_rgb_light_custom_effect_via_service(
     bulb.async_set_custom_pattern.reset_mock()
 
 
-async def test_migrate_from_yaml(hass: HomeAssistant) -> None:
+async def test_migrate_from_yaml_with_custom_effect(hass: HomeAssistant) -> None:
     """Test migrate from yaml."""
     config = {
         LIGHT_DOMAIN: [
@@ -878,6 +878,50 @@ async def test_migrate_from_yaml(hass: HomeAssistant) -> None:
         CONF_CUSTOM_EFFECT_COLORS: "[(255, 0, 0), (255, 255, 0), (0, 255, 0)]",
         CONF_CUSTOM_EFFECT_SPEED_PCT: 30,
         CONF_CUSTOM_EFFECT_TRANSITION: "strobe",
+    }
+
+
+async def test_migrate_from_yaml_no_custom_effect(hass: HomeAssistant) -> None:
+    """Test migrate from yaml."""
+    config = {
+        LIGHT_DOMAIN: [
+            {
+                CONF_PLATFORM: DOMAIN,
+                CONF_DEVICES: {
+                    IP_ADDRESS: {
+                        CONF_NAME: "flux_lamppost",
+                        CONF_PROTOCOL: "ledenet",
+                    }
+                },
+            }
+        ],
+    }
+    with _patch_discovery(), _patch_wifibulb():
+        await async_setup_component(hass, LIGHT_DOMAIN, config)
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert entries
+
+    migrated_entry = None
+    for entry in entries:
+        if entry.unique_id == MAC_ADDRESS:
+            migrated_entry = entry
+            break
+
+    assert migrated_entry is not None
+    assert migrated_entry.data == {
+        CONF_HOST: IP_ADDRESS,
+        CONF_NAME: "flux_lamppost",
+        CONF_PROTOCOL: "ledenet",
+    }
+    assert migrated_entry.options == {
+        CONF_MODE: "auto",
+        CONF_CUSTOM_EFFECT_COLORS: None,
+        CONF_CUSTOM_EFFECT_SPEED_PCT: 50,
+        CONF_CUSTOM_EFFECT_TRANSITION: "gradual",
     }
 
 

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -741,21 +741,23 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
     assert attributes[ATTR_EFFECT] == "custom"
 
 
-@pytest.mark.parametrize("effect_colors", [":: CANNOT BE PARSED ::", "None"])
+@pytest.mark.parametrize("effect_colors", [":: CANNOT BE PARSED ::", None])
 async def test_rgb_light_custom_effects_invalid_colors(
     hass: HomeAssistant, effect_colors: str
 ) -> None:
     """Test an rgb light with a invalid effect."""
+    options = {
+        CONF_MODE: MODE_AUTO,
+        CONF_CUSTOM_EFFECT_SPEED_PCT: 88,
+        CONF_CUSTOM_EFFECT_TRANSITION: TRANSITION_JUMP,
+    }
+    if effect_colors:
+        options[CONF_CUSTOM_EFFECT_COLORS] = effect_colors
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: IP_ADDRESS, CONF_NAME: DEFAULT_ENTRY_TITLE},
+        options=options,
         unique_id=MAC_ADDRESS,
-        options={
-            CONF_MODE: MODE_AUTO,
-            CONF_CUSTOM_EFFECT_COLORS: effect_colors,
-            CONF_CUSTOM_EFFECT_SPEED_PCT: 88,
-            CONF_CUSTOM_EFFECT_TRANSITION: TRANSITION_JUMP,
-        },
     )
     config_entry.add_to_hass(hass)
     bulb = _mocked_bulb()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix import of yaml config when there is no custom effect

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/Danielhiversen/flux_led/issues/134
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
