### PR TITLE
Add Group On/Off state management for Hue integration

### DIFF
--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -20,5 +20,6 @@ GROUP_TYPE_LUMINAIRE = "Luminaire"
 GROUP_TYPE_LIGHT_SOURCE = "LightSource"
 
 ATTR_GROUP_NAME = "group_name"
+ATTR_ON_STATE = "on_state"
 ATTR_SCENE_NAME = "scene_name"
 ATTR_TRANSITION = "transition"

--- a/homeassistant/components/hue/services.yaml
+++ b/homeassistant/components/hue/services.yaml
@@ -16,3 +16,21 @@ hue_activate_scene:
       example: "Energize"
       selector:
         text:
+hue_group_set_on_state:
+  name: Set Group On state
+  description: Set On/Off state for the group in Hue app.
+  fields:
+    group_name:
+      name: Group
+      description: Name of hue group/room from the hue app.
+      example: "Living Room"
+      required: true
+      selector:
+        text:
+    on_state:
+      name: On State
+      description: Boolean state to turn on/off the group.
+      example: "true"
+      required: true
+      selector:
+        boolean:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Before this - Hue integration mainly relied on "hue_activate_scene" to manage large amount of lights on multiple bridges.
While that allowed for a smooth "Enable Relax scene for Kitchen Group" actions - those could only **turn on** the mode.
And because Hue does not allow to create a Scene with all lights "off" in it - there previously have been no way to pair "hue_activate_scene" with "turning off", AFAIK.
Yes, it's technically possible to use HA's LightGroups and turn all the lights off, but that would have 2 problems:

1. HA's LightGroups for Hue work way worse than native Hue's hue_activate_scene, and the lights flicker out of order when managed that way
2. That would require to use "Hue native" Groups for "scene activation", and maintain separate list of LightGroups and sync them manually with Hue ones all the time.

Hence this PR is introducing a proper support for AIOHUE's State management, allowing to use "hue_activate_scene" and "hue_group_set_on_state" together, so now it's very easy in HA to train a Switch to control room presets as well as the rooms On/Off state.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

This PR tries to mimic existing "hue_activate_scene" as close as possible, including it's "reload" logic to keep them in parity.

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github
<img width="1257" alt="Screen Shot 2021-10-17 at 10 40 42 PM" src="https://user-images.githubusercontent.com/1311267/137777806-eb222510-10cd-4619-8e67-ab0c6013ff81.png">
.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
