### PR TITLE
Bump pychromecast to 9.3.0

### DIFF
--- a/homeassistant/components/cast/manifest.json
+++ b/homeassistant/components/cast/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Cast",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cast",
-  "requirements": ["pychromecast==9.2.1"],
+  "requirements": ["pychromecast==9.3.0"],
   "after_dependencies": [
     "cloud",
     "http",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1384,7 +1384,7 @@ pycfdns==1.2.1
 pychannels==1.0.0
 
 # homeassistant.components.cast
-pychromecast==9.2.1
+pychromecast==9.3.0
 
 # homeassistant.components.pocketcasts
 pycketcasts==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -823,7 +823,7 @@ pybotvac==0.0.22
 pycfdns==1.2.1
 
 # homeassistant.components.cast
-pychromecast==9.2.1
+pychromecast==9.3.0
 
 # homeassistant.components.climacell
 pyclimacell==0.18.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pychromecast from 9.2.1 to 9.3.0

Changes:
 - 9.3.0 (https://github.com/home-assistant-libs/pychromecast/releases/tag/9.3.0)
    - Update hostbrowser to only poll audio hosts [#549](/home-assistant-libs/pychromecast#549) @emontnemery
    - Bump flake8 from 4.0.0 to 4.0.1 [#548](/home-assistant-libs/pychromecast#548) @dependabot
    - Bump pylint from 2.10.2 to 2.11.1 [#536](/home-assistant-libs/pychromecast#536) @dependabot
    - Prepare for pylint 2.11 [#547](/home-assistant-libs/pychromecast#547) @emontnemery
    - Bump flake8 from 3.9.2 to 4.0.0 [#546](/home-assistant-libs/pychromecast#546) @dependabot
    - Increase timeout for HostBrowser's polling [#542](/home-assistant-libs/pychromecast#542) @emontnemery
    - Revert "Block JBL devices from host based polling" [#544](/home-assistant-libs/pychromecast#544) @emontnemery
    - Block JBL devices from host based polling [#543](/home-assistant-libs/pychromecast#543) @emontnemery
    - Fix bug in discovery when a device does not return multizone status [#541](/home-assistant-libs/pychromecast#541) @emontnemery
    - Remove unused Event from ReceiverController [#534](/home-assistant-libs/pychromecast#534) @emontnemery
    - Remove spotify controller [#535](/home-assistant-libs/pychromecast#535) @emontnemery

https://github.com/home-assistant-libs/pychromecast/compare/9.2.1...9.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #52020
  - fixes #55435
  - fixes #56793

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
