### PR TITLE
Rework Onewire tests to enable disabled entities

### DIFF
--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -1,5 +1,4 @@
 """Constants for 1-Wire integration."""
-
 from pi1wire import InvalidCRCException, UnsupportResponseException
 from pyownet.protocol import Error as ProtocolError
 
@@ -35,6 +34,8 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 
+ATTR_DEFAULT_DISABLED = "default_disabled"
+
 MANUFACTURER = "Maxim Integrated"
 
 MOCK_OWPROXY_DEVICES = {
@@ -62,7 +63,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
         ],
     },
@@ -106,7 +107,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "binary_sensor.12_111111111111_sensed_b",
@@ -115,7 +116,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
         ],
         SENSOR_DOMAIN: [
@@ -126,7 +127,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "25.1",
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
             {
@@ -136,7 +137,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "1025.1",
                 ATTR_UNIT_OF_MEASUREMENT: PRESSURE_MBAR,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
         ],
@@ -148,7 +149,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.12_111111111111_pio_b",
@@ -157,7 +158,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.12_111111111111_latch_a",
@@ -166,7 +167,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.12_111111111111_latch_b",
@@ -175,7 +176,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
         ],
     },
@@ -308,7 +309,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "72.8",
                 ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
             {
@@ -318,7 +319,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "73.8",
                 ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
             {
@@ -328,7 +329,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "74.8",
                 ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
             {
@@ -338,7 +339,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "75.8",
                 ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
             {
@@ -348,7 +349,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "unknown",
                 ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
             {
@@ -358,7 +359,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "969.3",
                 ATTR_UNIT_OF_MEASUREMENT: PRESSURE_MBAR,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
             {
@@ -368,7 +369,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "65.9",
                 ATTR_UNIT_OF_MEASUREMENT: LIGHT_LUX,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_ILLUMINANCE,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
             {
@@ -378,7 +379,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "3.0",
                 ATTR_UNIT_OF_MEASUREMENT: ELECTRIC_POTENTIAL_VOLT,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_VOLTAGE,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
             {
@@ -388,7 +389,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "4.7",
                 ATTR_UNIT_OF_MEASUREMENT: ELECTRIC_POTENTIAL_VOLT,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_VOLTAGE,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
             {
@@ -398,7 +399,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": "1.0",
                 ATTR_UNIT_OF_MEASUREMENT: ELECTRIC_CURRENT_AMPERE,
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_CURRENT,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
                 ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
             },
         ],
@@ -443,7 +444,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "binary_sensor.29_111111111111_sensed_1",
@@ -452,7 +453,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "binary_sensor.29_111111111111_sensed_2",
@@ -461,7 +462,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "binary_sensor.29_111111111111_sensed_3",
@@ -470,7 +471,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "binary_sensor.29_111111111111_sensed_4",
@@ -479,7 +480,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "binary_sensor.29_111111111111_sensed_5",
@@ -488,7 +489,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "binary_sensor.29_111111111111_sensed_6",
@@ -497,7 +498,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "binary_sensor.29_111111111111_sensed_7",
@@ -506,7 +507,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
         ],
         SWITCH_DOMAIN: [
@@ -517,7 +518,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_pio_1",
@@ -526,7 +527,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_pio_2",
@@ -535,7 +536,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_pio_3",
@@ -544,7 +545,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_pio_4",
@@ -553,7 +554,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_pio_5",
@@ -562,7 +563,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_pio_6",
@@ -571,7 +572,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_pio_7",
@@ -580,7 +581,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_latch_0",
@@ -589,7 +590,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_latch_1",
@@ -598,7 +599,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_latch_2",
@@ -607,7 +608,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_latch_3",
@@ -616,7 +617,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_latch_4",
@@ -625,7 +626,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_latch_5",
@@ -634,7 +635,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_latch_6",
@@ -643,7 +644,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.29_111111111111_latch_7",
@@ -652,7 +653,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
         ],
     },
@@ -674,7 +675,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "binary_sensor.3a_111111111111_sensed_b",
@@ -683,7 +684,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
         ],
         SWITCH_DOMAIN: [
@@ -694,7 +695,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_ON,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
             {
                 "entity_id": "switch.3a_111111111111_pio_b",
@@ -703,7 +704,7 @@ MOCK_OWPROXY_DEVICES = {
                 "result": STATE_OFF,
                 ATTR_UNIT_OF_MEASUREMENT: None,
                 ATTR_DEVICE_CLASS: None,
-                "disabled": True,
+                ATTR_DEFAULT_DISABLED: True,
             },
         ],
     },

--- a/tests/components/onewire/test_binary_sensor.py
+++ b/tests/components/onewire/test_binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from . import setup_owproxy_mock_devices
-from .const import MOCK_OWPROXY_DEVICES
+from .const import ATTR_DEFAULT_DISABLED, MOCK_OWPROXY_DEVICES
 
 from tests.common import mock_registry
 
@@ -40,7 +40,7 @@ async def test_owserver_binary_sensor(
 
     # Ensure all entities are enabled
     for expected_entity in expected_entities:
-        if expected_entity.get("disabled"):
+        if expected_entity.get(ATTR_DEFAULT_DISABLED):
             entity_id = expected_entity["entity_id"]
             registry_entry = entity_registry.entities.get(entity_id)
             assert registry_entry.disabled

--- a/tests/components/onewire/test_binary_sensor.py
+++ b/tests/components/onewire/test_binary_sensor.py
@@ -1,11 +1,9 @@
 """Tests for 1-Wire devices connected on OWServer."""
-import copy
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.onewire.binary_sensor import DEVICE_BINARY_SENSORS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -31,25 +29,27 @@ async def test_owserver_binary_sensor(
     """
     entity_registry = mock_registry(hass)
 
-    setup_owproxy_mock_devices(owproxy, BINARY_SENSOR_DOMAIN, [device_id])
-
     mock_device = MOCK_OWPROXY_DEVICES[device_id]
     expected_entities = mock_device.get(BINARY_SENSOR_DOMAIN, [])
 
-    # Force enable binary sensors
-    patch_device_binary_sensors = copy.deepcopy(DEVICE_BINARY_SENSORS)
-    if device_binary_sensor := patch_device_binary_sensors.get(device_id[0:2]):
-        for item in device_binary_sensor:
-            item.entity_registry_enabled_default = True
-
-    with patch.dict(
-        "homeassistant.components.onewire.binary_sensor.DEVICE_BINARY_SENSORS",
-        patch_device_binary_sensors,
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+    setup_owproxy_mock_devices(owproxy, BINARY_SENSOR_DOMAIN, [device_id])
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(entity_registry.entities) == len(expected_entities)
+
+    # Ensure all entities are enabled
+    for expected_entity in expected_entities:
+        if expected_entity.get("disabled"):
+            entity_id = expected_entity["entity_id"]
+            registry_entry = entity_registry.entities.get(entity_id)
+            assert registry_entry.disabled
+            assert registry_entry.disabled_by == "integration"
+            entity_registry.async_update_entity(entity_id, **{"disabled_by": None})
+
+    setup_owproxy_mock_devices(owproxy, BINARY_SENSOR_DOMAIN, [device_id])
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     for expected_entity in expected_entities:
         entity_id = expected_entity["entity_id"]

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import setup_owproxy_mock_devices, setup_sysbus_mock_devices
-from .const import MOCK_OWPROXY_DEVICES, MOCK_SYSBUS_DEVICES
+from .const import ATTR_DEFAULT_DISABLED, MOCK_OWPROXY_DEVICES, MOCK_SYSBUS_DEVICES
 
 from tests.common import assert_setup_component, mock_device_registry, mock_registry
 
@@ -150,7 +150,7 @@ async def test_owserver_setup_valid_device(
 
     # Ensure all entities are enabled
     for expected_entity in expected_entities:
-        if expected_entity.get("disabled"):
+        if expected_entity.get(ATTR_DEFAULT_DISABLED):
             entity_id = expected_entity["entity_id"]
             registry_entry = entity_registry.entities.get(entity_id)
             assert registry_entry.disabled

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -9,7 +9,7 @@ from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TOGGLE, STATE_OFF, STATE
 from homeassistant.core import HomeAssistant
 
 from . import setup_owproxy_mock_devices
-from .const import MOCK_OWPROXY_DEVICES
+from .const import ATTR_DEFAULT_DISABLED, MOCK_OWPROXY_DEVICES
 
 from tests.common import mock_registry
 
@@ -41,7 +41,7 @@ async def test_owserver_switch(
 
     # Ensure all entities are enabled
     for expected_entity in expected_entities:
-        if expected_entity.get("disabled"):
+        if expected_entity.get(ATTR_DEFAULT_DISABLED):
             entity_id = expected_entity["entity_id"]
             registry_entry = entity_registry.entities.get(entity_id)
             assert registry_entry.disabled

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -1,10 +1,8 @@
 """Tests for 1-Wire devices connected on OWServer."""
-import copy
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.onewire.switch import DEVICE_SWITCHES
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TOGGLE, STATE_OFF, STATE_ON
@@ -32,24 +30,27 @@ async def test_owserver_switch(
     """
     entity_registry = mock_registry(hass)
 
-    setup_owproxy_mock_devices(owproxy, SWITCH_DOMAIN, [device_id])
-
     mock_device = MOCK_OWPROXY_DEVICES[device_id]
     expected_entities = mock_device.get(SWITCH_DOMAIN, [])
 
-    # Force enable switches
-    patch_device_switches = copy.deepcopy(DEVICE_SWITCHES)
-    if device_switch := patch_device_switches.get(device_id[0:2]):
-        for item in device_switch:
-            item.entity_registry_enabled_default = True
-
-    with patch.dict(
-        "homeassistant.components.onewire.switch.DEVICE_SWITCHES", patch_device_switches
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+    setup_owproxy_mock_devices(owproxy, SWITCH_DOMAIN, [device_id])
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert len(entity_registry.entities) == len(expected_entities)
+
+    # Ensure all entities are enabled
+    for expected_entity in expected_entities:
+        if expected_entity.get("disabled"):
+            entity_id = expected_entity["entity_id"]
+            registry_entry = entity_registry.entities.get(entity_id)
+            assert registry_entry.disabled
+            assert registry_entry.disabled_by == "integration"
+            entity_registry.async_update_entity(entity_id, **{"disabled_by": None})
+
+    setup_owproxy_mock_devices(owproxy, SWITCH_DOMAIN, [device_id])
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     for expected_entity in expected_entities:
         entity_id = expected_entity["entity_id"]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rework tests so that we don't change the code-under-test-constant, but update the entity entry dynamically and reload the integration.
ref: https://github.com/home-assistant/core/pull/57973#discussion_r730923793
cc: @MartinHjelmare

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
