### PR TITLE
Remove device category filtering from Tuya init

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -33,7 +33,6 @@ from .const import (
     PLATFORMS,
     TUYA_DISCOVERY_NEW,
     TUYA_HA_SIGNAL_UPDATE_ENTITY,
-    TUYA_SUPPORTED_PRODUCT_CATEGORIES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -118,8 +117,7 @@ async def _init_tuya_sdk(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Register known device IDs
     for device in device_manager.device_map.values():
-        if device.category in TUYA_SUPPORTED_PRODUCT_CATEGORIES:
-            device_ids.add(device.id)
+        device_ids.add(device.id)
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     return True
@@ -178,20 +176,19 @@ class DeviceListener(TuyaDeviceListener):
 
     def add_device(self, device: TuyaDevice) -> None:
         """Add device added listener."""
-        if device.category in TUYA_SUPPORTED_PRODUCT_CATEGORIES:
-            # Ensure the device isn't present stale
-            self.hass.add_job(self.async_remove_device, device.id)
+        # Ensure the device isn't present stale
+        self.hass.add_job(self.async_remove_device, device.id)
 
-            self.device_ids.add(device.id)
-            dispatcher_send(self.hass, TUYA_DISCOVERY_NEW, [device.id])
+        self.device_ids.add(device.id)
+        dispatcher_send(self.hass, TUYA_DISCOVERY_NEW, [device.id])
 
-            device_manager = self.device_manager
-            device_manager.mq.stop()
-            tuya_mq = TuyaOpenMQ(device_manager.api)
-            tuya_mq.start()
+        device_manager = self.device_manager
+        device_manager.mq.stop()
+        tuya_mq = TuyaOpenMQ(device_manager.api)
+        tuya_mq.start()
 
-            device_manager.mq = tuya_mq
-            tuya_mq.add_message_listener(device_manager.on_message)
+        device_manager.mq = tuya_mq
+        tuya_mq.add_message_listener(device_manager.on_message)
 
     def remove_device(self, device_id: str) -> None:
         """Add device removed listener."""

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -84,41 +84,6 @@ TUYA_RESPONSE_MSG = "msg"
 TUYA_RESPONSE_SUCCESS = "success"
 TUYA_RESPONSE_PLATFORM_URL = "platform_url"
 
-TUYA_SUPPORTED_PRODUCT_CATEGORIES = (
-    "bh",  # Smart Kettle
-    "cwysj",  # Pet Water Feeder
-    "cz",  # Socket
-    "dc",  # Light string
-    "dd",  # Light strip
-    "dj",  # Light
-    "dlq",  # Breaker
-    "fs",  # Fan
-    "fsd",  # Ceiling Fan Light
-    "fwd",  # Ambient Light
-    "fwl",  # Ambient light
-    "gyd",  # Motion Sensor Light
-    "jsq",  # Humidifier's light
-    "kfj",  # Coffee maker
-    "kg",  # Switch
-    "kj",  # Air Purifier
-    "kt",  # Air conditioner
-    "ldcg",  # Luminance Sensor
-    "mcs",  # Door Window Sensor
-    "pc",  # Power Strip
-    "pir",  # PIR Detector
-    "qn",  # Heater
-    "sd",  # Robot vacuum
-    "sgbj",  # Siren Alarm
-    "sos",  # SOS Button
-    "sp",  # Smart Camera
-    "tgq",  # Dimmer
-    "tyndj",  # Solar Light
-    "wk",  # Thermostat
-    "xdd",  # Ceiling Light
-    "xxj",  # Diffuser
-    "zd",  # Vibration Sensor
-)
-
 TUYA_SMART_APP = "tuyaSmart"
 SMARTLIFE_APP = "smartlife"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

At this point, platforms are able to figure out what they support or not.
This PR removes the filter from the Tuya integration init, and just passes along all devices to the platforms, letting them decide.

This makes it easier to add support for devices, and also being able to support future events.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
