### PR TITLE
Rework octoprint

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -734,7 +734,7 @@ omit =
     homeassistant/components/nx584/alarm_control_panel.py
     homeassistant/components/nzbget/coordinator.py
     homeassistant/components/obihai/*
-    homeassistant/components/octoprint/*
+    homeassistant/components/octoprint/__init__.py
     homeassistant/components/oem/climate.py
     homeassistant/components/oasa_telematics/sensor.py
     homeassistant/components/ohmconnect/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -366,6 +366,7 @@ homeassistant/components/nut/* @bdraco @ollo69
 homeassistant/components/nws/* @MatthewFlamm
 homeassistant/components/nzbget/* @chriscla
 homeassistant/components/obihai/* @dshokouhi
+homeassistant/components/octoprint/* @rfleming71
 homeassistant/components/ohmconnect/* @robbiet480
 homeassistant/components/ombi/* @larssont
 homeassistant/components/omnilogic/* @oliver84 @djtimca @gentoosu

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -1,10 +1,12 @@
 """Support for monitoring OctoPrint 3D printers."""
+import asyncio
 from datetime import timedelta
 import logging
 
-from pyoctoprintapi import OctoprintClient, PrinterOffline
+from pyoctoprintapi import ApiError, OctoprintClient, PrinterOffline
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry, ConfigEntryNotReady
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_BINARY_SENSORS,
@@ -19,18 +21,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.discovery import async_load_platform
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import slugify as util_slugify
 import homeassistant.util.dt as dt_util
 
+from .const import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
-
-CONF_BED = "bed"
-CONF_NUMBER_OF_TOOLS = "number_of_tools"
-
-DEFAULT_NAME = "OctoPrint"
-DOMAIN = "octoprint"
 
 
 def has_all_unique_names(value):
@@ -49,6 +46,11 @@ def ensure_valid_path(value):
         value += "/"
     return value
 
+
+PLATFORMS = ["binary_sensor", "sensor"]
+DEFAULT_NAME = "Octoprint"
+CONF_NUMBER_OF_TOOLS = "number_of_tools"
+CONF_BED = "bed"
 
 BINARY_SENSOR_TYPES = [
     "Printing",
@@ -93,6 +95,8 @@ CONFIG_SCHEMA = vol.Schema(
                         vol.Optional(CONF_SSL, default=False): cv.boolean,
                         vol.Optional(CONF_PORT, default=80): cv.port,
                         vol.Optional(CONF_PATH, default="/"): ensure_valid_path,
+                        # Following values are not longer used in the configuration of the integration
+                        # and are here for historical purposes
                         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
                         vol.Optional(CONF_NUMBER_OF_TOOLS, default=0): cv.positive_int,
                         vol.Optional(CONF_BED, default=False): cv.boolean,
@@ -110,66 +114,79 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the OctoPrint component."""
-    printers = hass.data[DOMAIN] = {}
-    success = False
-
     if DOMAIN not in config:
-        # Skip the setup if there is no configuration present
         return True
 
-    for printer in config[DOMAIN]:
-        name = printer[CONF_NAME]
-        protocol = "https" if printer[CONF_SSL] else "http"
-        base_url = (
-            f"{protocol}://{printer[CONF_HOST]}:{printer[CONF_PORT]}"
-            f"{printer[CONF_PATH]}"
-        )
+    domain_config = config[DOMAIN]
 
-        session = async_get_clientsession(hass)
-        octoprint = OctoprintClient(
-            printer[CONF_HOST],
-            session,
-            printer[CONF_PORT],
-            printer[CONF_SSL],
-            printer[CONF_PATH],
-        )
-        octoprint.set_api_key(printer[CONF_API_KEY])
-        coordinator = OctoprintDataUpdateCoordinator(hass, octoprint, base_url, 30)
-        await coordinator.async_refresh()
-
-        printers[base_url] = coordinator
-
-        sensors = printer[CONF_SENSORS][CONF_MONITORED_CONDITIONS]
+    for conf in domain_config:
         hass.async_create_task(
-            async_load_platform(
-                hass,
-                "sensor",
+            hass.config_entries.flow.async_init(
                 DOMAIN,
-                {
-                    "name": name,
-                    "base_url": base_url,
-                    "sensors": sensors,
-                    CONF_NUMBER_OF_TOOLS: printer[CONF_NUMBER_OF_TOOLS],
-                    CONF_BED: printer[CONF_BED],
+                context={"source": SOURCE_IMPORT},
+                data={
+                    CONF_API_KEY: conf[CONF_API_KEY],
+                    CONF_HOST: conf[CONF_HOST],
+                    CONF_PATH: conf[CONF_PATH],
+                    CONF_PORT: conf[CONF_PORT],
+                    CONF_SSL: conf[CONF_SSL],
                 },
-                config,
             )
         )
-        b_sensors = printer[CONF_BINARY_SENSORS][CONF_MONITORED_CONDITIONS]
-        hass.async_create_task(
-            async_load_platform(
-                hass,
-                "binary_sensor",
-                DOMAIN,
-                {"name": name, "base_url": base_url, "sensors": b_sensors},
-                config,
-            )
-        )
-        success = True
 
-    return success
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up OctoPrint from a config entry."""
+
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+
+    websession = async_get_clientsession(hass)
+    client = OctoprintClient(
+        entry.data[CONF_HOST],
+        websession,
+        entry.data[CONF_PORT],
+        entry.data[CONF_SSL],
+        entry.data[CONF_PATH],
+    )
+
+    client.set_api_key(entry.data[CONF_API_KEY])
+
+    coordinator = OctoprintDataUpdateCoordinator(hass, client, entry.entry_id, 30)
+
+    await coordinator.async_refresh()
+
+    if not coordinator.last_update_success:
+        raise ConfigEntryNotReady
+
+    hass.data[DOMAIN][entry.entry_id] = {"coordinator": coordinator, "client": client}
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
 
 
 class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
@@ -179,23 +196,27 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         self,
         hass: HomeAssistant,
         octoprint: OctoprintClient,
-        device_id: str,
+        config_entry_id: str,
         interval: int,
     ):
         """Initialize."""
         super().__init__(
             hass,
             _LOGGER,
-            name=f"octoprint-{device_id}",
+            name=f"octoprint-{config_entry_id}",
             update_interval=timedelta(seconds=interval),
         )
         self._octoprint = octoprint
+        self._printer_offline = False
         self.data = {"printer": None, "job": None, "last_read_time": None}
 
     async def _async_update_data(self):
         """Update data via API."""
         printer = None
-        job = await self._octoprint.get_job_info()
+        try:
+            job = await self._octoprint.get_job_info()
+        except ApiError as err:
+            raise UpdateFailed(err) from err
 
         # If octoprint is on, but the printer is disconnected
         # printer will return a 409, so continue using the last
@@ -203,8 +224,12 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             printer = await self._octoprint.get_printer_info()
         except PrinterOffline:
-            _LOGGER.error("Unable to retrieve printer information: Printer offline")
+            if not self._printer_offline:
+                _LOGGER.error("Unable to retrieve printer information: Printer offline")
+            self._printer_offline = True
             if self.data and "printer" in self.data:
                 printer = self.data["printer"]
+        except ApiError as err:
+            raise UpdateFailed(err) from err
 
         return {"job": job, "printer": printer, "last_read_time": dt_util.utcnow()}

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -185,7 +185,7 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         octoprint: OctoprintClient,
         config_entry_id: str,
         interval: int,
-    ):
+    ) -> None:
         """Initialize."""
         super().__init__(
             hass,

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -218,10 +218,10 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         except PrinterOffline:
             if not self._printer_offline:
                 _LOGGER.error("Unable to retrieve printer information: Printer offline")
-            self._printer_offline = True
-            if self.data and "printer" in self.data:
-                printer = self.data["printer"]
+                self._printer_offline = True
         except ApiError as err:
             raise UpdateFailed(err) from err
+        else:
+            self._printer_offline = False
 
         return {"job": job, "printer": printer, "last_read_time": dt_util.utcnow()}

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -83,32 +83,37 @@ SENSOR_SCHEMA = vol.Schema(
 )
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.All(
-            cv.ensure_list,
-            [
-                vol.Schema(
-                    {
-                        vol.Required(CONF_API_KEY): cv.string,
-                        vol.Required(CONF_HOST): cv.string,
-                        vol.Optional(CONF_SSL, default=False): cv.boolean,
-                        vol.Optional(CONF_PORT, default=80): cv.port,
-                        vol.Optional(CONF_PATH, default="/"): ensure_valid_path,
-                        # Following values are not longer used in the configuration of the integration
-                        # and are here for historical purposes
-                        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-                        vol.Optional(CONF_NUMBER_OF_TOOLS, default=0): cv.positive_int,
-                        vol.Optional(CONF_BED, default=False): cv.boolean,
-                        vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
-                        vol.Optional(
-                            CONF_BINARY_SENSORS, default={}
-                        ): BINARY_SENSOR_SCHEMA,
-                    }
-                )
-            ],
-            has_all_unique_names,
-        )
-    },
+    vol.All(
+        cv.deprecated(DOMAIN),
+        {
+            DOMAIN: vol.All(
+                cv.ensure_list,
+                [
+                    vol.Schema(
+                        {
+                            vol.Required(CONF_API_KEY): cv.string,
+                            vol.Required(CONF_HOST): cv.string,
+                            vol.Optional(CONF_SSL, default=False): cv.boolean,
+                            vol.Optional(CONF_PORT, default=80): cv.port,
+                            vol.Optional(CONF_PATH, default="/"): ensure_valid_path,
+                            # Following values are not longer used in the configuration of the integration
+                            # and are here for historical purposes
+                            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+                            vol.Optional(
+                                CONF_NUMBER_OF_TOOLS, default=0
+                            ): cv.positive_int,
+                            vol.Optional(CONF_BED, default=False): cv.boolean,
+                            vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
+                            vol.Optional(
+                                CONF_BINARY_SENSORS, default={}
+                            ): BINARY_SENSOR_SCHEMA,
+                        }
+                    )
+                ],
+                has_all_unique_names,
+            )
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
 

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -158,30 +158,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     coordinator = OctoprintDataUpdateCoordinator(hass, client, entry.entry_id, 30)
 
-    await coordinator.async_refresh()
-
-    if not coordinator.last_update_success:
-        raise ConfigEntryNotReady
+    await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = {"coordinator": coordinator, "client": client}
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in PLATFORMS
-            ]
-        )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     )
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -1,12 +1,11 @@
 """Support for monitoring OctoPrint 3D printers."""
-import asyncio
 from datetime import timedelta
 import logging
 
 from pyoctoprintapi import ApiError, OctoprintClient, PrinterOffline
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry, ConfigEntryNotReady
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_BINARY_SENSORS,
@@ -170,7 +169,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    )
+
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -1,9 +1,8 @@
 """Support for monitoring OctoPrint 3D printers."""
+from datetime import timedelta
 import logging
-import time
 
-from aiohttp.hdrs import CONTENT_TYPE
-import requests
+from pyoctoprintapi import OctoprintClient, PrinterOffline
 import voluptuous as vol
 
 from homeassistant.const import (
@@ -16,14 +15,14 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_SENSORS,
     CONF_SSL,
-    CONTENT_TYPE_JSON,
-    PERCENTAGE,
-    TEMP_CELSIUS,
-    TIME_SECONDS,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify as util_slugify
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,11 +50,10 @@ def ensure_valid_path(value):
     return value
 
 
-BINARY_SENSOR_TYPES = {
-    # API Endpoint, Group, Key, unit
-    "Printing": ["printer", "state", "printing", None],
-    "Printing Error": ["printer", "state", "error", None],
-}
+BINARY_SENSOR_TYPES = [
+    "Printing",
+    "Printing Error",
+]
 
 BINARY_SENSOR_SCHEMA = vol.Schema(
     {
@@ -66,26 +64,13 @@ BINARY_SENSOR_SCHEMA = vol.Schema(
     }
 )
 
-SENSOR_TYPES = {
-    # API Endpoint, Group, Key, unit, icon
-    "Temperatures": ["printer", "temperature", "*", TEMP_CELSIUS],
-    "Current State": ["printer", "state", "text", None, "mdi:printer-3d"],
-    "Job Percentage": [
-        "job",
-        "progress",
-        "completion",
-        PERCENTAGE,
-        "mdi:file-percent",
-    ],
-    "Time Remaining": [
-        "job",
-        "progress",
-        "printTimeLeft",
-        TIME_SECONDS,
-        "mdi:clock-end",
-    ],
-    "Time Elapsed": ["job", "progress", "printTime", TIME_SECONDS, "mdi:clock-start"],
-}
+SENSOR_TYPES = [
+    "Temperatures",
+    "Current State",
+    "Job Percentage",
+    "Time Remaining",
+    "Time Elapsed",
+]
 
 SENSOR_SCHEMA = vol.Schema(
     {
@@ -125,7 +110,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def setup(hass, config):
+async def async_setup(hass, config):
     """Set up the OctoPrint component."""
     printers = hass.data[DOMAIN] = {}
     success = False
@@ -139,165 +124,87 @@ def setup(hass, config):
         protocol = "https" if printer[CONF_SSL] else "http"
         base_url = (
             f"{protocol}://{printer[CONF_HOST]}:{printer[CONF_PORT]}"
-            f"{printer[CONF_PATH]}api/"
+            f"{printer[CONF_PATH]}"
         )
-        api_key = printer[CONF_API_KEY]
-        number_of_tools = printer[CONF_NUMBER_OF_TOOLS]
-        bed = printer[CONF_BED]
-        try:
-            octoprint_api = OctoPrintAPI(base_url, api_key, bed, number_of_tools)
-            printers[base_url] = octoprint_api
-            octoprint_api.get("printer")
-            octoprint_api.get("job")
-        except requests.exceptions.RequestException as conn_err:
-            _LOGGER.error("Error setting up OctoPrint API: %r", conn_err)
-            continue
+
+        session = async_get_clientsession(hass)
+        octoprint = OctoprintClient(
+            printer[CONF_HOST],
+            session,
+            printer[CONF_PORT],
+            printer[CONF_SSL],
+            printer[CONF_PATH],
+        )
+        octoprint.set_api_key(printer[CONF_API_KEY])
+        coordinator = OctoprintDataUpdateCoordinator(hass, octoprint, base_url, 30)
+        await coordinator.async_refresh()
+
+        printers[base_url] = coordinator
 
         sensors = printer[CONF_SENSORS][CONF_MONITORED_CONDITIONS]
-        load_platform(
-            hass,
-            "sensor",
-            DOMAIN,
-            {"name": name, "base_url": base_url, "sensors": sensors},
-            config,
+        hass.async_create_task(
+            async_load_platform(
+                hass,
+                "sensor",
+                DOMAIN,
+                {
+                    "name": name,
+                    "base_url": base_url,
+                    "sensors": sensors,
+                    CONF_NUMBER_OF_TOOLS: printer[CONF_NUMBER_OF_TOOLS],
+                    CONF_BED: printer[CONF_BED],
+                },
+                config,
+            )
         )
         b_sensors = printer[CONF_BINARY_SENSORS][CONF_MONITORED_CONDITIONS]
-        load_platform(
-            hass,
-            "binary_sensor",
-            DOMAIN,
-            {"name": name, "base_url": base_url, "sensors": b_sensors},
-            config,
+        hass.async_create_task(
+            async_load_platform(
+                hass,
+                "binary_sensor",
+                DOMAIN,
+                {"name": name, "base_url": base_url, "sensors": b_sensors},
+                config,
+            )
         )
         success = True
 
     return success
 
 
-class OctoPrintAPI:
-    """Simple JSON wrapper for OctoPrint's API."""
+class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching Octoprint data."""
 
-    def __init__(self, api_url, key, bed, number_of_tools):
-        """Initialize OctoPrint API and set headers needed later."""
-        self.api_url = api_url
-        self.headers = {CONTENT_TYPE: CONTENT_TYPE_JSON, "X-Api-Key": key}
-        self.printer_last_reading = [{}, None]
-        self.job_last_reading = [{}, None]
-        self.job_available = False
-        self.printer_available = False
-        self.printer_error_logged = False
-        self.available = False
-        self.available_error_logged = False
-        self.job_error_logged = False
-        self.bed = bed
-        self.number_of_tools = number_of_tools
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        octoprint: OctoprintClient,
+        device_id: str,
+        interval: int,
+    ):
+        """Initialize."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"octoprint-{device_id}",
+            update_interval=timedelta(seconds=interval),
+        )
+        self._octoprint = octoprint
+        self.data = {"printer": None, "job": None, "last_read_time": None}
 
-    def get_tools(self):
-        """Get the list of tools that temperature is monitored on."""
-        tools = []
-        if self.number_of_tools > 0:
-            for tool_number in range(0, self.number_of_tools):
-                tools.append(f"tool{tool_number!s}")
-        if self.bed:
-            tools.append("bed")
-        if not self.bed and self.number_of_tools == 0:
-            temps = self.printer_last_reading[0].get("temperature")
-            if temps is not None:
-                tools = temps.keys()
-        return tools
+    async def _async_update_data(self):
+        """Update data via API."""
+        printer = None
+        job = await self._octoprint.get_job_info()
 
-    def get(self, endpoint):
-        """Send a get request, and return the response as a dict."""
-        # Only query the API at most every 30 seconds
-        now = time.time()
-        if endpoint == "job":
-            last_time = self.job_last_reading[1]
-            if last_time is not None and now - last_time < 30.0:
-                return self.job_last_reading[0]
-        elif endpoint == "printer":
-            last_time = self.printer_last_reading[1]
-            if last_time is not None and now - last_time < 30.0:
-                return self.printer_last_reading[0]
-
-        url = self.api_url + endpoint
+        # If octoprint is on, but the printer is disconnected
+        # printer will return a 409, so continue using the last
+        # reading if there is one
         try:
-            response = requests.get(url, headers=self.headers, timeout=9)
-            response.raise_for_status()
-            if endpoint == "job":
-                self.job_last_reading[0] = response.json()
-                self.job_last_reading[1] = time.time()
-                self.job_available = True
-            elif endpoint == "printer":
-                self.printer_last_reading[0] = response.json()
-                self.printer_last_reading[1] = time.time()
-                self.printer_available = True
+            printer = await self._octoprint.get_printer_info()
+        except PrinterOffline:
+            _LOGGER.error("Unable to retrieve printer information: Printer offline")
+            if self.data and "printer" in self.data:
+                printer = self.data["printer"]
 
-            self.available = self.printer_available and self.job_available
-            if self.available:
-                self.job_error_logged = False
-                self.printer_error_logged = False
-                self.available_error_logged = False
-
-            return response.json()
-
-        except requests.ConnectionError as exc_con:
-            log_string = f"Failed to connect to Octoprint server. Error: {exc_con}"
-
-            if not self.available_error_logged:
-                _LOGGER.error(log_string)
-                self.job_available = False
-                self.printer_available = False
-                self.available_error_logged = True
-
-            return None
-
-        except requests.HTTPError as ex_http:
-            status_code = ex_http.response.status_code
-
-            log_string = f"Failed to update OctoPrint status. Error: {ex_http}"
-            # Only log the first failure
-            if endpoint == "job":
-                log_string = f"Endpoint: job {log_string}"
-                if not self.job_error_logged:
-                    _LOGGER.error(log_string)
-                    self.job_error_logged = True
-                    self.job_available = False
-            elif endpoint == "printer":
-                if (
-                    status_code == 409
-                ):  # octoprint returns HTTP 409 when printer is not connected (and many other states)
-                    self.printer_available = False
-                else:
-                    log_string = f"Endpoint: printer {log_string}"
-                    if not self.printer_error_logged:
-                        _LOGGER.error(log_string)
-                        self.printer_error_logged = True
-                        self.printer_available = False
-
-            self.available = False
-
-            return None
-
-    def update(self, sensor_type, end_point, group, tool=None):
-        """Return the value for sensor_type from the provided endpoint."""
-        if (response := self.get(end_point)) is not None:
-            return get_value_from_json(response, sensor_type, group, tool)
-
-        return response
-
-
-def get_value_from_json(json_dict, sensor_type, group, tool):
-    """Return the value for sensor_type from the JSON."""
-    if group not in json_dict:
-        return None
-
-    if sensor_type in json_dict[group]:
-        if sensor_type == "target" and json_dict[sensor_type] is None:
-            return 0
-
-        return json_dict[group][sensor_type]
-
-    if tool is not None and sensor_type in json_dict[group][tool]:
-        return json_dict[group][tool][sensor_type]
-
-    return None
+        return {"job": job, "printer": printer, "last_read_time": dt_util.utcnow()}

--- a/homeassistant/components/octoprint/binary_sensor.py
+++ b/homeassistant/components/octoprint/binary_sensor.py
@@ -84,6 +84,11 @@ class OctoPrintBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
 
         return bool(self._get_flag_state(printer))
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.coordinator.data["printer"]
+
     @abstractmethod
     def _get_flag_state(self, printer_info: OctoprintPrinterInfo) -> bool | None:
         """Return the value of the sensor flag."""

--- a/homeassistant/components/octoprint/binary_sensor.py
+++ b/homeassistant/components/octoprint/binary_sensor.py
@@ -8,6 +8,7 @@ from pyoctoprintapi import OctoprintPrinterInfo
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -19,8 +20,10 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
-):
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up the available OctoPrint binary sensors."""
     coordinator = hass.data[COMPONENT_DOMAIN][config_entry.entry_id]["coordinator"]
 
@@ -40,7 +43,7 @@ class OctoPrintBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
         coordinator: DataUpdateCoordinator,
         sensor_type: str,
         device_id: str,
-    ):
+    ) -> None:
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator)
         self._name = f"Octoprint {sensor_type}"
@@ -83,7 +86,7 @@ class OctoPrintBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
 class OctoPrintPrintingBinarySensor(OctoPrintBinarySensorBase):
     """Representation an OctoPrint binary sensor."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str):
+    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str) -> None:
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator, "Printing", device_id)
 
@@ -94,7 +97,7 @@ class OctoPrintPrintingBinarySensor(OctoPrintBinarySensorBase):
 class OctoPrintPrintingErrorBinarySensor(OctoPrintBinarySensorBase):
     """Representation an OctoPrint binary sensor."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str):
+    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str) -> None:
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator, "Printing Error", device_id)
 

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -1,0 +1,202 @@
+"""Config flow for OctoPrint integration."""
+import logging
+from urllib.parse import urlsplit
+
+from pyoctoprintapi import ApiError, OctoprintClient, OctoprintException
+import voluptuous as vol
+
+from homeassistant import config_entries, data_entry_flow, exceptions
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_HOST,
+    CONF_PATH,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+)
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _schema_with_defaults(username="", host=None, port=80, path="/", ssl=False):
+    return vol.Schema(
+        {
+            vol.Required(CONF_USERNAME, default=username): cv.string,
+            vol.Required(CONF_HOST, default=host): cv.string,
+            vol.Optional(CONF_PORT, default=port): cv.port,
+            vol.Optional(CONF_PATH, default=path): cv.string,
+            vol.Optional(CONF_SSL, default=ssl): cv.boolean,
+        },
+        extra=vol.ALLOW_EXTRA,
+    )
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for OctoPrint."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+    api_key_task = None
+
+    def __init__(self):
+        """Handle a config flow for OctoPrint."""
+        self.discovery_schema = None
+        self._user_input = None
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        # When coming back from the progress steps, the user_input is stored in the
+        # instance variable instead of being passed in
+        if user_input is None and self._user_input:
+            user_input = self._user_input
+
+        if user_input is None:
+            data = self.discovery_schema or _schema_with_defaults()
+            return self.async_show_form(step_id="user", data_schema=data)
+
+        if CONF_API_KEY in user_input:
+            errors = {}
+            try:
+                return await self._finish_config(user_input)
+            except data_entry_flow.AbortFlow as err:
+                raise err from None
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                errors["base"] = "unknown"
+
+            if errors:
+                return self.async_show_form(
+                    step_id="user",
+                    errors=errors,
+                    data_schema=_schema_with_defaults(
+                        user_input.get(CONF_USERNAME),
+                        user_input[CONF_HOST],
+                        user_input[CONF_PORT],
+                        user_input[CONF_PATH],
+                        user_input[CONF_PORT],
+                    ),
+                )
+
+        self.api_key_task = None
+        return await self.async_step_get_api_key(user_input)
+
+    async def async_step_get_api_key(self, user_input):
+        """Get an Application Api Key."""
+        if not self.api_key_task:
+            self.api_key_task = self.hass.async_create_task(
+                self._async_get_auth_key(user_input)
+            )
+            return self.async_show_progress(
+                step_id="get_api_key", progress_action="get_api_key"
+            )
+
+        try:
+            await self.api_key_task
+        except OctoprintException as err:
+            _LOGGER.exception("Failed to get an application key: %s", err)
+            return self.async_show_progress_done(next_step_id="auth_failed")
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.exception("Failed to get an application key : %s", err)
+            return self.async_show_progress_done(next_step_id="auth_failed")
+
+        # store this off here to pick back up in the user step
+        self._user_input = user_input
+        return self.async_show_progress_done(next_step_id="user")
+
+    async def _finish_config(self, user_input):
+        """Finish the configuration setup."""
+        session = async_get_clientsession(self.hass)
+        octoprint = OctoprintClient(
+            user_input[CONF_HOST],
+            session,
+            user_input[CONF_PORT],
+            user_input[CONF_SSL],
+            user_input[CONF_PATH],
+        )
+        octoprint.set_api_key(user_input[CONF_API_KEY])
+
+        try:
+            discovery = await octoprint.get_discovery_info()
+        except ApiError as err:
+            _LOGGER.error("Failed to connect to printer")
+            raise CannotConnect from err
+
+        await self.async_set_unique_id(discovery.upnp_uuid, raise_on_progress=False)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
+
+    async def async_step_auth_failed(self, user_input):
+        """Handle api fetch failure."""
+        return self.async_abort(reason="auth_failed")
+
+    async def async_step_import(self, user_input):
+        """Handle import."""
+        return await self.async_step_user(user_input)
+
+    async def async_step_zeroconf(self, discovery_info):
+        """Handle discovery flow."""
+        uuid = discovery_info["properties"]["uuid"]
+        await self.async_set_unique_id(uuid)
+        self._abort_if_unique_id_configured()
+
+        self.context["title_placeholders"] = {
+            CONF_HOST: discovery_info[CONF_HOST],
+        }
+
+        self.discovery_schema = _schema_with_defaults(
+            host=discovery_info[CONF_HOST],
+            port=discovery_info[CONF_PORT],
+            path=discovery_info["properties"][CONF_PATH],
+        )
+
+        return await self.async_step_user()
+
+    async def async_step_ssdp(self, discovery_info):
+        """Handle ssdp discovery flow."""
+        uuid = discovery_info["UDN"][5:]
+        await self.async_set_unique_id(uuid)
+        self._abort_if_unique_id_configured()
+
+        url = urlsplit(discovery_info["presentationURL"])
+        self.context["title_placeholders"] = {
+            CONF_HOST: url.hostname,
+        }
+
+        self.discovery_schema = _schema_with_defaults(
+            host=url.hostname,
+            port=url.port,
+        )
+
+        return await self.async_step_user()
+
+    async def _async_get_auth_key(self, user_input: dict):
+        """Get application api key."""
+        session = async_get_clientsession(self.hass)
+        octoprint = OctoprintClient(
+            user_input[CONF_HOST],
+            session,
+            user_input[CONF_PORT],
+            user_input[CONF_SSL],
+            user_input[CONF_PATH],
+        )
+
+        try:
+            user_input[CONF_API_KEY] = await octoprint.request_app_key(
+                "Home Assistant", user_input[CONF_USERNAME], 30
+            )
+        finally:
+            # Continue the flow after show progress when the task is done.
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_configure(
+                    flow_id=self.flow_id, user_input=user_input
+                )
+            )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -78,7 +78,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         user_input[CONF_HOST],
                         user_input[CONF_PORT],
                         user_input[CONF_PATH],
-                        user_input[CONF_PORT],
+                        user_input[CONF_SSL],
                     ),
                 )
 

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
     api_key_task = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Handle a config flow for OctoPrint."""
         self.discovery_schema = None
         self._user_input = None

--- a/homeassistant/components/octoprint/const.py
+++ b/homeassistant/components/octoprint/const.py
@@ -1,0 +1,5 @@
+"""Constants for the OctoPrint integration."""
+
+DOMAIN = "octoprint"
+
+DEFAULT_NAME = "OctoPrint"

--- a/homeassistant/components/octoprint/manifest.json
+++ b/homeassistant/components/octoprint/manifest.json
@@ -3,7 +3,7 @@
   "name": "OctoPrint",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/octoprint",
-  "requirements": ["pyoctoprintapi==0.1.5"],
+  "requirements": ["pyoctoprintapi==0.1.6"],
   "codeowners": ["@rfleming71"],
   "zeroconf": ["_octoprint._tcp.local."],
   "ssdp": [

--- a/homeassistant/components/octoprint/manifest.json
+++ b/homeassistant/components/octoprint/manifest.json
@@ -1,9 +1,16 @@
 {
   "domain": "octoprint",
   "name": "OctoPrint",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/octoprint",
-  "after_dependencies": ["discovery"],
-  "requirements": ["pyoctoprintapi==0.1.3"],
-  "codeowners": [],
+  "requirements": ["pyoctoprintapi==0.1.5"],
+  "codeowners": ["@rfleming71"],
+  "zeroconf": ["_octoprint._tcp.local."],
+  "ssdp": [
+    {
+      "manufacturer": "The OctoPrint Project",
+      "deviceType": "urn:schemas-upnp-org:device:Basic:1"
+    }
+  ],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/octoprint/manifest.json
+++ b/homeassistant/components/octoprint/manifest.json
@@ -3,6 +3,7 @@
   "name": "OctoPrint",
   "documentation": "https://www.home-assistant.io/integrations/octoprint",
   "after_dependencies": ["discovery"],
+  "requirements": ["pyoctoprintapi==0.1.3"],
   "codeowners": [],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -24,8 +25,10 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
-):
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up the available OctoPrint binary sensors."""
     coordinator: DataUpdateCoordinator = hass.data[COMPONENT_DOMAIN][
         config_entry.entry_id
@@ -65,7 +68,7 @@ class OctoPrintSensorBase(CoordinatorEntity, SensorEntity):
         coordinator: DataUpdateCoordinator,
         sensor_type: str,
         device_id: str,
-    ):
+    ) -> None:
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator)
         self._state = None
@@ -96,7 +99,7 @@ class OctoPrintSensorBase(CoordinatorEntity, SensorEntity):
 class OctoPrintStatusSensor(OctoPrintSensorBase):
     """Representation of an OctoPrint sensor."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str):
+    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str) -> None:
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator, "Current State", device_id)
 
@@ -118,7 +121,7 @@ class OctoPrintStatusSensor(OctoPrintSensorBase):
 class OctoPrintJobPercentageSensor(OctoPrintSensorBase):
     """Representation of an OctoPrint sensor."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str):
+    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str) -> None:
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator, "Job Percentage", device_id)
 
@@ -149,7 +152,7 @@ class OctoPrintJobPercentageSensor(OctoPrintSensorBase):
 class OctoPrintEstimatedFinishTimeSensor(OctoPrintSensorBase):
     """Representation of an OctoPrint sensor."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str):
+    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str) -> None:
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator, "Estimated Finish Time", device_id)
 
@@ -173,7 +176,7 @@ class OctoPrintEstimatedFinishTimeSensor(OctoPrintSensorBase):
 class OctoPrintStartTimeSensor(OctoPrintSensorBase):
     """Representation of an OctoPrint sensor."""
 
-    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str):
+    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str) -> None:
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator, "Start Time", device_id)
 
@@ -204,7 +207,7 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
         tool: str,
         temp_type: str,
         device_id: str,
-    ):
+    ) -> None:
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator, f"{temp_type} {tool} temp", device_id)
         self._temp_type = temp_type

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -120,6 +120,11 @@ class OctoPrintStatusSensor(OctoPrintSensorBase):
         """Icon to use in the frontend."""
         return "mdi:printer-3d"
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.coordinator.data["printer"]
+
 
 class OctoPrintJobPercentageSensor(OctoPrintSensorBase):
     """Representation of an OctoPrint sensor."""
@@ -244,3 +249,8 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
                 )
 
         return None
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.coordinator.data["printer"]

--- a/homeassistant/components/octoprint/strings.json
+++ b/homeassistant/components/octoprint/strings.json
@@ -1,0 +1,30 @@
+{
+    "title": "OctoPrint",
+    "config": {
+      "flow_title": "OctoPrint Printer: {host}",
+      "step": {
+        "user": {
+          "data": {
+            "host": "[%key:common::config_flow::data::host%]",
+            "path": "Application Path",
+            "port": "Port Number",
+            "ssl": "Use SSL",
+            "username": "[%key:common::config_flow::data::username%]"
+          }
+        }
+      },
+      "error": {
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "unknown": "[%key:common::config_flow::error::unknown%]"
+      },
+      "abort": {
+        "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+        "unknown": "[%key:common::config_flow::error::unknown%]",
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "auth_failed": "Failed to retrieve application api key"
+      },
+      "progress": {
+        "get_api_key": "Open the OctoPrint UI and click 'Allow' on the Access Request for 'Home Assistant'."
+      }
+    }
+  }

--- a/homeassistant/components/octoprint/strings.json
+++ b/homeassistant/components/octoprint/strings.json
@@ -1,30 +1,29 @@
 {
-    "title": "OctoPrint",
-    "config": {
-      "flow_title": "OctoPrint Printer: {host}",
-      "step": {
-        "user": {
-          "data": {
-            "host": "[%key:common::config_flow::data::host%]",
-            "path": "Application Path",
-            "port": "Port Number",
-            "ssl": "Use SSL",
-            "username": "[%key:common::config_flow::data::username%]"
-          }
+  "config": {
+    "flow_title": "OctoPrint Printer: {host}",
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "path": "Application Path",
+          "port": "Port Number",
+          "ssl": "Use SSL",
+          "username": "[%key:common::config_flow::data::username%]"
         }
-      },
-      "error": {
-        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-        "unknown": "[%key:common::config_flow::error::unknown%]"
-      },
-      "abort": {
-        "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-        "unknown": "[%key:common::config_flow::error::unknown%]",
-        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-        "auth_failed": "Failed to retrieve application api key"
-      },
-      "progress": {
-        "get_api_key": "Open the OctoPrint UI and click 'Allow' on the Access Request for 'Home Assistant'."
       }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "auth_failed": "Failed to retrieve application api key"
+    },
+    "progress": {
+      "get_api_key": "Open the OctoPrint UI and click 'Allow' on the Access Request for 'Home Assistant'."
     }
   }
+}

--- a/homeassistant/components/octoprint/translations/en.json
+++ b/homeassistant/components/octoprint/translations/en.json
@@ -1,0 +1,31 @@
+{
+    "config": {
+        "flow_title": "OctoPrint Printer: {host}",
+        "abort": {
+            "already_configured": "Device is already configured",
+            "unknown": "[%key:common::config_flow::error::unknown%]",
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "auth_failed": "Failed to retrieve application api key"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "auth_failed": "Failed to retrieve application api key",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "path": "Application Path",
+                    "port": "Port Number",
+                    "username": "Username",
+                    "ssl": "Use SSL"
+                }
+            }
+        },
+        "progress": {
+            "get_api_key": "Open the OctoPrint UI and click 'Allow' on the Access Request for 'Home Assistant'."
+        }
+    },
+    "title": "OctoPrint"
+}

--- a/homeassistant/components/octoprint/translations/en.json
+++ b/homeassistant/components/octoprint/translations/en.json
@@ -1,16 +1,18 @@
 {
     "config": {
-        "flow_title": "OctoPrint Printer: {host}",
         "abort": {
             "already_configured": "Device is already configured",
-            "unknown": "[%key:common::config_flow::error::unknown%]",
-            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-            "auth_failed": "Failed to retrieve application api key"
+            "auth_failed": "Failed to retrieve application api key",
+            "cannot_connect": "Failed to connect",
+            "unknown": "Unexpected error"
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "auth_failed": "Failed to retrieve application api key",
             "unknown": "Unexpected error"
+        },
+        "flow_title": "OctoPrint Printer: {host}",
+        "progress": {
+            "get_api_key": "Open the OctoPrint UI and click 'Allow' on the Access Request for 'Home Assistant'."
         },
         "step": {
             "user": {
@@ -18,14 +20,10 @@
                     "host": "Host",
                     "path": "Application Path",
                     "port": "Port Number",
-                    "username": "Username",
-                    "ssl": "Use SSL"
+                    "ssl": "Use SSL",
+                    "username": "Username"
                 }
             }
-        },
-        "progress": {
-            "get_api_key": "Open the OctoPrint UI and click 'Allow' on the Access Request for 'Home Assistant'."
         }
-    },
-    "title": "OctoPrint"
+    }
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -201,6 +201,7 @@ FLOWS = [
     "nut",
     "nws",
     "nzbget",
+    "octoprint",
     "omnilogic",
     "ondilo_ico",
     "onewire",

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -171,6 +171,12 @@ SSDP = {
             "manufacturer": "NETGEAR, Inc."
         }
     ],
+    "octoprint": [
+        {
+            "deviceType": "urn:schemas-upnp-org:device:Basic:1",
+            "manufacturer": "The OctoPrint Project"
+        }
+    ],
     "roku": [
         {
             "deviceType": "urn:roku-com:device:player:1-0",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -194,6 +194,11 @@ ZEROCONF = {
             "domain": "nut"
         }
     ],
+    "_octoprint._tcp.local.": [
+        {
+            "domain": "octoprint"
+        }
+    ],
     "_plexmediasvr._tcp.local.": [
         {
             "domain": "plex"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1678,6 +1678,9 @@ pynzbgetapi==0.2.0
 # homeassistant.components.obihai
 pyobihai==1.3.1
 
+# homeassistant.components.octoprint
+pyoctoprintapi==0.1.3
+
 # homeassistant.components.ombi
 pyombi==0.1.10
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1679,7 +1679,7 @@ pynzbgetapi==0.2.0
 pyobihai==1.3.1
 
 # homeassistant.components.octoprint
-pyoctoprintapi==0.1.3
+pyoctoprintapi==0.1.5
 
 # homeassistant.components.ombi
 pyombi==0.1.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1679,7 +1679,7 @@ pynzbgetapi==0.2.0
 pyobihai==1.3.1
 
 # homeassistant.components.octoprint
-pyoctoprintapi==0.1.5
+pyoctoprintapi==0.1.6
 
 # homeassistant.components.ombi
 pyombi==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1006,6 +1006,9 @@ pynx584==0.5
 # homeassistant.components.nzbget
 pynzbgetapi==0.2.0
 
+# homeassistant.components.octoprint
+pyoctoprintapi==0.1.3
+
 # homeassistant.components.openuv
 pyopenuv==2.2.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1007,7 +1007,7 @@ pynx584==0.5
 pynzbgetapi==0.2.0
 
 # homeassistant.components.octoprint
-pyoctoprintapi==0.1.5
+pyoctoprintapi==0.1.6
 
 # homeassistant.components.openuv
 pyopenuv==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1007,7 +1007,7 @@ pynx584==0.5
 pynzbgetapi==0.2.0
 
 # homeassistant.components.octoprint
-pyoctoprintapi==0.1.3
+pyoctoprintapi==0.1.5
 
 # homeassistant.components.openuv
 pyopenuv==2.2.1

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -1,10 +1,17 @@
 """Tests for the OctoPrint integration."""
 from unittest.mock import patch
 
-from pyoctoprintapi import OctoprintJobInfo, OctoprintPrinterInfo
+from pyoctoprintapi import (
+    DiscoverySettings,
+    OctoprintJobInfo,
+    OctoprintPrinterInfo,
+    TrackingSetting,
+)
 
+from homeassistant import config_entries
 from homeassistant.components.octoprint import DOMAIN
-from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
 
 DEFAULT_JOB = {
     "job": {},
@@ -24,22 +31,38 @@ async def init_integration(
     hass, platform, printer: dict = DEFAULT_PRINTER, job: dict = DEFAULT_JOB
 ):
     """Set up the octoprint integration in Home Assistant."""
-    config = {
-        DOMAIN: {
-            "host": "192.168.1.5",
-            "api_key": "test-key",
-            "ssl": False,
-            "port": 80,
-            "path": "/",
-            "name": "Octoprint",
-        }
-    }
-    with patch(
+    with patch("homeassistant.components.octoprint.PLATFORMS", [platform]), patch(
+        "pyoctoprintapi.OctoprintClient.get_server_info", return_value={}
+    ), patch(
         "pyoctoprintapi.OctoprintClient.get_printer_info",
         return_value=OctoprintPrinterInfo(printer),
     ), patch(
         "pyoctoprintapi.OctoprintClient.get_job_info",
         return_value=OctoprintJobInfo(job),
+    ), patch(
+        "pyoctoprintapi.OctoprintClient.get_tracking_info",
+        return_value=TrackingSetting({"unique_id": "uuid"}),
+    ), patch(
+        "pyoctoprintapi.OctoprintClient.get_discovery_info",
+        return_value=DiscoverySettings({"upnpUuid": "uuid"}),
     ):
-        assert await async_setup_component(hass, DOMAIN, config)
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            entry_id="uuid",
+            unique_id="uuid",
+            data={
+                "host": "1.1.1.1",
+                "api_key": "test-key",
+                "name": "Octoprint",
+                "port": 81,
+                "ssl": True,
+                "path": "/",
+            },
+            title="Octoprint",
+        )
+        config_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
+
+    assert config_entry.state == config_entries.ENTRY_STATE_LOADED

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -1,0 +1,45 @@
+"""Tests for the OctoPrint integration."""
+from unittest.mock import patch
+
+from pyoctoprintapi import OctoprintJobInfo, OctoprintPrinterInfo
+
+from homeassistant.components.octoprint import DOMAIN
+from homeassistant.setup import async_setup_component
+
+DEFAULT_JOB = {
+    "job": {},
+    "progress": {"completion": 50},
+}
+
+DEFAULT_PRINTER = {
+    "state": {
+        "flags": {"printing": True, "error": False},
+        "text": "Operational",
+    },
+    "temperature": [],
+}
+
+
+async def init_integration(
+    hass, platform, printer: dict = DEFAULT_PRINTER, job: dict = DEFAULT_JOB
+):
+    """Set up the octoprint integration in Home Assistant."""
+    config = {
+        DOMAIN: {
+            "host": "192.168.1.5",
+            "api_key": "test-key",
+            "ssl": False,
+            "port": 80,
+            "path": "/",
+            "name": "Octoprint",
+        }
+    }
+    with patch(
+        "pyoctoprintapi.OctoprintClient.get_printer_info",
+        return_value=OctoprintPrinterInfo(printer),
+    ), patch(
+        "pyoctoprintapi.OctoprintClient.get_job_info",
+        return_value=OctoprintJobInfo(job),
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -13,6 +13,7 @@ from pyoctoprintapi import (
 
 from homeassistant.components.octoprint import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
 from tests.common import MockConfigEntry
 
@@ -33,19 +34,22 @@ DEFAULT_PRINTER = {
 async def init_integration(
     hass,
     platform,
-    printer: dict[str, Any] | None = None,
+    printer: dict[str, Any] | UndefinedType | None = UNDEFINED,
     job: dict[str, Any] | None = None,
 ):
     """Set up the octoprint integration in Home Assistant."""
-    if printer is None:
+    printer_info: OctoprintPrinterInfo | None = None
+    if printer is UNDEFINED:
         printer = DEFAULT_PRINTER
+    if printer is not None:
+        printer_info = OctoprintPrinterInfo(printer)
     if job is None:
         job = DEFAULT_JOB
     with patch("homeassistant.components.octoprint.PLATFORMS", [platform]), patch(
         "pyoctoprintapi.OctoprintClient.get_server_info", return_value={}
     ), patch(
         "pyoctoprintapi.OctoprintClient.get_printer_info",
-        return_value=OctoprintPrinterInfo(printer),
+        return_value=printer_info,
     ), patch(
         "pyoctoprintapi.OctoprintClient.get_job_info",
         return_value=OctoprintJobInfo(job),

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -1,4 +1,7 @@
 """Tests for the OctoPrint integration."""
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import patch
 
 from pyoctoprintapi import (
@@ -8,8 +11,8 @@ from pyoctoprintapi import (
     TrackingSetting,
 )
 
-from homeassistant import config_entries
 from homeassistant.components.octoprint import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 
 from tests.common import MockConfigEntry
 
@@ -28,9 +31,16 @@ DEFAULT_PRINTER = {
 
 
 async def init_integration(
-    hass, platform, printer: dict = DEFAULT_PRINTER, job: dict = DEFAULT_JOB
+    hass,
+    platform,
+    printer: dict[str, Any] | None = None,
+    job: dict[str, Any] | None = None,
 ):
     """Set up the octoprint integration in Home Assistant."""
+    if printer is None:
+        printer = DEFAULT_PRINTER
+    if job is None:
+        job = DEFAULT_JOB
     with patch("homeassistant.components.octoprint.PLATFORMS", [platform]), patch(
         "pyoctoprintapi.OctoprintClient.get_server_info", return_value={}
     ), patch(
@@ -65,4 +75,4 @@ async def init_integration(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == config_entries.ENTRY_STATE_LOADED
+    assert config_entry.state == ConfigEntryState.LOADED

--- a/tests/components/octoprint/test_binary_sensor.py
+++ b/tests/components/octoprint/test_binary_sensor.py
@@ -1,0 +1,27 @@
+"""The tests for Octoptint binary sensor module."""
+
+from homeassistant.const import STATE_OFF, STATE_ON
+
+from . import init_integration
+
+
+async def test_sensors(hass):
+    """Test the underlying sensors."""
+    printer = {
+        "state": {
+            "flags": {"printing": True, "error": False},
+            "text": "Operational",
+        },
+        "temperature": [],
+    }
+    await init_integration(hass, "binary_sensor", printer=printer)
+
+    state = hass.states.get("binary_sensor.octoprint_printing")
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.name == "Octoprint Printing"
+
+    state = hass.states.get("binary_sensor.octoprint_printing_error")
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.name == "Octoprint Printing Error"

--- a/tests/components/octoprint/test_binary_sensor.py
+++ b/tests/components/octoprint/test_binary_sensor.py
@@ -16,12 +16,18 @@ async def test_sensors(hass):
     }
     await init_integration(hass, "binary_sensor", printer=printer)
 
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
     state = hass.states.get("binary_sensor.octoprint_printing")
     assert state is not None
     assert state.state == STATE_ON
     assert state.name == "Octoprint Printing"
+    entry = entity_registry.async_get("binary_sensor.octoprint_printing")
+    assert entry.unique_id == "Printing-uuid"
 
     state = hass.states.get("binary_sensor.octoprint_printing_error")
     assert state is not None
     assert state.state == STATE_OFF
     assert state.name == "Octoprint Printing Error"
+    entry = entity_registry.async_get("binary_sensor.octoprint_printing_error")
+    assert entry.unique_id == "Printing Error-uuid"

--- a/tests/components/octoprint/test_binary_sensor.py
+++ b/tests/components/octoprint/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """The tests for Octoptint binary sensor module."""
 
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 
 from . import init_integration
 
@@ -28,6 +28,27 @@ async def test_sensors(hass):
     state = hass.states.get("binary_sensor.octoprint_printing_error")
     assert state is not None
     assert state.state == STATE_OFF
+    assert state.name == "Octoprint Printing Error"
+    entry = entity_registry.async_get("binary_sensor.octoprint_printing_error")
+    assert entry.unique_id == "Printing Error-uuid"
+
+
+async def test_sensors_printer_offline(hass):
+    """Test the underlying sensors when the printer is offline."""
+    await init_integration(hass, "binary_sensor", printer=None)
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    state = hass.states.get("binary_sensor.octoprint_printing")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    assert state.name == "Octoprint Printing"
+    entry = entity_registry.async_get("binary_sensor.octoprint_printing")
+    assert entry.unique_id == "Printing-uuid"
+
+    state = hass.states.get("binary_sensor.octoprint_printing_error")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
     assert state.name == "Octoprint Printing Error"
     entry = entity_registry.async_get("binary_sensor.octoprint_printing_error")
     assert entry.unique_id == "Printing Error-uuid"

--- a/tests/components/octoprint/test_config_flow.py
+++ b/tests/components/octoprint/test_config_flow.py
@@ -1,0 +1,421 @@
+"""Test the OctoPrint config flow."""
+from unittest.mock import patch
+
+from pyoctoprintapi import ApiError, DiscoverySettings
+
+from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.octoprint.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert not result["errors"]
+
+    with patch(
+        "pyoctoprintapi.OctoprintClient.request_app_key", return_value="test-key"
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "testuser",
+                "host": "1.1.1.1",
+                "name": "Printer",
+                "port": 81,
+                "ssl": True,
+                "path": "/",
+            },
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == "progress"
+
+    with patch(
+        "pyoctoprintapi.OctoprintClient.get_server_info",
+        return_value=True,
+    ), patch(
+        "pyoctoprintapi.OctoprintClient.get_discovery_info",
+        return_value=DiscoverySettings({"upnpUuid": "uuid"}),
+    ), patch(
+        "homeassistant.components.octoprint.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.octoprint.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "1.1.1.1"
+    assert result2["data"] == {
+        "username": "testuser",
+        "host": "1.1.1.1",
+        "api_key": "test-key",
+        "name": "Printer",
+        "port": 81,
+        "ssl": True,
+        "path": "/",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "username": "testuser",
+            "host": "1.1.1.1",
+            "name": "Printer",
+            "port": 81,
+            "ssl": True,
+            "path": "/",
+        },
+    )
+    assert result["type"] == "progress"
+
+    with patch(
+        "pyoctoprintapi.OctoprintClient.request_app_key", return_value="test-key"
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+        )
+
+    assert result["type"] == "progress_done"
+    with patch(
+        "pyoctoprintapi.OctoprintClient.get_discovery_info",
+        side_effect=ApiError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "testuser",
+                "host": "1.1.1.1",
+                "name": "Printer",
+                "port": 81,
+                "ssl": True,
+                "path": "/",
+                "api_key": "test-key",
+            },
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "cannot_connect"
+
+
+async def test_form_unknown_exception(hass):
+    """Test we handle a random error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "username": "testuser",
+            "host": "1.1.1.1",
+            "name": "Printer",
+            "port": 81,
+            "ssl": True,
+            "path": "/",
+        },
+    )
+    assert result["type"] == "progress"
+
+    with patch(
+        "pyoctoprintapi.OctoprintClient.request_app_key", return_value="test-key"
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+        )
+
+    assert result["type"] == "progress_done"
+    with patch(
+        "pyoctoprintapi.OctoprintClient.get_discovery_info",
+        side_effect=Exception,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "testuser",
+                "host": "1.1.1.1",
+                "name": "Printer",
+                "port": 81,
+                "ssl": True,
+                "path": "/",
+                "api_key": "test-key",
+            },
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "unknown"
+
+
+async def test_show_zerconf_form(hass: HomeAssistant) -> None:
+    """Test that the zeroconf confirmation form is served."""
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data={
+            "host": "192.168.1.123",
+            "port": 80,
+            "hostname": "example.local.",
+            "uuid": "83747482",
+            "properties": {"uuid": "83747482", "path": "/foo/"},
+        },
+    )
+    assert result["type"] == "form"
+    assert not result["errors"]
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "username": "testuser",
+        },
+    )
+    assert result["type"] == "progress"
+
+    with patch(
+        "pyoctoprintapi.OctoprintClient.request_app_key", return_value="test-key"
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "progress_done"
+
+    with patch(
+        "pyoctoprintapi.OctoprintClient.get_server_info",
+        return_value=True,
+    ), patch(
+        "pyoctoprintapi.OctoprintClient.get_discovery_info",
+        return_value=DiscoverySettings({"upnpUuid": "uuid"}),
+    ), patch(
+        "homeassistant.components.octoprint.async_setup", return_value=True
+    ), patch(
+        "homeassistant.components.octoprint.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "testuser",
+                "host": "1.1.1.1",
+                "name": "Printer",
+                "port": 81,
+                "ssl": True,
+                "path": "/",
+                "api_key": "test-key",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+async def test_show_ssdp_form(hass: HomeAssistant) -> None:
+    """Test that the zeroconf confirmation form is served."""
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data={
+            "presentationURL": "http://192.168.1.123:80/discovery/device.xml",
+            "port": 80,
+            "UDN": "uuid:83747482",
+        },
+    )
+    assert result["type"] == "form"
+    assert not result["errors"]
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "username": "testuser",
+        },
+    )
+    assert result["type"] == "progress"
+
+    with patch(
+        "pyoctoprintapi.OctoprintClient.request_app_key", return_value="test-key"
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "progress_done"
+
+    with patch(
+        "pyoctoprintapi.OctoprintClient.get_server_info",
+        return_value=True,
+    ), patch(
+        "pyoctoprintapi.OctoprintClient.get_discovery_info",
+        return_value=DiscoverySettings({"upnpUuid": "uuid"}),
+    ), patch(
+        "homeassistant.components.octoprint.async_setup", return_value=True
+    ), patch(
+        "homeassistant.components.octoprint.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "testuser",
+                "host": "1.1.1.1",
+                "name": "Printer",
+                "port": 81,
+                "ssl": True,
+                "path": "/",
+                "api_key": "test-key",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+async def test_import_yaml(hass: HomeAssistant) -> None:
+    """Test that the yaml import works."""
+    with patch(
+        "pyoctoprintapi.OctoprintClient.get_server_info",
+        return_value=True,
+    ), patch(
+        "pyoctoprintapi.OctoprintClient.get_discovery_info",
+        return_value=DiscoverySettings({"upnpUuid": "uuid"}),
+    ), patch(
+        "pyoctoprintapi.OctoprintClient.request_app_key", return_value="test-key"
+    ), patch(
+        "homeassistant.components.octoprint.async_setup", return_value=True
+    ), patch(
+        "homeassistant.components.octoprint.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                "host": "1.1.1.1",
+                "api_key": "test-key",
+                "name": "Printer",
+                "port": 81,
+                "ssl": True,
+                "path": "/",
+            },
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert "errors" not in result
+
+
+async def test_import_duplicate_yaml(hass: HomeAssistant) -> None:
+    """Test that the yaml import works."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "192.168.1.123"},
+        source=config_entries.SOURCE_IMPORT,
+        unique_id="uuid",
+    ).add_to_hass(hass)
+
+    with patch(
+        "pyoctoprintapi.OctoprintClient.get_discovery_info",
+        return_value=DiscoverySettings({"upnpUuid": "uuid"}),
+    ), patch(
+        "pyoctoprintapi.OctoprintClient.request_app_key", return_value="test-key"
+    ) as request_app_key:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                "host": "1.1.1.1",
+                "api_key": "test-key",
+                "name": "Printer",
+                "port": 81,
+                "ssl": True,
+                "path": "/",
+            },
+        )
+        await hass.async_block_till_done()
+        assert len(request_app_key.mock_calls) == 0
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_failed_auth(hass: HomeAssistant) -> None:
+    """Test we handle a random error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "username": "testuser",
+            "host": "1.1.1.1",
+            "name": "Printer",
+            "port": 81,
+            "ssl": True,
+            "path": "/",
+        },
+    )
+    assert result["type"] == "progress"
+
+    with patch("pyoctoprintapi.OctoprintClient.request_app_key", side_effect=ApiError):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+        )
+
+    assert result["type"] == "progress_done"
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "auth_failed"
+
+
+async def test_failed_auth_unexpected_error(hass: HomeAssistant) -> None:
+    """Test we handle a random error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "username": "testuser",
+            "host": "1.1.1.1",
+            "name": "Printer",
+            "port": 81,
+            "ssl": True,
+            "path": "/",
+        },
+    )
+    assert result["type"] == "progress"
+
+    with patch("pyoctoprintapi.OctoprintClient.request_app_key", side_effect=Exception):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+        )
+
+    assert result["type"] == "progress_done"
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "auth_failed"

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -1,0 +1,59 @@
+"""The tests for Octoptint binary sensor module."""
+from datetime import datetime
+from unittest.mock import patch
+
+from . import init_integration
+
+
+async def test_sensors(hass):
+    """Test the underlying sensors."""
+    printer = {
+        "state": {
+            "flags": {},
+            "text": "Operational",
+        },
+        "temperature": {"tool1": {"actual": 18.83136, "target": 37.83136}},
+    }
+    job = {
+        "job": {},
+        "progress": {"completion": 50, "printTime": 600, "printTimeLeft": 6000},
+    }
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=datetime(2020, 2, 20, 9, 10, 0)
+    ):
+        await init_integration(hass, "sensor", printer=printer, job=job)
+
+    state = hass.states.get("sensor.octoprint_job_percentage")
+    assert state is not None
+    assert state.state == "50"
+    assert state.name == "Octoprint Job Percentage"
+
+    state = hass.states.get("sensor.octoprint_current_state")
+    assert state is not None
+    assert state.state == "Operational"
+    assert state.name == "Octoprint Current State"
+
+    state = hass.states.get("sensor.octoprint_actual_tool1_temp")
+    assert state is not None
+    assert state.state == "18.83"
+    assert state.name == "Octoprint actual tool1 temp"
+
+    state = hass.states.get("sensor.octoprint_target_tool1_temp")
+    assert state is not None
+    assert state.state == "37.83"
+    assert state.name == "Octoprint target tool1 temp"
+
+    state = hass.states.get("sensor.octoprint_target_tool1_temp")
+    assert state is not None
+    assert state.state == "37.83"
+    assert state.name == "Octoprint target tool1 temp"
+
+    state = hass.states.get("sensor.octoprint_start_time")
+    assert state is not None
+    assert state.state == "2020-02-20T09:00:00"
+    assert state.name == "Octoprint Start Time"
+
+    state = hass.states.get("sensor.octoprint_estimated_finish_time")
+    assert state is not None
+    assert state.state == "2020-02-20T10:50:00"
+    assert state.name == "Octoprint Estimated Finish Time"

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -17,43 +17,60 @@ async def test_sensors(hass):
     job = {
         "job": {},
         "progress": {"completion": 50, "printTime": 600, "printTimeLeft": 6000},
+        "state": "Printing",
     }
     with patch(
         "homeassistant.util.dt.utcnow", return_value=datetime(2020, 2, 20, 9, 10, 0)
     ):
         await init_integration(hass, "sensor", printer=printer, job=job)
 
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
     state = hass.states.get("sensor.octoprint_job_percentage")
     assert state is not None
     assert state.state == "50"
     assert state.name == "Octoprint Job Percentage"
+    entry = entity_registry.async_get("sensor.octoprint_job_percentage")
+    assert entry.unique_id == "Job Percentage-uuid"
 
     state = hass.states.get("sensor.octoprint_current_state")
     assert state is not None
     assert state.state == "Operational"
     assert state.name == "Octoprint Current State"
+    entry = entity_registry.async_get("sensor.octoprint_current_state")
+    assert entry.unique_id == "Current State-uuid"
 
     state = hass.states.get("sensor.octoprint_actual_tool1_temp")
     assert state is not None
     assert state.state == "18.83"
     assert state.name == "Octoprint actual tool1 temp"
+    entry = entity_registry.async_get("sensor.octoprint_actual_tool1_temp")
+    assert entry.unique_id == "actual tool1 temp-uuid"
 
     state = hass.states.get("sensor.octoprint_target_tool1_temp")
     assert state is not None
     assert state.state == "37.83"
     assert state.name == "Octoprint target tool1 temp"
+    entry = entity_registry.async_get("sensor.octoprint_target_tool1_temp")
+    assert entry.unique_id == "target tool1 temp-uuid"
 
     state = hass.states.get("sensor.octoprint_target_tool1_temp")
     assert state is not None
     assert state.state == "37.83"
     assert state.name == "Octoprint target tool1 temp"
+    entry = entity_registry.async_get("sensor.octoprint_target_tool1_temp")
+    assert entry.unique_id == "target tool1 temp-uuid"
 
     state = hass.states.get("sensor.octoprint_start_time")
     assert state is not None
     assert state.state == "2020-02-20T09:00:00"
     assert state.name == "Octoprint Start Time"
+    entry = entity_registry.async_get("sensor.octoprint_start_time")
+    assert entry.unique_id == "Start Time-uuid"
 
     state = hass.states.get("sensor.octoprint_estimated_finish_time")
     assert state is not None
     assert state.state == "2020-02-20T10:50:00"
     assert state.name == "Octoprint Estimated Finish Time"
+    entry = entity_registry.async_get("sensor.octoprint_estimated_finish_time")
+    assert entry.unique_id == "Estimated Finish Time-uuid"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The OctoPrint integration migrated to configuration via the UI. Configuring OctoPrint via YAML configuration has been deprecated and will be removed in a future Home Assistant release.

Your existing YAML configuration is automatically imported on upgrade to this release; and thus can be safely removed from your YAML configuration after upgrading.

Sensors removed:
- sensor.<printer>_time_remaining
- sensor.<printer>_time_elapsed

Sensors added:
- sensor.octoprint_start_time
- sensor.octoprint_estimated_finish_time

Previously entities added would be prefixed by the printer name, i.e. if the printer was ender 5, the sensors would be `sensor.ender_5_bed_temp0`. After this change they will be `sensor.octoprint_bed_temp0` and can be renamed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updating octoprint integration to use library to handle the API and adding a config_flow.

Previous PRs for the initial two commits:
https://github.com/home-assistant/core/pull/46432
https://github.com/home-assistant/core/pull/46611

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

First two commits were reviewed before merge into rework-octoprint.
Following commits are to resolve issues after the rebase.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19854

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
