### PR TITLE
Activate tradfri in coverage and clean conftest for tradfri

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1101,7 +1101,13 @@ omit =
     homeassistant/components/tractive/entity.py
     homeassistant/components/tractive/sensor.py
     homeassistant/components/tractive/switch.py
-    homeassistant/components/tradfri/*
+    homeassistant/components/tradfri/__init__.py
+    homeassistant/components/tradfri/base_class.py
+    homeassistant/components/tradfri/config_flow.py
+    homeassistant/components/tradfri/cover.py
+    homeassistant/components/tradfri/light.py
+    homeassistant/components/tradfri/sensor.py
+    homeassistant/components/tradfri/switch.py
     homeassistant/components/trafikverket_train/sensor.py
     homeassistant/components/trafikverket_weatherstation/sensor.py
     homeassistant/components/transmission/sensor.py

--- a/tests/components/tradfri/__init__.py
+++ b/tests/components/tradfri/__init__.py
@@ -1,2 +1,3 @@
 """Tests for the tradfri component."""
-MOCK_GATEWAY_ID = "mock-gateway-id"
+GATEWAY_ID = "mock-gateway-id"
+TRADFRI_DIR = "homeassistant.components.tradfri"

--- a/tests/components/tradfri/__init__.py
+++ b/tests/components/tradfri/__init__.py
@@ -1,3 +1,3 @@
 """Tests for the tradfri component."""
 GATEWAY_ID = "mock-gateway-id"
-TRADFRI_DIR = "homeassistant.components.tradfri"
+TRADFRI_PATH = "homeassistant.components.tradfri"

--- a/tests/components/tradfri/conftest.py
+++ b/tests/components/tradfri/conftest.py
@@ -5,8 +5,6 @@ import pytest
 
 from . import GATEWAY_ID, TRADFRI_PATH
 
-from tests.components.light.conftest import mock_light_profiles  # noqa: F401
-
 # pylint: disable=protected-access
 
 
@@ -25,8 +23,8 @@ def mock_entry_setup():
         yield mock_setup
 
 
-@pytest.fixture
-def mock_gateway():
+@pytest.fixture(name="mock_gateway")
+def fixture_mock_gateway():
     """Mock a Tradfri gateway."""
 
     def get_devices():
@@ -57,8 +55,8 @@ def mock_gateway():
         yield gateway
 
 
-@pytest.fixture
-def mock_api(mock_gateway):
+@pytest.fixture(name="mock_api")
+def fixture_mock_api(mock_gateway):
     """Mock api."""
 
     async def api(command):
@@ -78,3 +76,10 @@ def mock_api_factory(mock_api):
         factory.init.return_value = factory.return_value
         factory.return_value.request = mock_api
         yield factory.return_value
+
+
+@pytest.fixture
+def mock_auth():
+    """Mock authenticate."""
+    with patch(f"{TRADFRI_PATH}.config_flow.authenticate") as auth:
+        yield auth

--- a/tests/components/tradfri/conftest.py
+++ b/tests/components/tradfri/conftest.py
@@ -76,10 +76,3 @@ def mock_api_factory(mock_api):
         factory.init.return_value = factory.return_value
         factory.return_value.request = mock_api
         yield factory.return_value
-
-
-@pytest.fixture
-def mock_auth():
-    """Mock authenticate."""
-    with patch(f"{TRADFRI_PATH}.config_flow.authenticate") as auth:
-        yield auth

--- a/tests/components/tradfri/conftest.py
+++ b/tests/components/tradfri/conftest.py
@@ -1,9 +1,9 @@
 """Common tradfri test fixtures."""
-from unittest.mock import Mock, patch
+from unittest import mock
 
 import pytest
 
-from . import MOCK_GATEWAY_ID
+from . import GATEWAY_ID, TRADFRI_DIR
 
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
@@ -13,28 +13,20 @@ from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 @pytest.fixture
 def mock_gateway_info():
     """Mock get_gateway_info."""
-    with patch(
-        "homeassistant.components.tradfri.config_flow.get_gateway_info"
-    ) as gateway_info:
+    with mock.patch(TRADFRI_DIR + ".config_flow.get_gateway_info") as gateway_info:
         yield gateway_info
 
 
 @pytest.fixture
 def mock_entry_setup():
     """Mock entry setup."""
-    with patch("homeassistant.components.tradfri.async_setup_entry") as mock_setup:
+    with mock.patch(TRADFRI_DIR + ".async_setup_entry") as mock_setup:
         mock_setup.return_value = True
         yield mock_setup
 
 
-@pytest.fixture(name="gateway_id")
-def mock_gateway_id_fixture():
-    """Return mock gateway_id."""
-    return MOCK_GATEWAY_ID
-
-
-@pytest.fixture(name="mock_gateway")
-def mock_gateway_fixture(gateway_id):
+@pytest.fixture
+def mock_gateway():
     """Mock a Tradfri gateway."""
 
     def get_devices():
@@ -45,13 +37,13 @@ def mock_gateway_fixture(gateway_id):
         """Return mock groups."""
         return gateway.mock_groups
 
-    gateway_info = Mock(id=gateway_id, firmware_version="1.2.1234")
+    gateway_info = mock.Mock(id=GATEWAY_ID, firmware_version="1.2.1234")
 
     def get_gateway_info():
         """Return mock gateway info."""
         return gateway_info
 
-    gateway = Mock(
+    gateway = mock.Mock(
         get_devices=get_devices,
         get_groups=get_groups,
         get_gateway_info=get_gateway_info,
@@ -59,30 +51,30 @@ def mock_gateway_fixture(gateway_id):
         mock_groups=[],
         mock_responses=[],
     )
-    with patch("homeassistant.components.tradfri.Gateway", return_value=gateway), patch(
-        "homeassistant.components.tradfri.config_flow.Gateway", return_value=gateway
+    with mock.patch(TRADFRI_DIR + ".Gateway", return_value=gateway), mock.patch(
+        TRADFRI_DIR + ".config_flow.Gateway", return_value=gateway
     ):
         yield gateway
 
 
-@pytest.fixture(name="mock_api")
-def mock_api_fixture(mock_gateway):
+@pytest.fixture
+def mock_api(mock_gateway):
     """Mock api."""
 
     async def api(command):
         """Mock api function."""
         # Store the data for "real" command objects.
-        if hasattr(command, "_data") and not isinstance(command, Mock):
+        if hasattr(command, "_data") and not isinstance(command, mock.Mock):
             mock_gateway.mock_responses.append(command._data)
         return command
 
     return api
 
 
-@pytest.fixture(name="api_factory")
-def mock_api_factory_fixture(mock_api):
+@pytest.fixture
+def mock_api_factory(mock_api):
     """Mock pytradfri api factory."""
-    with patch("homeassistant.components.tradfri.APIFactory", autospec=True) as factory:
+    with mock.patch(TRADFRI_DIR + ".APIFactory", autospec=True) as factory:
         factory.init.return_value = factory.return_value
         factory.return_value.request = mock_api
         yield factory.return_value

--- a/tests/components/tradfri/conftest.py
+++ b/tests/components/tradfri/conftest.py
@@ -1,9 +1,9 @@
 """Common tradfri test fixtures."""
-from unittest import mock
+from unittest.mock import Mock, patch
 
 import pytest
 
-from . import GATEWAY_ID, TRADFRI_DIR
+from . import GATEWAY_ID, TRADFRI_PATH
 
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
@@ -13,14 +13,14 @@ from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 @pytest.fixture
 def mock_gateway_info():
     """Mock get_gateway_info."""
-    with mock.patch(TRADFRI_DIR + ".config_flow.get_gateway_info") as gateway_info:
+    with patch(f"{TRADFRI_PATH}.config_flow.get_gateway_info") as gateway_info:
         yield gateway_info
 
 
 @pytest.fixture
 def mock_entry_setup():
     """Mock entry setup."""
-    with mock.patch(TRADFRI_DIR + ".async_setup_entry") as mock_setup:
+    with patch(f"{TRADFRI_PATH}.async_setup_entry") as mock_setup:
         mock_setup.return_value = True
         yield mock_setup
 
@@ -37,13 +37,13 @@ def mock_gateway():
         """Return mock groups."""
         return gateway.mock_groups
 
-    gateway_info = mock.Mock(id=GATEWAY_ID, firmware_version="1.2.1234")
+    gateway_info = Mock(id=GATEWAY_ID, firmware_version="1.2.1234")
 
     def get_gateway_info():
         """Return mock gateway info."""
         return gateway_info
 
-    gateway = mock.Mock(
+    gateway = Mock(
         get_devices=get_devices,
         get_groups=get_groups,
         get_gateway_info=get_gateway_info,
@@ -51,8 +51,8 @@ def mock_gateway():
         mock_groups=[],
         mock_responses=[],
     )
-    with mock.patch(TRADFRI_DIR + ".Gateway", return_value=gateway), mock.patch(
-        TRADFRI_DIR + ".config_flow.Gateway", return_value=gateway
+    with patch(f"{TRADFRI_PATH}.Gateway", return_value=gateway), patch(
+        f"{TRADFRI_PATH}.config_flow.Gateway", return_value=gateway
     ):
         yield gateway
 
@@ -64,7 +64,7 @@ def mock_api(mock_gateway):
     async def api(command):
         """Mock api function."""
         # Store the data for "real" command objects.
-        if hasattr(command, "_data") and not isinstance(command, mock.Mock):
+        if hasattr(command, "_data") and not isinstance(command, Mock):
             mock_gateway.mock_responses.append(command._data)
         return command
 
@@ -74,7 +74,7 @@ def mock_api(mock_gateway):
 @pytest.fixture
 def mock_api_factory(mock_api):
     """Mock pytradfri api factory."""
-    with mock.patch(TRADFRI_DIR + ".APIFactory", autospec=True) as factory:
+    with patch(f"{TRADFRI_PATH}.APIFactory", autospec=True) as factory:
         factory.init.return_value = factory.return_value
         factory.return_value.request = mock_api
         yield factory.return_value

--- a/tests/components/tradfri/conftest.py
+++ b/tests/components/tradfri/conftest.py
@@ -24,7 +24,7 @@ def mock_entry_setup():
 
 
 @pytest.fixture(name="mock_gateway")
-def fixture_mock_gateway():
+def mock_gateway_fixture():
     """Mock a Tradfri gateway."""
 
     def get_devices():
@@ -56,7 +56,7 @@ def fixture_mock_gateway():
 
 
 @pytest.fixture(name="mock_api")
-def fixture_mock_api(mock_gateway):
+def mock_api_fixture(mock_gateway):
     """Mock api."""
 
     async def api(command):

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -1,8 +1,6 @@
 """Test the Tradfri config flow."""
 from unittest.mock import AsyncMock, patch
 
-import pytest
-
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.tradfri import config_flow
 
@@ -11,22 +9,15 @@ from . import TRADFRI_PATH
 from tests.common import MockConfigEntry
 
 
-@pytest.fixture
-def mock_auth():
-    """Mock authenticate."""
-    with patch(f"{TRADFRI_PATH}.config_flow.authenticate") as mock_auth:
-        yield mock_auth
-
-
 async def test_already_paired(hass, mock_entry_setup):
     """Test Gateway already paired."""
     with patch(
         f"{TRADFRI_PATH}.config_flow.APIFactory",
         autospec=True,
     ) as mock_lib:
-        mx = AsyncMock()
-        mx.generate_psk.return_value = None
-        mock_lib.init.return_value = mx
+        mock_it = AsyncMock()
+        mock_it.generate_psk.return_value = None
+        mock_lib.init.return_value = mock_it
         result = await hass.config_entries.flow.async_init(
             "tradfri", context={"source": config_entries.SOURCE_USER}
         )

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -1,12 +1,21 @@
 """Test the Tradfri config flow."""
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.tradfri import config_flow
 
 from . import TRADFRI_PATH
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="mock_auth")
+def mock_auth_fixture():
+    """Mock authenticate."""
+    with patch(f"{TRADFRI_PATH}.config_flow.authenticate") as auth:
+        yield auth
 
 
 async def test_already_paired(hass, mock_entry_setup):

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -6,22 +6,22 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.tradfri import config_flow
 
+from . import TRADFRI_DIR
+
 from tests.common import MockConfigEntry
 
 
 @pytest.fixture
 def mock_auth():
     """Mock authenticate."""
-    with patch(
-        "homeassistant.components.tradfri.config_flow.authenticate"
-    ) as mock_auth:
+    with patch(TRADFRI_DIR + ".config_flow.authenticate") as mock_auth:
         yield mock_auth
 
 
 async def test_already_paired(hass, mock_entry_setup):
     """Test Gateway already paired."""
     with patch(
-        "homeassistant.components.tradfri.config_flow.APIFactory",
+        TRADFRI_DIR + ".config_flow.APIFactory",
         autospec=True,
     ) as mock_lib:
         mx = AsyncMock()

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.tradfri import config_flow
 
-from . import TRADFRI_DIR
+from . import TRADFRI_PATH
 
 from tests.common import MockConfigEntry
 
@@ -14,14 +14,14 @@ from tests.common import MockConfigEntry
 @pytest.fixture
 def mock_auth():
     """Mock authenticate."""
-    with patch(TRADFRI_DIR + ".config_flow.authenticate") as mock_auth:
+    with patch(f"{TRADFRI_PATH}.config_flow.authenticate") as mock_auth:
         yield mock_auth
 
 
 async def test_already_paired(hass, mock_entry_setup):
     """Test Gateway already paired."""
     with patch(
-        TRADFRI_DIR + ".config_flow.APIFactory",
+        f"{TRADFRI_PATH}.config_flow.APIFactory",
         autospec=True,
     ) as mock_lib:
         mx = AsyncMock()

--- a/tests/components/tradfri/test_init.py
+++ b/tests/components/tradfri/test_init.py
@@ -4,10 +4,12 @@ from unittest.mock import patch
 from homeassistant.components import tradfri
 from homeassistant.helpers import device_registry as dr
 
+from . import GATEWAY_ID
+
 from tests.common import MockConfigEntry
 
 
-async def test_entry_setup_unload(hass, api_factory, gateway_id):
+async def test_entry_setup_unload(hass, mock_api_factory):
     """Test config entry setup and unload."""
     entry = MockConfigEntry(
         domain=tradfri.DOMAIN,
@@ -16,7 +18,7 @@ async def test_entry_setup_unload(hass, api_factory, gateway_id):
             tradfri.CONF_IDENTITY: "mock-identity",
             tradfri.CONF_KEY: "mock-key",
             tradfri.CONF_IMPORT_GROUPS: True,
-            tradfri.CONF_GATEWAY_ID: gateway_id,
+            tradfri.CONF_GATEWAY_ID: GATEWAY_ID,
         },
     )
 
@@ -46,4 +48,4 @@ async def test_entry_setup_unload(hass, api_factory, gateway_id):
         assert await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
         assert unload.call_count == len(tradfri.PLATFORMS)
-        assert api_factory.shutdown.call_count == 1
+        assert mock_api_factory.shutdown.call_count == 1

--- a/tests/components/tradfri/test_light.py
+++ b/tests/components/tradfri/test_light.py
@@ -10,7 +10,7 @@ from pytradfri.device.light_control import LightControl
 
 from homeassistant.components import tradfri
 
-from . import MOCK_GATEWAY_ID
+from . import GATEWAY_ID
 
 from tests.common import MockConfigEntry
 
@@ -109,7 +109,7 @@ async def setup_integration(hass):
             "identity": "mock-identity",
             "key": "mock-key",
             "import_groups": True,
-            "gateway_id": MOCK_GATEWAY_ID,
+            "gateway_id": GATEWAY_ID,
         },
     )
 
@@ -153,7 +153,7 @@ def mock_light(test_features=None, test_state=None, light_number=0):
     return _mock_light
 
 
-async def test_light(hass, mock_gateway, api_factory):
+async def test_light(hass, mock_gateway, mock_api_factory):
     """Test that lights are correctly added."""
     features = {"can_set_dimmer": True, "can_set_color": True, "can_set_temp": True}
 
@@ -176,7 +176,7 @@ async def test_light(hass, mock_gateway, api_factory):
     assert lamp_1.attributes["hs_color"] == (0.549, 0.153)
 
 
-async def test_light_observed(hass, mock_gateway, api_factory):
+async def test_light_observed(hass, mock_gateway, mock_api_factory):
     """Test that lights are correctly observed."""
     light = mock_light()
     mock_gateway.mock_devices.append(light)
@@ -184,7 +184,7 @@ async def test_light_observed(hass, mock_gateway, api_factory):
     assert len(light.observe.mock_calls) > 0
 
 
-async def test_light_available(hass, mock_gateway, api_factory):
+async def test_light_available(hass, mock_gateway, mock_api_factory):
     """Test light available property."""
     light = mock_light({"state": True}, light_number=1)
     light.reachable = True
@@ -225,7 +225,7 @@ def create_all_turn_on_cases():
 async def test_turn_on(
     hass,
     mock_gateway,
-    api_factory,
+    mock_api_factory,
     test_features,
     test_data,
     expected_result,
@@ -288,7 +288,7 @@ async def test_turn_on(
             assert states.attributes[result] == pytest.approx(value, abs=0.01)
 
 
-async def test_turn_off(hass, mock_gateway, api_factory):
+async def test_turn_off(hass, mock_gateway, mock_api_factory):
     """Test turning off a light."""
     state = {"state": True, "dimmer": 100}
 
@@ -341,7 +341,7 @@ def mock_group(test_state=None, group_number=0):
     return _mock_group
 
 
-async def test_group(hass, mock_gateway, api_factory):
+async def test_group(hass, mock_gateway, mock_api_factory):
     """Test that groups are correctly added."""
     mock_gateway.mock_groups.append(mock_group())
     state = {"state": True, "dimmer": 100}
@@ -358,7 +358,7 @@ async def test_group(hass, mock_gateway, api_factory):
     assert group.attributes["brightness"] == 100
 
 
-async def test_group_turn_on(hass, mock_gateway, api_factory):
+async def test_group_turn_on(hass, mock_gateway, mock_api_factory):
     """Test turning on a group."""
     group = mock_group()
     group2 = mock_group(group_number=1)
@@ -391,7 +391,7 @@ async def test_group_turn_on(hass, mock_gateway, api_factory):
     group3.set_dimmer.assert_called_with(100, transition_time=10)
 
 
-async def test_group_turn_off(hass, mock_gateway, api_factory):
+async def test_group_turn_off(hass, mock_gateway, mock_api_factory):
     """Test turning off a group."""
     group = mock_group({"state": True})
     mock_gateway.mock_groups.append(group)

--- a/tests/components/tradfri/test_light.py
+++ b/tests/components/tradfri/test_light.py
@@ -126,31 +126,31 @@ def mock_light(test_features=None, test_state=None, light_number=0):
         test_state = {}
     mock_light_data = Mock(**test_state)
 
-    dev_info_mock = MagicMock()
-    dev_info_mock.manufacturer = "manufacturer"
-    dev_info_mock.model_number = "model"
-    dev_info_mock.firmware_version = "1.2.3"
-    _mock_light = Mock(
+    dev_infomock = MagicMock()
+    dev_infomock.manufacturer = "manufacturer"
+    dev_infomock.model_number = "model"
+    dev_infomock.firmware_version = "1.2.3"
+    mock_it = Mock(
         id=f"mock-light-id-{light_number}",
         reachable=True,
         observe=Mock(),
-        device_info=dev_info_mock,
+        device_info=dev_infomock,
         has_light_control=True,
         has_socket_control=False,
         has_blind_control=False,
         has_signal_repeater_control=False,
     )
-    _mock_light.name = f"tradfri_light_{light_number}"
+    mock_it.name = f"tradfri_light_{light_number}"
 
     # Set supported features for the light.
     features = {**DEFAULT_TEST_FEATURES, **test_features}
-    light_control = LightControl(_mock_light)
+    light_control = LightControl(mock_it)
     for attr, value in features.items():
         setattr(light_control, attr, value)
     # Store the initial state.
     setattr(light_control, "lights", [mock_light_data])
-    _mock_light.light_control = light_control
-    return _mock_light
+    mock_light.light_control = light_control
+    return mock_it
 
 
 async def test_light(hass, mock_gateway, mock_api_factory):
@@ -336,9 +336,9 @@ def mock_group(test_state=None, group_number=0):
 
     state = {**default_state, **test_state}
 
-    _mock_group = Mock(member_ids=[], observe=Mock(), **state)
-    _mock_group.name = f"tradfri_group_{group_number}"
-    return _mock_group
+    mock_it = Mock(member_ids=[], observe=Mock(), **state)
+    mock_it.name = f"tradfri_group_{group_number}"
+    return mock_it
 
 
 async def test_group(hass, mock_gateway, mock_api_factory):

--- a/tests/components/tradfri/test_light.py
+++ b/tests/components/tradfri/test_light.py
@@ -126,31 +126,31 @@ def mock_light(test_features=None, test_state=None, light_number=0):
         test_state = {}
     mock_light_data = Mock(**test_state)
 
-    dev_infomock = MagicMock()
-    dev_infomock.manufacturer = "manufacturer"
-    dev_infomock.model_number = "model"
-    dev_infomock.firmware_version = "1.2.3"
-    mock_it = Mock(
+    dev_info_mock = MagicMock()
+    dev_info_mock.manufacturer = "manufacturer"
+    dev_info_mock.model_number = "model"
+    dev_info_mock.firmware_version = "1.2.3"
+    _mock_light = Mock(
         id=f"mock-light-id-{light_number}",
         reachable=True,
         observe=Mock(),
-        device_info=dev_infomock,
+        device_info=dev_info_mock,
         has_light_control=True,
         has_socket_control=False,
         has_blind_control=False,
         has_signal_repeater_control=False,
     )
-    mock_it.name = f"tradfri_light_{light_number}"
+    _mock_light.name = f"tradfri_light_{light_number}"
 
     # Set supported features for the light.
     features = {**DEFAULT_TEST_FEATURES, **test_features}
-    light_control = LightControl(mock_it)
+    light_control = LightControl(_mock_light)
     for attr, value in features.items():
         setattr(light_control, attr, value)
     # Store the initial state.
     setattr(light_control, "lights", [mock_light_data])
-    mock_light.light_control = light_control
-    return mock_it
+    _mock_light.light_control = light_control
+    return _mock_light
 
 
 async def test_light(hass, mock_gateway, mock_api_factory):
@@ -336,9 +336,9 @@ def mock_group(test_state=None, group_number=0):
 
     state = {**default_state, **test_state}
 
-    mock_it = Mock(member_ids=[], observe=Mock(), **state)
-    mock_it.name = f"tradfri_group_{group_number}"
-    return mock_it
+    _mock_group = Mock(member_ids=[], observe=Mock(), **state)
+    _mock_group.name = f"tradfri_group_{group_number}"
+    return _mock_group
 
 
 async def test_group(hass, mock_gateway, mock_api_factory):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prepare to extend test suite by cleaning conftest.py and updating .coveragerc


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
