### PR TITLE
Add a Preset mode for Honeywell permanent hold

### DIFF
--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -78,8 +78,6 @@ PLATFORM_SCHEMA = vol.All(
     ),
 )
 
-HVAC_MODES = ["off","auto","cool","heat"]
-
 HVAC_MODE_TO_HW_MODE = {
     "SwitchOffAllowed": {HVAC_MODE_OFF: "off"},
     "SwitchAutoAllowed": {HVAC_MODE_HEAT_COOL: "auto"},
@@ -374,7 +372,7 @@ class HoneywellUSThermostat(ClimateEntity):
             _LOGGER.error("Can not get system mode")
             return
         # Check that we got a valid mode back
-        if mode in HVAC_MODES:
+        if mode in HW_MODE_TO_HVAC_MODE:
             try:
                 # Set permanent hold
                 setattr(self._device, f"hold_{mode}", True)

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -376,7 +376,7 @@ class HoneywellUSThermostat(ClimateEntity):
             try:
                 # Set permanent hold
                 setattr(self._device, f"hold_{mode}", True)
-            except SomeComfortError:
+            except somecomfort.SomeComfortError:
                 _LOGGER.error("Couldn't set permanent hold")
         else:
             _LOGGER.error("Invalid system mode returned: %s." % mode)

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -78,8 +78,6 @@ PLATFORM_SCHEMA = vol.All(
     ),
 )
 
-HVAC_MODES = ["off","auto","cool","heat"]
-
 HVAC_MODE_TO_HW_MODE = {
     "SwitchOffAllowed": {HVAC_MODE_OFF: "off"},
     "SwitchAutoAllowed": {HVAC_MODE_HEAT_COOL: "auto"},

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -372,7 +372,7 @@ class HoneywellUSThermostat(ClimateEntity):
             _LOGGER.error("Can not get system mode")
             return
         # Check that we got a valid mode back
-        if mode in HVAC_MODES:
+        if mode in HW_MODE_TO_HVAC_MODE:
             try:
                 # Set permanent hold
                 setattr(self._device, f"hold_{mode}", True)

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -274,7 +274,7 @@ class HoneywellUSThermostat(ClimateEntity):
             return PRESET_AWAY
         if self._is_permanent_hold():
             return PRESET_HOLD
-      
+
         return None
 
     @property

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -371,11 +371,15 @@ class HoneywellUSThermostat(ClimateEntity):
         except somecomfort.SomeComfortError:
             _LOGGER.error("Can not get system mode")
             return
-        try:
-            # Set permanent hold
-            setattr(self._device, f"hold_{mode}", True)
-        except somecomfort.SomeComfortError:
-            _LOGGER.error("Couldn't set permanent hold")
+        # Check that we got a valid mode back
+        if mode in HW_MODE_TO_HVAC_MODE.keys():
+            try:
+                # Set permanent hold
+                setattr(self._device, f"hold_{mode}", True)
+            except SomeComfortError:
+                _LOGGER.error("Couldn't set permanent hold")
+        else:
+            _LOGGER.error("Invalid system mode returned: %s." % mode)
 
     def _turn_away_mode_off(self) -> None:
         """Turn away/hold off."""

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -272,10 +272,10 @@ class HoneywellUSThermostat(ClimateEntity):
         """Return the current preset mode, e.g., home, away, temp."""
         if self._away:
             return PRESET_AWAY
-        elif self._is_permanent_hold():
+        if self._is_permanent_hold():
             return PRESET_HOLD
-        else:
-            return None
+      
+        return None
 
     @property
     def fan_mode(self) -> str | None:

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -57,6 +57,8 @@ ATTR_FAN_ACTION = "fan_action"
 
 ATTR_PERMANENT_HOLD = "permanent_hold"
 
+PRESET_HOLD = "Hold"
+
 PLATFORM_SCHEMA = vol.All(
     cv.deprecated(CONF_REGION),
     PLATFORM_SCHEMA.extend(
@@ -161,7 +163,7 @@ class HoneywellUSThermostat(ClimateEntity):
         self._attr_temperature_unit = (
             TEMP_CELSIUS if device.temperature_unit == "C" else TEMP_FAHRENHEIT
         )
-        self._attr_preset_modes = [PRESET_NONE, PRESET_AWAY]
+        self._attr_preset_modes = [PRESET_NONE, PRESET_AWAY, PRESET_HOLD]
         self._attr_is_aux_heat = device.system_mode == "emheat"
 
         # not all honeywell HVACs support all modes
@@ -268,7 +270,12 @@ class HoneywellUSThermostat(ClimateEntity):
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
-        return PRESET_AWAY if self._away else None
+        if self._away:
+            return PRESET_AWAY
+        elif self._is_permanent_hold():
+            return PRESET_HOLD
+        else:
+            return None
 
     @property
     def fan_mode(self) -> str | None:
@@ -356,8 +363,24 @@ class HoneywellUSThermostat(ClimateEntity):
                 "Temperature %.1f out of range", getattr(self, f"_{mode}_away_temp")
             )
 
+    def _turn_hold_mode_on(self) -> None:
+        """Turn permanent hold on.
+
+        """
+        try:
+            # Get current mode
+            mode = self._device.system_mode
+        except SomeComfortError:
+            _LOGGER.error("Can not get system mode")
+            return
+        try:
+            # Set permanent hold
+            setattr(self._device, f"hold_{mode}", True)
+        except SomeComfortError:
+            _LOGGER.error("Couldn't set permanent hold")
+
     def _turn_away_mode_off(self) -> None:
-        """Turn away off."""
+        """Turn away/hold off."""
         self._away = False
         try:
             # Disabling all hold modes
@@ -370,6 +393,8 @@ class HoneywellUSThermostat(ClimateEntity):
         """Set new preset mode."""
         if preset_mode == PRESET_AWAY:
             self._turn_away_mode_on()
+        elif preset_mode == PRESET_HOLD:
+            self._turn_hold_mode_on()
         else:
             self._turn_away_mode_off()
 

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -379,7 +379,7 @@ class HoneywellUSThermostat(ClimateEntity):
             except somecomfort.SomeComfortError:
                 _LOGGER.error("Couldn't set permanent hold")
         else:
-            _LOGGER.error("Invalid system mode returned: %s.", mode)
+            _LOGGER.error("Invalid system mode returned: %s", mode)
 
     def _turn_away_mode_off(self) -> None:
         """Turn away/hold off."""

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -394,6 +394,7 @@ class HoneywellUSThermostat(ClimateEntity):
         if preset_mode == PRESET_AWAY:
             self._turn_away_mode_on()
         elif preset_mode == PRESET_HOLD:
+            self._away = False
             self._turn_hold_mode_on()
         else:
             self._turn_away_mode_off()

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -364,19 +364,17 @@ class HoneywellUSThermostat(ClimateEntity):
             )
 
     def _turn_hold_mode_on(self) -> None:
-        """Turn permanent hold on.
-
-        """
+        """Turn permanent hold on."""
         try:
             # Get current mode
             mode = self._device.system_mode
-        except SomeComfortError:
+        except somecomfort.SomeComfortError:
             _LOGGER.error("Can not get system mode")
             return
         try:
             # Set permanent hold
             setattr(self._device, f"hold_{mode}", True)
-        except SomeComfortError:
+        except somecomfort.SomeComfortError:
             _LOGGER.error("Couldn't set permanent hold")
 
     def _turn_away_mode_off(self) -> None:

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -78,6 +78,8 @@ PLATFORM_SCHEMA = vol.All(
     ),
 )
 
+HVAC_MODES = ["off","auto","cool","heat"]
+
 HVAC_MODE_TO_HW_MODE = {
     "SwitchOffAllowed": {HVAC_MODE_OFF: "off"},
     "SwitchAutoAllowed": {HVAC_MODE_HEAT_COOL: "auto"},
@@ -372,14 +374,14 @@ class HoneywellUSThermostat(ClimateEntity):
             _LOGGER.error("Can not get system mode")
             return
         # Check that we got a valid mode back
-        if mode in HW_MODE_TO_HVAC_MODE.keys():
+        if mode in HVAC_MODES:
             try:
                 # Set permanent hold
                 setattr(self._device, f"hold_{mode}", True)
             except somecomfort.SomeComfortError:
                 _LOGGER.error("Couldn't set permanent hold")
         else:
-            _LOGGER.error("Invalid system mode returned: %s." % mode)
+            _LOGGER.error("Invalid system mode returned: %s.", mode)
 
     def _turn_away_mode_off(self) -> None:
         """Turn away/hold off."""

--- a/homeassistant/components/honeywell/manifest.json
+++ b/homeassistant/components/honeywell/manifest.json
@@ -3,7 +3,7 @@
   "name": "Honeywell Total Connect Comfort (US)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/honeywell",
-  "requirements": ["somecomfort==0.7.0"],
+  "requirements": ["somecomfort==0.8.0"],
   "codeowners": ["@rdfurman"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2187,7 +2187,7 @@ solaredge==0.0.2
 solax==0.2.8
 
 # homeassistant.components.honeywell
-somecomfort==0.7.0
+somecomfort==0.8.0
 
 # homeassistant.components.somfy_mylink
 somfy-mylink-synergy==1.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1257,7 +1257,7 @@ soco==0.24.0
 solaredge==0.0.2
 
 # homeassistant.components.honeywell
-somecomfort==0.7.0
+somecomfort==0.8.0
 
 # homeassistant.components.somfy_mylink
 somfy-mylink-synergy==1.0.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
Add ability to set a permanent hold on Honeywell thermostats via a Preset.  Also reflects whether a thermostat is currently in hold or not.
-->

Diff view:
https://github.com/kk7ds/somecomfort/compare/0.7.0...0.8.0

Releases:
https://github.com/kk7ds/somecomfort/releases

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
