### PR TITLE
Re-add support for realtime SimpliSafe websocket

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -507,8 +507,6 @@ class SimpliSafe:
             self._api.add_refresh_token_listener(async_save_refresh_token)
         )
 
-        if TYPE_CHECKING:
-            assert self._api.refresh_token
         async_save_refresh_token(self._api.refresh_token)
 
     async def async_update(self) -> None:

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -636,7 +636,8 @@ class SimpliSafeEntity(CoordinatorEntity):
         # Ignore this event if it belongs to a entity with a different serial
         # number from this one's:
         if (
-            event.event_type in WEBSOCKET_EVENTS_REQUIRING_SERIAL
+            self._device
+            and event.event_type in WEBSOCKET_EVENTS_REQUIRING_SERIAL
             and event.sensor_serial != self._device.serial
         ):
             return

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -315,6 +315,7 @@ class SimpliSafe:
         """Initialize."""
         self._api = api
         self._hass = hass
+        self._listener_unsub: list[Callable[..., None]] = []
         self._system_notifications: dict[int, set[SystemNotification]] = {}
         self.entry = entry
         self.systems: dict[int, SystemV2 | SystemV3] = {}

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -459,7 +459,9 @@ class SimpliSafe:
             """Define an event handler to disconnect from the websocket."""
             if TYPE_CHECKING:
                 assert self._api.websocket
-            await self._api.websocket.async_disconnect()
+
+            if self._api.websocket.connected:
+                await self._api.websocket.async_disconnect()
 
         self.entry.async_on_unload(
             self._hass.bus.async_listen_once(

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -315,7 +315,6 @@ class SimpliSafe:
         """Initialize."""
         self._api = api
         self._hass = hass
-        self._listener_unsub: list[Callable[..., None]] = []
         self._system_notifications: dict[int, set[SystemNotification]] = {}
         self.entry = entry
         self.systems: dict[int, SystemV2 | SystemV3] = {}

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -70,6 +70,8 @@ ATTR_RF_JAMMING = "rf_jamming"
 ATTR_WALL_POWER_LEVEL = "wall_power_level"
 ATTR_WIFI_STRENGTH = "wifi_strength"
 
+DEFAULT_ERRORS_TO_ACCOMMODATE = 2
+
 VOLUME_STRING_MAP = {
     VOLUME_HIGH: "high",
     VOLUME_LOW: "low",
@@ -95,6 +97,8 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanelEntity):
     def __init__(self, simplisafe: SimpliSafe, system: SystemV2 | SystemV3) -> None:
         """Initialize the SimpliSafe alarm."""
         super().__init__(simplisafe, system)
+
+        self._errors = 0
 
         if code := self._simplisafe.entry.options.get(CONF_CODE):
             if code.isdigit():
@@ -220,6 +224,19 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanelEntity):
                     ATTR_WIFI_STRENGTH: self._system.wifi_strength,
                 }
             )
+
+        # SimpliSafe can incorrectly return an error state when there isn't any
+        # error. This can lead to the system having an unknown state frequently.
+        # To protect against that, we measure how many "error states" we receive
+        # and only alter the state if we detect a few in a row:
+        if self._system.state == SystemStates.error:
+            if self._errors > DEFAULT_ERRORS_TO_ACCOMMODATE:
+                self._attr_state = None
+            else:
+                self._errors += 1
+            return
+
+        self._errors = 0
 
         if self._system.state == SystemStates.alarm:
             self._attr_state = STATE_ALARM_TRIGGERED

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -262,7 +262,8 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanelEntity):
             self._attr_state = STATE_ALARM_ARMING
         else:
             LOGGER.error(
-                "Unknown websocket event triggered state change: %s", event.event_type
+                "Unknown websocket event triggered alarm_control_panel state change: %s",
+                event.event_type,
             )
             self._attr_state = None
 

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -260,11 +260,5 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanelEntity):
             EVENT_HOME_EXIT_DELAY,
         ):
             self._attr_state = STATE_ALARM_ARMING
-        else:
-            LOGGER.error(
-                "Unknown websocket event triggered alarm_control_panel state change: %s",
-                event.event_type,
-            )
-            self._attr_state = None
 
         self._attr_changed_by = event.changed_by

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -102,9 +102,3 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
             self._attr_is_locked = True
         elif event.event_type == EVENT_LOCK_UNLOCKED:
             self._attr_is_locked = False
-        else:
-            LOGGER.error(
-                "Unknown websocket event triggered lock state change: %s",
-                event.event_type,
-            )
-            self._attr_is_locked = None

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -1,7 +1,7 @@
 """Support for SimpliSafe locks."""
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from simplipy.device.lock import Lock, LockStates
 from simplipy.errors import SimplipyError
@@ -23,6 +23,14 @@ from .const import DATA_CLIENT, DOMAIN, LOGGER
 
 ATTR_LOCK_LOW_BATTERY = "lock_low_battery"
 ATTR_PIN_PAD_LOW_BATTERY = "pin_pad_low_battery"
+
+STATE_MAP_FROM_WEBSOCKET_EVENT = {
+    EVENT_LOCK_ERROR: None,
+    EVENT_LOCK_LOCKED: True,
+    EVENT_LOCK_UNLOCKED: False,
+}
+
+WEBSOCKET_EVENTS_TO_LISTEN_FOR = (EVENT_LOCK_LOCKED, EVENT_LOCK_UNLOCKED)
 
 
 async def async_setup_entry(
@@ -48,12 +56,14 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
 
     def __init__(self, simplisafe: SimpliSafe, system: SystemV3, lock: Lock) -> None:
         """Initialize."""
-        super().__init__(simplisafe, system, device=lock)
+        super().__init__(
+            simplisafe,
+            system,
+            device=lock,
+            additional_websocket_events=WEBSOCKET_EVENTS_TO_LISTEN_FOR,
+        )
 
         self._device: Lock
-
-        for websocket_event_type in (EVENT_LOCK_LOCKED, EVENT_LOCK_UNLOCKED):
-            self.websocket_events_to_listen_for.append(websocket_event_type)
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
@@ -93,12 +103,6 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
     @callback
     def async_update_from_websocket_event(self, event: WebsocketEvent) -> None:
         """Update the entity when new data comes from the websocket."""
-        if event.event_type == EVENT_LOCK_ERROR:
-            # Unfortunately, the websocket doesn't give insight into *what* type of
-            # error we have (the lock could be jammed, the batteries could be dead,
-            # etc.) – so, if we get this event, we settle for setting the state as None:
-            self._attr_is_locked = None
-        elif event.event_type == EVENT_LOCK_LOCKED:
-            self._attr_is_locked = True
-        elif event.event_type == EVENT_LOCK_UNLOCKED:
-            self._attr_is_locked = False
+        if TYPE_CHECKING:
+            assert event.event_type
+        self._attr_is_locked = STATE_MAP_FROM_WEBSOCKET_EVENT[event.event_type]

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -102,6 +102,7 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
             self._attr_is_locked = True
         elif event.event_type == EVENT_LOCK_UNLOCKED:
             self._attr_is_locked = False
+        else:
             LOGGER.error(
                 "Unknown websocket event triggered lock state change: %s",
                 event.event_type,

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -6,7 +6,12 @@ from typing import Any
 from simplipy.device.lock import Lock, LockStates
 from simplipy.errors import SimplipyError
 from simplipy.system.v3 import SystemV3
-from simplipy.websocket import EVENT_LOCK_LOCKED, EVENT_LOCK_UNLOCKED, WebsocketEvent
+from simplipy.websocket import (
+    EVENT_LOCK_ERROR,
+    EVENT_LOCK_LOCKED,
+    EVENT_LOCK_UNLOCKED,
+    WebsocketEvent,
+)
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
@@ -88,6 +93,11 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
     @callback
     def async_update_from_websocket_event(self, event: WebsocketEvent) -> None:
         """Update the entity when new data comes from the websocket."""
+        if event.event_type == EVENT_LOCK_ERROR:
+            self._attr_is_jammed = True
+        else:
+            self._attr_is_jammed = False
+
         if event.event_type == EVENT_LOCK_LOCKED:
             self._attr_is_locked = True
         else:

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==12.0.0"],
+  "requirements": ["simplisafe-python==12.0.1"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/simplisafe/manifest.json
+++ b/homeassistant/components/simplisafe/manifest.json
@@ -3,7 +3,7 @@
   "name": "SimpliSafe",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/simplisafe",
-  "requirements": ["simplisafe-python==12.0.1"],
+  "requirements": ["simplisafe-python==12.0.2"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2140,7 +2140,7 @@ simplehound==0.3
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==12.0.1
+simplisafe-python==12.0.2
 
 # homeassistant.components.sisyphus
 sisyphus-control==3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2140,7 +2140,7 @@ simplehound==0.3
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==12.0.0
+simplisafe-python==12.0.1
 
 # homeassistant.components.sisyphus
 sisyphus-control==3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1239,7 +1239,7 @@ sharkiqpy==0.1.8
 simplehound==0.3
 
 # homeassistant.components.simplisafe
-simplisafe-python==12.0.1
+simplisafe-python==12.0.2
 
 # homeassistant.components.slack
 slackclient==2.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1239,7 +1239,7 @@ sharkiqpy==0.1.8
 simplehound==0.3
 
 # homeassistant.components.simplisafe
-simplisafe-python==12.0.0
+simplisafe-python==12.0.1
 
 # homeassistant.components.slack
 slackclient==2.5.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Now that https://github.com/home-assistant/core/pull/57212 is merged, we can reintroduce realtime websocket functionality to SimpliSafe. This is effectively a revert of https://github.com/home-assistant/core/pull/50213, just with some cleaning and updating of standards.

Changelog: https://github.com/bachya/simplisafe-python/releases/tag/12.0.2
Diff: https://github.com/bachya/simplisafe-python/compare/12.0.0...12.0.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19867

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
