### PR TITLE
Clean up SimpliSafe entity inheritance structure

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -313,6 +313,7 @@ class SimpliSafe:
         """Initialize."""
         self._api = api
         self._hass = hass
+        self._listener_unsub: list[Callable[..., None]] = []
         self._system_notifications: dict[int, set[SystemNotification]] = {}
         self.entry = entry
         self.systems: dict[int, SystemV2 | SystemV3] = {}

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -61,6 +61,8 @@ from .const import (
 
 EVENT_SIMPLISAFE_NOTIFICATION = "SIMPLISAFE_NOTIFICATION"
 
+DEFAULT_ENTITY_MODEL = "alarm_control_panel"
+DEFAULT_ENTITY_NAME = "Alarm Control Panel"
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
 DEFAULT_SOCKET_MIN_RETRY = 15
 
@@ -435,8 +437,8 @@ class SimpliSafeEntity(CoordinatorEntity):
             name = " ".join([w.title() for w in device.type.name.split("_")])
             serial = device.serial
         else:
-            model = "alarm_control_panel"
-            name = "Alarm Control Panel"
+            model = DEFAULT_ENTITY_MODEL
+            name = DEFAULT_ENTITY_NAME
             serial = system.serial
 
         self._attr_extra_state_attributes = {ATTR_SYSTEM_ID: system.system_id}

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -313,7 +313,6 @@ class SimpliSafe:
         """Initialize."""
         self._api = api
         self._hass = hass
-        self._listener_unsub: list[Callable[..., None]] = []
         self._system_notifications: dict[int, set[SystemNotification]] = {}
         self.entry = entry
         self.systems: dict[int, SystemV2 | SystemV3] = {}

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -7,8 +7,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, cast
 
 from simplipy import API
-from simplipy.device.sensor.v2 import SensorV2
-from simplipy.device.sensor.v3 import SensorV3
+from simplipy.device import Device
 from simplipy.errors import (
     EndpointUnavailableError,
     InvalidCredentialsError,
@@ -424,29 +423,34 @@ class SimpliSafeEntity(CoordinatorEntity):
         self,
         simplisafe: SimpliSafe,
         system: SystemV2 | SystemV3,
-        name: str,
         *,
-        serial: str | None = None,
+        device: Device | None = None,
     ) -> None:
         """Initialize."""
         assert simplisafe.coordinator
         super().__init__(simplisafe.coordinator)
 
-        if serial:
-            self._serial = serial
+        if device:
+            model = device.type.name
+            name = " ".join([w.title() for w in device.type.name.split("_")])
+            serial = device.serial
         else:
-            self._serial = system.serial
+            model = "alarm_control_panel"
+            name = "Alarm Control Panel"
+            serial = system.serial
 
         self._attr_extra_state_attributes = {ATTR_SYSTEM_ID: system.system_id}
         self._attr_device_info = {
             "identifiers": {(DOMAIN, system.system_id)},
             "manufacturer": "SimpliSafe",
-            "model": str(system.version),
+            "model": model,
             "name": name,
             "via_device": (DOMAIN, system.serial),
         }
+
         self._attr_name = f"{system.address} {name}"
-        self._attr_unique_id = self._serial
+        self._attr_unique_id = serial
+        self._device = device
         self._online = True
         self._simplisafe = simplisafe
         self._system = system
@@ -481,29 +485,3 @@ class SimpliSafeEntity(CoordinatorEntity):
     def async_update_from_rest_api(self) -> None:
         """Update the entity with the provided REST API data."""
         raise NotImplementedError()
-
-
-class SimpliSafeBaseSensor(SimpliSafeEntity):
-    """Define a SimpliSafe base (binary) sensor."""
-
-    def __init__(
-        self,
-        simplisafe: SimpliSafe,
-        system: SystemV2 | SystemV3,
-        sensor: SensorV2 | SensorV3,
-    ) -> None:
-        """Initialize."""
-        super().__init__(simplisafe, system, sensor.name, serial=sensor.serial)
-
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, sensor.serial)},
-            "manufacturer": "SimpliSafe",
-            "model": sensor.type.name,
-            "name": sensor.name,
-            "via_device": (DOMAIN, system.serial),
-        }
-
-        human_friendly_name = " ".join([w.title() for w in sensor.type.name.split("_")])
-        self._attr_name = f"{super().name} {human_friendly_name}"
-
-        self._sensor = sensor

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -160,7 +160,7 @@ async def async_register_base_station(
     device_registry = await dr.async_get_registry(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, system.serial)},
+        identifiers={(DOMAIN, system.system_id)},
         manufacturer="SimpliSafe",
         model=system.version,
         name=system.address,
@@ -434,23 +434,23 @@ class SimpliSafeEntity(CoordinatorEntity):
 
         if device:
             model = device.type.name
-            name = " ".join([w.title() for w in device.type.name.split("_")])
+            device_name = device.name
             serial = device.serial
         else:
             model = DEFAULT_ENTITY_MODEL
-            name = DEFAULT_ENTITY_NAME
+            device_name = DEFAULT_ENTITY_NAME
             serial = system.serial
 
         self._attr_extra_state_attributes = {ATTR_SYSTEM_ID: system.system_id}
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, system.system_id)},
+            "identifiers": {(DOMAIN, serial)},
             "manufacturer": "SimpliSafe",
             "model": model,
-            "name": name,
-            "via_device": (DOMAIN, system.serial),
+            "name": device_name,
+            "via_device": (DOMAIN, system.system_id),
         }
 
-        self._attr_name = f"{system.address} {name}"
+        self._attr_name = f"{system.address} {device_name} {' '.join([w.title() for w in model.split('_')])}"
         self._attr_unique_id = serial
         self._device = device
         self._online = True

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -80,7 +80,7 @@ class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanelEntity):
 
     def __init__(self, simplisafe: SimpliSafe, system: SystemV2 | SystemV3) -> None:
         """Initialize the SimpliSafe alarm."""
-        super().__init__(simplisafe, system, "Alarm Control Panel")
+        super().__init__(simplisafe, system)
 
         if code := self._simplisafe.entry.options.get(CONF_CODE):
             if code.isdigit():

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 from simplipy.device import DeviceTypes
-from simplipy.device.sensor.v2 import SensorV2
 from simplipy.device.sensor.v3 import SensorV3
-from simplipy.system.v2 import SystemV2
 from simplipy.system.v3 import SystemV3
 
 from homeassistant.components.binary_sensor import (
@@ -82,15 +80,15 @@ class TriggeredBinarySensor(SimpliSafeEntity, BinarySensorEntity):
     def __init__(
         self,
         simplisafe: SimpliSafe,
-        system: SystemV2 | SystemV3,
-        sensor: SensorV2 | SensorV3,
+        system: SystemV3,
+        sensor: SensorV3,
         device_class: str,
     ) -> None:
         """Initialize."""
         super().__init__(simplisafe, system, device=sensor)
 
         self._attr_device_class = device_class
-        self._device: SensorV2 | SensorV3
+        self._device: SensorV3
 
     @callback
     def async_update_from_rest_api(self) -> None:
@@ -104,17 +102,14 @@ class BatteryBinarySensor(SimpliSafeEntity, BinarySensorEntity):
     _attr_device_class = DEVICE_CLASS_BATTERY
 
     def __init__(
-        self,
-        simplisafe: SimpliSafe,
-        system: SystemV2 | SystemV3,
-        sensor: SensorV2 | SensorV3,
+        self, simplisafe: SimpliSafe, system: SystemV3, sensor: SensorV3
     ) -> None:
         """Initialize."""
         super().__init__(simplisafe, system, device=sensor)
 
         self._attr_name = f"{super().name} Battery"
         self._attr_unique_id = f"{super().unique_id}-battery"
-        self._device: SensorV2 | SensorV3
+        self._device: SensorV3
 
     @callback
     def async_update_from_rest_api(self) -> None:

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -21,7 +21,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import SimpliSafe, SimpliSafeBaseSensor
+from . import SimpliSafe, SimpliSafeEntity
 from .const import DATA_CLIENT, DOMAIN, LOGGER
 
 SUPPORTED_BATTERY_SENSOR_TYPES = [
@@ -76,7 +76,7 @@ async def async_setup_entry(
     async_add_entities(sensors)
 
 
-class TriggeredBinarySensor(SimpliSafeBaseSensor, BinarySensorEntity):
+class TriggeredBinarySensor(SimpliSafeEntity, BinarySensorEntity):
     """Define a binary sensor related to whether an entity has been triggered."""
 
     def __init__(
@@ -87,17 +87,18 @@ class TriggeredBinarySensor(SimpliSafeBaseSensor, BinarySensorEntity):
         device_class: str,
     ) -> None:
         """Initialize."""
-        super().__init__(simplisafe, system, sensor)
+        super().__init__(simplisafe, system, device=sensor)
 
         self._attr_device_class = device_class
+        self._device: SensorV2 | SensorV3
 
     @callback
     def async_update_from_rest_api(self) -> None:
         """Update the entity with the provided REST API data."""
-        self._attr_is_on = self._sensor.triggered
+        self._attr_is_on = self._device.triggered
 
 
-class BatteryBinarySensor(SimpliSafeBaseSensor, BinarySensorEntity):
+class BatteryBinarySensor(SimpliSafeEntity, BinarySensorEntity):
     """Define a SimpliSafe battery binary sensor entity."""
 
     _attr_device_class = DEVICE_CLASS_BATTERY
@@ -109,11 +110,12 @@ class BatteryBinarySensor(SimpliSafeBaseSensor, BinarySensorEntity):
         sensor: SensorV2 | SensorV3,
     ) -> None:
         """Initialize."""
-        super().__init__(simplisafe, system, sensor)
+        super().__init__(simplisafe, system, device=sensor)
 
         self._attr_unique_id = f"{super().unique_id}-battery"
+        self._device: SensorV2 | SensorV3
 
     @callback
     def async_update_from_rest_api(self) -> None:
         """Update the entity with the provided REST API data."""
-        self._attr_is_on = self._sensor.low_battery
+        self._attr_is_on = self._device.low_battery

--- a/homeassistant/components/simplisafe/binary_sensor.py
+++ b/homeassistant/components/simplisafe/binary_sensor.py
@@ -112,6 +112,7 @@ class BatteryBinarySensor(SimpliSafeEntity, BinarySensorEntity):
         """Initialize."""
         super().__init__(simplisafe, system, device=sensor)
 
+        self._attr_name = f"{super().name} Battery"
         self._attr_unique_id = f"{super().unique_id}-battery"
         self._device: SensorV2 | SensorV3
 

--- a/homeassistant/components/simplisafe/lock.py
+++ b/homeassistant/components/simplisafe/lock.py
@@ -42,16 +42,16 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
 
     def __init__(self, simplisafe: SimpliSafe, system: SystemV3, lock: Lock) -> None:
         """Initialize."""
-        super().__init__(simplisafe, system, lock.name, serial=lock.serial)
+        super().__init__(simplisafe, system, device=lock)
 
-        self._lock = lock
+        self._device: Lock
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
         try:
-            await self._lock.async_lock()
+            await self._device.async_lock()
         except SimplipyError as err:
-            LOGGER.error('Error while locking "%s": %s', self._lock.name, err)
+            LOGGER.error('Error while locking "%s": %s', self._device.name, err)
             return
 
         self._attr_is_locked = True
@@ -60,9 +60,9 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
         try:
-            await self._lock.async_unlock()
+            await self._device.async_unlock()
         except SimplipyError as err:
-            LOGGER.error('Error while unlocking "%s": %s', self._lock.name, err)
+            LOGGER.error('Error while unlocking "%s": %s', self._device.name, err)
             return
 
         self._attr_is_locked = False
@@ -73,10 +73,10 @@ class SimpliSafeLock(SimpliSafeEntity, LockEntity):
         """Update the entity with the provided REST API data."""
         self._attr_extra_state_attributes.update(
             {
-                ATTR_LOCK_LOW_BATTERY: self._lock.lock_low_battery,
-                ATTR_PIN_PAD_LOW_BATTERY: self._lock.pin_pad_low_battery,
+                ATTR_LOCK_LOW_BATTERY: self._device.lock_low_battery,
+                ATTR_PIN_PAD_LOW_BATTERY: self._device.pin_pad_low_battery,
             }
         )
 
-        self._attr_is_jammed = self._lock.state == LockStates.jammed
-        self._attr_is_locked = self._lock.state == LockStates.locked
+        self._attr_is_jammed = self._device.state == LockStates.jammed
+        self._attr_is_locked = self._device.state == LockStates.locked

--- a/homeassistant/components/simplisafe/sensor.py
+++ b/homeassistant/components/simplisafe/sensor.py
@@ -1,8 +1,13 @@
 """Support for SimpliSafe freeze sensor."""
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from simplipy.device import DeviceTypes
+from simplipy.device.sensor.v2 import SensorV2
 from simplipy.device.sensor.v3 import SensorV3
+from simplipy.system.v2 import SystemV2
+from simplipy.system.v3 import SystemV3
 
 from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -10,7 +15,7 @@ from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import SimpliSafeBaseSensor
+from . import SimpliSafe, SimpliSafeEntity
 from .const import DATA_CLIENT, DOMAIN, LOGGER
 
 
@@ -33,16 +38,25 @@ async def async_setup_entry(
     async_add_entities(sensors)
 
 
-class SimplisafeFreezeSensor(SimpliSafeBaseSensor, SensorEntity):
+class SimplisafeFreezeSensor(SimpliSafeEntity, SensorEntity):
     """Define a SimpliSafe freeze sensor entity."""
 
     _attr_device_class = DEVICE_CLASS_TEMPERATURE
     _attr_native_unit_of_measurement = TEMP_FAHRENHEIT
     _attr_state_class = STATE_CLASS_MEASUREMENT
 
+    def __init__(
+        self,
+        simplisafe: SimpliSafe,
+        system: SystemV2 | SystemV3,
+        sensor: SensorV2 | SensorV3,
+    ) -> None:
+        """Initialize."""
+        super().__init__(simplisafe, system, device=sensor)
+
     @callback
     def async_update_from_rest_api(self) -> None:
         """Update the entity with the provided REST API data."""
         if TYPE_CHECKING:
-            assert isinstance(self._sensor, SensorV3)
-        self._attr_native_value = self._sensor.temperature
+            assert isinstance(self._device, SensorV3)
+        self._attr_native_value = self._device.temperature

--- a/homeassistant/components/simplisafe/sensor.py
+++ b/homeassistant/components/simplisafe/sensor.py
@@ -1,12 +1,8 @@
 """Support for SimpliSafe freeze sensor."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from simplipy.device import DeviceTypes
-from simplipy.device.sensor.v2 import SensorV2
 from simplipy.device.sensor.v3 import SensorV3
-from simplipy.system.v2 import SystemV2
 from simplipy.system.v3 import SystemV3
 
 from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
@@ -46,17 +42,14 @@ class SimplisafeFreezeSensor(SimpliSafeEntity, SensorEntity):
     _attr_state_class = STATE_CLASS_MEASUREMENT
 
     def __init__(
-        self,
-        simplisafe: SimpliSafe,
-        system: SystemV2 | SystemV3,
-        sensor: SensorV2 | SensorV3,
+        self, simplisafe: SimpliSafe, system: SystemV3, sensor: SensorV3
     ) -> None:
         """Initialize."""
         super().__init__(simplisafe, system, device=sensor)
 
+        self._device: SensorV3
+
     @callback
     def async_update_from_rest_api(self) -> None:
         """Update the entity with the provided REST API data."""
-        if TYPE_CHECKING:
-            assert isinstance(self._device, SensorV3)
         self._attr_native_value = self._device.temperature


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SimpliSafe had unnecessary levels of inheritance, which muddied things. This PR cleans up both that and the fact that battery sensors were receiving bad entity IDs (e.g., `sensor.motion_sensor_2` instead of `sensor.motion_sensor_battery`). It shouldn't be a breaking change, as existing SimpliSafe users will not have their entity IDs touched.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
