### PR TITLE
Allow setting up groups from the UI

### DIFF
--- a/homeassistant/components/group/binary_sensor.py
+++ b/homeassistant/components/group/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.binary_sensor import (
     PLATFORM_SCHEMA,
     BinarySensorEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DEVICE_CLASS,
@@ -42,6 +43,19 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ALL): cv.boolean,
     }
 )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Initialize cover group from a config entry."""
+    async_add_entities(
+        [
+            BinarySensorGroup(
+                entry.entry_id, entry.title, None, entry.options[CONF_ENTITIES], None
+            )
+        ]
+    )
 
 
 async def async_setup_platform(

--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import ATTR_FRIENDLY_NAME, CONF_DOMAIN, CONF_ENTITIES
-from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.core import HomeAssistant, callback, split_entity_id
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 from homeassistant.loader import async_get_integration
@@ -43,6 +43,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize config flow."""
         self.domain: str | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> OptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -1,0 +1,142 @@
+"""Config flow for Group integration."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import ATTR_FRIENDLY_NAME, CONF_DOMAIN, CONF_ENTITIES
+from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
+from homeassistant.loader import async_get_integration
+
+from . import PLATFORMS
+from .const import DOMAIN
+
+SUPPORTED_DOMAINS = [domain for domain in PLATFORMS if domain != "notify"]
+
+
+async def _async_name_to_type_map(hass: HomeAssistant) -> dict[str, str]:
+    """Create a mapping of types of platforms group can support."""
+    integrations = await asyncio.gather(
+        *(async_get_integration(hass, domain) for domain in SUPPORTED_DOMAINS),
+        return_exceptions=True,
+    )
+    name_to_type_map = {
+        domain: domain
+        if isinstance(integrations[idx], Exception)
+        else integrations[idx].name
+        for idx, domain in enumerate(SUPPORTED_DOMAINS)
+    }
+    return name_to_type_map
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Group."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize config flow."""
+        self.domain: str | None = None
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Choose specific domains in bridge mode."""
+        if user_input is not None:
+            self.domain = user_input[CONF_DOMAIN]
+            return await self.async_step_entities()
+
+        all_entities = _async_get_matching_entities(self.hass, None)
+        domains_with_entities = _domains_set_from_entities(all_entities)
+        name_to_type_map = await _async_name_to_type_map(self.hass)
+        domains = {
+            domain: name
+            for domain, name in name_to_type_map.items()
+            if domain in domains_with_entities
+        }
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_DOMAIN): vol.In(domains),
+                }
+            ),
+        )
+
+    async def async_step_entities(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle options flow."""
+        assert self.domain is not None
+
+        if user_input is not None:
+            name_to_type_map = await _async_name_to_type_map(self.hass)
+            domain_name = name_to_type_map[self.domain]
+            return self.async_create_entry(
+                title=f"{domain_name} Group",
+                data={CONF_DOMAIN: self.domain},
+                options=user_input,
+            )
+
+        domain_entities = _async_get_matching_entities(self.hass, [self.domain])
+        return self.async_show_form(
+            step_id="entities",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ENTITIES): cv.multi_select(domain_entities),
+                }
+            ),
+        )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a option flow for group."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle options flow."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        domain = self.config_entry.data[CONF_DOMAIN]
+        entities = self.config_entry.options[CONF_ENTITIES]
+        domain_entities = _async_get_matching_entities(self.hass, [domain])
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ENTITIES, default=entities): cv.multi_select(
+                        domain_entities
+                    ),
+                }
+            ),
+        )
+
+
+def _domains_set_from_entities(entity_ids: Iterable) -> set[str]:
+    """Build a set of domains for the given entity ids."""
+    return {split_entity_id(entity_id)[0] for entity_id in entity_ids}
+
+
+def _async_get_matching_entities(
+    hass: HomeAssistant, domains: list[str] | None
+) -> dict[str, str]:
+    """Fetch all entities or entities in the given domains."""
+    return {
+        state.entity_id: f"{state.attributes.get(ATTR_FRIENDLY_NAME, state.entity_id)} ({state.entity_id})"
+        for state in sorted(
+            hass.states.async_all(domains and set(domains)),
+            key=lambda item: item.entity_id,
+        )
+    }

--- a/homeassistant/components/group/const.py
+++ b/homeassistant/components/group/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Group integration."""
+
+DOMAIN = "group"

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -30,6 +30,7 @@ from homeassistant.components.cover import (
     SUPPORT_STOP_TILT,
     CoverEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
@@ -65,6 +66,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
 )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Initialize cover group from a config entry."""
+    async_add_entities(
+        [CoverGroup(entry.entry_id, entry.title, entry.options[CONF_ENTITIES])]
+    )
 
 
 async def async_setup_platform(

--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -25,6 +25,7 @@ from homeassistant.components.fan import (
     SUPPORT_SET_SPEED,
     FanEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
@@ -62,6 +63,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Initialize fan group from a config entry."""
+    async_add_entities(
+        [FanGroup(entry.entry_id, entry.title, entry.options[CONF_ENTITIES])]
+    )
 
 
 async def async_setup_platform(

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -34,6 +34,7 @@ from homeassistant.components.light import (
     SUPPORT_TRANSITION,
     SUPPORT_WHITE_VALUE,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
@@ -65,6 +66,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 SUPPORT_GROUP_LIGHT = (
     SUPPORT_EFFECT | SUPPORT_FLASH | SUPPORT_TRANSITION | SUPPORT_WHITE_VALUE
 )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Initialize light group platform from a config entry."""
+    async_add_entities(
+        [LightGroup(entry.entry_id, entry.title, entry.options[CONF_ENTITIES])]
+    )
 
 
 async def async_setup_platform(

--- a/homeassistant/components/group/manifest.json
+++ b/homeassistant/components/group/manifest.json
@@ -2,7 +2,10 @@
   "domain": "group",
   "name": "Group",
   "documentation": "https://www.home-assistant.io/integrations/group",
-  "codeowners": ["@home-assistant/core"],
+  "codeowners": [
+    "@home-assistant/core"
+  ],
   "quality_scale": "internal",
-  "iot_class": "calculated"
+  "iot_class": "calculated",
+  "config_flow": true
 }

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -44,6 +44,7 @@ from homeassistant.components.media_player import (
     SUPPORT_VOLUME_STEP,
     MediaPlayerEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
@@ -57,6 +58,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State, callback
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, EventType
 
@@ -78,6 +80,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
 )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Initialize media group from a config entry."""
+    async_add_entities(
+        [MediaGroup(entry.entry_id, entry.title, entry.options[CONF_ENTITIES])]
+    )
 
 
 async def async_setup_platform(

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -13,5 +13,28 @@
       "ok": "[%key:component::binary_sensor::state::problem::off%]",
       "problem": "[%key:component::binary_sensor::state::problem::on%]"
     }
-  }
+  },
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "domain": "Domain to group"
+        }
+      },
+      "entities": {
+        "data": {
+          "entities": "Entities to group"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "entities": "[%key:component::group::config::step::entities::data::entities%]"
+        }
+      }
+    }
+  }  
 }

--- a/homeassistant/components/group/translations/en.json
+++ b/homeassistant/components/group/translations/en.json
@@ -1,10 +1,33 @@
 {
+    "config": {
+        "step": {
+            "entities": {
+                "data": {
+                    "entities": "Entities to group"
+                }
+            },
+            "user": {
+                "data": {
+                    "domain": "Domain to group"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "entities": "Entities to group"
+                }
+            }
+        }
+    },
     "state": {
         "_": {
             "closed": "Closed",
-            "home": "Home",
+            "home": "[%key:common::state::home%]",
             "locked": "Locked",
-            "not_home": "Away",
+            "not_home": "[%key:common::state::not_home%]",
             "off": "Off",
             "ok": "OK",
             "on": "On",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -111,6 +111,7 @@ FLOWS = [
     "google_travel_time",
     "gpslogger",
     "gree",
+    "group",
     "growatt_server",
     "guardian",
     "habitica",

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -1,0 +1,89 @@
+"""Test the Group config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.group.config_flow import CannotConnect, InvalidAuth
+from homeassistant.components.group.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.group.config_flow.PlaceholderHub.authenticate",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.group.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "Name of the device"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "username": "test-username",
+        "password": "test-password",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass: HomeAssistant) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.group.config_flow.PlaceholderHub.authenticate",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.group.config_flow.PlaceholderHub.authenticate",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -1,89 +1,100 @@
 """Test the Group config flow."""
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import config_entries
-from homeassistant.components.group.config_flow import CannotConnect, InvalidAuth
+from homeassistant.components.group.config_flow import SUPPORTED_DOMAINS
 from homeassistant.components.group.const import DOMAIN
+from homeassistant.const import CONF_DOMAIN, CONF_ENTITIES, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+from homeassistant.loader import async_get_integration
+
+from tests.common import MockConfigEntry
 
 
-async def test_form(hass: HomeAssistant) -> None:
-    """Test we get the form."""
+@pytest.mark.parametrize("domain", SUPPORTED_DOMAINS)
+async def test_form(hass: HomeAssistant, domain: str) -> None:
+    """Test we can create a new group from the UI."""
+
+    hass.states.async_set(f"{domain}.dummy", STATE_ON)
+    hass.states.async_set(f"{domain}.dummy2", STATE_ON)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] is None
 
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_DOMAIN: domain,
+        },
+    )
+    await hass.async_block_till_done()
+
     with patch(
-        "homeassistant.components.group.config_flow.PlaceholderHub.authenticate",
-        return_value=True,
-    ), patch(
         "homeassistant.components.group.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                CONF_ENTITIES: [f"{domain}.dummy", f"{domain}.dummy2"],
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] == RESULT_TYPE_CREATE_ENTRY
+    integration = await async_get_integration(hass, domain)
+    assert result3["title"] == f"{integration.name} Group"
+    assert result3["data"] == {CONF_DOMAIN: domain}
+    assert result3["options"] == {
+        CONF_ENTITIES: [f"{domain}.dummy", f"{domain}.dummy2"],
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize("domain", SUPPORTED_DOMAINS)
+async def test_options(hass: HomeAssistant, domain: str) -> None:
+    """Test we can edit an existing group from the UI."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DOMAIN: domain},
+        options={CONF_ENTITIES: [f"{domain}.dummy", f"{domain}.dummy2"]},
+    )
+    entry.add_to_hass(hass)
+
+    hass.states.async_set(f"{domain}.dummy", STATE_ON)
+    hass.states.async_set(f"{domain}.dummy2", STATE_ON)
+    hass.states.async_set(f"{domain}.dummy3", STATE_ON)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.group.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.options.async_configure(
             result["flow_id"],
             {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
+                CONF_ENTITIES: [
+                    f"{domain}.dummy",
+                    f"{domain}.dummy2",
+                    f"{domain}.dummy3",
+                ],
             },
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == "Name of the device"
-    assert result2["data"] == {
-        "host": "1.1.1.1",
-        "username": "test-username",
-        "password": "test-password",
+    assert entry.options == {
+        CONF_ENTITIES: [f"{domain}.dummy", f"{domain}.dummy2", f"{domain}.dummy3"]
     }
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_form_invalid_auth(hass: HomeAssistant) -> None:
-    """Test we handle invalid auth."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with patch(
-        "homeassistant.components.group.config_flow.PlaceholderHub.authenticate",
-        side_effect=InvalidAuth,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-
-    assert result2["type"] == RESULT_TYPE_FORM
-    assert result2["errors"] == {"base": "invalid_auth"}
-
-
-async def test_form_cannot_connect(hass: HomeAssistant) -> None:
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with patch(
-        "homeassistant.components.group.config_flow.PlaceholderHub.authenticate",
-        side_effect=CannotConnect,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-
-    assert result2["type"] == RESULT_TYPE_FORM
-    assert result2["errors"] == {"base": "cannot_connect"}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://community.home-assistant.io/t/why-the-heck-arent-groups-ui-configurable/219797
https://community.home-assistant.io/t/groups-via-ui/216413

- This is a very simple config flow that resolves the
  UX of accidentally typo-ing the entity when configuring
  it manually.

- One of the nice quality of life benefits is we get unique
  ids for free and the user does not have to think about it
  which makes it much easier to change the name/entity id.

- This was born out of frustration of debugging a typo in
  a large group of entities. Manually managing 42 light groups
  in a yaml file is painful and error prone.

- Groups can still be setup from yaml as well if the user
  wants to utilize the more complex options (currently only binary sensor
  support additional options)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
