### PR TITLE
Fix media_player grouping while media_player is off

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -899,10 +899,13 @@ class MediaPlayerEntity(Entity):
     @property
     def state_attributes(self):
         """Return the state attributes."""
-        if self.state == STATE_OFF:
-            return None
-
         state_attr = {}
+
+        if self.support_grouping:
+            state_attr[ATTR_GROUP_MEMBERS] = self.group_members
+
+        if self.state == STATE_OFF:
+            return state_attr
 
         for attr in ATTR_TO_PROPERTY:
             value = getattr(self, attr)
@@ -911,9 +914,6 @@ class MediaPlayerEntity(Entity):
 
         if self.media_image_remotely_accessible:
             state_attr["entity_picture_local"] = self.media_image_local
-
-        if self.support_grouping:
-            state_attr[ATTR_GROUP_MEMBERS] = self.group_members
 
         return state_attr
 

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -189,24 +189,23 @@ async def test_media_browse(hass, hass_ws_client):
 
 async def test_group_members_available_when_off(hass):
     """Test that group_members are still available when media_player is off."""
-
-    # Fake group support for DemoYoutubePlayer
-    youtube_player_support_orig = demo.mediaplayer.YOUTUBE_PLAYER_SUPPORT
-    demo.mediaplayer.YOUTUBE_PLAYER_SUPPORT |= SUPPORT_GROUPING
-
     await async_setup_component(
         hass, "media_player", {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
-    await hass.services.async_call(
-        "media_player",
-        "turn_off",
-        {ATTR_ENTITY_ID: "media_player.bedroom"},
-        blocking=True,
-    )
+    # Fake group support for DemoYoutubePlayer
+    with patch(
+        "homeassistant.components.demo.media_player.YOUTUBE_PLAYER_SUPPORT",
+        media_player.SUPPORT_GROUPING | media_player.SUPPORT_TURN_OFF,
+    ):
+        await hass.services.async_call(
+            "media_player",
+            "turn_off",
+            {ATTR_ENTITY_ID: "media_player.bedroom"},
+            blocking=True,
+        )
 
     state = hass.states.get("media_player.bedroom")
+    assert state.state == STATE_OFF
     assert "group_members" in state.attributes
-
-    demo.mediaplayer.YOUTUBE_PLAYER_SUPPORT = youtube_player_support_orig

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -2,10 +2,9 @@
 import base64
 from unittest.mock import patch
 
-from homeassistant.components import demo, media_player
-from homeassistant.components.media_player.const import SUPPORT_GROUPING
+from homeassistant.components import media_player
 from homeassistant.components.websocket_api.const import TYPE_RESULT
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF
 from homeassistant.setup import async_setup_component
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make the `group_members` attribute available for media_players that support grouping even when the media_player is off.

I tested this with the `yamaha_musiccast`-integration and it works flawlessly there. It seems like only the `roon` integration also uses the `group_members` currently. I don't have roon devices to test, but from my understanding of the code and because `turn_off` sends the devices into standby, I'm pretty sure it should also work for the `roon` integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #58068
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
