### PR TITLE
Add deCONZ number config entity for Hue motion sensor delay

### DIFF
--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -10,6 +10,7 @@ from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.siren import DOMAIN as SIREN_DOMAIN
@@ -40,6 +41,7 @@ PLATFORMS = [
     FAN_DOMAIN,
     LIGHT_DOMAIN,
     LOCK_DOMAIN,
+    NUMBER_DOMAIN,
     SCENE_DOMAIN,
     SENSOR_DOMAIN,
     SIREN_DOMAIN,

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
   "requirements": [
-    "pydeconz==84"
+    "pydeconz==85"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/deconz/number.py
+++ b/homeassistant/components/deconz/number.py
@@ -11,6 +11,7 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -22,7 +23,7 @@ from .gateway import get_gateway_from_config_entry
 class DeconzNumberEntityDescription(NumberEntityDescription):
     """Class describing deCONZ number entities."""
 
-    entity_category = "config"
+    entity_category = ENTITY_CATEGORY_CONFIG
     device_property: str | None = None
     suffix: str | None = None
     update_key: str | None = None

--- a/homeassistant/components/deconz/number.py
+++ b/homeassistant/components/deconz/number.py
@@ -95,12 +95,10 @@ class DeconzNumber(DeconzDevice, NumberEntity):
 
     def __init__(self, device, gateway, description):
         """Initialize deCONZ number entity."""
+        self.entity_description = description
         super().__init__(device, gateway)
 
-        self.entity_description = description
-
         self._attr_name = f"{self._device.name} {description.suffix}"
-        self._attr_unique_id = f"{self.serial}-{description.suffix.lower()}"
         self._attr_max_value = description.max_value
         self._attr_min_value = description.min_value
         self._attr_step = description.step
@@ -121,3 +119,8 @@ class DeconzNumber(DeconzDevice, NumberEntity):
         """Set sensor config."""
         data = {self.entity_description.device_property: int(value)}
         await self._device.set_config(**data)
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique identifier for this entity."""
+        return f"{self.serial}-{self.entity_description.suffix.lower()}"

--- a/homeassistant/components/deconz/number.py
+++ b/homeassistant/components/deconz/number.py
@@ -63,7 +63,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 continue
 
             known_number_entities = set(gateway.entities[DOMAIN])
-            for description in ENTITY_DESCRIPTIONS.get(sensor.__class__, []):
+            for description in ENTITY_DESCRIPTIONS.get(type(sensor), []):
 
                 if getattr(sensor, description.device_property) is None:
                     continue

--- a/homeassistant/components/deconz/number.py
+++ b/homeassistant/components/deconz/number.py
@@ -1,0 +1,120 @@
+"""Support for configuring different deCONZ sensors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydeconz.sensor import Presence
+
+from homeassistant.components.number import (
+    DOMAIN,
+    NumberEntity,
+    NumberEntityDescription,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .deconz_device import DeconzDevice
+from .gateway import get_gateway_from_config_entry
+
+
+@dataclass
+class DeconzNumberEntityDescription(NumberEntityDescription):
+    """Class describing deCONZ number entities."""
+
+    entity_category = "config"
+    attribute: str | None = None
+    suffix: str | None = None
+    update_key: str | None = None
+    max_value: int | None = None
+    min_value: int | None = None
+    step: int | None = None
+
+
+ENTITY_DESCRIPTIONS = {
+    Presence: [
+        DeconzNumberEntityDescription(
+            key="duration",
+            attribute="duration",
+            suffix="Duration",
+            update_key="duration",
+            max_value=65535,
+            min_value=0,
+            step=1,
+        )
+    ]
+}
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the deCONZ number entity."""
+    gateway = get_gateway_from_config_entry(hass, config_entry)
+    gateway.entities[DOMAIN] = set()
+
+    @callback
+    def async_add_sensor(sensors=gateway.api.sensors.values()):
+        """Add number config sensor from deCONZ."""
+        entities = []
+
+        for sensor in sensors:
+
+            if sensor.type.startswith("CLIP"):
+                continue
+
+            known_number_entities = set(gateway.entities[DOMAIN])
+            for description in ENTITY_DESCRIPTIONS.get(sensor.__class__, []):
+                if getattr(sensor, description.attribute) is None:
+                    continue
+                new_number_entity = DeconzNumber(sensor, gateway, description)
+                if new_number_entity.unique_id not in known_number_entities:
+                    entities.append(new_number_entity)
+
+        if entities:
+            async_add_entities(entities)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            gateway.signal_new_sensor,
+            async_add_sensor,
+        )
+    )
+
+    async_add_sensor(
+        [gateway.api.sensors[key] for key in sorted(gateway.api.sensors, key=int)]
+    )
+
+
+class DeconzNumber(DeconzDevice, NumberEntity):
+    """Representation of a deCONZ number config entity."""
+
+    TYPE = DOMAIN
+
+    def __init__(self, device, gateway, description):
+        """Initialize deCONZ binary sensor."""
+        super().__init__(device, gateway)
+
+        self.entity_description = description
+
+        self._attr_name = f"{self._device.name} {description.suffix}"
+        self._attr_unique_id = f"{self.serial}-{self.entity_description.suffix.lower()}"
+        self._attr_max_value = self.entity_description.max_value
+        self._attr_min_value = self.entity_description.min_value
+        self._attr_step = self.entity_description.step
+
+    @callback
+    def async_update_callback(self, force_update: bool = False) -> None:
+        """Update the number value."""
+        keys = {self.entity_description.update_key, "reachable"}
+        if force_update or self._device.changed_keys.intersection(keys):
+            super().async_update_callback(force_update=force_update)
+
+    @property
+    def value(self) -> float:
+        """Return the value of the sensor attribute."""
+        return getattr(self._device, self.entity_description.attribute)
+
+    async def async_set_value(self, value: float) -> None:
+        """Set sensor config."""
+        data = {self.entity_description.attribute: int(value)}
+        await self._device.set_config(**data)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1417,7 +1417,7 @@ pydaikin==2.6.0
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==84
+pydeconz==85
 
 # homeassistant.components.delijn
 pydelijn==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -838,7 +838,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.6.0
 
 # homeassistant.components.deconz
-pydeconz==84
+pydeconz==85
 
 # homeassistant.components.dexcom
 pydexcom==0.2.0

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -23,6 +23,7 @@ from homeassistant.components.deconz.gateway import (
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.siren import DOMAIN as SIREN_DOMAIN
@@ -162,10 +163,11 @@ async def test_gateway_setup(hass, aioclient_mock):
         assert forward_entry_setup.mock_calls[4][1] == (config_entry, FAN_DOMAIN)
         assert forward_entry_setup.mock_calls[5][1] == (config_entry, LIGHT_DOMAIN)
         assert forward_entry_setup.mock_calls[6][1] == (config_entry, LOCK_DOMAIN)
-        assert forward_entry_setup.mock_calls[7][1] == (config_entry, SCENE_DOMAIN)
-        assert forward_entry_setup.mock_calls[8][1] == (config_entry, SENSOR_DOMAIN)
-        assert forward_entry_setup.mock_calls[9][1] == (config_entry, SIREN_DOMAIN)
-        assert forward_entry_setup.mock_calls[10][1] == (config_entry, SWITCH_DOMAIN)
+        assert forward_entry_setup.mock_calls[7][1] == (config_entry, NUMBER_DOMAIN)
+        assert forward_entry_setup.mock_calls[8][1] == (config_entry, SCENE_DOMAIN)
+        assert forward_entry_setup.mock_calls[9][1] == (config_entry, SENSOR_DOMAIN)
+        assert forward_entry_setup.mock_calls[10][1] == (config_entry, SIREN_DOMAIN)
+        assert forward_entry_setup.mock_calls[11][1] == (config_entry, SWITCH_DOMAIN)
 
 
 async def test_gateway_retry(hass):

--- a/tests/components/deconz/test_number.py
+++ b/tests/components/deconz/test_number.py
@@ -1,0 +1,60 @@
+"""deCONZ number platform tests."""
+
+from unittest.mock import patch
+
+from homeassistant.const import STATE_UNAVAILABLE
+
+from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
+
+
+async def test_no_number_entities(hass, aioclient_mock):
+    """Test that no sensors in deconz results in no number entities."""
+    await setup_deconz_integration(hass, aioclient_mock)
+    assert len(hass.states.async_all()) == 0
+
+
+async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
+    """Test successful creation of binary sensor entities."""
+    data = {
+        "sensors": {
+            "1": {
+                "name": "Presence sensor",
+                "type": "ZHAPresence",
+                "state": {"dark": False, "presence": False},
+                "config": {
+                    "duration": 1,
+                    "on": True,
+                    "reachable": True,
+                    "temperature": 10,
+                },
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
+
+    assert len(hass.states.async_all()) == 3
+    number = hass.states.get("number.presence_sensor_duration")
+    assert number.state == "1"
+
+    # event_changed_sensor = {
+    #     "t": "event",
+    #     "e": "changed",
+    #     "r": "sensors",
+    #     "id": "1",
+    #     "state": {"presence": True},
+    # }
+    # await mock_deconz_websocket(data=event_changed_sensor)
+    # await hass.async_block_till_done()
+
+    # assert hass.states.get("binary_sensor.presence_sensor").state == STATE_ON
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    assert hass.states.get("number.presence_sensor_duration").state == STATE_UNAVAILABLE
+
+    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_number.py
+++ b/tests/components/deconz/test_number.py
@@ -2,9 +2,20 @@
 
 from unittest.mock import patch
 
-from homeassistant.const import STATE_UNAVAILABLE
+import pytest
 
-from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+
+from .test_gateway import (
+    DECONZ_WEB_REQUEST,
+    mock_deconz_put_request,
+    setup_deconz_integration,
+)
 
 
 async def test_no_number_entities(hass, aioclient_mock):
@@ -17,12 +28,12 @@ async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
     """Test successful creation of binary sensor entities."""
     data = {
         "sensors": {
-            "1": {
+            "0": {
                 "name": "Presence sensor",
                 "type": "ZHAPresence",
                 "state": {"dark": False, "presence": False},
                 "config": {
-                    "duration": 1,
+                    "delay": 0,
                     "on": True,
                     "reachable": True,
                     "temperature": 10,
@@ -35,24 +46,57 @@ async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
         config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 3
-    number = hass.states.get("number.presence_sensor_duration")
-    assert number.state == "1"
+    assert hass.states.get("number.presence_sensor_delay").state == "0"
 
-    # event_changed_sensor = {
-    #     "t": "event",
-    #     "e": "changed",
-    #     "r": "sensors",
-    #     "id": "1",
-    #     "state": {"presence": True},
-    # }
-    # await mock_deconz_websocket(data=event_changed_sensor)
-    # await hass.async_block_till_done()
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "config": {"delay": 10},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
 
-    # assert hass.states.get("binary_sensor.presence_sensor").state == STATE_ON
+    assert hass.states.get("number.presence_sensor_delay").state == "10"
+
+    # Verify service calls
+
+    mock_deconz_put_request(aioclient_mock, config_entry.data, "/sensors/0/config")
+
+    # Service set supported value
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.presence_sensor_delay", ATTR_VALUE: 111},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[1][2] == {"delay": 111}
+
+    # Service set float value
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.presence_sensor_delay", ATTR_VALUE: 0.1},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[2][2] == {"delay": 0}
+
+    # Service set value beyond the supported range
+
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "number.presence_sensor_delay", ATTR_VALUE: 66666},
+            blocking=True,
+        )
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 
-    assert hass.states.get("number.presence_sensor_duration").state == STATE_UNAVAILABLE
+    assert hass.states.get("number.presence_sensor_delay").state == STATE_UNAVAILABLE
 
     await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add number platform support to deCONZ integration
First up is a config entity to set the delay between occupied/unoccupied state of Hue motion sensors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
