### PR TITLE
Explicit handling of available property of deCONZ entities

### DIFF
--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -112,14 +112,14 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
         self.alarm_system = get_alarm_system_for_unique_id(gateway, device.unique_id)
 
     @callback
-    def async_update_callback(self, force_update: bool = False) -> None:
+    def async_update_callback(self) -> None:
         """Update the control panels state."""
         keys = {"panel", "reachable"}
-        if force_update or (
+        if (
             self._device.changed_keys.intersection(keys)
             and self._device.state in DECONZ_TO_ALARM_STATE
         ):
-            super().async_update_callback(force_update=force_update)
+            super().async_update_callback()
 
     @property
     def state(self) -> str | None:

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -129,11 +129,11 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
             self.entity_description = entity_description
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self):
         """Update the sensor's state."""
         keys = {"on", "reachable", "state"}
-        if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback(force_update=force_update)
+        if self._device.changed_keys.intersection(keys):
+            super().async_update_callback()
 
     @property
     def is_on(self):
@@ -183,11 +183,11 @@ class DeconzTampering(DeconzDevice, BinarySensorEntity):
         return f"{self.serial}-tampered"
 
     @callback
-    def async_update_callback(self, force_update: bool = False) -> None:
+    def async_update_callback(self) -> None:
         """Update the sensor's state."""
         keys = {"tampered", "reachable"}
-        if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback(force_update=force_update)
+        if self._device.changed_keys.intersection(keys):
+            super().async_update_callback()
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/deconz/deconz_device.py
+++ b/homeassistant/components/deconz/deconz_device.py
@@ -66,7 +66,9 @@ class DeconzDevice(DeconzBase, Entity):
         self.gateway.deconz_ids[self.entity_id] = self._device.deconz_id
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass, self.gateway.signal_reachable, self.async_update_callback
+                self.hass,
+                self.gateway.signal_reachable,
+                self.async_update_connection_state,
             )
         )
 
@@ -77,9 +79,14 @@ class DeconzDevice(DeconzBase, Entity):
         self.gateway.entities[self.TYPE].remove(self.unique_id)
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_connection_state(self):
+        """Update the device's available state."""
+        self.async_write_ha_state()
+
+    @callback
+    def async_update_callback(self):
         """Update the device's state."""
-        if not force_update and self.gateway.ignore_state_updates:
+        if self.gateway.ignore_state_updates:
             return
 
         self.async_write_ha_state()

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -109,7 +109,7 @@ class DeconzEvent(DeconzBase):
         self._device.remove_callback(self.async_update_callback)
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self):
         """Fire the event if reason is that state is updated."""
         if (
             self.gateway.ignore_state_updates
@@ -156,7 +156,7 @@ class DeconzAlarmEvent(DeconzEvent):
     """Alarm control panel companion event when user interacts with a keypad."""
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self):
         """Fire the event if reason is new action is updated."""
         if (
             self.gateway.ignore_state_updates

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -159,11 +159,11 @@ class DeconzFan(DeconzDevice, FanEntity):
         return self._attr_supported_features
 
     @callback
-    def async_update_callback(self, force_update=False) -> None:
+    def async_update_callback(self) -> None:
         """Store latest configured speed from the device."""
         if self._device.speed in ORDERED_NAMED_FAN_SPEEDS:
             self._default_on_speed = self._device.speed
-        super().async_update_callback(force_update)
+        super().async_update_callback()
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -109,7 +109,7 @@ class DeconzGateway:
         """Handle signals of gateway connection status."""
         self.available = available
         self.ignore_state_updates = False
-        async_dispatcher_send(self.hass, self.signal_reachable, True)
+        async_dispatcher_send(self.hass, self.signal_reachable)
 
     @callback
     def async_add_device_callback(

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -191,11 +191,11 @@ class DeconzSensor(DeconzDevice, SensorEntity):
             self.entity_description = entity_description
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self):
         """Update the sensor's state."""
         keys = {"on", "reachable", "state"}
-        if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback(force_update=force_update)
+        if self._device.changed_keys.intersection(keys):
+            super().async_update_callback()
 
     @property
     def native_value(self):
@@ -255,11 +255,11 @@ class DeconzTemperature(DeconzDevice, SensorEntity):
         return f"{self.serial}-temperature"
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self):
         """Update the sensor's state."""
         keys = {"temperature", "reachable"}
-        if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback(force_update=force_update)
+        if self._device.changed_keys.intersection(keys):
+            super().async_update_callback()
 
     @property
     def native_value(self):
@@ -280,11 +280,11 @@ class DeconzBattery(DeconzDevice, SensorEntity):
         self._attr_name = f"{self._device.name} Battery Level"
 
     @callback
-    def async_update_callback(self, force_update=False):
+    def async_update_callback(self):
         """Update the battery's state, if needed."""
         keys = {"battery", "reachable"}
-        if force_update or self._device.changed_keys.intersection(keys):
-            super().async_update_callback(force_update=force_update)
+        if self._device.changed_keys.intersection(keys):
+            super().async_update_callback()
 
     @property
     def unique_id(self):
@@ -337,7 +337,7 @@ class DeconzSensorStateTracker:
         self.sensor = None
 
     @callback
-    def async_update_callback(self, ignore_update=False):
+    def async_update_callback(self):
         """Sensor state updated."""
         if "battery" in self.sensor.changed_keys:
             async_dispatcher_send(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make signalling for availability state changes more explicit.
When reviewing look at gateway.py and deconz_device.py first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
