### PR TITLE
Please pylint for modbus test

### DIFF
--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -32,8 +32,8 @@ class ReadResult:
         self.bits = register_words
 
 
-@pytest.fixture
-def mock_pymodbus():
+@pytest.fixture(name="mock_pymodbus")
+def mock_pymodbus_fixture():
     """Mock pymodbus."""
     mock_pb = mock.MagicMock()
     with mock.patch(
@@ -52,32 +52,32 @@ def mock_pymodbus():
         yield mock_pb
 
 
-@pytest.fixture
-def check_config_loaded():
+@pytest.fixture(name="check_config_loaded")
+def check_config_loaded_fixture():
     """Set default for check_config_loaded."""
     return True
 
 
-@pytest.fixture
-def register_words():
+@pytest.fixture(name="register_words")
+def register_words_fixture():
     """Set default for register_words."""
     return [0x00, 0x00]
 
 
-@pytest.fixture
-def config_addon():
+@pytest.fixture(name="config_addon")
+def config_addon_fixture():
     """Add entra configuration items."""
     return None
 
 
-@pytest.fixture
-def do_exception():
+@pytest.fixture(name="do_exception")
+def do_exception_fixture():
     """Remove side_effect to pymodbus calls."""
     return False
 
 
-@pytest.fixture
-async def mock_modbus(
+@pytest.fixture(name="mock_modbus")
+async def mock_modbus_fixture(
     hass, caplog, register_words, check_config_loaded, config_addon, do_config
 ):
     """Load integration modbus using mocked pymodbus."""
@@ -115,8 +115,8 @@ async def mock_modbus(
         yield mock_pb
 
 
-@pytest.fixture
-async def mock_pymodbus_exception(hass, do_exception, mock_modbus):
+@pytest.fixture(name="mock_pymodbus_exception")
+async def mock_pymodbus_exception_fixture(hass, do_exception, mock_modbus):
     """Trigger update call with time_changed event."""
     if do_exception:
         exc = ModbusException("fail read_coils")
@@ -126,8 +126,8 @@ async def mock_pymodbus_exception(hass, do_exception, mock_modbus):
         mock_modbus.read_holding_registers.side_effect = exc
 
 
-@pytest.fixture
-async def mock_pymodbus_return(hass, register_words, mock_modbus):
+@pytest.fixture(name="mock_pymodbus_return")
+async def mock_pymodbus_return_fixture(hass, register_words, mock_modbus):
     """Trigger update call with time_changed event."""
     read_result = ReadResult(register_words)
     mock_modbus.read_coils.return_value = read_result
@@ -136,8 +136,8 @@ async def mock_pymodbus_return(hass, register_words, mock_modbus):
     mock_modbus.read_holding_registers.return_value = read_result
 
 
-@pytest.fixture
-async def mock_do_cycle(hass, mock_pymodbus_exception, mock_pymodbus_return):
+@pytest.fixture(name="mock_do_cycle")
+async def mock_do_cycle_fixture(hass, mock_pymodbus_exception, mock_pymodbus_return):
     """Trigger update call with time_changed event."""
     now = dt_util.utcnow() + timedelta(seconds=90)
     with mock.patch(
@@ -159,21 +159,21 @@ async def do_next_cycle(hass, now, cycle):
         return now
 
 
-@pytest.fixture
-async def mock_test_state(hass, request):
+@pytest.fixture(name="mock_test_state")
+async def mock_test_state_fixture(hass, request):
     """Mock restore cache."""
     mock_restore_cache(hass, request.param)
     return request.param
 
 
-@pytest.fixture
-async def mock_ha(hass, mock_pymodbus_return):
+@pytest.fixture(name="mock_ha")
+async def mock_ha_fixture(hass, mock_pymodbus_return):
     """Load homeassistant to allow service calls."""
     assert await async_setup_component(hass, "homeassistant", {})
     await hass.async_block_till_done()
 
 
-@pytest.fixture
-async def caplog_setup_text(caplog):
+@pytest.fixture(name="caplog_setup_text")
+async def caplog_setup_text_fixture(caplog):
     """Return setup log of integration."""
     yield caplog.text

--- a/tests/components/modbus/test_cover.py
+++ b/tests/components/modbus/test_cover.py
@@ -33,6 +33,7 @@ from homeassistant.core import State
 from .conftest import TEST_ENTITY_NAME, ReadResult, do_next_cycle
 
 ENTITY_ID = f"{COVER_DOMAIN}.{TEST_ENTITY_NAME}"
+ENTITY_ID2 = f"{ENTITY_ID}2"
 
 
 @pytest.mark.parametrize(
@@ -281,7 +282,6 @@ async def test_restore_state_cover(hass, mock_test_state, mock_modbus):
 async def test_service_cover_move(hass, mock_modbus, mock_ha):
     """Run test for service homeassistant.update_entity."""
 
-    ENTITY_ID2 = f"{ENTITY_ID}2"
     mock_modbus.read_holding_registers.return_value = ReadResult([0x01])
     await hass.services.async_call(
         "cover", "open_cover", {"entity_id": ENTITY_ID}, blocking=True

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -38,6 +38,7 @@ from homeassistant.setup import async_setup_component
 from .conftest import TEST_ENTITY_NAME, TEST_MODBUS_HOST, TEST_PORT_TCP, ReadResult
 
 ENTITY_ID = f"{FAN_DOMAIN}.{TEST_ENTITY_NAME}"
+ENTITY_ID2 = f"{ENTITY_ID}2"
 
 
 @pytest.mark.parametrize(
@@ -223,7 +224,6 @@ async def test_restore_state_fan(hass, mock_test_state, mock_modbus):
 async def test_fan_service_turn(hass, caplog, mock_pymodbus):
     """Run test for service turn_on/turn_off."""
 
-    ENTITY_ID2 = f"{FAN_DOMAIN}.{TEST_ENTITY_NAME}2"
     config = {
         MODBUS_DOMAIN: {
             CONF_TYPE: TCP,

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -38,6 +38,7 @@ from homeassistant.setup import async_setup_component
 from .conftest import TEST_ENTITY_NAME, TEST_MODBUS_HOST, TEST_PORT_TCP, ReadResult
 
 ENTITY_ID = f"{LIGHT_DOMAIN}.{TEST_ENTITY_NAME}"
+ENTITY_ID2 = f"{ENTITY_ID}2"
 
 
 @pytest.mark.parametrize(
@@ -223,7 +224,6 @@ async def test_restore_state_light(hass, mock_test_state, mock_modbus):
 async def test_light_service_turn(hass, caplog, mock_pymodbus):
     """Run test for service turn_on/turn_off."""
 
-    ENTITY_ID2 = f"{ENTITY_ID}2"
     config = {
         MODBUS_DOMAIN: {
             CONF_TYPE: TCP,

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -52,6 +52,7 @@ from .conftest import (
 from tests.common import async_fire_time_changed
 
 ENTITY_ID = f"{SWITCH_DOMAIN}.{TEST_ENTITY_NAME}"
+ENTITY_ID2 = f"{ENTITY_ID}2"
 
 
 @pytest.mark.parametrize(
@@ -282,7 +283,6 @@ async def test_restore_state_switch(hass, mock_test_state, mock_modbus):
 async def test_switch_service_turn(hass, caplog, mock_pymodbus):
     """Run test for service turn_on/turn_off."""
 
-    ENTITY_ID2 = f"{SWITCH_DOMAIN}.{TEST_ENTITY_NAME}2"
     config = {
         MODBUS_DOMAIN: {
             CONF_TYPE: TCP,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
based on discussion in PR #58058 this solves all pylint remarks for the modbus test suite.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
