### PR TITLE
Cleanup device registration in Onewire

### DIFF
--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -5,7 +5,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN, PLATFORMS
 from .onewirehub import CannotConnect, OneWireHub
@@ -25,31 +25,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = onewirehub
 
-    async def cleanup_registry() -> None:
+    async def cleanup_registry(onewirehub: OneWireHub) -> None:
         # Get registries
-        device_registry, entity_registry = await asyncio.gather(
-            hass.helpers.device_registry.async_get_registry(),
-            hass.helpers.entity_registry.async_get_registry(),
-        )
+        device_registry = await hass.helpers.device_registry.async_get_registry()
         # Generate list of all device entries
-        registry_devices = [
-            entry.id
-            for entry in dr.async_entries_for_config_entry(
-                device_registry, entry.entry_id
-            )
-        ]
+        registry_devices = list(
+            dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        )
         # Remove devices that don't belong to any entity
-        for device_id in registry_devices:
-            if not er.async_entries_for_device(
-                entity_registry, device_id, include_disabled_entities=True
-            ):
+        for device in registry_devices:
+            if not onewirehub.has_device_in_cache(device):
                 _LOGGER.debug(
-                    "Removing device `%s` because it does not have any entities",
-                    device_id,
+                    "Removing device `%s` because it is no longer available",
+                    device.id,
                 )
-                device_registry.async_remove_device(device_id)
+                device_registry.async_remove_device(device.id)
 
-    async def start_platforms() -> None:
+    async def start_platforms(onewirehub: OneWireHub) -> None:
         """Start platforms and cleanup devices."""
         # wait until all required platforms are ready
         await asyncio.gather(
@@ -58,9 +50,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 for platform in PLATFORMS
             )
         )
-        await cleanup_registry()
+        await cleanup_registry(onewirehub)
 
-    hass.async_create_task(start_platforms())
+    hass.async_create_task(start_platforms(onewirehub))
 
     return True
 

--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def cleanup_registry(onewirehub: OneWireHub) -> None:
         # Get registries
-        device_registry = await hass.helpers.device_registry.async_get_registry()
+        device_registry = dr.async_get(hass)
         # Generate list of all device entries
         registry_devices = list(
             dr.async_entries_for_config_entry(device_registry, entry.entry_id)

--- a/homeassistant/components/onewire/model.py
+++ b/homeassistant/components/onewire/model.py
@@ -1,12 +1,32 @@
 """Type definitions for 1-Wire integration."""
 from __future__ import annotations
 
-from typing import TypedDict
+from dataclasses import dataclass
+
+from pi1wire import OneWireInterface
+
+from homeassistant.helpers.entity import DeviceInfo
 
 
-class OWServerDeviceDescription(TypedDict):
+@dataclass
+class OWDeviceDescription:
+    """OWDeviceDescription device description class."""
+
+    device_info: DeviceInfo
+
+
+@dataclass
+class OWDirectDeviceDescription(OWDeviceDescription):
+    """SysBus device description class."""
+
+    interface: OneWireInterface
+
+
+@dataclass
+class OWServerDeviceDescription(OWDeviceDescription):
     """OWServer device description class."""
 
-    path: str
     family: str
+    id: str
+    path: str
     type: str

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -1,23 +1,42 @@
 """Hub for communication with 1-Wire server or mount_dir."""
 from __future__ import annotations
 
+import logging
 import os
+from typing import TYPE_CHECKING
 
 from pi1wire import Pi1Wire
 from pyownet import protocol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TYPE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.entity import DeviceInfo
 
-from .const import CONF_MOUNT_DIR, CONF_TYPE_OWSERVER, CONF_TYPE_SYSBUS
-from .model import OWServerDeviceDescription
+from .const import CONF_MOUNT_DIR, CONF_TYPE_OWSERVER, CONF_TYPE_SYSBUS, DOMAIN
+from .model import (
+    OWDeviceDescription,
+    OWDirectDeviceDescription,
+    OWServerDeviceDescription,
+)
 
 DEVICE_COUPLERS = {
     # Family : [branches]
     "1F": ["aux", "main"]
 }
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class OneWireHub:
@@ -29,7 +48,7 @@ class OneWireHub:
         self.type: str | None = None
         self.pi1proxy: Pi1Wire | None = None
         self.owproxy: protocol._Proxy | None = None
-        self.devices: list | None = None
+        self.devices: list[OWDeviceDescription] | None = None
 
     async def connect(self, host: str, port: int) -> None:
         """Connect to the owserver host."""
@@ -56,41 +75,91 @@ class OneWireHub:
             port = config_entry.data[CONF_PORT]
             await self.connect(host, port)
         await self.discover_devices()
+        if TYPE_CHECKING:
+            assert self.devices
+        # Register discovered devices on Hub
+        device_registry = dr.async_get(self.hass)
+        for device in self.devices:
+            device_info: DeviceInfo = device.device_info
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry.entry_id,
+                identifiers=device_info[ATTR_IDENTIFIERS],
+                manufacturer=device_info[ATTR_MANUFACTURER],
+                model=device_info[ATTR_MODEL],
+                name=device_info[ATTR_NAME],
+            )
 
     async def discover_devices(self) -> None:
         """Discover all devices."""
         if self.devices is None:
             if self.type == CONF_TYPE_SYSBUS:
-                assert self.pi1proxy
                 self.devices = await self.hass.async_add_executor_job(
-                    self.pi1proxy.find_all_sensors
+                    self._discover_devices_sysbus
                 )
             if self.type == CONF_TYPE_OWSERVER:
                 self.devices = await self.hass.async_add_executor_job(
                     self._discover_devices_owserver
                 )
 
-    def _discover_devices_owserver(
-        self, path: str = "/"
-    ) -> list[OWServerDeviceDescription]:
+    def _discover_devices_sysbus(self) -> list[OWDeviceDescription]:
+        """Discover all sysbus devices."""
+        devices: list[OWDeviceDescription] = []
+        assert self.pi1proxy
+        for interface in self.pi1proxy.find_all_sensors():
+            family = interface.mac_address[:2]
+            device_id = f"{family}-{interface.mac_address[2:]}"
+            device_info: DeviceInfo = {
+                ATTR_IDENTIFIERS: {(DOMAIN, device_id)},
+                ATTR_MANUFACTURER: "Maxim Integrated",
+                ATTR_MODEL: family,
+                ATTR_NAME: device_id,
+            }
+            device = OWDirectDeviceDescription(
+                device_info=device_info,
+                interface=interface,
+            )
+            devices.append(device)
+        return devices
+
+    def _discover_devices_owserver(self, path: str = "/") -> list[OWDeviceDescription]:
         """Discover all owserver devices."""
-        devices = []
+        devices: list[OWDeviceDescription] = []
         assert self.owproxy
         for device_path in self.owproxy.dir(path):
+            device_id = os.path.split(os.path.split(device_path)[0])[1]
             device_family = self.owproxy.read(f"{device_path}family").decode()
+            _LOGGER.debug("read `%sfamily`: %s", device_path, device_family)
             device_type = self.owproxy.read(f"{device_path}type").decode()
+            _LOGGER.debug("read `%stype`: %s", device_path, device_type)
+            device_info: DeviceInfo = {
+                ATTR_IDENTIFIERS: {(DOMAIN, device_id)},
+                ATTR_MANUFACTURER: "Maxim Integrated",
+                ATTR_MODEL: device_type,
+                ATTR_NAME: device_id,
+            }
+            device = OWServerDeviceDescription(
+                device_info=device_info,
+                id=device_id,
+                family=device_family,
+                path=device_path,
+                type=device_type,
+            )
+            devices.append(device)
             if device_branches := DEVICE_COUPLERS.get(device_family):
                 for branch in device_branches:
                     devices += self._discover_devices_owserver(f"{device_path}{branch}")
-            else:
-                devices.append(
-                    {
-                        "path": device_path,
-                        "family": device_family,
-                        "type": device_type,
-                    }
-                )
+
         return devices
+
+    def has_device_in_cache(self, device: DeviceEntry) -> bool:
+        """Check if device was present in the cache."""
+        if TYPE_CHECKING:
+            assert self.devices
+        for internal_device in self.devices:
+            for identifier in internal_device.device_info[ATTR_IDENTIFIERS]:
+                if identifier in device.identifiers:
+                    return True
+        return False
 
 
 class CannotConnect(HomeAssistantError):

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -4,19 +4,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from homeassistant.components.onewire.model import OWServerDeviceDescription
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_IDENTIFIERS,
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_NAME,
-    CONF_TYPE,
-)
+from homeassistant.const import CONF_TYPE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -120,23 +114,16 @@ def get_entities(onewirehub: OneWireHub) -> list[SwitchEntity]:
     entities: list[SwitchEntity] = []
 
     for device in onewirehub.devices:
-        family = device["family"]
-        device_type = device["type"]
-        device_id = os.path.split(os.path.split(device["path"])[0])[1]
+        if TYPE_CHECKING:
+            assert isinstance(device, OWServerDeviceDescription)
+        family = device.family
+        device_id = device.id
+        device_info = device.device_info
 
         if family not in DEVICE_SWITCHES:
             continue
-
-        device_info: DeviceInfo = {
-            ATTR_IDENTIFIERS: {(DOMAIN, device_id)},
-            ATTR_MANUFACTURER: "Maxim Integrated",
-            ATTR_MODEL: device_type,
-            ATTR_NAME: device_id,
-        }
         for description in DEVICE_SWITCHES[family]:
-            device_file = os.path.join(
-                os.path.split(device["path"])[0], description.key
-            )
+            device_file = os.path.join(os.path.split(device.path)[0], description.key)
             name = f"{device_id} {description.name}"
             entities.append(
                 OneWireProxySwitch(

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -57,6 +57,13 @@ def check_device_registry(
         assert registry_entry.manufacturer == expected_device[ATTR_MANUFACTURER]
         assert registry_entry.name == expected_device[ATTR_NAME]
         assert registry_entry.model == expected_device[ATTR_MODEL]
+        if expected_via_device := expected_device.get("via_device"):
+            assert registry_entry.via_device_id is not None
+            parent_entry = device_registry.async_get_device({expected_via_device})
+            assert parent_entry is not None
+            assert registry_entry.via_device_id == parent_entry.id
+        else:
+            assert registry_entry.via_device_id is None
 
 
 def check_entities(

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -45,15 +45,18 @@ def check_and_enable_disabled_entities(
 
 
 def check_device_registry(
-    device_registry: DeviceRegistry, expected_device: MappingProxyType
+    device_registry: DeviceRegistry, expected_devices: list[MappingProxyType]
 ) -> None:
-    """Ensure that the expected_device is correctly registered."""
-    registry_entry = device_registry.async_get_device(expected_device[ATTR_IDENTIFIERS])
-    assert registry_entry is not None
-    assert registry_entry.identifiers == expected_device[ATTR_IDENTIFIERS]
-    assert registry_entry.manufacturer == expected_device[ATTR_MANUFACTURER]
-    assert registry_entry.name == expected_device[ATTR_NAME]
-    assert registry_entry.model == expected_device[ATTR_MODEL]
+    """Ensure that the expected_devices are correctly registered."""
+    for expected_device in expected_devices:
+        registry_entry = device_registry.async_get_device(
+            expected_device[ATTR_IDENTIFIERS]
+        )
+        assert registry_entry is not None
+        assert registry_entry.identifiers == expected_device[ATTR_IDENTIFIERS]
+        assert registry_entry.manufacturer == expected_device[ATTR_MANUFACTURER]
+        assert registry_entry.name == expected_device[ATTR_NAME]
+        assert registry_entry.model == expected_device[ATTR_MODEL]
 
 
 def check_entities(
@@ -77,37 +80,95 @@ def check_entities(
 
 
 def setup_owproxy_mock_devices(
-    owproxy: MagicMock, platform: str, device_ids: list(str)
+    owproxy: MagicMock, platform: str, device_ids: list[str]
 ) -> None:
     """Set up mock for owproxy."""
-    dir_return_value = []
+    main_dir_return_value = []
+    sub_dir_side_effect = []
     main_read_side_effect = []
     sub_read_side_effect = []
 
     for device_id in device_ids:
-        mock_device = MOCK_OWPROXY_DEVICES[device_id]
-
-        # Setup directory listing
-        dir_return_value += [f"/{device_id}/"]
-
-        # Setup device reads
-        main_read_side_effect += [device_id[0:2].encode()]
-        if ATTR_INJECT_READS in mock_device:
-            main_read_side_effect += mock_device[ATTR_INJECT_READS]
-
-        # Setup sub-device reads
-        device_sensors = mock_device.get(platform, [])
-        for expected_sensor in device_sensors:
-            sub_read_side_effect.append(expected_sensor[ATTR_INJECT_READS])
+        _setup_owproxy_mock_device(
+            main_dir_return_value,
+            sub_dir_side_effect,
+            main_read_side_effect,
+            sub_read_side_effect,
+            device_id,
+            platform,
+        )
 
     # Ensure enough read side effect
+    dir_side_effect = [main_dir_return_value] + sub_dir_side_effect
     read_side_effect = (
         main_read_side_effect
         + sub_read_side_effect
         + [ProtocolError("Missing injected value")] * 20
     )
-    owproxy.return_value.dir.return_value = dir_return_value
+    owproxy.return_value.dir.side_effect = dir_side_effect
     owproxy.return_value.read.side_effect = read_side_effect
+
+
+def _setup_owproxy_mock_device(
+    main_dir_return_value: list,
+    sub_dir_side_effect: list,
+    main_read_side_effect: list,
+    sub_read_side_effect: list,
+    device_id: str,
+    platform: str,
+) -> None:
+    """Set up mock for owproxy."""
+    mock_device = MOCK_OWPROXY_DEVICES[device_id]
+
+    # Setup directory listing
+    main_dir_return_value += [f"/{device_id}/"]
+    if "branches" in mock_device:
+        # Setup branch directory listing
+        for branch, branch_details in mock_device["branches"].items():
+            sub_dir_side_effect.append(
+                [  # dir on branch
+                    f"/{device_id}/{branch}/{sub_device_id}/"
+                    for sub_device_id in branch_details
+                ]
+            )
+
+    _setup_owproxy_mock_device_reads(
+        main_read_side_effect,
+        sub_read_side_effect,
+        mock_device,
+        device_id,
+        platform,
+    )
+
+    if "branches" in mock_device:
+        for branch_details in mock_device["branches"].values():
+            for sub_device_id, sub_device in branch_details.items():
+                _setup_owproxy_mock_device_reads(
+                    main_read_side_effect,
+                    sub_read_side_effect,
+                    sub_device,
+                    sub_device_id,
+                    platform,
+                )
+
+
+def _setup_owproxy_mock_device_reads(
+    main_read_side_effect: list,
+    sub_read_side_effect: list,
+    mock_device: Any,
+    device_id: str,
+    platform: str,
+) -> None:
+    """Set up mock for owproxy."""
+    # Setup device reads
+    main_read_side_effect += [device_id[0:2].encode()]
+    if ATTR_INJECT_READS in mock_device:
+        main_read_side_effect += mock_device[ATTR_INJECT_READS]
+
+    # Setup sub-device reads
+    device_sensors = mock_device.get(platform, [])
+    for expected_sensor in device_sensors:
+        sub_read_side_effect.append(expected_sensor[ATTR_INJECT_READS])
 
 
 def setup_sysbus_mock_devices(

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -8,8 +8,16 @@ from unittest.mock import MagicMock
 from pyownet.protocol import ProtocolError
 
 from homeassistant.components.onewire.const import DEFAULT_SYSBUS_MOUNT_DIR
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_STATE
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_STATE,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .const import (
@@ -34,6 +42,18 @@ def check_and_enable_disabled_entities(
             assert registry_entry.disabled
             assert registry_entry.disabled_by == "integration"
             entity_registry.async_update_entity(entity_id, **{"disabled_by": None})
+
+
+def check_device_registry(
+    device_registry: DeviceRegistry, expected_device: MappingProxyType
+) -> None:
+    """Ensure that the expected_device is correctly registered."""
+    registry_entry = device_registry.async_get_device(expected_device[ATTR_IDENTIFIERS])
+    assert registry_entry is not None
+    assert registry_entry.identifiers == expected_device[ATTR_IDENTIFIERS]
+    assert registry_entry.manufacturer == expected_device[ATTR_MANUFACTURER]
+    assert registry_entry.name == expected_device[ATTR_NAME]
+    assert registry_entry.model == expected_device[ATTR_MODEL]
 
 
 def check_entities(

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -212,12 +212,20 @@ MOCK_OWPROXY_DEVICES = {
         ATTR_INJECT_READS: [
             b"DS2409",  # read device type
         ],
-        ATTR_DEVICE_INFO: {
-            ATTR_IDENTIFIERS: {(DOMAIN, "1F.111111111111")},
-            ATTR_MANUFACTURER: MANUFACTURER,
-            ATTR_MODEL: "DS2409",
-            ATTR_NAME: "1F.111111111111",
-        },
+        ATTR_DEVICE_INFO: [
+            {
+                ATTR_IDENTIFIERS: {(DOMAIN, "1F.111111111111")},
+                ATTR_MANUFACTURER: MANUFACTURER,
+                ATTR_MODEL: "DS2409",
+                ATTR_NAME: "1F.111111111111",
+            },
+            {
+                ATTR_IDENTIFIERS: {(DOMAIN, "1D.111111111111")},
+                ATTR_MANUFACTURER: MANUFACTURER,
+                ATTR_MODEL: "DS2423",
+                ATTR_NAME: "1D.111111111111",
+            },
+        ],
         "branches": {
             "aux": {},
             "main": {
@@ -225,12 +233,6 @@ MOCK_OWPROXY_DEVICES = {
                     ATTR_INJECT_READS: [
                         b"DS2423",  # read device type
                     ],
-                    ATTR_DEVICE_INFO: {
-                        ATTR_IDENTIFIERS: {(DOMAIN, "1D.111111111111")},
-                        ATTR_MANUFACTURER: MANUFACTURER,
-                        ATTR_MODEL: "DS2423",
-                        ATTR_NAME: "1D.111111111111",
-                    },
                     SENSOR_DOMAIN: [
                         {
                             ATTR_DEVICE_FILE: "/1F.111111111111/main/1D.111111111111/counter.A",

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -224,6 +224,7 @@ MOCK_OWPROXY_DEVICES = {
                 ATTR_MANUFACTURER: MANUFACTURER,
                 ATTR_MODEL: "DS2423",
                 ATTR_NAME: "1D.111111111111",
+                "via_device": (DOMAIN, "1F.111111111111"),
             },
         ],
         "branches": {

--- a/tests/components/onewire/test_binary_sensor.py
+++ b/tests/components/onewire/test_binary_sensor.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.config_validation import ensure_list
 
 from . import (
     check_and_enable_disabled_entities,
@@ -37,16 +38,14 @@ async def test_owserver_binary_sensor(
 
     mock_device = MOCK_OWPROXY_DEVICES[device_id]
     expected_entities = mock_device.get(BINARY_SENSOR_DOMAIN, [])
+    expected_devices = ensure_list(mock_device.get(ATTR_DEVICE_INFO))
 
     setup_owproxy_mock_devices(owproxy, BINARY_SENSOR_DOMAIN, [device_id])
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
+    check_device_registry(device_registry, expected_devices)
     assert len(entity_registry.entities) == len(expected_entities)
-    if len(expected_entities) > 0:
-        assert len(device_registry.devices) == 1
-        check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
-
     check_and_enable_disabled_entities(entity_registry, expected_entities)
 
     setup_owproxy_mock_devices(owproxy, BINARY_SENSOR_DOMAIN, [device_id])

--- a/tests/components/onewire/test_binary_sensor.py
+++ b/tests/components/onewire/test_binary_sensor.py
@@ -9,12 +9,13 @@ from homeassistant.core import HomeAssistant
 
 from . import (
     check_and_enable_disabled_entities,
+    check_device_registry,
     check_entities,
     setup_owproxy_mock_devices,
 )
-from .const import MOCK_OWPROXY_DEVICES
+from .const import ATTR_DEVICE_INFO, MOCK_OWPROXY_DEVICES
 
-from tests.common import mock_registry
+from tests.common import mock_device_registry, mock_registry
 
 
 @pytest.fixture(autouse=True)
@@ -31,6 +32,7 @@ async def test_owserver_binary_sensor(
 
     This test forces all entities to be enabled.
     """
+    device_registry = mock_device_registry(hass)
     entity_registry = mock_registry(hass)
 
     mock_device = MOCK_OWPROXY_DEVICES[device_id]
@@ -48,4 +50,7 @@ async def test_owserver_binary_sensor(
     await hass.config_entries.async_reload(config_entry.entry_id)
     await hass.async_block_till_done()
 
+    if len(expected_entities) > 0:
+        assert len(device_registry.devices) == 1
+        check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
     check_entities(hass, entity_registry, expected_entities)

--- a/tests/components/onewire/test_binary_sensor.py
+++ b/tests/components/onewire/test_binary_sensor.py
@@ -43,6 +43,9 @@ async def test_owserver_binary_sensor(
     await hass.async_block_till_done()
 
     assert len(entity_registry.entities) == len(expected_entities)
+    if len(expected_entities) > 0:
+        assert len(device_registry.devices) == 1
+        check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
 
     check_and_enable_disabled_entities(entity_registry, expected_entities)
 
@@ -50,7 +53,4 @@ async def test_owserver_binary_sensor(
     await hass.config_entries.async_reload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    if len(expected_entities) > 0:
-        assert len(device_registry.devices) == 1
-        check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
     check_entities(hass, entity_registry, expected_entities)

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -102,6 +102,9 @@ async def test_owserver_setup_valid_device(
     await hass.async_block_till_done()
 
     assert len(entity_registry.entities) == len(expected_entities)
+    if len(expected_entities) > 0:
+        assert len(device_registry.devices) == 1
+        check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
 
     check_and_enable_disabled_entities(entity_registry, expected_entities)
 
@@ -109,9 +112,6 @@ async def test_owserver_setup_valid_device(
     await hass.config_entries.async_reload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    if len(expected_entities) > 0:
-        assert len(device_registry.devices) == 1
-        check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
     check_entities(hass, entity_registry, expected_entities)
 
 
@@ -139,8 +139,8 @@ async def test_onewiredirect_setup_valid_device(
         await hass.async_block_till_done()
 
     assert len(entity_registry.entities) == len(expected_entities)
-
     if len(expected_entities) > 0:
         assert len(device_registry.devices) == 1
         check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
+
     check_entities(hass, entity_registry, expected_entities)

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -16,12 +16,13 @@ from homeassistant.core import HomeAssistant
 
 from . import (
     check_and_enable_disabled_entities,
+    check_device_registry,
     check_entities,
     setup_owproxy_mock_devices,
 )
-from .const import MOCK_OWPROXY_DEVICES
+from .const import ATTR_DEVICE_INFO, MOCK_OWPROXY_DEVICES
 
-from tests.common import mock_registry
+from tests.common import mock_device_registry, mock_registry
 
 
 @pytest.fixture(autouse=True)
@@ -38,6 +39,7 @@ async def test_owserver_switch(
 
     This test forces all entities to be enabled.
     """
+    device_registry = mock_device_registry(hass)
     entity_registry = mock_registry(hass)
 
     mock_device = MOCK_OWPROXY_DEVICES[device_id]
@@ -55,6 +57,9 @@ async def test_owserver_switch(
     await hass.config_entries.async_reload(config_entry.entry_id)
     await hass.async_block_till_done()
 
+    if len(expected_entities) > 0:
+        assert len(device_registry.devices) == 1
+        check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
     check_entities(hass, entity_registry, expected_entities)
 
     # Test TOGGLE service

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.config_validation import ensure_list
 
 from . import (
     check_and_enable_disabled_entities,
@@ -44,16 +45,14 @@ async def test_owserver_switch(
 
     mock_device = MOCK_OWPROXY_DEVICES[device_id]
     expected_entities = mock_device.get(SWITCH_DOMAIN, [])
+    expected_devices = ensure_list(mock_device.get(ATTR_DEVICE_INFO))
 
     setup_owproxy_mock_devices(owproxy, SWITCH_DOMAIN, [device_id])
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
+    check_device_registry(device_registry, expected_devices)
     assert len(entity_registry.entities) == len(expected_entities)
-    if len(expected_entities) > 0:
-        assert len(device_registry.devices) == 1
-        check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
-
     check_and_enable_disabled_entities(entity_registry, expected_entities)
 
     setup_owproxy_mock_devices(owproxy, SWITCH_DOMAIN, [device_id])

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -50,6 +50,9 @@ async def test_owserver_switch(
     await hass.async_block_till_done()
 
     assert len(entity_registry.entities) == len(expected_entities)
+    if len(expected_entities) > 0:
+        assert len(device_registry.devices) == 1
+        check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
 
     check_and_enable_disabled_entities(entity_registry, expected_entities)
 
@@ -57,9 +60,6 @@ async def test_owserver_switch(
     await hass.config_entries.async_reload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    if len(expected_entities) > 0:
-        assert len(device_registry.devices) == 1
-        check_device_registry(device_registry, mock_device[ATTR_DEVICE_INFO])
     check_entities(hass, entity_registry, expected_entities)
 
     # Test TOGGLE service


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure devices are registered during hub initialisation (before the platforms) to ensure that devices without entities are correctly registered (eg. couplers).
Ensure devices without entities are not removed by `cleanup_registry` if they are present on the bus but do not have any entities.
Set `via_device` for devices on a coupler.

In tests, move device registry checks to init.py
In tests also, drop "sensor on coupler" tests has they are now covered in `test_owserver_{platform}`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
