### PR TITLE
Add `configuration_url` to Denon AVR integration

### DIFF
--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -147,14 +147,13 @@ class DenonDevice(MediaPlayerEntity):
         """Initialize the device."""
         self._attr_name = receiver.name
         self._attr_unique_id = unique_id
-        if config_entry.data[CONF_SERIAL_NUMBER] is not None:
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, config_entry.unique_id)},
-                manufacturer=config_entry.data[CONF_MANUFACTURER],
-                name=config_entry.title,
-                model=f"{config_entry.data[CONF_MODEL]}-{config_entry.data[CONF_TYPE]}",
-                configuration_url=f"http://{config_entry.data[CONF_HOST]}/",
-            )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, config_entry.unique_id)},
+            manufacturer=config_entry.data[CONF_MANUFACTURER],
+            name=config_entry.title,
+            model=f"{config_entry.data[CONF_MODEL]}-{config_entry.data[CONF_TYPE]}",
+            configuration_url=f"http://{config_entry.data[CONF_HOST]}/",
+        )
         self._attr_sound_mode_list = receiver.sound_mode_list
         self._attr_source_list = receiver.input_func_list
 

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -35,9 +35,10 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
 )
-from homeassistant.const import ATTR_COMMAND, STATE_PAUSED, STATE_PLAYING
+from homeassistant.const import ATTR_COMMAND, CONF_HOST, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers.entity import DeviceInfo
 
 from . import CONF_RECEIVER
 from .config_flow import (
@@ -144,9 +145,20 @@ class DenonDevice(MediaPlayerEntity):
         update_audyssey: bool,
     ) -> None:
         """Initialize the device."""
+        self._attr_name = receiver.name
+        self._attr_unique_id = unique_id
+        if config_entry.data[CONF_SERIAL_NUMBER] is not None:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, config_entry.unique_id)},
+                manufacturer=config_entry.data[CONF_MANUFACTURER],
+                name=config_entry.title,
+                model=f"{config_entry.data[CONF_MODEL]}-{config_entry.data[CONF_TYPE]}",
+                configuration_url=f"http://{config_entry.data[CONF_HOST]}/",
+            )
+        self._attr_sound_mode_list = receiver.sound_mode_list
+        self._attr_source_list = receiver.input_func_list
+
         self._receiver = receiver
-        self._unique_id = unique_id
-        self._config_entry = config_entry
         self._update_audyssey = update_audyssey
 
         self._supported_features_base = SUPPORT_DENON
@@ -231,31 +243,6 @@ class DenonDevice(MediaPlayerEntity):
         return self._available
 
     @property
-    def unique_id(self):
-        """Return the unique id of the zone."""
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        """Return the device info of the receiver."""
-        if self._config_entry.data[CONF_SERIAL_NUMBER] is None:
-            return None
-
-        device_info = {
-            "identifiers": {(DOMAIN, self._config_entry.unique_id)},
-            "manufacturer": self._config_entry.data[CONF_MANUFACTURER],
-            "name": self._config_entry.title,
-            "model": f"{self._config_entry.data[CONF_MODEL]}-{self._config_entry.data[CONF_TYPE]}",
-        }
-
-        return device_info
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._receiver.name
-
-    @property
     def state(self):
         """Return the state of the device."""
         return self._receiver.state
@@ -280,19 +267,9 @@ class DenonDevice(MediaPlayerEntity):
         return self._receiver.input_func
 
     @property
-    def source_list(self):
-        """Return a list of available input sources."""
-        return self._receiver.input_func_list
-
-    @property
     def sound_mode(self):
         """Return the current matched sound mode."""
         return self._receiver.sound_mode
-
-    @property
-    def sound_mode_list(self):
-        """Return a list of available sound modes."""
-        return self._receiver.sound_mode_list
 
     @property
     def supported_features(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR:
- adds `configuration_url` to `device_info`
- uses attrs instead of properties

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
