### PR TITLE
Add warning if Sonos not linked to Plex

### DIFF
--- a/homeassistant/components/plex/services.py
+++ b/homeassistant/components/plex/services.py
@@ -2,7 +2,7 @@
 import json
 import logging
 
-from plexapi.exceptions import NotFound
+from plexapi.exceptions import BadRequest, NotFound
 import voluptuous as vol
 
 from homeassistant.exceptions import HomeAssistantError
@@ -133,7 +133,13 @@ def play_on_sonos(hass, content_type, content_id, speaker_name):
     Called by Sonos 'media_player.play_media' service.
     """
     media, plex_server = lookup_plex_media(hass, content_type, content_id)
-    sonos_speaker = plex_server.account.sonos_speaker(speaker_name)
+    try:
+        sonos_speaker = plex_server.account.sonos_speaker(speaker_name)
+    except BadRequest:
+        raise HomeAssistantError(
+            "Sonos speakers not linked to Plex account, complete this step in the Plex app"
+        )
+
     if sonos_speaker is None:
         message = f"Sonos speaker '{speaker_name}' is not associated with '{plex_server.friendly_name}'"
         _LOGGER.error(message)

--- a/homeassistant/components/plex/services.py
+++ b/homeassistant/components/plex/services.py
@@ -135,10 +135,10 @@ def play_on_sonos(hass, content_type, content_id, speaker_name):
     media, plex_server = lookup_plex_media(hass, content_type, content_id)
     try:
         sonos_speaker = plex_server.account.sonos_speaker(speaker_name)
-    except BadRequest:
+    except BadRequest as exc:
         raise HomeAssistantError(
             "Sonos speakers not linked to Plex account, complete this step in the Plex app"
-        )
+        ) from exc
 
     if sonos_speaker is None:
         message = f"Sonos speaker '{speaker_name}' is not associated with '{plex_server.friendly_name}'"

--- a/tests/components/plex/test_services.py
+++ b/tests/components/plex/test_services.py
@@ -154,6 +154,13 @@ async def test_sonos_play_media(
     await hass.config_entries.async_unload(entry.entry_id)
     mock_plex_server = await setup_plex_server()
 
+    # Test with unlinked Plex/Sonos accounts
+    requests_mock.get("https://sonos.plex.tv/resources", status_code=403)
+    with pytest.raises(HomeAssistantError) as excinfo:
+        play_on_sonos(hass, MEDIA_TYPE_MUSIC, media_content_id, sonos_speaker_name)
+    assert "Sonos speakers not linked to Plex account" in str(excinfo.value)
+    assert playback_mock.call_count == 0
+
     # Test with no speakers available
     requests_mock.get("https://sonos.plex.tv/resources", text=empty_payload)
     with pytest.raises(HomeAssistantError) as excinfo:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Provide a more descriptive warning if attempting to play on Sonos speakers and the Plex/Sonos accounts have not yet been linked together.

Uncovered in https://community.home-assistant.io/t/trouble-playing-plex-music-to-sonos-from-ha/333601


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
