### PR TITLE
Bump velbusaio to 2021.10.6

### DIFF
--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.10.3"],
+  "requirements": ["velbus-aio==2021.10.5"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.10.1"],
+  "requirements": ["velbus-aio==2021.10.3"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/homeassistant/components/velbus/manifest.json
+++ b/homeassistant/components/velbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "velbus",
   "name": "Velbus",
   "documentation": "https://www.home-assistant.io/integrations/velbus",
-  "requirements": ["velbus-aio==2021.10.5"],
+  "requirements": ["velbus-aio==2021.10.6"],
   "config_flow": true,
   "codeowners": ["@Cereal2nd", "@brefra"],
   "iot_class": "local_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2357,7 +2357,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.10.3
+velbus-aio==2021.10.5
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2357,7 +2357,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.10.1
+velbus-aio==2021.10.3
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2357,7 +2357,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.8.1
 
 # homeassistant.components.velbus
-velbus-aio==2021.10.5
+velbus-aio==2021.10.6
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1355,7 +1355,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.10.1
+velbus-aio==2021.10.3
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1355,7 +1355,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.10.3
+velbus-aio==2021.10.5
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1355,7 +1355,7 @@ url-normalize==1.4.1
 uvcclient==0.11.0
 
 # homeassistant.components.velbus
-velbus-aio==2021.10.5
+velbus-aio==2021.10.6
 
 # homeassistant.components.venstar
 venstarcolortouch==0.14


### PR DESCRIPTION
## Proposed change
Bump velbusaio to 2021.10.6
- fix vmbtc module
- fix vmb1ts module
- fix problems with the serial communications
- fix problems with the serial communications
- Do not pin pyserial to a fixed version

https://github.com/Cereal2nd/velbus-aio/compare/2021.10.1...2021.10.6

## Type of change
- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
