### PR TITLE
Add support for min/max dimmer brightness in Tuya

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1131,6 +1131,7 @@ omit =
     homeassistant/components/tuya/sensor.py
     homeassistant/components/tuya/siren.py
     homeassistant/components/tuya/switch.py
+    homeassistant/components/tuya/util.py
     homeassistant/components/tuya/vacuum.py
     homeassistant/components/twentemilieu/const.py
     homeassistant/components/twentemilieu/sensor.py

--- a/homeassistant/components/tuya/base.py
+++ b/homeassistant/components/tuya/base.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from .const import DOMAIN, TUYA_HA_SIGNAL_UPDATE_ENTITY
+from .util import remap_value
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,9 +54,7 @@ class IntegerTypeData:
         reverse: bool = False,
     ) -> float:
         """Remap a value from this range to a new range."""
-        if reverse:
-            value = self.max - value + self.min
-        return ((value - self.min) / (self.max - self.min)) * (to_max - to_min) + to_min
+        return remap_value(value, self.min, self.max, to_min, to_max, reverse)
 
     def remap_value_from(
         self,
@@ -65,11 +64,7 @@ class IntegerTypeData:
         reverse: bool = False,
     ) -> float:
         """Remap a value from its current range to this range."""
-        if reverse:
-            value = from_max - value + from_min
-        return ((value - from_min) / (from_max - from_min)) * (
-            self.max - self.min
-        ) + self.min
+        return remap_value(value, from_min, from_max, self.min, self.max, reverse)
 
     @classmethod
     def from_json(cls, data: str) -> IntegerTypeData:

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -139,6 +139,12 @@ class DPCode(str, Enum):
     BRIGHT_VALUE_2 = "bright_value_2"
     BRIGHT_VALUE_3 = "bright_value_3"
     BRIGHT_VALUE_V2 = "bright_value_v2"
+    BRIGHTNESS_MAX_1 = "brightness_max_1"
+    BRIGHTNESS_MAX_2 = "brightness_max_2"
+    BRIGHTNESS_MAX_3 = "brightness_max_3"
+    BRIGHTNESS_MIN_1 = "brightness_min_1"
+    BRIGHTNESS_MIN_2 = "brightness_min_2"
+    BRIGHTNESS_MIN_3 = "brightness_min_3"
     C_F = "c_f"  # Temperature unit switching
     CH2O_STATE = "ch2o_state"
     CH2O_VALUE = "ch2o_value"

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -26,16 +26,19 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import HomeAssistantTuyaData
 from .base import IntegerTypeData, TuyaEntity
 from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode, WorkMode
+from .util import remap_value
 
 
 @dataclass
 class TuyaLightEntityDescription(LightEntityDescription):
     """Describe an Tuya light entity."""
 
-    color_mode: DPCode | None = None
+    brightness_max: DPCode | None = None
+    brightness_min: DPCode | None = None
     brightness: DPCode | tuple[DPCode, ...] | None = None
-    color_temp: DPCode | tuple[DPCode, ...] | None = None
     color_data: DPCode | tuple[DPCode, ...] | None = None
+    color_mode: DPCode | None = None
+    color_temp: DPCode | tuple[DPCode, ...] | None = None
 
 
 LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
@@ -276,6 +279,8 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
 
     entity_description: TuyaLightEntityDescription
     _brightness_dpcode: DPCode | None = None
+    _brightness_max_type: IntegerTypeData | None = None
+    _brightness_min_type: IntegerTypeData | None = None
     _brightness_type: IntegerTypeData | None = None
     _color_data_dpcode: DPCode | None = None
     _color_data_type: ColorTypeData | None = None
@@ -348,6 +353,20 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
             self._brightness_type = IntegerTypeData.from_json(
                 device.status_range[self._brightness_dpcode].values
             )
+
+            # Check if min/max capable
+            if (
+                description.brightness_max is not None
+                and description.brightness_min is not None
+                and description.brightness_max in device.function
+                and description.brightness_min in device.function
+            ):
+                self._brightness_max_type = IntegerTypeData.from_json(
+                    device.status_range[description.brightness_max].values
+                )
+                self._brightness_min_type = IntegerTypeData.from_json(
+                    device.status_range[description.brightness_min].values
+                )
 
         # Update internals based on found color temperature dpcode
         if self._color_temp_dpcode:
@@ -485,7 +504,41 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         if brightness is None:
             return None
 
-        return round(self._brightness_type.remap_value_to(brightness))
+        # Remap value to our scale
+        brightness = self._brightness_type.remap_value_to(brightness)
+
+        # If there is a min/max value, the brightness is actually limited.
+        # Meaning it is actually not on a 0-255 scale.
+        if (
+            self._brightness_max_type is not None
+            and self._brightness_min_type is not None
+            and self.entity_description.brightness_max is not None
+            and self.entity_description.brightness_min is not None
+            and (
+                brightness_max := self.device.status.get(
+                    self.entity_description.brightness_max
+                )
+            )
+            is not None
+            and (
+                brightness_min := self.device.status.get(
+                    self.entity_description.brightness_min
+                )
+            )
+            is not None
+        ):
+            # Remap values onto our scale
+            brightness_max = self._brightness_max_type.remap_value_to(brightness_max)
+            brightness_min = self._brightness_min_type.remap_value_to(brightness_min)
+
+            # Remap the brightness value from their min-max to our 0-255 scale
+            brightness = remap_value(
+                brightness,
+                from_min=brightness_min,
+                from_max=brightness_max,
+            )
+
+        return round(brightness)
 
     @property
     def color_temp(self) -> int | None:

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -101,7 +101,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MAX_2,
-            name="Maximum Brightness",
+            name="Maximum Brightness 2",
             icon="mdi:lightbulb-on-outline",
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
@@ -113,7 +113,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MAX_3,
-            name="Maximum Brightness",
+            name="Maximum Brightness 3",
             icon="mdi:lightbulb-on-outline",
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
@@ -141,7 +141,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MAX_2,
-            name="Maximum Brightness",
+            name="Maximum Brightness 2",
             icon="mdi:lightbulb-on-outline",
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -78,6 +78,74 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
     ),
+    # Dimmer Switch
+    # https://developer.tuya.com/en/docs/iot/categorytgkg?id=Kaiuz0ktx7m0o
+    "tgkg": (
+        NumberEntityDescription(
+            key=DPCode.BRIGHTNESS_MIN_1,
+            name="Minimum Brightness",
+            icon="mdi:lightbulb-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.BRIGHTNESS_MAX_1,
+            name="Maximum Brightness",
+            icon="mdi:lightbulb-on-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.BRIGHTNESS_MIN_2,
+            name="Minimum Brightness 2",
+            icon="mdi:lightbulb-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.BRIGHTNESS_MAX_2,
+            name="Maximum Brightness",
+            icon="mdi:lightbulb-on-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.BRIGHTNESS_MIN_3,
+            name="Minimum Brightness 3",
+            icon="mdi:lightbulb-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.BRIGHTNESS_MAX_3,
+            name="Maximum Brightness",
+            icon="mdi:lightbulb-on-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+    ),
+    # Dimmer Switch
+    # https://developer.tuya.com/en/docs/iot/categorytgkg?id=Kaiuz0ktx7m0o
+    "tgq": (
+        NumberEntityDescription(
+            key=DPCode.BRIGHTNESS_MIN_1,
+            name="Minimum Brightness",
+            icon="mdi:lightbulb-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.BRIGHTNESS_MAX_1,
+            name="Maximum Brightness",
+            icon="mdi:lightbulb-on-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.BRIGHTNESS_MIN_2,
+            name="Minimum Brightness 2",
+            icon="mdi:lightbulb-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.BRIGHTNESS_MAX_2,
+            name="Maximum Brightness",
+            icon="mdi:lightbulb-on-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+    ),
     # Vibration Sensor
     # https://developer.tuya.com/en/docs/iot/categoryzd?id=Kaiuz3a5vrzno
     "zd": (

--- a/homeassistant/components/tuya/util.py
+++ b/homeassistant/components/tuya/util.py
@@ -1,0 +1,16 @@
+"""Utility methods for the Tuya integration."""
+from __future__ import annotations
+
+
+def remap_value(
+    value: float | int,
+    from_min: float | int,
+    from_max: float | int,
+    to_min: float | int = 0,
+    to_max: float | int = 255,
+    reverse: bool = False,
+) -> float:
+    """Remap a value from its current range, to a new range."""
+    if reverse:
+        value = from_max - value + from_min
+    return ((value - from_min) / (from_max - from_min)) * (to_max - to_min) + to_min

--- a/homeassistant/components/tuya/util.py
+++ b/homeassistant/components/tuya/util.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 def remap_value(
     value: float | int,
-    from_min: float | int,
-    from_max: float | int,
+    from_min: float | int = 0,
+    from_max: float | int = 255,
     to_min: float | int = 0,
     to_max: float | int = 255,
     reverse: bool = False,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Implemented min/max dimmer brightness settings for the `tgkg` and `tgq` Tuya product categories.

Min/Max brightness can be applies on a light in case of e.g., flickering when dimming a LED light to low, or set a max if the bulb is just to bright to look at.

When a min/max is set, the current brightness in Home Assistant will still be 0-255 (normal) but will be remapped into the available space (min <-> max brightness).

![image](https://user-images.githubusercontent.com/195327/138495582-1cd1ffd8-13a8-4eee-a8c0-20c477c40fe6.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
