### PR TITLE
[WIP] Prepare for USB discovery of Sonoff Zigbee 3.0 USB Dongle Plus

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -16,6 +16,7 @@
   ],
   "usb": [
    {"vid":"10C4","pid":"EA60","description":"*2652*","known_devices":["slae.sh cc2652rb stick"]},
+   {"vid":"10C4","pid":"EA60","description":"*sonoff*","known_devices":["Sonoff Zigbee 3.0 USB Dongle Plus"]},
    {"vid":"10C4","pid":"EA60","description":"*tubeszb*","known_devices":["TubesZB Coordinator"]},
    {"vid":"1A86","pid":"7523","description":"*tubeszb*","known_devices":["TubesZB Coordinator"]},
    {"vid":"1CF1","pid":"0030","description":"*conbee*","known_devices":["Conbee II"]},

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -16,7 +16,7 @@
   ],
   "usb": [
    {"vid":"10C4","pid":"EA60","description":"*2652*","known_devices":["slae.sh cc2652rb stick"]},
-   {"vid":"10C4","pid":"EA60","description":"*sonoff*","known_devices":["Sonoff Zigbee 3.0 USB Dongle Plus"]},
+   {"vid":"10C4","pid":"EA60","description":"*Sonoff*","known_devices":["ITead Sonoff Zigbee 3.0 USB Dongle Plus"]},
    {"vid":"10C4","pid":"EA60","description":"*tubeszb*","known_devices":["TubesZB Coordinator"]},
    {"vid":"1A86","pid":"7523","description":"*tubeszb*","known_devices":["TubesZB Coordinator"]},
    {"vid":"1CF1","pid":"0030","description":"*conbee*","known_devices":["Conbee II"]},

--- a/homeassistant/generated/usb.py
+++ b/homeassistant/generated/usb.py
@@ -25,6 +25,12 @@ USB = [
     },
     {
         "domain": "zha",
+        "vid": "10C4",
+        "pid": "EA60",
+        "description": "sonoff*"
+    },
+    {
+        "domain": "zha",
         "vid": "1A86",
         "pid": "7523",
         "description": "*tubeszb*"

--- a/homeassistant/generated/usb.py
+++ b/homeassistant/generated/usb.py
@@ -27,7 +27,7 @@ USB = [
         "domain": "zha",
         "vid": "10C4",
         "pid": "EA60",
-        "description": "sonoff*"
+        "description": "*Sonoff*"
     },
     {
         "domain": "zha",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

No.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

[Work-in-Progress] Preparing for USB discovery in the ZHA integration of “ITead Sonoff Zigbee 3.0 USB Dongle Plus” adapter.

https://community.home-assistant.io/t/sonoff-zigbee-3-0-usb-dongle-plus-by-itead-is-based-on-texas-instruments-cc2652p-can-be-pre-ordered-for-10-99/340705

This will allow the ZHA integration to auto-discovery ITead Sonoff Zigbee 3.0 USB Dongle Plus adapters as discussed here:

https://community.home-assistant.io/t/community-help-wanted-to-whitelist-all-compatible-zigbee-and-z-wave-usb-adapters-for-automatic-discovery-in-home-assistant-os/344412/

WIP as has not yet been tested and not confirmed as of yet that ITead written this product description identifier to their latest batch.

Update: It is now confirmed that ITead has written “ITead Sonoff Zigbee 3.0 USB Dongle Plus” description to the CP2102N EEPROM.

Back-story:

My feedback to ITead was that the first batch(es) of ITead Sonoff Zigbee 3.0 USB Dongle Plus (which has Silabs CP2102N USB-to-UART bridge with programable EEPROM) is missing a custom “Product Description” value string written to CP210x EEPROM , which prevents HAOS and the ZHA integration to use USB discovery in order to auto direct their adapter as a unique device. 

I, therefore, requested them to add a custom PRODUCT STING to their next batch and if possible also provide a script for changing the USB Product Description String on those adapters already purchases, (which can probably be done via  https://github.com/VCTLabs/cp210x-program fork of http://cp210x-program.sourceforge.net/ or a similar tool).

After giving that feedback I relatively soon got an e-mail from ITead that they will change the default “CP2102 USB to UART Bridge Controller” text in the Product Description String value field to custom “Sonoff Zigbee 3.0 USB Dongle Plus” value in their next batch.

Anyway, the mail said ITead already tested that USB discovery works in Home Assistant on Linux with custom Product Description.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
