### PR TITLE
Mark Octoprint printer entities unavailable when printer is offline

### DIFF
--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -210,12 +210,12 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         # reading if there is one
         try:
             printer = await self._octoprint.get_printer_info()
-            self._printer_offline = False
         except PrinterOffline:
             if not self._printer_offline:
                 _LOGGER.error("Unable to retrieve printer information: Printer offline")
-                self._printer_offline = True
         except ApiError as err:
             raise UpdateFailed(err) from err
+        else:
+            self._printer_offline = True
 
         return {"job": job, "printer": printer, "last_read_time": dt_util.utcnow()}

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -213,9 +213,10 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         except PrinterOffline:
             if not self._printer_offline:
                 _LOGGER.error("Unable to retrieve printer information: Printer offline")
+                self._printer_offline = True
         except ApiError as err:
             raise UpdateFailed(err) from err
         else:
-            self._printer_offline = True
+            self._printer_offline = False
 
         return {"job": job, "printer": printer, "last_read_time": dt_util.utcnow()}

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -210,12 +210,11 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         # reading if there is one
         try:
             printer = await self._octoprint.get_printer_info()
+            self._printer_offline = False
         except PrinterOffline:
             if not self._printer_offline:
                 _LOGGER.error("Unable to retrieve printer information: Printer offline")
-            self._printer_offline = True
-            if self.data and "printer" in self.data:
-                printer = self.data["printer"]
+                self._printer_offline = True
         except ApiError as err:
             raise UpdateFailed(err) from err
 

--- a/homeassistant/components/octoprint/binary_sensor.py
+++ b/homeassistant/components/octoprint/binary_sensor.py
@@ -84,6 +84,11 @@ class OctoPrintBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
 
         return bool(self._get_flag_state(printer))
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.coordinator.data["printer"]
+
     @abstractmethod
     def _get_flag_state(self, printer_info: OctoprintPrinterInfo) -> bool | None:
         """Return the value of the sensor flag."""

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -120,6 +120,11 @@ class OctoPrintStatusSensor(OctoPrintSensorBase):
         """Icon to use in the frontend."""
         return "mdi:printer-3d"
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.coordinator.data["printer"]
+
 
 class OctoPrintJobPercentageSensor(OctoPrintSensorBase):
     """Representation of an OctoPrint sensor."""
@@ -244,3 +249,8 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
                 )
 
         return None
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.coordinator.data["printer"]

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -13,6 +13,7 @@ from pyoctoprintapi import (
 
 from homeassistant.components.octoprint import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.helpers.typing import UNDEFINED
 
 from tests.common import MockConfigEntry
 
@@ -33,11 +34,13 @@ DEFAULT_PRINTER = {
 async def init_integration(
     hass,
     platform,
-    printer: dict[str, Any] | None = DEFAULT_PRINTER,
+    printer: dict[str, Any] | UNDEFINED | None = UNDEFINED,
     job: dict[str, Any] | None = None,
 ):
     """Set up the octoprint integration in Home Assistant."""
     printer_info: OctoprintPrinterInfo | None = None
+    if printer is UNDEFINED:
+        printer = DEFAULT_PRINTER
     if printer is not None:
         printer_info = OctoprintPrinterInfo(printer)
     if job is None:

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -33,19 +33,20 @@ DEFAULT_PRINTER = {
 async def init_integration(
     hass,
     platform,
-    printer: dict[str, Any] | None = None,
+    printer: dict[str, Any] | None = DEFAULT_PRINTER,
     job: dict[str, Any] | None = None,
 ):
     """Set up the octoprint integration in Home Assistant."""
-    if printer is None:
-        printer = DEFAULT_PRINTER
+    printer_info: OctoprintPrinterInfo | None = None
+    if printer is not None:
+        printer_info = OctoprintPrinterInfo(printer)
     if job is None:
         job = DEFAULT_JOB
     with patch("homeassistant.components.octoprint.PLATFORMS", [platform]), patch(
         "pyoctoprintapi.OctoprintClient.get_server_info", return_value={}
     ), patch(
         "pyoctoprintapi.OctoprintClient.get_printer_info",
-        return_value=OctoprintPrinterInfo(printer),
+        return_value=printer_info,
     ), patch(
         "pyoctoprintapi.OctoprintClient.get_job_info",
         return_value=OctoprintJobInfo(job),

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -13,7 +13,7 @@ from pyoctoprintapi import (
 
 from homeassistant.components.octoprint import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.helpers.typing import UNDEFINED
+from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
 from tests.common import MockConfigEntry
 
@@ -34,7 +34,7 @@ DEFAULT_PRINTER = {
 async def init_integration(
     hass,
     platform,
-    printer: dict[str, Any] | UNDEFINED | None = UNDEFINED,
+    printer: dict[str, Any] | UndefinedType | None = UNDEFINED,
     job: dict[str, Any] | None = None,
 ):
     """Set up the octoprint integration in Home Assistant."""

--- a/tests/components/octoprint/test_binary_sensor.py
+++ b/tests/components/octoprint/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """The tests for Octoptint binary sensor module."""
 
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 
 from . import init_integration
 
@@ -28,6 +28,27 @@ async def test_sensors(hass):
     state = hass.states.get("binary_sensor.octoprint_printing_error")
     assert state is not None
     assert state.state == STATE_OFF
+    assert state.name == "Octoprint Printing Error"
+    entry = entity_registry.async_get("binary_sensor.octoprint_printing_error")
+    assert entry.unique_id == "Printing Error-uuid"
+
+
+async def test_sensors_printer_offline(hass):
+    """Test the underlying sensors when the printer is offline."""
+    await init_integration(hass, "binary_sensor", printer=None)
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    state = hass.states.get("binary_sensor.octoprint_printing")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    assert state.name == "Octoprint Printing"
+    entry = entity_registry.async_get("binary_sensor.octoprint_printing")
+    assert entry.unique_id == "Printing-uuid"
+
+    state = hass.states.get("binary_sensor.octoprint_printing_error")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
     assert state.name == "Octoprint Printing Error"
     entry = entity_registry.async_get("binary_sensor.octoprint_printing_error")
     assert entry.unique_id == "Printing Error-uuid"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the printer in octoprint is disconnected, mark the entities for it as unavailable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Built ontop of the existing octoprint rework PR (https://github.com/home-assistant/core/pull/58040)

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/58040
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
