### PR TITLE
Add an image placeholder for Nest WebRTC cameras

### DIFF
--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -40,11 +40,10 @@ _LOGGER = logging.getLogger(__name__)
 # Used to schedule an alarm to refresh the stream before expiration
 STREAM_EXPIRATION_BUFFER = datetime.timedelta(seconds=30)
 
-# Battery powered cameras only have image thumbnails/clips for events, not
-# when idle. The Google Home app dispays a placeholder image that appears
-# as a blurry/dim light source, giving a better indication the camera is
-# present, and not just broken. Emulate that behavior with a blurred ellipse
-# off the top left of the screen
+# The Google Home app dispays a placeholder image that appears as a faint
+# light source (dim, blurred sphere) giving the user an indication the camera
+# is available, not just a blank screen. These constants define a blurred
+# ellipse at the top left of the thumbnail.
 PLACEHOLDER_ELLIPSE_BLUR = 0.1
 PLACEHOLDER_ELLIPSE_XY = [-0.4, 0.3, 0.3, 0.4]
 PLACEHOLDER_OVERLAY_COLOR = "#ffffff"
@@ -75,7 +74,7 @@ async def async_setup_sdm_entry(
 
 
 def placeholder_image(width: int | None = None, height: int | None = None) -> Image:
-    """Return a camera image preview for cameras that do not support live grab."""
+    """Return a camera image preview for cameras without live thumbnails."""
     if not width or not height:
         return Image.new("RGB", (1, 1))
     # Draw a dark scene with a fake light source
@@ -250,8 +249,8 @@ class NestCamera(Camera):
         if not stream_url:
             if self.frontend_stream_type != STREAM_TYPE_WEB_RTC:
                 return None
-            # Nest Web RTC cams only have image previews for events by design
-            # and need their own image placeholder.
+            # Nest Web RTC cams only have image previews for events, and not
+            # for "now" by design to save batter, and need a placeholder.
             image = placeholder_image(width=width, height=height)
             with io.BytesIO() as content:
                 image.save(content, format="JPEG", optimize=True)

--- a/tests/components/nest/test_camera_sdm.py
+++ b/tests/components/nest/test_camera_sdm.py
@@ -134,7 +134,7 @@ async def fire_alarm(hass, point_in_time):
         await hass.async_block_till_done()
 
 
-async def async_get_image(hass):
+async def async_get_image(hass, width=None, height=None):
     """Get image from the camera, a wrapper around camera.async_get_image."""
     # Note: this patches ImageFrame to simulate decoding an image from a live
     # stream, however the test may not use it. Tests assert on the image
@@ -144,7 +144,9 @@ async def async_get_image(hass):
         autopatch=True,
         return_value=IMAGE_BYTES_FROM_STREAM,
     ):
-        return await camera.async_get_image(hass, "camera.my_camera")
+        return await camera.async_get_image(
+            hass, "camera.my_camera", width=width, height=height
+        )
 
 
 async def test_no_devices(hass):
@@ -720,9 +722,11 @@ async def test_camera_web_rtc(hass, auth, hass_ws_client):
     assert msg["success"]
     assert msg["result"]["answer"] == "v=0\r\ns=-\r\n"
 
-    # Nest WebRTC cameras do not support a still image
-    with pytest.raises(HomeAssistantError):
-        await async_get_image(hass)
+    # Nest WebRTC cameras return a placeholder
+    content = await async_get_image(hass)
+    assert content.content_type == "image/jpeg"
+    content = await async_get_image(hass, width=1024, height=768)
+    assert content.content_type == "image/jpeg"
 
 
 async def test_camera_web_rtc_unsupported(hass, auth, hass_ws_client):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Render an image placeholder for Nest WebRTC cameras that do not have an
RTSP source. The behavior is to mimic the Google Home app which returns a
mostly black image with a blurry light gray sphere. This is a sublte effect
but lets you know the camera isn't dead, compared to a blank black image or
the current broken image.

Current behavior where users will assume everything is broken:
<img width="355" alt="Screen Shot 2021-10-26 at 7 29 09 PM" src="https://user-images.githubusercontent.com/6026418/138989716-db35d591-33ad-4a59-b9e3-b90c7d1454fa.png">

New behavior:
<img width="454" alt="Screen Shot 2021-10-22 at 12 51 29 PM" src="https://user-images.githubusercontent.com/6026418/138515141-37cf6bc0-716c-4225-a0e0-d1b827e75c46.png">

Alternatives considered:
- 1x1 black only: Simpler, though not as nice looking and inconsistent with home app
- Change API between core and home assistant to support this case explicitly: Does not seem worth introducing this complexity for one integration
- Leave as broken image: Not user friendly


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
