### PR TITLE
Allow data sources to affect client tracker state after reconnecting to UniFi controller

### DIFF
--- a/homeassistant/components/unifi/device_tracker.py
+++ b/homeassistant/components/unifi/device_tracker.py
@@ -149,6 +149,7 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
         self.heartbeat_check = False
         self._is_connected = False
         self._controller_connection_state_changed = False
+        self._only_listen_to_event_source = False
 
         if client.last_seen:
             self._is_connected = (
@@ -191,11 +192,13 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
 
             if self.controller.available:
                 self.schedule_update = True
+                self._only_listen_to_event_source = False
 
             else:
                 self.controller.async_heartbeat(self.unique_id)
 
         elif self.client.last_updated == SOURCE_EVENT:
+            self._only_listen_to_event_source = True
             if (self.is_wired and self.client.event.event in WIRED_CONNECTION) or (
                 not self.is_wired and self.client.event.event in WIRELESS_CONNECTION
             ):
@@ -209,7 +212,7 @@ class UniFiClientTracker(UniFiClient, ScannerEntity):
                 self.schedule_update = True
 
         elif (
-            not self.client.event
+            not self._only_listen_to_event_source
             and self.client.last_updated == SOURCE_DATA
             and self.is_wired == self.client.is_wired
         ):

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -68,7 +68,7 @@ async def test_tracked_wireless_clients(hass, aioclient_mock, mock_unifi_websock
     await hass.async_block_till_done()
 
     client_state = hass.states.get("device_tracker.client")
-    assert client_state.state == "home"
+    assert client_state.state == STATE_HOME
     assert client_state.attributes["ip"] == "10.0.0.1"
     assert client_state.attributes["mac"] == "00:00:00:00:00:01"
     assert client_state.attributes["hostname"] == "client"
@@ -109,6 +109,23 @@ async def test_tracked_wireless_clients(hass, aioclient_mock, mock_unifi_websock
     with patch("homeassistant.util.dt.utcnow", return_value=new_time):
         async_fire_time_changed(hass, new_time)
         await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
+
+    # To limit false positives in client tracker
+    # data sources other than events are only used to update state
+    # until the first event has been received.
+    # This control will be reset if controller connection has been lost.
+
+    # New data doesn't change state
+
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client],
+        }
+    )
+    await hass.async_block_till_done()
 
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
 
@@ -475,6 +492,91 @@ async def test_controller_state_change(hass, aioclient_mock, mock_unifi_websocke
 
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
     assert hass.states.get("device_tracker.device").state == STATE_HOME
+
+
+async def test_controller_state_change_client_to_listen_on_all_state_changes(
+    hass, aioclient_mock, mock_unifi_websocket
+):
+    """Verify entities state reflect on controller becoming unavailable."""
+    client = {
+        "ap_mac": "00:00:00:00:02:01",
+        "essid": "ssid",
+        "hostname": "client",
+        "ip": "10.0.0.1",
+        "is_wired": False,
+        "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+        "mac": "00:00:00:00:00:01",
+    }
+    config_entry = await setup_unifi_integration(
+        hass, aioclient_mock, clients_response=[client]
+    )
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
+    assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
+    assert hass.states.get("device_tracker.client").state == STATE_HOME
+
+    # Disconnected event
+
+    event = {
+        "user": client["mac"],
+        "ssid": client["essid"],
+        "hostname": client["hostname"],
+        "ap": client["ap_mac"],
+        "duration": 467,
+        "bytes": 459039,
+        "key": "EVT_WU_Disconnected",
+        "subsystem": "wlan",
+        "site_id": "name",
+        "time": 1587752927000,
+        "datetime": "2020-04-24T18:28:47Z",
+        "msg": f'User{[client["mac"]]} disconnected from "{client["essid"]}" (7m 47s connected, 448.28K bytes, last AP[{client["ap_mac"]}])',
+        "_id": "5ea32ff730c49e00f90dca1a",
+    }
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_EVENT},
+            "data": [event],
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.client").state == STATE_HOME
+
+    # Change time to mark client as away
+
+    new_time = dt_util.utcnow() + controller.option_detection_time
+    with patch("homeassistant.util.dt.utcnow", return_value=new_time):
+        async_fire_time_changed(hass, new_time)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
+
+    # Controller unavailable
+    mock_unifi_websocket(state=STATE_DISCONNECTED)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.client").state == STATE_UNAVAILABLE
+
+    # Controller available
+    mock_unifi_websocket(state=STATE_RUNNING)
+    await hass.async_block_till_done()
+
+    # To limit false positives in client tracker
+    # data sources other than events are only used to update state
+    # until the first event has been received.
+    # This control will be reset if controller connection has been lost.
+
+    # New data can change state
+
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client],
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.client").state == STATE_HOME
 
 
 async def test_option_track_clients(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is an attempt to increase robustness of client tracker in cases connection to UniFi controller has been lost and later reconnected.
There are reports that events aren't sent properly upon reconnecting. So this is a stab in the dark that other data is sent from the controller.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #56365
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
