### PR TITLE
Add new attribute constants for DeviceInfo registration

### DIFF
--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -10,6 +10,13 @@ from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import (
+    ATTR_CONNECTIONS,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SUGGESTED_AREA,
+    ATTR_SW_VERSION,
     CONF_ADDRESS,
     CONF_NAME,
     CONF_PROTOCOL,
@@ -322,25 +329,27 @@ class AppleTVManager:
 
     async def _async_setup_device_registry(self):
         attrs = {
-            "identifiers": {(DOMAIN, self.config_entry.unique_id)},
-            "manufacturer": "Apple",
-            "name": self.config_entry.data[CONF_NAME],
+            ATTR_IDENTIFIERS: {(DOMAIN, self.config_entry.unique_id)},
+            ATTR_MANUFACTURER: "Apple",
+            ATTR_NAME: self.config_entry.data[CONF_NAME],
         }
 
-        area = attrs["name"]
+        area = attrs[ATTR_NAME]
         name_trailer = f" {DEFAULT_NAME}"
         if area.endswith(name_trailer):
             area = area[: -len(name_trailer)]
-        attrs["suggested_area"] = area
+        attrs[ATTR_SUGGESTED_AREA] = area
 
         if self.atv:
             dev_info = self.atv.device_info
 
-            attrs["model"] = DEFAULT_NAME + " " + dev_info.model.name.replace("Gen", "")
-            attrs["sw_version"] = dev_info.version
+            attrs[ATTR_MODEL] = (
+                DEFAULT_NAME + " " + dev_info.model.name.replace("Gen", "")
+            )
+            attrs[ATTR_SW_VERSION] = dev_info.version
 
             if dev_info.mac:
-                attrs["connections"] = {(dr.CONNECTION_NETWORK_MAC, dev_info.mac)}
+                attrs[ATTR_CONNECTIONS] = {(dr.CONNECTION_NETWORK_MAC, dev_info.mac)}
 
         device_registry = await dr.async_get_registry(self.hass)
         device_registry.async_get_or_create(

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -10,7 +10,13 @@ from typing import Any
 from aiohttp import ClientError
 from bond_api import BPUPSubscriptions
 
-from homeassistant.const import ATTR_MODEL, ATTR_NAME, ATTR_SW_VERSION, ATTR_VIA_DEVICE
+from homeassistant.const import (
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SUGGESTED_AREA,
+    ATTR_SW_VERSION,
+    ATTR_VIA_DEVICE,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.event import async_track_time_interval
@@ -65,7 +71,7 @@ class BondEntity(Entity):
         if self._hub.bond_id is not None:
             device_info[ATTR_VIA_DEVICE] = (DOMAIN, self._hub.bond_id)
         if self._device.location is not None:
-            device_info["suggested_area"] = self._device.location
+            device_info[ATTR_SUGGESTED_AREA] = self._device.location
         if not self._hub.is_bridge:
             if self._hub.model is not None:
                 device_info[ATTR_MODEL] = self._hub.model

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -23,6 +23,7 @@ from homeassistant.components.climate.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
+    ATTR_SUGGESTED_AREA,
     ATTR_TEMPERATURE,
     PRECISION_HALVES,
     STATE_OFF,
@@ -115,8 +116,6 @@ DEFAULT_MAX_TEMP = 30
 
 NA_THERM = "NATherm1"
 NA_VALVE = "NRV"
-
-SUGGESTED_AREA = "suggested_area"
 
 
 async def async_setup_entry(
@@ -616,5 +615,5 @@ class NetatmoThermostat(NetatmoBase, ClimateEntity):
     def device_info(self) -> DeviceInfo:
         """Return the device info for the thermostat."""
         device_info: DeviceInfo = super().device_info
-        device_info["suggested_area"] = self._room_data["name"]
+        device_info[ATTR_SUGGESTED_AREA] = self._room_data["name"]
         return device_info

--- a/homeassistant/components/plugwise/gateway.py
+++ b/homeassistant/components/plugwise/gateway.py
@@ -15,6 +15,9 @@ from plugwise.smile import Smile
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_CONFIGURATION_URL,
+    ATTR_MODEL,
+    ATTR_VIA_DEVICE,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
@@ -199,13 +202,15 @@ class SmileGateway(CoordinatorEntity):
         )
 
         if entry := self.coordinator.config_entry:
-            device_information["configuration_url"] = f"http://{entry.data[CONF_HOST]}"
+            device_information[
+                ATTR_CONFIGURATION_URL
+            ] = f"http://{entry.data[CONF_HOST]}"
 
         if self._model is not None:
-            device_information["model"] = self._model.replace("_", " ").title()
+            device_information[ATTR_MODEL] = self._model.replace("_", " ").title()
 
         if self._dev_id != self._api.gateway_id:
-            device_information["via_device"] = (DOMAIN, self._api.gateway_id)
+            device_information[ATTR_VIA_DEVICE] = (DOMAIN, self._api.gateway_id)
 
         return device_information
 

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -18,9 +18,16 @@ from zwave_js_server.model.value import Value, ValueNotification
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_CONFIG_ENTRY_ID,
     ATTR_DEVICE_ID,
     ATTR_DOMAIN,
     ATTR_ENTITY_ID,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SUGGESTED_AREA,
+    ATTR_SW_VERSION,
     CONF_URL,
     EVENT_HOMEASSISTANT_STOP,
 )
@@ -120,15 +127,17 @@ def register_node_in_dev_reg(
     ):
         remove_device_func(device)
     params = {
-        "config_entry_id": entry.entry_id,
-        "identifiers": {device_id},
-        "sw_version": node.firmware_version,
-        "name": node.name or node.device_config.description or f"Node {node.node_id}",
-        "model": node.device_config.label,
-        "manufacturer": node.device_config.manufacturer,
+        ATTR_CONFIG_ENTRY_ID: entry.entry_id,
+        ATTR_IDENTIFIERS: {device_id},
+        ATTR_SW_VERSION: node.firmware_version,
+        ATTR_NAME: node.name
+        or node.device_config.description
+        or f"Node {node.node_id}",
+        ATTR_MODEL: node.device_config.label,
+        ATTR_MANUFACTURER: node.device_config.manufacturer,
     }
     if node.location:
-        params["suggested_area"] = node.location
+        params[ATTR_SUGGESTED_AREA] = node.location
     device = dev_reg.async_get_or_create(**params)
 
     async_dispatcher_send(hass, EVENT_DEVICE_ADDED_TO_REGISTRY, device)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -352,8 +352,12 @@ ATTR_LOCATION: Final = "location"
 
 ATTR_MODE: Final = "mode"
 
+ATTR_CONFIG_ENTRY_ID: Final = "config_entry_id"
+ATTR_CONFIGURATION_URL: Final = "configuration_url"
+ATTR_CONNECTIONS: Final = "connections"
 ATTR_MANUFACTURER: Final = "manufacturer"
 ATTR_MODEL: Final = "model"
+ATTR_SUGGESTED_AREA: Final = "suggested_area"
 ATTR_SW_VERSION: Final = "sw_version"
 ATTR_VIA_DEVICE: Final = "via_device"
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new DeviceInfo attribute constants to core `const.py`, to be used in device registration:
```python
ATTR_CONFIG_ENTRY_ID: Final = "config_entry_id"
ATTR_CONFIGURATION_URL: Final = "configuration_url"
ATTR_CONNECTIONS: Final = "connections"
ATTR_SUGGESTED_AREA: Final = "suggested_area"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
