### PR TITLE
Initial support for Tradfri STARKVIND Air purifier

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1109,6 +1109,7 @@ omit =
     homeassistant/components/tradfri/base_class.py
     homeassistant/components/tradfri/config_flow.py
     homeassistant/components/tradfri/cover.py
+    homeassistant/components/tradfri/fan.py
     homeassistant/components/tradfri/light.py
     homeassistant/components/tradfri/sensor.py
     homeassistant/components/tradfri/switch.py

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from pytradfri.command import Command
 from pytradfri.device import Device
+from pytradfri.device.air_purifier import AirPurifier
+from pytradfri.device.air_purifier_control import AirPurifierControl
 from pytradfri.device.blind import Blind
 from pytradfri.device.blind_control import BlindControl
 from pytradfri.device.light import Light
@@ -58,10 +60,10 @@ class TradfriBaseClass(Entity):
         """Initialize a device."""
         self._api = handle_error(api)
         self._device: Device = device
-        self._device_control: BlindControl | LightControl | SocketControl | SignalRepeaterControl | None = (
+        self._device_control: BlindControl | LightControl | SocketControl | SignalRepeaterControl | AirPurifierControl | None = (
             None
         )
-        self._device_data: Socket | Light | Blind | None = None
+        self._device_data: Socket | Light | Blind | AirPurifier | None = None
         self._gateway_id = gateway_id
         self._refresh(device)
 

--- a/homeassistant/components/tradfri/const.py
+++ b/homeassistant/components/tradfri/const.py
@@ -23,4 +23,4 @@ GROUPS = "tradfri_groups"
 KEY_SECURITY_CODE = "security_code"
 SUPPORTED_GROUP_FEATURES = SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
 SUPPORTED_LIGHT_FEATURES = SUPPORT_TRANSITION
-PLATFORMS = ["cover", "light", "sensor", "switch"]
+PLATFORMS = ["cover", "light", "sensor", "switch", "fan"]

--- a/homeassistant/components/tradfri/const.py
+++ b/homeassistant/components/tradfri/const.py
@@ -23,4 +23,4 @@ GROUPS = "tradfri_groups"
 KEY_SECURITY_CODE = "security_code"
 SUPPORTED_GROUP_FEATURES = SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
 SUPPORTED_LIGHT_FEATURES = SUPPORT_TRANSITION
-PLATFORMS = ["cover", "light", "sensor", "switch", "fan"]
+PLATFORMS = ["cover", "fan", "light", "sensor", "switch"]

--- a/homeassistant/components/tradfri/const.py
+++ b/homeassistant/components/tradfri/const.py
@@ -2,6 +2,7 @@
 from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_TRANSITION
 from homeassistant.const import CONF_HOST  # noqa: F401 pylint: disable=unused-import
 
+ATTR_AUTO = "Auto"
 ATTR_DIMMER = "dimmer"
 ATTR_HUE = "hue"
 ATTR_SAT = "saturation"

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -120,7 +120,11 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
         """Return the current preset mode."""
         if not self._device_data:
             return None
-        return str(self._device_data.mode)
+
+        if self._device_data.mode == ATTR_AUTO:
+            return ATTR_AUTO
+
+        return None
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -131,7 +131,7 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
         preset_mode: str | None = None,
         **kwargs: Any,
     ) -> None:
-        """Turn on the fan in the auto mode."""
+        """Turn on the fan."""
         if not self._device_control:
             return
 

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -1,0 +1,109 @@
+"""Represent an air purifier."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
+
+from pytradfri.command import Command
+
+from homeassistant.components.fan import SUPPORT_PRESET_MODE, FanEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .base_class import TradfriBaseDevice
+from .const import CONF_GATEWAY_ID, DEVICES, DOMAIN, KEY_API
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Load Tradfri switches based on a config entry."""
+    gateway_id = config_entry.data[CONF_GATEWAY_ID]
+    tradfri_data = hass.data[DOMAIN][config_entry.entry_id]
+    api = tradfri_data[KEY_API]
+    devices = tradfri_data[DEVICES]
+
+    purifiers = [dev for dev in devices if dev.has_air_purifier_control]
+    if purifiers:
+        async_add_entities(
+            TradfriAirPurifierFan(purifier, api, gateway_id) for purifier in purifiers
+        )
+
+
+class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
+    """The platform class required by Home Assistant."""
+
+    def __init__(
+        self,
+        device: Command,
+        api: Callable[[Command | list[Command]], Any],
+        gateway_id: str,
+    ) -> None:
+        """Initialize a switch."""
+        super().__init__(device, api, gateway_id)
+        self._attr_unique_id = f"{gateway_id}-{device.id}"
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return SUPPORT_PRESET_MODE
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return 11
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if switch is on."""
+        if not self._device_data:
+            return False
+        return cast(bool, self._device_data.mode)
+
+    @property
+    def preset_modes(self) -> list[str] | None:
+        """Return a list of available preset modes."""
+        return ["0", "1", "10", "15", "20", "25", "30", "35", "40", "45", "50"]
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode."""
+        if not self._device_data:
+            return None
+        return str(self._device_data.mode)
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode of the fan."""
+        if not self._device_control:
+            return
+        await self._api(self._device_control.set_mode(int(preset_mode)))
+
+    async def async_turn_on(
+        self,
+        speed: str | None = None,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn on the fan in the auto mode."""
+        if not self._device_control:
+            return
+        await self._api(self._device_control.set_mode(1))
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the fan."""
+        if not self._device_control:
+            return
+        await self._api(self._device_control.set_mode(0))
+
+    def _refresh(self, device: Command) -> None:
+        """Refresh the purifier data."""
+        super()._refresh(device)
+
+        # Caching of air purifier control and purifier object
+        self._device_control = device.air_purifier_control
+        self._device_data = device.air_purifier_control.air_purifiers[0]

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -139,8 +139,8 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
             await self._api(self._device_control.set_mode(_from_percentage(percentage)))
             return
 
-        if preset_mode and preset_mode == ATTR_AUTO:
-            await self._api(self._device_control.set_mode(1))
+        if preset_mode:
+            await self.async_set_preset_mode(preset_mode)
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import logging
 from typing import Any, cast
 
 from pytradfri.command import Command
@@ -19,8 +18,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base_class import TradfriBaseDevice
 from .const import ATTR_AUTO, CONF_GATEWAY_ID, DEVICES, DOMAIN, KEY_API
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base_class import TradfriBaseDevice
-from .const import CONF_GATEWAY_ID, DEVICES, DOMAIN, KEY_API
+from .const import ATTR_AUTO, CONF_GATEWAY_ID, DEVICES, DOMAIN, KEY_API
 
 
 async def async_setup_entry(
@@ -55,7 +55,7 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
     @property
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
-        return 11
+        return 10
 
     @property
     def is_on(self) -> bool:
@@ -67,7 +67,7 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
     @property
     def preset_modes(self) -> list[str] | None:
         """Return a list of available preset modes."""
-        return ["0", "1", "10", "15", "20", "25", "30", "35", "40", "45", "50"]
+        return [ATTR_AUTO]
 
     @property
     def preset_mode(self) -> str | None:
@@ -80,7 +80,10 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
         """Set the preset mode of the fan."""
         if not self._device_control:
             return
-        await self._api(self._device_control.set_mode(int(preset_mode)))
+
+        if not preset_mode == ATTR_AUTO:
+            raise ValueError("Preset must be 'Auto'.")
+        await self._api(self._device_control.set_mode(1))
 
     async def async_turn_on(
         self,
@@ -92,7 +95,9 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
         """Turn on the fan in the auto mode."""
         if not self._device_control:
             return
-        await self._api(self._device_control.set_mode(1))
+
+        if preset_mode and preset_mode == ATTR_AUTO:
+            await self._api(self._device_control.set_mode(1))
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -40,12 +40,12 @@ async def async_setup_entry(
 
 def _from_percentage(percentage: int) -> int:
     """Convert percent to a value that the Tradfri API understands."""
-    return int(percentage / 100 * 50)
+    return round(percentage / 100 * 50)
 
 
 def _from_fan_speed(fan_speed: int) -> int:
     """Convert the Tradfri API fan speed to a percentage value."""
-    return int(fan_speed / 50 * 100)
+    return round(fan_speed / 50 * 100)
 
 
 class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -40,6 +40,11 @@ async def async_setup_entry(
 
 def _from_percentage(percentage: int) -> int:
     """Convert percent to a value that the Tradfri API understands."""
+    if percentage < 20:
+        # The device cannot be set to speed 5 (10%), so we should turn off the device
+        # for any value below 20
+        return 0
+
     nearest_10: int = round(percentage / 10) * 10  # Round to nearest multiple of 10
     return round(nearest_10 / 100 * 50)
 
@@ -149,10 +154,6 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
         if not self._device_control:
             return
 
-        # The device cannot be set to speed 5 (10%), so we should turn off the device
-        # for any value below 20
-        if percentage < 20:
-            percentage = 0
         await self._api(self._device_control.set_mode(_from_percentage(percentage)))
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -137,7 +137,7 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
         if not self._device_control:
             return
 
-        if percentage:
+        if percentage is not None:
             await self._api(self._device_control.set_mode(_from_percentage(percentage)))
             return
 

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -137,6 +137,7 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
 
         if percentage:
             await self._api(self._device_control.set_mode(_from_percentage(percentage)))
+            return
 
         if preset_mode and preset_mode == ATTR_AUTO:
             await self._api(self._device_control.set_mode(1))

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -40,7 +40,8 @@ async def async_setup_entry(
 
 def _from_percentage(percentage: int) -> int:
     """Convert percent to a value that the Tradfri API understands."""
-    return round(percentage / 100 * 50)
+    nearest_10: int = round(percentage / 10) * 10  # Round to nearest multiple of 10
+    return round(nearest_10 / 100 * 50)
 
 
 def _from_fan_speed(fan_speed: int) -> int:

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -46,7 +46,8 @@ def _from_percentage(percentage: int) -> int:
 
 def _from_fan_speed(fan_speed: int) -> int:
     """Convert the Tradfri API fan speed to a percentage value."""
-    return round(fan_speed / 50 * 100)
+    nearest_10: int = round(fan_speed / 10) * 10  # Round to nearest multiple of 10
+    return round(nearest_10 / 50 * 100)
 
 
 class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -147,6 +147,10 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
         if not self._device_control:
             return
 
+        # The device cannot be set to speed 5 (10%), so we should turn off the device
+        # for any value below 20
+        if percentage < 20:
+            percentage = 0
         await self._api(self._device_control.set_mode(_from_percentage(percentage)))
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/homeassistant/components/tradfri/sensor.py
+++ b/homeassistant/components/tradfri/sensor.py
@@ -34,6 +34,7 @@ async def async_setup_entry(
         and not dev.has_socket_control
         and not dev.has_blind_control
         and not dev.has_signal_repeater_control
+        and not dev.has_air_purifier_control
     )
     if sensors:
         async_add_entities(TradfriSensor(sensor, api, gateway_id) for sensor in sensors)

--- a/tests/components/tradfri/test_light.py
+++ b/tests/components/tradfri/test_light.py
@@ -139,6 +139,7 @@ def mock_light(test_features=None, test_state=None, light_number=0):
         has_socket_control=False,
         has_blind_control=False,
         has_signal_repeater_control=False,
+        has_air_purifier_control=False,
     )
     _mock_light.name = f"tradfri_light_{light_number}"
 

--- a/tests/components/tradfri/test_util.py
+++ b/tests/components/tradfri/test_util.py
@@ -9,5 +9,5 @@ def test_from_fan_speed():
 
 
 def test_from_percentage():
-    """Test that we can convert percentage to fan speed."""
+    """Test that we can convert percentage value to fan speed."""
     assert _from_percentage(80) == 40

--- a/tests/components/tradfri/test_util.py
+++ b/tests/components/tradfri/test_util.py
@@ -5,7 +5,7 @@ from homeassistant.components.tradfri.fan import _from_fan_speed, _from_percenta
 
 def test_from_fan_speed():
     """Test that we can convert fan speed to percentage value."""
-    assert _from_fan_speed(40) == 80
+    assert _from_fan_speed(41) == 80
 
 
 def test_from_percentage():

--- a/tests/components/tradfri/test_util.py
+++ b/tests/components/tradfri/test_util.py
@@ -10,4 +10,4 @@ def test_from_fan_speed():
 
 def test_from_percentage():
     """Test that we can convert percentage value to fan speed."""
-    assert _from_percentage(80) == 40
+    assert _from_percentage(84) == 40

--- a/tests/components/tradfri/test_util.py
+++ b/tests/components/tradfri/test_util.py
@@ -11,3 +11,12 @@ def test_from_fan_speed():
 def test_from_percentage():
     """Test that we can convert percentage value to fan speed."""
     assert _from_percentage(84) == 40
+
+
+def test_from_percentage_limit():
+    """
+    Test that we can convert percentage value to fan speed.
+
+    Handle special case of percent value being below 20.
+    """
+    assert _from_percentage(10) == 0

--- a/tests/components/tradfri/test_util.py
+++ b/tests/components/tradfri/test_util.py
@@ -1,0 +1,13 @@
+"""Tradfri utility function tests."""
+
+from homeassistant.components.tradfri.fan import _from_fan_speed, _from_percentage
+
+
+def test_from_fan_speed():
+    """Test that we can convert fan speed to percentage value."""
+    assert _from_fan_speed(40) == 80
+
+
+def test_from_percentage():
+    """Test that we can convert percentage to fan speed."""
+    assert _from_percentage(80) == 40


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds initial support for the Tradfri STARKVIND Air purifier. The suggested change allows us to watch the state the fan and to set the level of the fan according to a list of supported states.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19925/files

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
