### PR TITLE
Publish nest event ids in camera related events

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -122,13 +122,14 @@ class SignalUpdateCallback:
         device_entry = device_registry.async_get_device({(DOMAIN, device_id)})
         if not device_entry:
             return
-        for event in events:
-            if not (event_type := EVENT_NAME_MAP.get(event)):
+        for api_event_type, image_event in events.items():
+            if not (event_type := EVENT_NAME_MAP.get(api_event_type)):
                 continue
             message = {
                 "device_id": device_entry.id,
                 "type": event_type,
                 "timestamp": event_message.timestamp,
+                "nest_event_id": image_event.event_id,
             }
             self._hass.bus.async_fire(NEST_EVENT, message)
 

--- a/homeassistant/components/nest/events.py
+++ b/homeassistant/components/nest/events.py
@@ -17,11 +17,17 @@ NEST_EVENT = "nest_event"
 # The nest_event namespace will fire events that are triggered from messages
 # received via the Pub/Sub subscriber.
 #
-# An example event data payload:
+# An example event payload:
+#
 # {
-#   "device_id": "enterprises/some/device/identifier"
-#   "event_type": "camera_motion"
-#   "nest_event_id": "KcO1HIR9sPKQ2bqby_vTcCcEov..."
+#   "event_type": "nest_event"
+#   "data": {
+#       "device_id": "my-device-id",
+#       "type": "camera_motion",
+#       "timestamp": "2021-10-24T19:42:43.304000+00:00",
+#       "nest_event_id": "KcO1HIR9sPKQ2bqby_vTcCcEov..."
+#   },
+#   ...
 # }
 #
 # The nest_event_id corresponds to the event id in the SDM API used to retrieve

--- a/homeassistant/components/nest/events.py
+++ b/homeassistant/components/nest/events.py
@@ -21,7 +21,11 @@ NEST_EVENT = "nest_event"
 # {
 #   "device_id": "enterprises/some/device/identifier"
 #   "event_type": "camera_motion"
+#   "nest_event_id": "KcO1HIR9sPKQ2bqby_vTcCcEov..."
 # }
+#
+# The nest_event_id corresponds to the event id in the SDM API used to retrieve
+# snapshots.
 #
 # The following event types are fired:
 EVENT_DOORBELL_CHIME = "doorbell_chime"

--- a/tests/components/nest/test_events.py
+++ b/tests/components/nest/test_events.py
@@ -1,4 +1,4 @@
-"""Test for Nest binary sensor platform for the Smart Device Management API.
+"""Test for Nest events for the Smart Device Management API.
 
 These tests fake out the subscriber/devicemanager, and are not using a real
 pubsub subscriber.
@@ -117,6 +117,7 @@ async def test_doorbell_chime_event(hass):
         "device_id": entry.device_id,
         "type": "doorbell_chime",
         "timestamp": event_time,
+        "nest_event_id": EVENT_ID,
     }
 
 
@@ -144,6 +145,7 @@ async def test_camera_motion_event(hass):
         "device_id": entry.device_id,
         "type": "camera_motion",
         "timestamp": event_time,
+        "nest_event_id": EVENT_ID,
     }
 
 
@@ -171,6 +173,7 @@ async def test_camera_sound_event(hass):
         "device_id": entry.device_id,
         "type": "camera_sound",
         "timestamp": event_time,
+        "nest_event_id": EVENT_ID,
     }
 
 
@@ -198,6 +201,7 @@ async def test_camera_person_event(hass):
         "device_id": entry.device_id,
         "type": "camera_person",
         "timestamp": event_time,
+        "nest_event_id": EVENT_ID,
     }
 
 
@@ -234,11 +238,13 @@ async def test_camera_multiple_event(hass):
         "device_id": entry.device_id,
         "type": "camera_motion",
         "timestamp": event_time,
+        "nest_event_id": EVENT_ID,
     }
     assert events[1].data == {
         "device_id": entry.device_id,
         "type": "camera_person",
         "timestamp": event_time,
+        "nest_event_id": EVENT_ID,
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the camera event id to the payload. The event id can be used to fetch a
camera snapshot for a specific event.

Future work here includes exposing a service similar to `camera.snapshot`
for nest that accepts the event id as input.

See https://developers.google.com/nest/device-access/api/events for details on how events work in the Nest SDM API

Related work includes:
- [X] Publish nest event ids (this pr)
- [ ] Add a event snapshot service
- [ ] Add Height & Width parameters to event snapshot service
- [ ] Support video clips for new battery cameras
- [ ] Update documentation with new service calls and automation examples
- [ ] An API for proxying media related to events, separate from the camera image thumbnail
- [ ] A Nest MediaSource for browsing media related to events

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: Future work includes how to document event snapshots

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
