### PR TITLE
Add option to select quality of camera snapshots taken from Synology DSM connected cameras

### DIFF
--- a/homeassistant/components/synology_dsm/camera.py
+++ b/homeassistant/components/synology_dsm/camera.py
@@ -22,7 +22,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import SynoApi, SynologyDSMBaseEntity
-from .const import COORDINATOR_CAMERAS, DOMAIN, SYNO_API, SynologyDSMEntityDescription
+from .const import (
+    CONF_SNAPSHOT_QUALITY,
+    COORDINATOR_CAMERAS,
+    DEFAULT_SNAPSHOT_QUALITY,
+    DOMAIN,
+    SYNO_API,
+    SynologyDSMEntityDescription,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,6 +84,9 @@ class SynoDSMCamera(SynologyDSMBaseEntity, Camera):
             entity_registry_enabled_default=coordinator.data["cameras"][
                 camera_id
             ].is_enabled,
+        )
+        self.snapshot_quality = api._entry.options.get(
+            CONF_SNAPSHOT_QUALITY, DEFAULT_SNAPSHOT_QUALITY
         )
         super().__init__(api, coordinator, description)
         Camera.__init__(self)
@@ -135,7 +145,7 @@ class SynoDSMCamera(SynologyDSMBaseEntity, Camera):
         if not self.available:
             return None
         try:
-            return self._api.surveillance_station.get_camera_image(self.entity_description.key)  # type: ignore[no-any-return]
+            return self._api.surveillance_station.get_camera_image(self.entity_description.key, self.snapshot_quality)  # type: ignore[no-any-return]
         except (
             SynologyDSMAPIErrorException,
             SynologyDSMRequestException,

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -7,6 +7,11 @@ from typing import Any
 from urllib.parse import urlparse
 
 from synology_dsm import SynologyDSM
+from synology_dsm.api.surveillance_station.const import (
+    SNAPSHOT_PROFILE_BALANCED,
+    SNAPSHOT_PROFILE_HIGH_QUALITY,
+    SNAPSHOT_PROFILE_LOW_BANDWIDTH,
+)
 from synology_dsm.exceptions import (
     SynologyDSMException,
     SynologyDSMLogin2SAFailedException,
@@ -39,10 +44,12 @@ from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import (
     CONF_DEVICE_TOKEN,
+    CONF_SNAPSHOT_QUALITY,
     CONF_VOLUMES,
     DEFAULT_PORT,
     DEFAULT_PORT_SSL,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SNAPSHOT_QUALITY,
     DEFAULT_TIMEOUT,
     DEFAULT_USE_SSL,
     DEFAULT_VERIFY_SSL,
@@ -357,18 +364,30 @@ class SynologyDSMOptionsFlowHandler(OptionsFlow):
 
         data_schema = vol.Schema(
             {
-                vol.Optional(
+                vol.Required(
                     CONF_SCAN_INTERVAL,
                     default=self.config_entry.options.get(
                         CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                     ),
                 ): cv.positive_int,
-                vol.Optional(
+                vol.Required(
                     CONF_TIMEOUT,
                     default=self.config_entry.options.get(
                         CONF_TIMEOUT, DEFAULT_TIMEOUT
                     ),
                 ): cv.positive_int,
+                vol.Required(
+                    CONF_SNAPSHOT_QUALITY,
+                    default=self.config_entry.options.get(
+                        CONF_SNAPSHOT_QUALITY, DEFAULT_SNAPSHOT_QUALITY
+                    ),
+                ): vol.In(
+                    [
+                        SNAPSHOT_PROFILE_HIGH_QUALITY,
+                        SNAPSHOT_PROFILE_BALANCED,
+                        SNAPSHOT_PROFILE_LOW_BANDWIDTH,
+                    ]
+                ),
             }
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -7,11 +7,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 from synology_dsm import SynologyDSM
-from synology_dsm.api.surveillance_station.const import (
-    SNAPSHOT_PROFILE_BALANCED,
-    SNAPSHOT_PROFILE_HIGH_QUALITY,
-    SNAPSHOT_PROFILE_LOW_BANDWIDTH,
-)
 from synology_dsm.exceptions import (
     SynologyDSMException,
     SynologyDSMLogin2SAFailedException,
@@ -381,13 +376,7 @@ class SynologyDSMOptionsFlowHandler(OptionsFlow):
                     default=self.config_entry.options.get(
                         CONF_SNAPSHOT_QUALITY, DEFAULT_SNAPSHOT_QUALITY
                     ),
-                ): vol.In(
-                    [
-                        SNAPSHOT_PROFILE_HIGH_QUALITY,
-                        SNAPSHOT_PROFILE_BALANCED,
-                        SNAPSHOT_PROFILE_LOW_BANDWIDTH,
-                    ]
-                ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=2)),
             }
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -9,6 +9,7 @@ from synology_dsm.api.core.utilization import SynoCoreUtilization
 from synology_dsm.api.dsm.information import SynoDSMInformation
 from synology_dsm.api.storage.storage import SynoStorage
 from synology_dsm.api.surveillance_station import SynoSurveillanceStation
+from synology_dsm.api.surveillance_station.const import SNAPSHOT_PROFILE_BALANCED
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -47,6 +48,7 @@ UNDO_UPDATE_LISTENER = "undo_update_listener"
 CONF_SERIAL = "serial"
 CONF_VOLUMES = "volumes"
 CONF_DEVICE_TOKEN = "device_token"
+CONF_SNAPSHOT_QUALITY = "snap_profile_type"
 
 DEFAULT_USE_SSL = True
 DEFAULT_VERIFY_SSL = False
@@ -55,6 +57,7 @@ DEFAULT_PORT_SSL = 5001
 # Options
 DEFAULT_SCAN_INTERVAL = 15  # min
 DEFAULT_TIMEOUT = 10  # sec
+DEFAULT_SNAPSHOT_QUALITY = SNAPSHOT_PROFILE_BALANCED
 
 ENTITY_UNIT_LOAD = "load"
 

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -56,7 +56,8 @@
       "init": {
         "data": {
           "scan_interval": "Minutes between scans",
-          "timeout": "Timeout (seconds)"
+          "timeout": "Timeout (seconds)",
+          "snap_profile_type": "Quality level of camera snapshots (0:high 1:medium 2:low)"
         }
       }
     }

--- a/homeassistant/components/synology_dsm/translations/en.json
+++ b/homeassistant/components/synology_dsm/translations/en.json
@@ -31,14 +31,6 @@
                 "description": "Do you want to setup {name} ({host})?",
                 "title": "Synology DSM"
             },
-            "reauth": {
-                "data": {
-                    "password": "Password",
-                    "username": "Username"
-                },
-                "description": "Reason: {details}",
-                "title": "Synology DSM Reauthenticate Integration"
-            },
             "reauth_confirm": {
                 "data": {
                     "password": "Password",
@@ -64,6 +56,7 @@
             "init": {
                 "data": {
                     "scan_interval": "Minutes between scans",
+                    "snap_profile_type": "Quality level of camera snapshots (0:high 1:medium 2:low)",
                     "timeout": "Timeout (seconds)"
                 }
             }

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -14,10 +14,12 @@ from homeassistant import data_entry_flow
 from homeassistant.components import ssdp
 from homeassistant.components.synology_dsm.config_flow import CONF_OTP_CODE
 from homeassistant.components.synology_dsm.const import (
+    CONF_SNAPSHOT_QUALITY,
     CONF_VOLUMES,
     DEFAULT_PORT,
     DEFAULT_PORT_SSL,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SNAPSHOT_QUALITY,
     DEFAULT_TIMEOUT,
     DEFAULT_USE_SSL,
     DEFAULT_VERIFY_SSL,
@@ -545,13 +547,15 @@ async def test_options_flow(hass: HomeAssistant, service: MagicMock):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options[CONF_SCAN_INTERVAL] == DEFAULT_SCAN_INTERVAL
     assert config_entry.options[CONF_TIMEOUT] == DEFAULT_TIMEOUT
+    assert config_entry.options[CONF_SNAPSHOT_QUALITY] == DEFAULT_SNAPSHOT_QUALITY
 
     # Manual
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_SCAN_INTERVAL: 2, CONF_TIMEOUT: 30},
+        user_input={CONF_SCAN_INTERVAL: 2, CONF_TIMEOUT: 30, CONF_SNAPSHOT_QUALITY: 0},
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options[CONF_SCAN_INTERVAL] == 2
     assert config_entry.options[CONF_TIMEOUT] == 30
+    assert config_entry.options[CONF_SNAPSHOT_QUALITY] == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will add an option to the Synology DSM integration for setting the quality level of snapshots taken by the `camera.snapshot` service.
~To achieve this, the `py-synologydsm-api` is bumped to 1.0.5~
- ~changelog: https://github.com/mib1185/py-synologydsm-api/releases/tag/v1.0.5~
- ~most interressting: https://github.com/mib1185/py-synologydsm-api/pull/61~
- ~Commits: https://github.com/mib1185/py-synologydsm-api/compare/v1.0.4...v1.0.5~

lib already bumped with #63786

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #57684
- This PR is related to issue:
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
