### PR TITLE
Fix bug in MediaSource definintion and enable strict type checking

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -72,6 +72,7 @@ homeassistant.components.mailbox.*
 homeassistant.components.media_player.*
 homeassistant.components.modbus.*
 homeassistant.components.modem_callerid.*
+homeassistant.components.media_source.*
 homeassistant.components.mysensors.*
 homeassistant.components.nam.*
 homeassistant.components.nanoleaf.*

--- a/homeassistant/components/media_source/models.py
+++ b/homeassistant/components/media_source/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from abc import ABC
 from dataclasses import dataclass
+from typing import Any, cast
 
 from homeassistant.components.media_player import BrowseMedia
 from homeassistant.components.media_player.const import (
@@ -27,9 +28,11 @@ class PlayMedia:
 class BrowseMediaSource(BrowseMedia):
     """Represent a browsable media file."""
 
-    children: list[BrowseMediaSource] | None
+    children: list[BrowseMediaSource | BrowseMedia] | None
 
-    def __init__(self, *, domain: str | None, identifier: str | None, **kwargs) -> None:
+    def __init__(
+        self, *, domain: str | None, identifier: str | None, **kwargs: Any
+    ) -> None:
         """Initialize media source browse media."""
         media_content_id = f"{URI_SCHEME}{domain or ''}"
         if identifier:
@@ -85,7 +88,7 @@ class MediaSourceItem:
     @callback
     def async_media_source(self) -> MediaSource:
         """Return media source that owns this item."""
-        return self.hass.data[DOMAIN][self.domain]
+        return cast(MediaSource, self.hass.data[DOMAIN][self.domain])
 
     @classmethod
     def from_uri(cls, hass: HomeAssistant, uri: str) -> MediaSourceItem:
@@ -104,7 +107,7 @@ class MediaSourceItem:
 class MediaSource(ABC):
     """Represents a source of media files."""
 
-    name: str = None
+    name: str | None = None
 
     def __init__(self, domain: str) -> None:
         """Initialize a media source."""
@@ -116,8 +119,6 @@ class MediaSource(ABC):
         """Resolve a media item to a playable item."""
         raise NotImplementedError
 
-    async def async_browse_media(
-        self, item: MediaSourceItem, media_types: tuple[str]
-    ) -> BrowseMediaSource:
+    async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
         """Browse media."""
         raise NotImplementedError

--- a/homeassistant/components/netatmo/media_source.py
+++ b/homeassistant/components/netatmo/media_source.py
@@ -52,11 +52,7 @@ class NetatmoSource(MediaSource):
         url = self.events[camera_id][event_id]["media_url"]
         return PlayMedia(url, MIME_TYPE)
 
-    async def async_browse_media(
-        self,
-        item: MediaSourceItem,
-        media_types: tuple[str] = ("video",),
-    ) -> BrowseMediaSource:
+    async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
         """Return media."""
         try:
             source, camera_id, event_id = async_parse_identifier(item)

--- a/homeassistant/components/xbox/media_source.py
+++ b/homeassistant/components/xbox/media_source.py
@@ -17,7 +17,6 @@ from homeassistant.components.media_player.const import (
     MEDIA_CLASS_IMAGE,
     MEDIA_CLASS_VIDEO,
 )
-from homeassistant.components.media_source.const import MEDIA_MIME_TYPES
 from homeassistant.components.media_source.models import (
     BrowseMediaSource,
     MediaSource,
@@ -87,9 +86,7 @@ class XboxSource(MediaSource):
         kind = category.split("#", 1)[1]
         return PlayMedia(url, MIME_TYPE_MAP[kind])
 
-    async def async_browse_media(
-        self, item: MediaSourceItem, media_types: tuple[str] = MEDIA_MIME_TYPES
-    ) -> BrowseMediaSource:
+    async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
         """Return media."""
         title, category, _ = async_parse_identifier(item)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -803,6 +803,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.media_source.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.mysensors.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -1690,9 +1701,6 @@ ignore_errors = true
 ignore_errors = true
 
 [mypy-homeassistant.components.lyric.*]
-ignore_errors = true
-
-[mypy-homeassistant.components.media_source.*]
 ignore_errors = true
 
 [mypy-homeassistant.components.melcloud.*]

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -72,7 +72,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.luftdaten.*",
     "homeassistant.components.lutron_caseta.*",
     "homeassistant.components.lyric.*",
-    "homeassistant.components.media_source.*",
     "homeassistant.components.melcloud.*",
     "homeassistant.components.meteo_france.*",
     "homeassistant.components.metoffice.*",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the `media_types` argument in `MediaSource.async_browse_media` which is never
passed in, and never used in subclasses. This fixes the definition to match the actual usage.

Enable mypy strict type checking, and fix existing typing errors and improve typing coverage for untyped functions.

Found when implementing a new `MediaSource` which doesn't work when implementing the old definition.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
