### PR TITLE
Add select platform to Litter-Robot integration

### DIFF
--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from .const import DOMAIN
 from .hub import LitterRobotHub
 
-PLATFORMS = ["sensor", "switch", "vacuum"]
+PLATFORMS = ["select", "sensor", "switch", "vacuum"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/litterrobot/select.py
+++ b/homeassistant/components/litterrobot/select.py
@@ -1,0 +1,54 @@
+"""Support for Litter-Robot selects."""
+from __future__ import annotations
+
+from pylitterbot.robot import VALID_WAIT_TIMES
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import LitterRobotControlEntity
+from .hub import LitterRobotHub
+
+TYPE_CLEAN_CYCLE_WAIT_TIME_MINUTES = "Clean Cycle Wait Time Minutes"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Litter-Robot selects using config entry."""
+    hub: LitterRobotHub = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = []
+    for robot in hub.account.robots:
+        entities.append(
+            LitterRobotSelect(
+                robot=robot, entity_type=TYPE_CLEAN_CYCLE_WAIT_TIME_MINUTES, hub=hub
+            )
+        )
+
+    async_add_entities(entities, True)
+
+
+class LitterRobotSelect(LitterRobotControlEntity, SelectEntity):
+    """Litter-Robot Select."""
+
+    _attr_icon = "mdi:timer-outline"
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        return str(self.robot.clean_cycle_wait_time_minutes)
+
+    @property
+    def options(self) -> list[str]:
+        """Return a set of selectable options."""
+        return [str(minute) for minute in VALID_WAIT_TIMES]
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.perform_action_and_refresh(self.robot.set_wait_time, int(option))

--- a/homeassistant/components/litterrobot/select.py
+++ b/homeassistant/components/litterrobot/select.py
@@ -23,15 +23,14 @@ async def async_setup_entry(
     """Set up Litter-Robot selects using config entry."""
     hub: LitterRobotHub = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities = []
-    for robot in hub.account.robots:
-        entities.append(
-            LitterRobotSelect(
-                robot=robot, entity_type=TYPE_CLEAN_CYCLE_WAIT_TIME_MINUTES, hub=hub
-            )
+    entities = [
+        LitterRobotSelect(
+            robot=robot, entity_type=TYPE_CLEAN_CYCLE_WAIT_TIME_MINUTES, hub=hub
         )
+        for robot in hub.account.robots
+    ]
 
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 class LitterRobotSelect(LitterRobotControlEntity, SelectEntity):

--- a/tests/components/litterrobot/test_select.py
+++ b/tests/components/litterrobot/test_select.py
@@ -1,0 +1,66 @@
+"""Test the Litter-Robot select entity."""
+from datetime import timedelta
+
+from pylitterbot.robot import VALID_WAIT_TIMES
+import pytest
+
+from homeassistant.components.litterrobot.entity import REFRESH_WAIT_TIME_SECONDS
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as PLATFORM_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import utcnow
+
+from .conftest import setup_integration
+
+from tests.common import async_fire_time_changed
+
+SELECT_ENTITY_ID = "select.test_clean_cycle_wait_time_minutes"
+
+
+async def test_wait_time_select(hass: HomeAssistant, mock_account):
+    """Tests the wait time select entity."""
+    await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
+
+    select = hass.states.get(SELECT_ENTITY_ID)
+    assert select
+
+    data = {ATTR_ENTITY_ID: SELECT_ENTITY_ID}
+
+    count = 0
+    for wait_time in VALID_WAIT_TIMES:
+        count += 1
+        data[ATTR_OPTION] = wait_time
+
+        await hass.services.async_call(
+            PLATFORM_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            data,
+            blocking=True,
+        )
+
+        future = utcnow() + timedelta(seconds=REFRESH_WAIT_TIME_SECONDS)
+        async_fire_time_changed(hass, future)
+        assert mock_account.robots[0].set_wait_time.call_count == count
+
+
+async def test_invalid_wait_time_select(hass: HomeAssistant, mock_account):
+    """Tests the wait time select entity with invalid value."""
+    await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
+
+    select = hass.states.get(SELECT_ENTITY_ID)
+    assert select
+
+    data = {ATTR_ENTITY_ID: SELECT_ENTITY_ID, ATTR_OPTION: "10"}
+
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            PLATFORM_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            data,
+            blocking=True,
+        )
+    assert not mock_account.robots[0].set_wait_time.called


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the select platform to the Litter-Robot integration for managing the clean cycle wait time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19936

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
