### PR TITLE
Fix color temp selection when brightness changed in Tuya light

### DIFF
--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -30,8 +30,6 @@ from .base import IntegerTypeData, TuyaEntity
 from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode, WorkMode
 from .util import remap_value
 
-_LOGGER = logging.getLogger(__name__)
-
 
 @dataclass
 class TuyaLightEntityDescription(LightEntityDescription):
@@ -444,7 +442,6 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn on or control the light."""
-        _LOGGER.debug("light kwargs -> %s, cm = %s", kwargs, self.color_mode)
         commands = [{"code": self.entity_description.key, "value": True}]
 
         if self._color_temp_type and ATTR_COLOR_TEMP in kwargs:

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
-import logging
 from typing import Any
 
 from tuya_iot import TuyaDevice, TuyaDeviceManager

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
+import logging
 from typing import Any
 
 from tuya_iot import TuyaDevice, TuyaDeviceManager
@@ -28,6 +29,8 @@ from . import HomeAssistantTuyaData
 from .base import IntegerTypeData, TuyaEntity
 from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode, WorkMode
 from .util import remap_value
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -441,6 +444,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn on or control the light."""
+        _LOGGER.debug("light kwargs -> %s, cm = %s", kwargs, self.color_mode)
         commands = [{"code": self.entity_description.key, "value": True}]
 
         if self._color_data_type and (

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -447,7 +447,29 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         _LOGGER.debug("light kwargs -> %s, cm = %s", kwargs, self.color_mode)
         commands = [{"code": self.entity_description.key, "value": True}]
 
-        if self._color_data_type and (
+        if self._color_temp_type and ATTR_COLOR_TEMP in kwargs:
+            if color_mode_dpcode := self.entity_description.color_mode:
+                commands += [
+                    {
+                        "code": color_mode_dpcode,
+                        "value": WorkMode.WHITE,
+                    },
+                ]
+
+            commands += [
+                {
+                    "code": self._color_temp_dpcode,
+                    "value": round(
+                        self._color_temp_type.remap_value_from(
+                            kwargs[ATTR_COLOR_TEMP],
+                            self.min_mireds,
+                            self.max_mireds,
+                            reverse=True,
+                        )
+                    ),
+                },
+            ]
+        elif self._color_data_type and (
             ATTR_HS_COLOR in kwargs
             or (ATTR_BRIGHTNESS in kwargs and self.color_mode == COLOR_MODE_HS)
         ):
@@ -486,29 +508,6 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
                                 )
                             ),
                         }
-                    ),
-                },
-            ]
-
-        elif ATTR_COLOR_TEMP in kwargs and self._color_temp_type:
-            if color_mode_dpcode := self.entity_description.color_mode:
-                commands += [
-                    {
-                        "code": color_mode_dpcode,
-                        "value": WorkMode.WHITE,
-                    },
-                ]
-
-            commands += [
-                {
-                    "code": self._color_temp_dpcode,
-                    "value": round(
-                        self._color_temp_type.remap_value_from(
-                            kwargs[ATTR_COLOR_TEMP],
-                            self.min_mireds,
-                            self.max_mireds,
-                            reverse=True,
-                        )
                     ),
                 },
             ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If a light was in color mode HS and received a command to set brightness and color temperature, test branching would cause it to reconfigure the brightness of the existing color mode.  Add a condition so the temperature mode branch is taken when a temperature mode configuration is requested.

This restores a fix lost after #57624 was overwritten.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
