### PR TITLE
Add an entity service for saving nest event related snapshots

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -820,6 +820,7 @@ async def async_handle_snapshot_service(
     def _write_image(to_file: str, image_data: bytes | None) -> None:
         """Executor helper to write image."""
         if image_data is None:
+            _LOGGER.info("No image captured")
             return
         if not os.path.exists(os.path.dirname(to_file)):
             os.makedirs(os.path.dirname(to_file), exist_ok=True)

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -820,7 +820,6 @@ async def async_handle_snapshot_service(
     def _write_image(to_file: str, image_data: bytes | None) -> None:
         """Executor helper to write image."""
         if image_data is None:
-            _LOGGER.info("No image captured")
             return
         if not os.path.exists(os.path.dirname(to_file)):
             os.makedirs(os.path.dirname(to_file), exist_ok=True)

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import datetime
 import logging
 from pathlib import Path
+import os
 from typing import Any
 
 from google_nest_sdm.camera_traits import (
@@ -19,6 +20,7 @@ from google_nest_sdm.device import Device
 from google_nest_sdm.event import ImageEventBase
 from google_nest_sdm.exceptions import GoogleNestException
 from haffmpeg.tools import IMAGE_JPEG
+import voluptuous as vol
 
 from homeassistant.components.camera import SUPPORT_STREAM, Camera
 from homeassistant.components.camera.const import STREAM_TYPE_HLS, STREAM_TYPE_WEB_RTC
@@ -26,12 +28,13 @@ from homeassistant.components.ffmpeg import async_get_image
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
 
-from .const import DATA_SUBSCRIBER, DOMAIN
+from .const import DATA_SUBSCRIBER, DOMAIN, SERVICE_SNAPSHOT_EVENT
 from .device_info import NestDeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,6 +66,17 @@ async def async_setup_sdm_entry(
         ):
             entities.append(NestCamera(device))
     async_add_entities(entities)
+
+    platform = entity_platform.async_get_current_platform()
+
+    platform.async_register_entity_service(
+        SERVICE_SNAPSHOT_EVENT,
+        {
+            vol.Required("nest_event_id"): cv.string,
+            vol.Required("filename"): cv.string,
+        },
+        "_async_snapshot_event",
+    )
 
 
 class NestCamera(Camera):
@@ -292,3 +306,34 @@ class NestCamera(Camera):
         except GoogleNestException as err:
             raise HomeAssistantError(f"Nest API error: {err}") from err
         return stream.answer_sdp
+
+    async def _async_snapshot_event(self, nest_event_id: str, filename: str) -> None:
+        """Save media for a Nest event, based on `camera.snapshot`."""
+        _LOGGER.debug("Taking snapshot for event id '%s'", nest_event_id)
+        if not self.hass.config.is_allowed_path(filename):
+            raise HomeAssistantError("No access to write snapshot '%s'" % filename)
+        # Fetch media associated with the event
+        if not (trait := self._device.traits.get(CameraEventImageTrait.NAME)):
+            raise HomeAssistantError("Camera does not support event image snapshots")
+        try:
+            event_image = await trait.generate_image(nest_event_id)
+        except GoogleNestException as err:
+            raise HomeAssistantError("Unable to create event snapshot") from err
+        try:
+            image = await event_image.contents()
+        except GoogleNestException as err:
+            raise HomeAssistantError("Unable to fetch event snapshot") from err
+
+        _LOGGER.debug("Writing event snapshot to '%s'", filename)
+
+        def _write_image() -> None:
+            """Executor helper to write image."""
+            if not os.path.exists(os.path.dirname(filename)):
+                os.makedirs(os.path.dirname(filename), exist_ok=True)
+            with open(filename, "wb") as img_file:
+                img_file.write(image)
+
+        try:
+            await self.hass.async_add_executor_job(_write_image)
+        except OSError as err:
+            raise HomeAssistantError("Failed to write snapshot image") from err

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from collections.abc import Callable
 import datetime
 import logging
-from pathlib import Path
 import os
+from pathlib import Path
 from typing import Any
 
 from google_nest_sdm.camera_traits import (

--- a/homeassistant/components/nest/camera_sdm.py
+++ b/homeassistant/components/nest/camera_sdm.py
@@ -328,8 +328,7 @@ class NestCamera(Camera):
 
         def _write_image() -> None:
             """Executor helper to write image."""
-            if not os.path.exists(os.path.dirname(filename)):
-                os.makedirs(os.path.dirname(filename), exist_ok=True)
+            os.makedirs(os.path.dirname(filename), exist_ok=True)
             with open(filename, "wb") as img_file:
                 img_file.write(image)
 

--- a/homeassistant/components/nest/const.py
+++ b/homeassistant/components/nest/const.py
@@ -1,23 +1,21 @@
 """Constants used by the Nest component."""
 
-from typing import Final
+DOMAIN = "nest"
+DATA_SDM = "sdm"
+DATA_SUBSCRIBER = "subscriber"
 
-DOMAIN: Final = "nest"
-DATA_SDM: Final = "sdm"
-DATA_SUBSCRIBER: Final = "subscriber"
-
-SIGNAL_NEST_UPDATE: Final = "nest_update"
+SIGNAL_NEST_UPDATE = "nest_update"
 
 # For the Google Nest Device Access API
-OAUTH2_AUTHORIZE: Final = (
+OAUTH2_AUTHORIZE = (
     "https://nestservices.google.com/partnerconnections/{project_id}/auth"
 )
-OAUTH2_TOKEN: Final = "https://www.googleapis.com/oauth2/v4/token"
-SDM_SCOPES: Final = [
+OAUTH2_TOKEN = "https://www.googleapis.com/oauth2/v4/token"
+SDM_SCOPES = [
     "https://www.googleapis.com/auth/sdm.service",
     "https://www.googleapis.com/auth/pubsub",
 ]
-API_URL: Final = "https://smartdevicemanagement.googleapis.com/v1"
-OOB_REDIRECT_URI: Final = "urn:ietf:wg:oauth:2.0:oob"
+API_URL = "https://smartdevicemanagement.googleapis.com/v1"
+OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
 
-SERVICE_SNAPSHOT_EVENT: Final = "snapshot_event"
+SERVICE_SNAPSHOT_EVENT = "snapshot_event"

--- a/homeassistant/components/nest/const.py
+++ b/homeassistant/components/nest/const.py
@@ -1,19 +1,23 @@
 """Constants used by the Nest component."""
 
-DOMAIN = "nest"
-DATA_SDM = "sdm"
-DATA_SUBSCRIBER = "subscriber"
+from typing import Final
 
-SIGNAL_NEST_UPDATE = "nest_update"
+DOMAIN: Final = "nest"
+DATA_SDM: Final = "sdm"
+DATA_SUBSCRIBER: Final = "subscriber"
+
+SIGNAL_NEST_UPDATE: Final = "nest_update"
 
 # For the Google Nest Device Access API
-OAUTH2_AUTHORIZE = (
+OAUTH2_AUTHORIZE: Final = (
     "https://nestservices.google.com/partnerconnections/{project_id}/auth"
 )
-OAUTH2_TOKEN = "https://www.googleapis.com/oauth2/v4/token"
-SDM_SCOPES = [
+OAUTH2_TOKEN: Final = "https://www.googleapis.com/oauth2/v4/token"
+SDM_SCOPES: Final = [
     "https://www.googleapis.com/auth/sdm.service",
     "https://www.googleapis.com/auth/pubsub",
 ]
-API_URL = "https://smartdevicemanagement.googleapis.com/v1"
-OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
+API_URL: Final = "https://smartdevicemanagement.googleapis.com/v1"
+OOB_REDIRECT_URI: Final = "urn:ietf:wg:oauth:2.0:oob"
+
+SERVICE_SNAPSHOT_EVENT: Final = "snapshot_event"

--- a/homeassistant/components/nest/services.yaml
+++ b/homeassistant/components/nest/services.yaml
@@ -1,8 +1,30 @@
 # Describes the format for available Nest services
 
+snapshot_event:
+  name: Take event snapshot
+  description: Take a snapshot from a camera for an event.
+  target:
+    entity:
+      integration: nest
+      domain: camera
+  fields:
+    nest_event_id:
+      name: Nest Event Id
+      description: The nest_event_id from the event to snapshot. Can be populated by an automation trigger for a 'nest_event' with 'data_template'.
+      required: true
+      selector:
+        text:
+    filename:
+      name: Filename
+      description: A filename where the snapshot for the event is written.
+      required: true
+      example: "/tmp/snapshot_my_camera.jpg"
+      selector:
+        text:
+
 set_away_mode:
   name: Set away mode
-  description: Set the away mode for a Nest structure.
+  description: Set the away mode for a Nest structure. For Legacy API.
   fields:
     away_mode:
       name: Away mode
@@ -22,7 +44,7 @@ set_away_mode:
 
 set_eta:
   name: Set estimated time of arrival
-  description: Set or update the estimated time of arrival window for a Nest structure.
+  description: Set or update the estimated time of arrival window for a Nest structure. For Legacy API.
   fields:
     eta:
       name: ETA
@@ -51,7 +73,7 @@ set_eta:
 
 cancel_eta:
   name: Cancel ETA
-  description: Cancel an existing estimated time of arrival window for a Nest structure.
+  description: Cancel an existing estimated time of arrival window for a Nest structure. For Legacy API.
   fields:
     trip_id:
       name: Trip ID

--- a/tests/components/nest/test_camera_sdm.py
+++ b/tests/components/nest/test_camera_sdm.py
@@ -7,6 +7,7 @@ pubsub subscriber.
 
 import datetime
 from http import HTTPStatus
+import os
 from unittest.mock import patch
 
 import aiohttp
@@ -21,7 +22,9 @@ from homeassistant.components.camera import (
     STREAM_TYPE_HLS,
     STREAM_TYPE_WEB_RTC,
 )
+from homeassistant.components.nest.const import SERVICE_SNAPSHOT_EVENT
 from homeassistant.components.websocket_api.const import TYPE_RESULT
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -148,6 +151,20 @@ async def async_get_image(hass, width=None, height=None):
         return await camera.async_get_image(
             hass, "camera.my_camera", width=width, height=height
         )
+
+
+async def async_call_service_event_snapshot(hass, filename):
+    """Call the event snapshot service."""
+    return await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SNAPSHOT_EVENT,
+        {
+            ATTR_ENTITY_ID: "camera.my_camera",
+            "nest_event_id": "some-event-id",
+            "filename": filename,
+        },
+        blocking=True,
+    )
 
 
 async def test_no_devices(hass):
@@ -519,7 +536,7 @@ async def test_camera_image_from_last_event(hass, auth):
 
 async def test_camera_image_from_event_not_supported(hass, auth):
     """Test fallback to stream image when event images are not supported."""
-    # Create a device that does not support the CameraEventImgae trait
+    # Create a device that does not support the CameraEventImage trait
     traits = DEVICE_TRAITS.copy()
     del traits["sdm.devices.traits.CameraEventImage"]
     subscriber = await async_setup_camera(hass, traits, auth=auth)
@@ -865,3 +882,114 @@ async def test_camera_multiple_streams(hass, auth, hass_ws_client):
     assert msg["type"] == TYPE_RESULT
     assert msg["success"]
     assert msg["result"]["answer"] == "v=0\r\ns=-\r\n"
+
+
+async def test_service_snapshot_event_image(hass, auth, tmpdir):
+    """Test calling the snapshot_event service."""
+    await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    auth.responses = [
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+    ]
+
+    filename = f"{tmpdir}/snapshot.jpg"
+    with patch.object(hass.config, "is_allowed_path", return_value=True):
+        assert await async_call_service_event_snapshot(hass, filename)
+
+    assert os.path.exists(filename)
+    with open(filename, "rb") as f:
+        contents = f.read()
+    assert contents == IMAGE_BYTES_FROM_EVENT
+
+
+async def test_service_snapshot_no_access_to_filename(hass, auth, tmpdir):
+    """Test calling the snapshot_event service with a disallowed file path."""
+    await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    filename = f"{tmpdir}/snapshot.jpg"
+    with patch.object(
+        hass.config, "is_allowed_path", return_value=False
+    ), pytest.raises(HomeAssistantError, match=r"No access.*"):
+        assert await async_call_service_event_snapshot(hass, filename)
+
+    assert not os.path.exists(filename)
+
+
+async def test_camera_snapshot_from_event_not_supported(hass, auth, tmpdir):
+    """Test a camera that does not support snapshots."""
+    # Create a device that does not support the CameraEventImage trait
+    traits = DEVICE_TRAITS.copy()
+    del traits["sdm.devices.traits.CameraEventImage"]
+    await async_setup_camera(hass, traits, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    filename = f"{tmpdir}/snapshot.jpg"
+    with patch.object(hass.config, "is_allowed_path", return_value=True), pytest.raises(
+        HomeAssistantError, match=r"Camera does not support.*"
+    ):
+        await async_call_service_event_snapshot(hass, filename)
+    assert not os.path.exists(filename)
+
+
+async def test_service_snapshot_event_generate_url_failure(hass, auth, tmpdir):
+    """Test failure while creating a snapshot url."""
+    await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    auth.responses = [
+        aiohttp.web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR),
+    ]
+
+    filename = f"{tmpdir}/snapshot.jpg"
+    with patch.object(hass.config, "is_allowed_path", return_value=True), pytest.raises(
+        HomeAssistantError, match=r"Unable to create.*"
+    ):
+        await async_call_service_event_snapshot(hass, filename)
+    assert not os.path.exists(filename)
+
+
+async def test_service_snapshot_event_image_fetch_invalid(hass, auth, tmpdir):
+    """Test failure when fetching an image snapshot."""
+    await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    auth.responses = [
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        aiohttp.web.Response(status=HTTPStatus.INTERNAL_SERVER_ERROR),
+    ]
+
+    filename = f"{tmpdir}/snapshot.jpg"
+    with patch.object(hass.config, "is_allowed_path", return_value=True), pytest.raises(
+        HomeAssistantError, match=r"Unable to fetch.*"
+    ):
+        await async_call_service_event_snapshot(hass, filename)
+    assert not os.path.exists(filename)
+
+
+async def test_service_snapshot_event_image_create_directory(hass, auth, tmpdir):
+    """Test creating the directory when writing the snapshot."""
+    await async_setup_camera(hass, DEVICE_TRAITS, auth=auth)
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("camera.my_camera")
+
+    auth.responses = [
+        aiohttp.web.json_response(GENERATE_IMAGE_URL_RESPONSE),
+        aiohttp.web.Response(body=IMAGE_BYTES_FROM_EVENT),
+    ]
+
+    filename = f"{tmpdir}/path/does/not/exist/snapshot.jpg"
+    with patch.object(hass.config, "is_allowed_path", return_value=True):
+        assert await async_call_service_event_snapshot(hass, filename)
+
+    assert os.path.exists(filename)
+    with open(filename, "rb") as f:
+        contents = f.read()
+    assert contents == IMAGE_BYTES_FROM_EVENT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an entity service `nest.snapshot_event` for recording camera event related media to disk. This is based on `camera.snapshot` but takes in a parameter for a Nest API event_id.

This service can be called in response to a `nest_event` event, using `data_template` to populate the the event id from the event message. An example automation:
```yaml
alias: Save snapshot on doorbell
description: Save snapshot when the doorbell is pressed
trigger:
  - platform: device
    device_id: 414142ABCDEF01234567890
    domain: nest
    type: doorbell_chime
condition: []
action:
  - service: nest.snapshot_event
    target:
      device_id: 414142ABCDEF01234567890
    data_template:
      nest_event_id: '{{trigger.event.data.type}}'
      filename: /tmp/snapshot.jpg
mode: single
```

Nest already supports fetching event images from the camera thumbnail, however, using an event is more accurate. It also is needed because new nest cameras support an mp4 10-frame clip which is not currently served as the camera thumbnail (and maintainers didn't think it was a fit there).

See https://developers.google.com/nest/device-access/api/camera#handle_camera_events for more details on the camera event APIs.

Future related work includes:
- [X] Publish nest event ids (#58299) for hooking up to a service via automation
- [X] Add a event snapshot service (this pr #58369)
- [ ] Add Height & Width parameters to event snapshot service (motivation https://github.com/allenporter/python-google-nest-sdm/issues/52)
- [ ] Support video clips for new battery cameras
- [ ] Update documentation with new service calls and automation examples
- [ ] An API for proxying media related to events, separate from the camera image thumbnail
- [ ] A Nest MediaSource for browsing media related to events


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
