### PR TITLE
Add entity_category to SmartThings sensors

### DIFF
--- a/homeassistant/components/smartthings/binary_sensor.py
+++ b/homeassistant/components/smartthings/binary_sensor.py
@@ -15,6 +15,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_SOUND,
     BinarySensorEntity,
 )
+from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN
@@ -40,6 +41,9 @@ ATTRIB_TO_CLASS = {
     Attribute.tamper: DEVICE_CLASS_PROBLEM,
     Attribute.valve: DEVICE_CLASS_OPENING,
     Attribute.water: DEVICE_CLASS_MOISTURE,
+}
+ATTRIB_TO_ENTTIY_CATEGORY = {
+    Attribute.tamper: ENTITY_CATEGORY_DIAGNOSTIC,
 }
 
 
@@ -88,3 +92,8 @@ class SmartThingsBinarySensor(SmartThingsEntity, BinarySensorEntity):
     def device_class(self):
         """Return the class of this device."""
         return ATTRIB_TO_CLASS[self._attribute]
+
+    @property
+    def entity_category(self):
+        """Return the entity category of this device."""
+        return ATTRIB_TO_ENTTIY_CATEGORY.get(self._attribute)

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -28,6 +28,8 @@ from homeassistant.const import (
     DEVICE_CLASS_VOLTAGE,
     ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
+    ENTITY_CATEGORY_CONFIG,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     LIGHT_LUX,
     MASS_KILOGRAMS,
     PERCENTAGE,
@@ -40,22 +42,54 @@ from homeassistant.const import (
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN
 
-Map = namedtuple("map", "attribute name default_unit device_class state_class")
+Map = namedtuple(
+    "map", "attribute name default_unit device_class state_class entity_category"
+)
 
 CAPABILITY_TO_SENSORS = {
     Capability.activity_lighting_mode: [
-        Map(Attribute.lighting_mode, "Activity Lighting Mode", None, None, None)
+        Map(
+            Attribute.lighting_mode,
+            "Activity Lighting Mode",
+            None,
+            None,
+            None,
+            ENTITY_CATEGORY_CONFIG,
+        )
     ],
     Capability.air_conditioner_mode: [
-        Map(Attribute.air_conditioner_mode, "Air Conditioner Mode", None, None, None)
+        Map(
+            Attribute.air_conditioner_mode,
+            "Air Conditioner Mode",
+            None,
+            None,
+            None,
+            ENTITY_CATEGORY_CONFIG,
+        )
     ],
     Capability.air_quality_sensor: [
-        Map(Attribute.air_quality, "Air Quality", "CAQI", None, STATE_CLASS_MEASUREMENT)
+        Map(
+            Attribute.air_quality,
+            "Air Quality",
+            "CAQI",
+            None,
+            STATE_CLASS_MEASUREMENT,
+            None,
+        )
     ],
-    Capability.alarm: [Map(Attribute.alarm, "Alarm", None, None, None)],
-    Capability.audio_volume: [Map(Attribute.volume, "Volume", PERCENTAGE, None, None)],
+    Capability.alarm: [Map(Attribute.alarm, "Alarm", None, None, None, None)],
+    Capability.audio_volume: [
+        Map(Attribute.volume, "Volume", PERCENTAGE, None, None, None)
+    ],
     Capability.battery: [
-        Map(Attribute.battery, "Battery", PERCENTAGE, DEVICE_CLASS_BATTERY, None)
+        Map(
+            Attribute.battery,
+            "Battery",
+            PERCENTAGE,
+            DEVICE_CLASS_BATTERY,
+            None,
+            ENTITY_CATEGORY_DIAGNOSTIC,
+        )
     ],
     Capability.body_mass_index_measurement: [
         Map(
@@ -64,6 +98,7 @@ CAPABILITY_TO_SENSORS = {
             f"{MASS_KILOGRAMS}/{AREA_SQUARE_METERS}",
             None,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.body_weight_measurement: [
@@ -73,6 +108,7 @@ CAPABILITY_TO_SENSORS = {
             MASS_KILOGRAMS,
             None,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.carbon_dioxide_measurement: [
@@ -82,10 +118,18 @@ CAPABILITY_TO_SENSORS = {
             CONCENTRATION_PARTS_PER_MILLION,
             DEVICE_CLASS_CO2,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.carbon_monoxide_detector: [
-        Map(Attribute.carbon_monoxide, "Carbon Monoxide Detector", None, None, None)
+        Map(
+            Attribute.carbon_monoxide,
+            "Carbon Monoxide Detector",
+            None,
+            None,
+            None,
+            None,
+        )
     ],
     Capability.carbon_monoxide_measurement: [
         Map(
@@ -94,28 +138,49 @@ CAPABILITY_TO_SENSORS = {
             CONCENTRATION_PARTS_PER_MILLION,
             DEVICE_CLASS_CO,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.dishwasher_operating_state: [
-        Map(Attribute.machine_state, "Dishwasher Machine State", None, None, None),
-        Map(Attribute.dishwasher_job_state, "Dishwasher Job State", None, None, None),
+        Map(
+            Attribute.machine_state, "Dishwasher Machine State", None, None, None, None
+        ),
+        Map(
+            Attribute.dishwasher_job_state,
+            "Dishwasher Job State",
+            None,
+            None,
+            None,
+            None,
+        ),
         Map(
             Attribute.completion_time,
             "Dishwasher Completion Time",
             None,
             DEVICE_CLASS_TIMESTAMP,
             None,
+            None,
         ),
     ],
-    Capability.dryer_mode: [Map(Attribute.dryer_mode, "Dryer Mode", None, None, None)],
+    Capability.dryer_mode: [
+        Map(
+            Attribute.dryer_mode,
+            "Dryer Mode",
+            None,
+            None,
+            None,
+            ENTITY_CATEGORY_CONFIG,
+        )
+    ],
     Capability.dryer_operating_state: [
-        Map(Attribute.machine_state, "Dryer Machine State", None, None, None),
-        Map(Attribute.dryer_job_state, "Dryer Job State", None, None, None),
+        Map(Attribute.machine_state, "Dryer Machine State", None, None, None, None),
+        Map(Attribute.dryer_job_state, "Dryer Job State", None, None, None, None),
         Map(
             Attribute.completion_time,
             "Dryer Completion Time",
             None,
             DEVICE_CLASS_TIMESTAMP,
+            None,
             None,
         ),
     ],
@@ -126,8 +191,16 @@ CAPABILITY_TO_SENSORS = {
             None,
             None,
             STATE_CLASS_MEASUREMENT,
+            None,
         ),
-        Map(Attribute.dust_level, "Dust Level", None, None, STATE_CLASS_MEASUREMENT),
+        Map(
+            Attribute.dust_level,
+            "Dust Level",
+            None,
+            None,
+            STATE_CLASS_MEASUREMENT,
+            None,
+        ),
     ],
     Capability.energy_meter: [
         Map(
@@ -136,6 +209,7 @@ CAPABILITY_TO_SENSORS = {
             ENERGY_KILO_WATT_HOUR,
             DEVICE_CLASS_ENERGY,
             STATE_CLASS_TOTAL_INCREASING,
+            None,
         )
     ],
     Capability.equivalent_carbon_dioxide_measurement: [
@@ -145,6 +219,7 @@ CAPABILITY_TO_SENSORS = {
             CONCENTRATION_PARTS_PER_MILLION,
             None,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.formaldehyde_measurement: [
@@ -154,6 +229,7 @@ CAPABILITY_TO_SENSORS = {
             CONCENTRATION_PARTS_PER_MILLION,
             None,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.gas_meter: [
@@ -163,13 +239,17 @@ CAPABILITY_TO_SENSORS = {
             ENERGY_KILO_WATT_HOUR,
             None,
             STATE_CLASS_MEASUREMENT,
+            None,
         ),
-        Map(Attribute.gas_meter_calorific, "Gas Meter Calorific", None, None, None),
+        Map(
+            Attribute.gas_meter_calorific, "Gas Meter Calorific", None, None, None, None
+        ),
         Map(
             Attribute.gas_meter_time,
             "Gas Meter Time",
             None,
             DEVICE_CLASS_TIMESTAMP,
+            None,
             None,
         ),
         Map(
@@ -178,6 +258,7 @@ CAPABILITY_TO_SENSORS = {
             VOLUME_CUBIC_METERS,
             None,
             STATE_CLASS_MEASUREMENT,
+            None,
         ),
     ],
     Capability.illuminance_measurement: [
@@ -187,6 +268,7 @@ CAPABILITY_TO_SENSORS = {
             LIGHT_LUX,
             DEVICE_CLASS_ILLUMINANCE,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.infrared_level: [
@@ -196,31 +278,50 @@ CAPABILITY_TO_SENSORS = {
             PERCENTAGE,
             None,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.media_input_source: [
-        Map(Attribute.input_source, "Media Input Source", None, None, None)
+        Map(Attribute.input_source, "Media Input Source", None, None, None, None)
     ],
     Capability.media_playback_repeat: [
-        Map(Attribute.playback_repeat_mode, "Media Playback Repeat", None, None, None)
+        Map(
+            Attribute.playback_repeat_mode,
+            "Media Playback Repeat",
+            None,
+            None,
+            None,
+            None,
+        )
     ],
     Capability.media_playback_shuffle: [
-        Map(Attribute.playback_shuffle, "Media Playback Shuffle", None, None, None)
+        Map(
+            Attribute.playback_shuffle, "Media Playback Shuffle", None, None, None, None
+        )
     ],
     Capability.media_playback: [
-        Map(Attribute.playback_status, "Media Playback Status", None, None, None)
+        Map(Attribute.playback_status, "Media Playback Status", None, None, None, None)
     ],
     Capability.odor_sensor: [
-        Map(Attribute.odor_level, "Odor Sensor", None, None, None)
+        Map(Attribute.odor_level, "Odor Sensor", None, None, None, None)
     ],
-    Capability.oven_mode: [Map(Attribute.oven_mode, "Oven Mode", None, None, None)],
+    Capability.oven_mode: [
+        Map(
+            Attribute.oven_mode,
+            "Oven Mode",
+            None,
+            None,
+            None,
+            ENTITY_CATEGORY_CONFIG,
+        )
+    ],
     Capability.oven_operating_state: [
-        Map(Attribute.machine_state, "Oven Machine State", None, None, None),
-        Map(Attribute.oven_job_state, "Oven Job State", None, None, None),
-        Map(Attribute.completion_time, "Oven Completion Time", None, None, None),
+        Map(Attribute.machine_state, "Oven Machine State", None, None, None, None),
+        Map(Attribute.oven_job_state, "Oven Job State", None, None, None, None),
+        Map(Attribute.completion_time, "Oven Completion Time", None, None, None, None),
     ],
     Capability.oven_setpoint: [
-        Map(Attribute.oven_setpoint, "Oven Set Point", None, None, None)
+        Map(Attribute.oven_setpoint, "Oven Set Point", None, None, None, None)
     ],
     Capability.power_consumption_report: [],
     Capability.power_meter: [
@@ -230,10 +331,18 @@ CAPABILITY_TO_SENSORS = {
             POWER_WATT,
             DEVICE_CLASS_POWER,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.power_source: [
-        Map(Attribute.power_source, "Power Source", None, None, None)
+        Map(
+            Attribute.power_source,
+            "Power Source",
+            None,
+            None,
+            None,
+            ENTITY_CATEGORY_DIAGNOSTIC,
+        )
     ],
     Capability.refrigeration_setpoint: [
         Map(
@@ -241,6 +350,7 @@ CAPABILITY_TO_SENSORS = {
             "Refrigeration Setpoint",
             None,
             DEVICE_CLASS_TEMPERATURE,
+            None,
             None,
         )
     ],
@@ -251,6 +361,7 @@ CAPABILITY_TO_SENSORS = {
             PERCENTAGE,
             DEVICE_CLASS_HUMIDITY,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.robot_cleaner_cleaning_mode: [
@@ -260,11 +371,17 @@ CAPABILITY_TO_SENSORS = {
             None,
             None,
             None,
+            ENTITY_CATEGORY_CONFIG,
         )
     ],
     Capability.robot_cleaner_movement: [
         Map(
-            Attribute.robot_cleaner_movement, "Robot Cleaner Movement", None, None, None
+            Attribute.robot_cleaner_movement,
+            "Robot Cleaner Movement",
+            None,
+            None,
+            None,
+            None,
         )
     ],
     Capability.robot_cleaner_turbo_mode: [
@@ -274,20 +391,29 @@ CAPABILITY_TO_SENSORS = {
             None,
             None,
             None,
+            ENTITY_CATEGORY_CONFIG,
         )
     ],
     Capability.signal_strength: [
-        Map(Attribute.lqi, "LQI Signal Strength", None, None, STATE_CLASS_MEASUREMENT),
+        Map(
+            Attribute.lqi,
+            "LQI Signal Strength",
+            None,
+            None,
+            STATE_CLASS_MEASUREMENT,
+            ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
         Map(
             Attribute.rssi,
             "RSSI Signal Strength",
             None,
             DEVICE_CLASS_SIGNAL_STRENGTH,
             STATE_CLASS_MEASUREMENT,
+            ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     ],
     Capability.smoke_detector: [
-        Map(Attribute.smoke, "Smoke Detector", None, None, None)
+        Map(Attribute.smoke, "Smoke Detector", None, None, None, None)
     ],
     Capability.temperature_measurement: [
         Map(
@@ -296,6 +422,7 @@ CAPABILITY_TO_SENSORS = {
             None,
             DEVICE_CLASS_TEMPERATURE,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.thermostat_cooling_setpoint: [
@@ -305,10 +432,18 @@ CAPABILITY_TO_SENSORS = {
             None,
             DEVICE_CLASS_TEMPERATURE,
             None,
+            None,
         )
     ],
     Capability.thermostat_fan_mode: [
-        Map(Attribute.thermostat_fan_mode, "Thermostat Fan Mode", None, None, None)
+        Map(
+            Attribute.thermostat_fan_mode,
+            "Thermostat Fan Mode",
+            None,
+            None,
+            None,
+            ENTITY_CATEGORY_CONFIG,
+        )
     ],
     Capability.thermostat_heating_setpoint: [
         Map(
@@ -317,15 +452,24 @@ CAPABILITY_TO_SENSORS = {
             None,
             DEVICE_CLASS_TEMPERATURE,
             None,
+            ENTITY_CATEGORY_CONFIG,
         )
     ],
     Capability.thermostat_mode: [
-        Map(Attribute.thermostat_mode, "Thermostat Mode", None, None, None)
+        Map(
+            Attribute.thermostat_mode,
+            "Thermostat Mode",
+            None,
+            None,
+            None,
+            ENTITY_CATEGORY_CONFIG,
+        )
     ],
     Capability.thermostat_operating_state: [
         Map(
             Attribute.thermostat_operating_state,
             "Thermostat Operating State",
+            None,
             None,
             None,
             None,
@@ -338,12 +482,13 @@ CAPABILITY_TO_SENSORS = {
             None,
             DEVICE_CLASS_TEMPERATURE,
             None,
+            ENTITY_CATEGORY_CONFIG,
         )
     ],
     Capability.three_axis: [],
     Capability.tv_channel: [
-        Map(Attribute.tv_channel, "Tv Channel", None, None, None),
-        Map(Attribute.tv_channel_name, "Tv Channel Name", None, None, None),
+        Map(Attribute.tv_channel, "Tv Channel", None, None, None, None),
+        Map(Attribute.tv_channel_name, "Tv Channel Name", None, None, None, None),
     ],
     Capability.tvoc_measurement: [
         Map(
@@ -352,6 +497,7 @@ CAPABILITY_TO_SENSORS = {
             CONCENTRATION_PARTS_PER_MILLION,
             None,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.ultraviolet_index: [
@@ -361,6 +507,7 @@ CAPABILITY_TO_SENSORS = {
             None,
             None,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.voltage_measurement: [
@@ -370,19 +517,28 @@ CAPABILITY_TO_SENSORS = {
             ELECTRIC_POTENTIAL_VOLT,
             DEVICE_CLASS_VOLTAGE,
             STATE_CLASS_MEASUREMENT,
+            None,
         )
     ],
     Capability.washer_mode: [
-        Map(Attribute.washer_mode, "Washer Mode", None, None, None)
+        Map(
+            Attribute.washer_mode,
+            "Washer Mode",
+            None,
+            None,
+            None,
+            ENTITY_CATEGORY_CONFIG,
+        )
     ],
     Capability.washer_operating_state: [
-        Map(Attribute.machine_state, "Washer Machine State", None, None, None),
-        Map(Attribute.washer_job_state, "Washer Job State", None, None, None),
+        Map(Attribute.machine_state, "Washer Machine State", None, None, None, None),
+        Map(Attribute.washer_job_state, "Washer Job State", None, None, None, None),
         Map(
             Attribute.completion_time,
             "Washer Completion Time",
             None,
             DEVICE_CLASS_TIMESTAMP,
+            None,
             None,
         ),
     ],
@@ -431,6 +587,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                             m.default_unit,
                             m.device_class,
                             m.state_class,
+                            m.entity_category,
                         )
                         for m in maps
                     ]
@@ -448,6 +605,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                             m.default_unit,
                             m.device_class,
                             m.state_class,
+                            m.entity_category,
                         )
                         for m in maps
                     ]
@@ -474,6 +632,7 @@ class SmartThingsSensor(SmartThingsEntity, SensorEntity):
         default_unit: str,
         device_class: str,
         state_class: str | None,
+        entity_category: str | None,
     ) -> None:
         """Init the class."""
         super().__init__(device)
@@ -482,6 +641,7 @@ class SmartThingsSensor(SmartThingsEntity, SensorEntity):
         self._device_class = device_class
         self._default_unit = default_unit
         self._attr_state_class = state_class
+        self._attr_entity_category = entity_category
 
     @property
     def name(self) -> str:

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     PERCENTAGE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -94,6 +95,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     entry = entity_registry.async_get("sensor.sensor_1_battery")
     assert entry
     assert entry.unique_id == f"{device.device_id}.{Attribute.battery}"
+    assert entry.entity_category == ENTITY_CATEGORY_DIAGNOSTIC
     entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
     assert entry
     assert entry.name == device.label
@@ -120,6 +122,7 @@ async def test_energy_sensors_for_switch_device(hass, device_factory):
     entry = entity_registry.async_get("sensor.switch_1_energy_meter")
     assert entry
     assert entry.unique_id == f"{device.device_id}.{Attribute.energy}"
+    assert entry.entity_category is None
     entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
     assert entry
     assert entry.name == device.label
@@ -132,6 +135,7 @@ async def test_energy_sensors_for_switch_device(hass, device_factory):
     entry = entity_registry.async_get("sensor.switch_1_power_meter")
     assert entry
     assert entry.unique_id == f"{device.device_id}.{Attribute.power}"
+    assert entry.entity_category is None
     entry = device_registry.async_get_device({(DOMAIN, device.device_id)})
     assert entry
     assert entry.name == device.label


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Add entity categories for SmartThings sensors, removing them from default generated Lovelace cards and Google/Amazon voice assistance.

- Sensors for device diagnostic are no longer included by default (tamper, battery, power source, and signal strength).
- Sensors about device configuration are also no longer included by default (activity lighting mode, air conditioning mode, dryer mode, oven mode, robot cleaner mode,  thermostat set point, thermostat fan mode, thermostat mode,  and washer mode).


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added the categories based on my assumptions about how entity categories
should be assigned, and my own view of what sensors are added for multi-sensor
devices.

Devices added as ENTITY_CATEGORY_DIAGNOSTIC include:
- tamper sensor
- battery
- power source (e.g. "battery")
- signal strength

Note for reviewer:  Please review for decisions about which sensors should be assigned an entity category.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
