### PR TITLE
Handle Shelly multiclick

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 import logging
+from threading import Timer
 from typing import Any, Final, cast
 
 import aioshelly
@@ -66,6 +67,9 @@ BLOCK_PLATFORMS: Final = ["binary_sensor", "cover", "light", "sensor", "switch"]
 BLOCK_SLEEPING_PLATFORMS: Final = ["binary_sensor", "sensor"]
 RPC_PLATFORMS: Final = ["binary_sensor", "light", "sensor", "switch"]
 _LOGGER: Final = logging.getLogger(__name__)
+
+# Multiclick delay between clicks in seconds
+MC_MULTICLICK_DELAY = 0.7
 
 COAP_SCHEMA: Final = vol.Schema(
     {
@@ -269,6 +273,11 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
             self.async_add_listener(self._async_device_updates_handler)
         )
         self._last_input_events_count: dict = {}
+        self._mc_device_name = device_name
+        self._mc_last_events: dict = {}
+        self._mc_last_state: dict = {}
+        self._mc_click_count: dict = {}
+        self._mc_click_timer: dict = {}
 
         entry.async_on_unload(
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop)
@@ -278,6 +287,38 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         """Reload entry."""
         _LOGGER.debug("Reloading entry %s", self.name)
         await self.hass.config_entries.async_reload(self.entry.entry_id)
+
+    def _mc_send_event(
+        self, channel, delete, momentary_button, click_count, click_events
+    ):
+        if momentary_button:
+            self.hass.bus.async_fire(
+                "shelly.multiclick",
+                {
+                    ATTR_DEVICE_ID: self.device_id,
+                    ATTR_DEVICE: self.device.settings["device"]["hostname"],
+                    "device_name": self._mc_device_name,
+                    ATTR_CHANNEL: channel,
+                    "click_count" : 0,
+                    "click_events" : click_events
+                },
+            )
+        else:
+            self.hass.bus.async_fire(
+                "shelly.multiclick",
+                {
+                    ATTR_DEVICE_ID: self.device_id,
+                    ATTR_DEVICE: self.device.settings["device"]["hostname"],
+                    "device_name": self._mc_device_name,
+                    ATTR_CHANNEL: channel,
+                    "click_count" : click_count,
+                    "click_events" : ""
+                },
+            )
+
+        if delete:
+            self._mc_click_count[channel] = 0
+            self._mc_last_events[channel] = ""
 
     @callback
     def _async_device_updates_handler(self) -> None:
@@ -297,6 +338,11 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
                     self._last_input_events_count[1] = -1
 
                 break
+
+        mc_momentary_button = True
+        if "longpush_time" in self.device.settings:
+            if self.device.settings["longpush_time"] <= 10:
+                mc_momentary_button = False
 
         # Check for input events and config change
         cfg_changed = 0
@@ -326,6 +372,109 @@ class BlockDeviceWrapper(update_coordinator.DataUpdateCoordinator):
             event_type = block.inputEvent
             last_event_count = self._last_input_events_count.get(channel)
             self._last_input_events_count[channel] = block.inputEventCnt
+
+            mc_curr_event = block.inputEvent
+            if block.inputEventCnt is not None:
+                if self._mc_click_count.get(channel) is None:
+                    self._mc_click_count[channel] = 0
+                    self._mc_last_events[channel] = ""
+                if (
+                    last_event_count is not None 
+                    and self._mc_last_state.get(channel) is not None
+                ):
+                    if block.inputEventCnt != last_event_count:
+                        if self._mc_click_timer.get(channel) is not None:
+                            self._mc_click_timer[channel].cancel()
+                            self._mc_click_timer[channel] = None
+
+                        if mc_curr_event == "S":
+                            if self._mc_last_state.get(channel) == 1:
+                                self._mc_click_count[channel] += 1
+                            else:
+                                self._mc_click_count[channel] += 2
+                            if block.input == 1:
+                                self._mc_click_count[channel] += 1
+
+                            if block.inputEventCnt - last_event_count > 1:
+                                self._mc_click_count[channel] += (block.inputEventCnt - last_event_count - 1) * 2
+                                mc_curr_event = "S" * (block.inputEventCnt - last_event_count)
+
+                        if mc_curr_event == "L":
+                            if mc_momentary_button:
+                                if block.input != self._mc_last_state.get(channel):
+                                    self._mc_click_count[channel] += 1
+                                self._mc_send_event(
+                                    channel, 
+                                    False, 
+                                    mc_momentary_button, 
+                                    0, 
+                                    self._mc_last_events[channel] + "LSTART",
+                                )
+                            else:
+                                if self._mc_last_state.get(channel) == 0:
+                                    self._mc_click_count[channel] += 1
+                                else:
+                                    self._mc_click_count[channel] += 2
+
+                                if block.input == 0:
+                                    self._mc_click_count[channel] += 1
+
+                                if block.inputEventCnt - last_event_count > 1:
+                                    self._mc_click_count[channel] += (
+                                        block.inputEventCnt - last_event_count - 1
+                                    ) * 2
+
+                        self._mc_last_events[channel] += mc_curr_event
+
+                        if not mc_momentary_button or block.input == 0:
+                            self._mc_click_timer[channel] = Timer(
+                                MC_MULTICLICK_DELAY, 
+                                self._mc_send_event, 
+                                args=(
+                                    channel, 
+                                    True, 
+                                    mc_momentary_button, 
+                                    self._mc_click_count[channel], 
+                                    self._mc_last_events[channel],
+                                ),
+                            )
+                            self._mc_click_timer[channel].start()
+
+                    if block.inputEventCnt == last_event_count and block.input != self._mc_last_state.get(channel):
+                        if self._mc_click_timer.get(channel) is not None:
+                            self._mc_click_timer[channel].cancel()
+                            self._mc_click_timer[channel] = None
+
+                        self._mc_click_count[channel] += 1
+
+                        if (
+                            mc_momentary_button 
+                            and block.input == 0 
+                            and len(self._mc_last_events[channel]) > 0
+                        ):
+                            if self._mc_last_events[channel][-1] == "L":
+                                self._mc_send_event(
+                                    channel, 
+                                    False, 
+                                    mc_momentary_button, 
+                                    0, 
+                                    self._mc_last_events[channel] + "STOP",
+                                )
+
+                        if not mc_momentary_button or block.input == 0:
+                            self._mc_click_timer[channel] = Timer(
+                                MC_MULTICLICK_DELAY, 
+                                self._mc_send_event, 
+                                args=(
+                                    channel, 
+                                    True,
+                                    mc_momentary_button, 
+                                    self._mc_click_count[channel], 
+                                    self._mc_last_events[channel],
+                                ),
+                            )
+                            self._mc_click_timer[channel].start()
+                self._mc_last_state[channel] = block.input
 
             if (
                 last_event_count is None


### PR DESCRIPTION
Handling Shelly multiclick events with detached buttons.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR handles multiclick events on Shelly1, Shelly2.5, Shelly Dimmer and Shelly Dimmer2. 
These events allow to:
- control more devices from switch of the Shelly1, Shelly2.5 or Shelly Dimmer.
- control a dimmer from switch of the Shelly1 or Shelly 2.5

### 1.  If momentary button is attached to Shelly
1.1 The `click_events` parameter of new `shelly.multiclick` event contains a click pattern. In this example a double short click:
```
{
    "event_type": "shelly.multiclick",
    "data": {
        "device_id": "ab4ea6193cafc2a64359eb06f488a24e",
        "device": "shelly1-F4CFAXXXXXXX",
        "device_name": "lamp_bedroom_ceiling",
        "channel": 1,
        "click_count": 0,
        "click_events": "SS"
    },
    "origin": "LOCAL",
    "time_fired": "2021-10-25T19:45:45.077967+00:00",
    "context": {
        "id": "ca1531b13ecf9c4ae28fea6047310766",
        "parent_id": null,
        "user_id": null
    }
}
```
This event will be send after last release of button.

1.2 In case of long push, it also sends another events: when the long push starting (LSTART) and when the long push stopping (LSTOP). For example, if the user press a short click + long click, the following events will be sent: 
```
{
    "event_type": "shelly.multiclick",
    "data": {
        "device_id": "ab4ea6193cafc2a64359eb06f488a24e",
        "device": "shelly1-F4CFAXXXXXXX",
        "device_name": "lamp_bedroom_ceiling",
        "channel": 1,
        "click_count": 0,
        "click_events": "SLSTART"
    },
    "origin": "LOCAL",
    "time_fired": "2021-10-25T19:54:49.768865+00:00",
    "context": {
        "id": "8240d113346371c6739d51af32094199",
        "parent_id": null,
        "user_id": null
    }
}
```
```
{
    "event_type": "shelly.multiclick",
    "data": {
        "device_id": "ab4ea6193cafc2a64359eb06f488a24e",
        "device": "shelly1-F4CFAXXXXXXX",
        "device_name": "lamp_bedroom_ceiling",
        "channel": 1,
        "click_count": 0,
        "click_events": "SLSTOP"
    },
    "origin": "LOCAL",
    "time_fired": "2021-10-25T19:54:50.664530+00:00",
    "context": {
        "id": "f5dfd2e9a6a64c28ee020742c0f8c17a",
        "parent_id": null,
        "user_id": null
    }
}
```
```
{
    "event_type": "shelly.multiclick",
    "data": {
        "device_id": "ab4ea6193cafc2a64359eb06f488a24e",
        "device": "shelly1-F4CFAXXXXXXX",
        "device_name": "lamp_bedroom_ceiling",
        "channel": 1,
        "click_count": 0,
        "click_events": "SL"
    },
    "origin": "LOCAL",
    "time_fired": "2021-10-25T19:54:51.366770+00:00",
    "context": {
        "id": "ff596ad07054f450943a6edc2e94a479",
        "parent_id": null,
        "user_id": null
    }
}
```
"LSTART" and "LSTOP" are very useful when the long push is the last action in the push pattern. With "LSTART" event can start executing the action before the user release the long push. 

1.3 The time diagram of events
![kép](https://user-images.githubusercontent.com/70820303/102123219-f0971c80-3e46-11eb-9504-bf95f6ede709.png)

### 2. If toggle button is attached to Shelly
If toggle button is attached to Shelly, then in shelly settings (web interface) the `long push time` parameter must be set to 10 ms. In this case the `click_count` parameter of new `shelly.multiclick` event contains number of clicks, like this:
```
{
    "event_type": "shelly.multiclick",
    "data": {
        "device_id": "b04ed7e02bee6157d6201883c1c0f6a4",
        "device": "shelly1-483FDAXXXXXX",
        "device_name": "lamp_garage",
        "channel": 1,
        "click_count": 2,
        "click_events": ""
    },
    "origin": "LOCAL",
    "time_fired": "2021-10-25T20:12:45.328315+00:00",
    "context": {
        "id": "e36afd09a70f8a9f86bf4e5d2a7eae23",
        "parent_id": null,
        "user_id": null
    }
}
```

### 3. Automation examples
3.1 Shelly1 with momentary, detached button:
- Short click: toggle ceiling lamp (this is the main function of the button):
```
  trigger:
    platform: event
    event_type: shelly.multiclick
    event_data:
      device_name: lamp_bedroom_ceiling
      channel: 1
      click_events: "S"
  action:
    - service: light.toggle
      entity_id: light.lamp_bedroom_ceiling
```
      
- Double short click: toggle night lamp:
```
  trigger:
    platform: event
    event_type: shelly.multiclick
    event_data:
      device_name: lamp_bedroom_ceiling
      channel: 1
      click_events: "SS"
  action:
    - service: light.toggle
      entity_id: light.lamp_bedroom_night
```      
      
- Long click: turn off all lights of room:
```
  trigger:
    platform: event
    event_type: shelly.multiclick
    event_data:
      device_name: lamp_bedroom_ceiling
      channel: 1
      click_events: "LSTART"
  action:
    - service: light.turn_off
      entity_id: light.lamp_bedroom_ceiling
    - service: light.turn_off
      entity_id: light.lamp_bedroom_bed_left
    - service: light.turn_off
      entity_id: light.lamp_bedroom_bed_right
```

- Short click + Long click: open or close the shutter:
```
  trigger:
    platform: event
    event_type: shelly.multiclick
    event_data:
      device_name: lamp_bedroom_ceiling
      channel: 1
      click_events: "SLSTART"
  action:
    - service: script.bedroom_shutter_open_or_close
```
3.2 Shelly dimmmer with momentary, detached button:
- Short click: toggle own lamp:
```
  trigger:
    platform: event
    event_type: shelly.multiclick
    event_data:
      device_name: lamp_dining_table
      channel: 1
      click_events: "S"
  action:
    - service: light.toggle
      entity_id: light.lamp_dining_table
```
- Long click start: start own lamp dim up or down:
```
  trigger:
    platform: event
    event_type: shelly.multiclick
    event_data:
      device_name: lamp_dining_table
      channel: 1
  condition:
    condition: template
    value_template: "{{ trigger.event.data['click_events'] | replace('L', '') == 'START' }}"
  action:
    - service: rest_command.shelly_dim_cycle
      data:
        ip: '192.168.5.221'
```
- Long click stop: stop own lamp dim:
```
  trigger:
    platform: event
    event_type: shelly.multiclick
    event_data:
      device_name: lamp_dining_table
      channel: 1
  condition:
    condition: template
    value_template: "{{ trigger.event.data['click_events'] | replace('L', '') == 'STOP' }}"
  action:
    - service: rest_command.shelly_dim_stop
      data:
        ip: '192.168.5.221'
```
- Double short click: toggle another lamp
```
  trigger:
    platform: event
    event_type: shelly.multiclick
    event_data:
      device_name: lamp_dining_table
      channel: 1
      click_events: "SS"
  action:
    - service: light.toggle
      entity_id: light.lampa_living_room
```
- Short click + long click start: start another lamp dim up or down:
```
  trigger:
    platform: event
    event_type: shelly.multiclick
    event_data:
      device_name: lamp_dining_table
      channel: 1
  condition:
    condition: template
    value_template: "{{ trigger.event.data['click_events'] | replace('L', '') == 'SSTART' }}"
  action:
    - service: rest_command.shelly_dim_cycle
      data:
        ip: '192.168.5.224'
```
- Short click + long click end: stop another lamp dim:
```
  trigger:
    platform: event
    event_type: shelly.multiclick
    event_data:
      device_name: lamp_dining_table
      channel: 1
  condition:
    condition: template
    value_template: "{{ trigger.event.data['click_events'] | replace('L', '') == 'SSTOP' }}"
  action:
    - service: rest_command.shelly_dim_stop
      data:
        ip: '192.168.5.224'
```
- The dim services in example:
```
rest_command:
  shelly_dim_cycle:
    url: "http://{{ ip }}/light/0?dim=cycle"
  shelly_dim_stop:
    url: "http://{{ ip }}/light/0?dim=stop"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
