### PR TITLE
Aurora abb energy metering

### DIFF
--- a/homeassistant/components/aurora_abb_powerone/aurora_device.py
+++ b/homeassistant/components/aurora_abb_powerone/aurora_device.py
@@ -32,7 +32,7 @@ class AuroraDevice(Entity):
     def unique_id(self) -> str:
         """Return the unique id for this device."""
         serial = self._data[ATTR_SERIAL_NUMBER]
-        return f"{serial}_{self.type}"
+        return f"{serial}_{self.entity_description.key}"
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/aurora_abb_powerone/sensor.py
+++ b/homeassistant/components/aurora_abb_powerone/sensor.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
     SensorEntityDescription,
 )
@@ -39,18 +40,21 @@ SENSOR_TYPES = [
         key="instantaneouspower",
         device_class=DEVICE_CLASS_POWER,
         native_unit_of_measurement=POWER_WATT,
+        state_class=STATE_CLASS_MEASUREMENT,
         name="Power Output",
     ),
     SensorEntityDescription(
         key="temp",
         device_class=DEVICE_CLASS_TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=STATE_CLASS_MEASUREMENT,
         name="Temperature",
     ),
     SensorEntityDescription(
         key="totalenergy",
         device_class=DEVICE_CLASS_ENERGY,
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
         name="Total Energy",
     ),
 ]
@@ -93,8 +97,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
 
 class AuroraSensor(AuroraDevice, SensorEntity):
     """Representation of a Sensor on a Aurora ABB PowerOne Solar inverter."""
-
-    _attr_state_class = STATE_CLASS_MEASUREMENT
 
     def __init__(
         self,

--- a/homeassistant/components/aurora_abb_powerone/sensor.py
+++ b/homeassistant/components/aurora_abb_powerone/sensor.py
@@ -26,9 +26,7 @@ from homeassistant.const import (
     POWER_WATT,
     TEMP_CELSIUS,
 )
-from homeassistant.exceptions import InvalidStateError
 import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 
 from .aurora_device import AuroraDevice
 from .const import DEFAULT_ADDRESS, DOMAIN
@@ -107,12 +105,6 @@ class AuroraSensor(AuroraDevice, SensorEntity):
         """Initialize the sensor."""
         super().__init__(client, data)
         self.entity_description = entity_description
-        if entity_description.key == "totalenergy":
-            self._attr_last_reset = dt_util.utc_from_timestamp(0)
-        elif entity_description.key not in [s.key for s in SENSOR_TYPES]:
-            raise InvalidStateError(
-                f"Unrecognised sensor type  '{entity_description.key}'"
-            )
         self.availableprev = True
 
     def update(self):

--- a/homeassistant/components/aurora_abb_powerone/sensor.py
+++ b/homeassistant/components/aurora_abb_powerone/sensor.py
@@ -101,7 +101,7 @@ class AuroraSensor(AuroraDevice, SensorEntity):
         client: AuroraSerialClient,
         data: Mapping[str, Any],
         entity_description: SensorEntityDescription,
-    ):
+    ) -> None:
         """Initialize the sensor."""
         super().__init__(client, data)
         self.entity_description = entity_description

--- a/homeassistant/components/aurora_abb_powerone/sensor.py
+++ b/homeassistant/components/aurora_abb_powerone/sensor.py
@@ -1,4 +1,5 @@
 """Support for Aurora ABB PowerOne Solar Photvoltaic (PV) inverter."""
+from __future__ import annotations
 
 from collections.abc import Mapping
 import logging

--- a/tests/components/aurora_abb_powerone/test_sensor.py
+++ b/tests/components/aurora_abb_powerone/test_sensor.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from aurorapy.client import AuroraError
-import pytest
 
 from homeassistant.components.aurora_abb_powerone.const import (
     ATTR_DEVICE_NAME,
@@ -13,11 +12,8 @@ from homeassistant.components.aurora_abb_powerone.const import (
     DEFAULT_INTEGRATION_TITLE,
     DOMAIN,
 )
-from homeassistant.components.aurora_abb_powerone.sensor import AuroraSensor
-from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_ADDRESS, CONF_PORT
-from homeassistant.exceptions import InvalidStateError
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -117,36 +113,6 @@ async def test_sensors(hass):
         energy = hass.states.get("sensor.total_energy")
         assert energy
         assert energy.state == "12.35"
-
-
-async def test_sensor_invalid_type(hass):
-    """Test invalid sensor type during setup."""
-    entities = []
-    mock_entry = _mock_config_entry()
-
-    with patch("aurorapy.client.AuroraSerialClient.connect", return_value=None), patch(
-        "aurorapy.client.AuroraSerialClient.measure",
-        side_effect=_simulated_returns,
-    ):
-        mock_entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(mock_entry.entry_id)
-        await hass.async_block_till_done()
-
-        client = hass.data[DOMAIN][mock_entry.unique_id]
-        data = mock_entry.data
-    with pytest.raises(InvalidStateError):
-        entities.append(
-            AuroraSensor(
-                client,
-                data,
-                SensorEntityDescription(
-                    key="wrongsensor",
-                    device_class="gas",
-                    native_unit_of_measurement="mph",
-                    name="WrongSensor",
-                ),
-            )
-        )
 
 
 async def test_sensor_dark(hass):

--- a/tests/components/aurora_abb_powerone/test_sensor.py
+++ b/tests/components/aurora_abb_powerone/test_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.components.aurora_abb_powerone.const import (
     DOMAIN,
 )
 from homeassistant.components.aurora_abb_powerone.sensor import AuroraSensor
+from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_ADDRESS, CONF_PORT
 from homeassistant.exceptions import InvalidStateError
@@ -134,7 +135,18 @@ async def test_sensor_invalid_type(hass):
         client = hass.data[DOMAIN][mock_entry.unique_id]
         data = mock_entry.data
     with pytest.raises(InvalidStateError):
-        entities.append(AuroraSensor(client, data, "WrongSensor", "wrongparameter"))
+        entities.append(
+            AuroraSensor(
+                client,
+                data,
+                SensorEntityDescription(
+                    key="wrongsensor",
+                    device_class="gas",
+                    native_unit_of_measurement="mph",
+                    name="WrongSensor",
+                ),
+            )
+        )
 
 
 async def test_sensor_dark(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add energy metering to aurora_abb_powerone solar PV by exposing the total energy generated as a sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
https://github.com/home-assistant/home-assistant.io/pull/19983

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
