### PR TITLE
Remove redundant value test in KNX Number entity

### DIFF
--- a/homeassistant/components/knx/number.py
+++ b/homeassistant/components/knx/number.py
@@ -97,9 +97,4 @@ class KNXNumber(KnxEntity, NumberEntity, RestoreEntity):
 
     async def async_set_value(self, value: float) -> None:
         """Set new value."""
-        if value < self.min_value or value > self.max_value:
-            raise ValueError(
-                f"Invalid value for {self.entity_id}: {value} "
-                f"(range {self.min_value} - {self.max_value})"
-            )
         await self._device.set(value)

--- a/tests/components/knx/test_number.py
+++ b/tests/components/knx/test_number.py
@@ -1,23 +1,100 @@
 """Test KNX number."""
-from homeassistant.components.knx.const import KNX_ADDRESS
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.knx.const import CONF_RESPOND_TO_READ, KNX_ADDRESS
 from homeassistant.components.knx.schema import NumberSchema
 from homeassistant.const import CONF_NAME, CONF_TYPE
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 
 from .conftest import KNXTestKit
 
 
-async def test_number_unit_of_measurement(hass: HomeAssistant, knx: KNXTestKit):
-    """Test simple KNX number."""
+async def test_number_set_value(hass: HomeAssistant, knx: KNXTestKit):
+    """Test KNX number with passive_address and respond_to_read restoring state."""
     test_address = "1/1/1"
     await knx.setup_integration(
         {
             NumberSchema.PLATFORM_NAME: {
                 CONF_NAME: "test",
                 KNX_ADDRESS: test_address,
-                CONF_TYPE: "illuminance",
+                CONF_TYPE: "percent",
             }
         }
     )
-    assert len(hass.states.async_all()) == 1
-    assert hass.states.get("number.test").attributes.get("unit_of_measurement") == "lx"
+    # set value
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": "number.test", "value": 4.0},
+        blocking=True,
+    )
+    await knx.assert_write(test_address, (0x0A,))
+    state = hass.states.get("number.test")
+    assert state.state == "4"
+    assert state.attributes.get("unit_of_measurement") == "%"
+
+    # set value out of range
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {"entity_id": "number.test", "value": 101.0},
+            blocking=True,
+        )
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            "number",
+            "set_value",
+            {"entity_id": "number.test", "value": -1},
+            blocking=True,
+        )
+    await knx.assert_no_telegram()
+    state = hass.states.get("number.test")
+    assert state.state == "4"
+
+    # update from KNX
+    await knx.receive_write(test_address, (0xE6,))
+    state = hass.states.get("number.test")
+    assert state.state == "90"
+
+
+async def test_number_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit):
+    """Test KNX number with passive_address and respond_to_read restoring state."""
+    test_address = "1/1/1"
+    test_passive_address = "3/3/3"
+    fake_state = State("number.test", "160")
+
+    with patch(
+        "homeassistant.helpers.restore_state.RestoreEntity.async_get_last_state",
+        return_value=fake_state,
+    ):
+        await knx.setup_integration(
+            {
+                NumberSchema.PLATFORM_NAME: {
+                    CONF_NAME: "test",
+                    KNX_ADDRESS: [test_address, test_passive_address],
+                    CONF_RESPOND_TO_READ: True,
+                    CONF_TYPE: "illuminance",
+                }
+            }
+        )
+    # restored state - doesn't send telegram
+    state = hass.states.get("number.test")
+    assert state.state == "160.0"
+    assert state.attributes.get("unit_of_measurement") == "lx"
+    await knx.assert_telegram_count(0)
+
+    # respond with restored state
+    await knx.receive_read(test_address)
+    await knx.assert_response(test_address, (0x1F, 0xD0))
+
+    # don't respond to passive address
+    await knx.receive_read(test_passive_address)
+    await knx.assert_no_telegram()
+
+    # update from KNX passive address
+    await knx.receive_write(test_passive_address, (0x4E, 0xDE))
+    state = hass.states.get("number.test")
+    assert state.state == "9000.96"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Remove redundant test for out of bound value in KNX Number entity
this is already covered in the service call wrapper https://github.com/home-assistant/core/blob/cee51ead91090976dde11d7372850f823b05ab36/homeassistant/components/number/__init__.py#L63
- increase test coverage

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
