### PR TITLE
Limit add-on stats to add-ons that are running

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -46,6 +46,8 @@ from .const import (
     ATTR_PASSWORD,
     ATTR_REPOSITORY,
     ATTR_SLUG,
+    ATTR_STARTED,
+    ATTR_STATE,
     ATTR_URL,
     ATTR_VERSION,
     DATA_KEY_ADDONS,
@@ -539,12 +541,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                 hassio.get_os_info(),
             )
 
-            addon_slugs = [
-                addon[ATTR_SLUG]
+            addons = [
+                addon
                 for addon in hass.data[DATA_SUPERVISOR_INFO].get("addons", [])
+                if addon[ATTR_STATE] == ATTR_STARTED
             ]
             stats_data = await asyncio.gather(
-                *[update_addon_stats(slug) for slug in addon_slugs]
+                *[update_addon_stats(addon[ATTR_SLUG]) for addon in addons]
             )
             hass.data[DATA_ADDONS_STATS] = dict(stats_data)
 

--- a/homeassistant/components/hassio/binary_sensor.py
+++ b/homeassistant/components/hassio/binary_sensor.py
@@ -14,7 +14,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ADDONS_COORDINATOR
-from .const import ATTR_STATE, ATTR_UPDATE_AVAILABLE, DATA_KEY_ADDONS, DATA_KEY_OS
+from .const import (
+    ATTR_STARTED,
+    ATTR_STATE,
+    ATTR_UPDATE_AVAILABLE,
+    DATA_KEY_ADDONS,
+    DATA_KEY_OS,
+)
 from .entity import HassioAddonEntity, HassioOSEntity
 
 
@@ -37,7 +43,7 @@ ENTITY_DESCRIPTIONS = (
         entity_registry_enabled_default=False,
         key=ATTR_STATE,
         name="Running",
-        target="started",
+        target=ATTR_STARTED,
     ),
 )
 

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -46,6 +46,7 @@ ATTR_CPU_PERCENT = "cpu_percent"
 ATTR_MEMORY_PERCENT = "memory_percent"
 ATTR_SLUG = "slug"
 ATTR_STATE = "state"
+ATTR_STARTED = "started"
 ATTR_URL = "url"
 ATTR_REPOSITORY = "repository"
 

--- a/homeassistant/components/hassio/entity.py
+++ b/homeassistant/components/hassio/entity.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import DOMAIN, HassioDataUpdateCoordinator
-from .const import ATTR_SLUG
+from .const import ATTR_SLUG, DATA_KEY_ADDONS, DATA_KEY_OS
 
 
 class HassioAddonEntity(CoordinatorEntity):
@@ -28,6 +28,15 @@ class HassioAddonEntity(CoordinatorEntity):
         self._attr_unique_id = f"{addon[ATTR_SLUG]}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, addon[ATTR_SLUG])})
 
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return (
+            super().available
+            and self.entity_description.key
+            in self.coordinator.data[DATA_KEY_ADDONS][self._addon_slug]
+        )
+
 
 class HassioOSEntity(CoordinatorEntity):
     """Base Entity for Hass.io OS."""
@@ -43,3 +52,11 @@ class HassioOSEntity(CoordinatorEntity):
         self._attr_name = f"Home Assistant Operating System: {entity_description.name}"
         self._attr_unique_id = f"home_assistant_os_{entity_description.key}"
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, "OS")})
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return (
+            super().available
+            and self.entity_description.key in self.coordinator.data[DATA_KEY_OS]
+        )

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -493,6 +493,7 @@ async def test_device_registry_calls(hass):
         "addons": [
             {
                 "name": "test",
+                "state": "started",
                 "slug": "test",
                 "installed": True,
                 "update_available": False,
@@ -503,6 +504,7 @@ async def test_device_registry_calls(hass):
             },
             {
                 "name": "test2",
+                "state": "started",
                 "slug": "test2",
                 "installed": True,
                 "update_available": False,
@@ -537,6 +539,7 @@ async def test_device_registry_calls(hass):
         "addons": [
             {
                 "name": "test2",
+                "state": "started",
                 "slug": "test2",
                 "installed": True,
                 "update_available": False,
@@ -568,6 +571,7 @@ async def test_device_registry_calls(hass):
             {
                 "name": "test2",
                 "slug": "test2",
+                "state": "started",
                 "installed": True,
                 "update_available": False,
                 "version": "1.0.0",
@@ -577,6 +581,7 @@ async def test_device_registry_calls(hass):
             {
                 "name": "test3",
                 "slug": "test3",
+                "state": "stopped",
                 "installed": True,
                 "update_available": False,
                 "version": "1.0.0",

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -66,6 +66,7 @@ def mock_all(aioclient_mock, request):
                 "addons": [
                     {
                         "name": "test",
+                        "state": "started",
                         "slug": "test",
                         "installed": True,
                         "update_available": False,
@@ -76,6 +77,7 @@ def mock_all(aioclient_mock, request):
                     },
                     {
                         "name": "test2",
+                        "state": "stopped",
                         "slug": "test2",
                         "installed": True,
                         "update_available": False,
@@ -101,22 +103,6 @@ def mock_all(aioclient_mock, request):
                 "network_tx": 82374138,
                 "blk_read": 46010945536,
                 "blk_write": 15051526144,
-            },
-        },
-    )
-    aioclient_mock.get(
-        "http://127.0.0.1/addons/test2/stats",
-        json={
-            "result": "ok",
-            "data": {
-                "cpu_percent": 0.8,
-                "memory_usage": 51941376,
-                "memory_limit": 3977146368,
-                "memory_percent": 1.31,
-                "network_rx": 31338284,
-                "network_tx": 15692900,
-                "blk_read": 740077568,
-                "blk_write": 6004736,
             },
         },
     )
@@ -149,9 +135,9 @@ async def test_sensors(hass, aioclient_mock):
         "sensor.test2_version": "3.1.0",
         "sensor.test2_newest_version": "3.2.0",
         "sensor.test_cpu_percent": "0.99",
-        "sensor.test2_cpu_percent": "0.8",
+        "sensor.test2_cpu_percent": "unavailable",
         "sensor.test_memory_percent": "4.59",
-        "sensor.test2_memory_percent": "1.31",
+        "sensor.test2_memory_percent": "unavailable",
     }
 
     """Check that entities are disabled by default."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We can not get stats from containers that are not running.
This PR limits the fetching of stats to running add-ons only.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
