### PR TITLE
Code rework for the velbus light platform

### DIFF
--- a/homeassistant/components/velbus/light.py
+++ b/homeassistant/components/velbus/light.py
@@ -21,32 +21,23 @@ async def async_setup_entry(hass, entry, async_add_entities):
     cntrl = hass.data[DOMAIN][entry.entry_id]["cntrl"]
     entities = []
     for channel in cntrl.get_all("light"):
-        entities.append(VelbusLight(channel, False))
+        entities.append(VelbusLight(channel))
     for channel in cntrl.get_all("led"):
-        entities.append(VelbusLight(channel, True))
+        entities.append(VelbusButtonLight(channel))
     async_add_entities(entities)
 
 
 class VelbusLight(VelbusEntity, LightEntity):
     """Representation of a Velbus light."""
 
-    def __init__(self, channel, led):
-        """Initialize a light Velbus entity."""
-        super().__init__(channel)
-        self._is_led = led
-
     @property
     def name(self):
         """Return the display name of this entity."""
-        if self._is_led:
-            return f"LED {self._channel.get_name()}"
         return self._channel.get_name()
 
     @property
     def supported_features(self):
         """Flag supported features."""
-        if self._is_led:
-            return SUPPORT_FLASH
         return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
 
     @property
@@ -61,43 +52,76 @@ class VelbusLight(VelbusEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Instruct the Velbus light to turn on."""
-        if self._is_led:
-            if ATTR_FLASH in kwargs:
-                if kwargs[ATTR_FLASH] == FLASH_LONG:
-                    attr, *args = "set_led_state", "slow"
-                elif kwargs[ATTR_FLASH] == FLASH_SHORT:
-                    attr, *args = "set_led_state", "fast"
-                else:
-                    attr, *args = "set_led_state", "on"
+        if ATTR_BRIGHTNESS in kwargs:
+            # Make sure a low but non-zero value is not rounded down to zero
+            if kwargs[ATTR_BRIGHTNESS] == 0:
+                brightness = 0
             else:
-                attr, *args = "set_led_state", "on"
+                brightness = max(int((kwargs[ATTR_BRIGHTNESS] * 100) / 255), 1)
+            attr, *args = (
+                "set_dimmer_state",
+                brightness,
+                kwargs.get(ATTR_TRANSITION, 0),
+            )
         else:
-            if ATTR_BRIGHTNESS in kwargs:
-                # Make sure a low but non-zero value is not rounded down to zero
-                if kwargs[ATTR_BRIGHTNESS] == 0:
-                    brightness = 0
-                else:
-                    brightness = max(int((kwargs[ATTR_BRIGHTNESS] * 100) / 255), 1)
-                attr, *args = (
-                    "set_dimmer_state",
-                    brightness,
-                    kwargs.get(ATTR_TRANSITION, 0),
-                )
-            else:
-                attr, *args = (
-                    "restore_dimmer_state",
-                    kwargs.get(ATTR_TRANSITION, 0),
-                )
+            attr, *args = (
+                "restore_dimmer_state",
+                kwargs.get(ATTR_TRANSITION, 0),
+            )
         await getattr(self._channel, attr)(*args)
 
     async def async_turn_off(self, **kwargs):
         """Instruct the velbus light to turn off."""
-        if self._is_led:
-            attr, *args = "set_led_state", "off"
-        else:
-            attr, *args = (
-                "set_dimmer_state",
-                0,
-                kwargs.get(ATTR_TRANSITION, 0),
-            )
+        attr, *args = (
+            "set_dimmer_state",
+            0,
+            kwargs.get(ATTR_TRANSITION, 0),
+        )
         await getattr(self._channel, attr)(*args)
+
+
+class VelbusButtonLight(VelbusEntity, LightEntity):
+    """Representation of a Velbus light."""
+
+    @property
+    def name(self):
+        """Return the display name of this entity."""
+        return f"LED {self._channel.get_name()}"
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_FLASH
+
+    @property
+    def is_on(self):
+        """Return true if the light is on."""
+        return self._channel.is_on()
+
+    @property
+    def brightness(self):
+        """Return the brightness of the light."""
+        return int((self._channel.get_dimmer_state() * 255) / 100)
+
+    async def async_turn_on(self, **kwargs):
+        """Instruct the Velbus light to turn on."""
+        if ATTR_FLASH in kwargs:
+            if kwargs[ATTR_FLASH] == FLASH_LONG:
+                attr, *args = "set_led_state", "slow"
+            elif kwargs[ATTR_FLASH] == FLASH_SHORT:
+                attr, *args = "set_led_state", "fast"
+            else:
+                attr, *args = "set_led_state", "on"
+        else:
+            attr, *args = "set_led_state", "on"
+        await getattr(self._channel, attr)(*args)
+
+    async def async_turn_off(self, **kwargs):
+        """Instruct the velbus light to turn off."""
+        attr, *args = "set_led_state", "off"
+        await getattr(self._channel, attr)(*args)
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Disable these entities by default."""
+        return False

--- a/homeassistant/components/velbus/switch.py
+++ b/homeassistant/components/velbus/switch.py
@@ -32,3 +32,12 @@ class VelbusSwitch(VelbusEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the switch to turn off."""
         await self._channel.turn_off()
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return the state attributes of the sun."""
+        return {
+            "Forced on": self._channel.is_forced_on(),
+            "Inhibit": self._channel.is_inhibit(),
+            "Disabled": self._channel.is_disabled(),
+        }


### PR DESCRIPTION
## Proposed change
This change is just some code-cleanup in the velbus light platform.

instead of one massive VelbusLight object with a lot of the same if structures there are now 2 objects with each there own function

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
