### PR TITLE
Minor cleanup on stream

### DIFF
--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -18,7 +18,14 @@ from .const import (
     MAX_SEGMENTS,
     NUM_PLAYLIST_SEGMENTS,
 )
-from .core import PROVIDERS, IdleTimer, StreamOutput, StreamSettings, StreamView
+from .core import (
+    PROVIDERS,
+    IdleTimer,
+    Segment,
+    StreamOutput,
+    StreamSettings,
+    StreamView,
+)
 from .fmp4utils import get_codec_string
 
 if TYPE_CHECKING:
@@ -44,7 +51,7 @@ class HlsStreamOutput(StreamOutput):
         """Initialize HLS output."""
         super().__init__(hass, idle_timer, deque_maxlen=MAX_SEGMENTS)
         self.stream_settings: StreamSettings = hass.data[DOMAIN][ATTR_SETTINGS]
-        self._target_duration = 0.0
+        self._target_duration = self.stream_settings.min_segment_duration
 
     @property
     def name(self) -> str:
@@ -53,19 +60,22 @@ class HlsStreamOutput(StreamOutput):
 
     @property
     def target_duration(self) -> float:
-        """
-        Return the target duration.
-
-        The target duration is calculated as the max duration of any given segment,
-        and it is calculated only one time to avoid changing during playback.
-        """
-        if self._target_duration:
-            return self._target_duration
-        durations = [s.duration for s in self._segments if s.complete]
-        if len(durations) < 2:
-            return self.stream_settings.min_segment_duration
-        self._target_duration = max(durations)
+        """Return the target duration."""
         return self._target_duration
+
+    @callback
+    def _async_put(self, segment: Segment) -> None:
+        """Async put and also update the target duration.
+
+        The target duration is calculated as the max duration of any given segment.
+        Technically it should not change per the hls spec, but some cameras adjust
+        their GOPs periodically so we need to account for this change.
+        """
+        super()._async_put(segment)
+        self._target_duration = (
+            max((s.duration for s in self._segments), default=segment.duration)
+            or self.stream_settings.min_segment_duration
+        )
 
 
 class HlsMasterPlaylistView(StreamView):

--- a/tests/components/stream/test_ll_hls.py
+++ b/tests/components/stream/test_ll_hls.py
@@ -224,7 +224,9 @@ async def test_ll_hls_stream(hass, hls_stream, stream_worker_sync):
                     datetimes[-1] - datetimes.popleft()
                 ).total_seconds()
                 if segment_duration:
-                    assert datetime_duration == segment_duration
+                    assert math.isclose(
+                        datetime_duration, segment_duration, rel_tol=1e-3
+                    )
                     tested[datetime_re] = True
             continue
         match = inf_re.match(line)
@@ -232,7 +234,7 @@ async def test_ll_hls_stream(hass, hls_stream, stream_worker_sync):
             segment_duration = float(match.group("segment_duration"))
             # Check that segment durations are consistent with part durations
             if len(part_durations) > 1:
-                assert math.isclose(sum(part_durations), segment_duration)
+                assert math.isclose(sum(part_durations), segment_duration, rel_tol=1e-3)
                 tested[inf_re] = True
                 part_durations.clear()
     # make sure all playlist tests were performed

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -194,7 +194,7 @@ async def test_record_stream_audio(
     await async_setup_component(hass, "stream", {"stream": {}})
 
     # Generate source video with no audio
-    source = generate_h264_video(container_format="mov")
+    orig_source = generate_h264_video(container_format="mov")
 
     for a_codec, expected_audio_streams in (
         ("aac", 1),  # aac is a valid mp4 codec
@@ -202,9 +202,8 @@ async def test_record_stream_audio(
         ("empty", 0),  # audio stream with no packets
         (None, 0),  # no audio stream
     ):
-
         # Remux source video with new audio
-        source = remux_with_audio(source, "mov", a_codec)  # mov can store PCM
+        source = remux_with_audio(orig_source, "mov", a_codec)  # mov can store PCM
 
         record_worker_sync.reset()
         stream_worker_sync.pause()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR 
1) Allows for EXT-X-TARGETDURATION to change. Although technically EXT-X-TARGETDURATION should not change, on long running streams the camera encoding may change leading to an EXT-X-TARGETDURATION change.
2) Allows for minor rounding errors during playlist validation
3) Reuses the original source in test_record_stream_audio. Remuxing the source several times with different audio seems to lead to a final file with a large timescale. This doesn't cause any problems currently but led to some rounding errors in the test when I was investigating other things.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
