### PR TITLE
When tradfri device goes offline set attr_available false

### DIFF
--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -19,7 +19,7 @@ from pytradfri.device.socket import Socket
 from pytradfri.device.socket_control import SocketControl
 from pytradfri.error import PytradfriError
 
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from .const import DOMAIN
@@ -53,27 +53,30 @@ class TradfriBaseClass(Entity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         device: Device,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize a device."""
+        self.hass = hass
         self._api = handle_error(api)
+        self._attr_name = device.name
+        self._attr_available = device.reachable
         self._device: Device = device
         self._device_control: BlindControl | LightControl | SocketControl | SignalRepeaterControl | AirPurifierControl | None = (
             None
         )
         self._device_data: Socket | Light | Blind | AirPurifier | None = None
         self._gateway_id = gateway_id
-        self._refresh(device)
 
     @callback
     def _async_start_observe(self, exc: Exception | None = None) -> None:
         """Start observation of device."""
         if exc:
+            self._attr_available = False
             self.async_write_ha_state()
             _LOGGER.warning("Observation failed for %s", self._attr_name, exc_info=exc)
-
         try:
             cmd = self._device.observe(
                 callback=self._observe_update,
@@ -82,6 +85,8 @@ class TradfriBaseClass(Entity):
             )
             self.hass.async_create_task(self._api(cmd))
         except PytradfriError as err:
+            self._attr_available = False
+            self.async_write_ha_state()
             _LOGGER.warning("Observation failed, trying again", exc_info=err)
             self._async_start_observe()
 
@@ -93,12 +98,14 @@ class TradfriBaseClass(Entity):
     def _observe_update(self, device: Device) -> None:
         """Receive new state data for this device."""
         self._refresh(device)
-        self.async_write_ha_state()
 
-    def _refresh(self, device: Device) -> None:
+    def _refresh(self, device: Device, write_ha: bool = True) -> None:
         """Refresh the device data."""
         self._device = device
         self._attr_name = device.name
+        self._attr_available = device.reachable
+        if write_ha:
+            self.async_write_ha_state()
 
 
 class TradfriBaseDevice(TradfriBaseClass):
@@ -119,8 +126,3 @@ class TradfriBaseDevice(TradfriBaseClass):
             sw_version=info.firmware_version,
             via_device=(DOMAIN, self._gateway_id),
         )
-
-    def _refresh(self, device: Device) -> None:
-        """Refresh the device data."""
-        super()._refresh(device)
-        self._attr_available = device.reachable

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -19,7 +19,7 @@ from pytradfri.device.socket import Socket
 from pytradfri.device.socket_control import SocketControl
 from pytradfri.error import PytradfriError
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from .const import DOMAIN
@@ -53,13 +53,11 @@ class TradfriBaseClass(Entity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         device: Device,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize a device."""
-        self.hass = hass
         self._api = handle_error(api)
         self._attr_name = device.name
         self._attr_available = device.reachable

--- a/homeassistant/components/tradfri/cover.py
+++ b/homeassistant/components/tradfri/cover.py
@@ -28,9 +28,7 @@ async def async_setup_entry(
 
     covers = [dev for dev in devices if dev.has_blind_control]
     if covers:
-        async_add_entities(
-            TradfriCover(hass, cover, api, gateway_id) for cover in covers
-        )
+        async_add_entities(TradfriCover(cover, api, gateway_id) for cover in covers)
 
 
 class TradfriCover(TradfriBaseDevice, CoverEntity):
@@ -38,14 +36,13 @@ class TradfriCover(TradfriBaseDevice, CoverEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         device: Command,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize a cover."""
         self._attr_unique_id = f"{gateway_id}-{device.id}"
-        super().__init__(hass, device, api, gateway_id)
+        super().__init__(device, api, gateway_id)
         self._refresh(device, write_ha=False)
 
     @property

--- a/homeassistant/components/tradfri/cover.py
+++ b/homeassistant/components/tradfri/cover.py
@@ -28,7 +28,9 @@ async def async_setup_entry(
 
     covers = [dev for dev in devices if dev.has_blind_control]
     if covers:
-        async_add_entities(TradfriCover(cover, api, gateway_id) for cover in covers)
+        async_add_entities(
+            TradfriCover(hass, cover, api, gateway_id) for cover in covers
+        )
 
 
 class TradfriCover(TradfriBaseDevice, CoverEntity):
@@ -36,15 +38,15 @@ class TradfriCover(TradfriBaseDevice, CoverEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         device: Command,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize a cover."""
-        super().__init__(device, api, gateway_id)
         self._attr_unique_id = f"{gateway_id}-{device.id}"
-
-        self._refresh(device)
+        super().__init__(hass, device, api, gateway_id)
+        self._refresh(device, write_ha=False)
 
     @property
     def extra_state_attributes(self) -> dict[str, str] | None:
@@ -90,11 +92,10 @@ class TradfriCover(TradfriBaseDevice, CoverEntity):
         """Return if the cover is closed or not."""
         return self.current_cover_position == 0
 
-    def _refresh(self, device: Command) -> None:
+    def _refresh(self, device: Command, write_ha: bool = True) -> None:
         """Refresh the cover data."""
-        super()._refresh(device)
-        self._device = device
-
         # Caching of BlindControl and cover object
+        self._device = device
         self._device_control = device.blind_control
         self._device_data = device.blind_control.blinds[0]
+        super()._refresh(device, write_ha=write_ha)

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -34,7 +34,8 @@ async def async_setup_entry(
     purifiers = [dev for dev in devices if dev.has_air_purifier_control]
     if purifiers:
         async_add_entities(
-            TradfriAirPurifierFan(purifier, api, gateway_id) for purifier in purifiers
+            TradfriAirPurifierFan(hass, purifier, api, gateway_id)
+            for purifier in purifiers
         )
 
 
@@ -60,12 +61,13 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         device: Command,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize a switch."""
-        super().__init__(device, api, gateway_id)
+        super().__init__(hass, device, api, gateway_id)
         self._attr_unique_id = f"{gateway_id}-{device.id}"
 
     @property
@@ -166,10 +168,9 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
             return
         await self._api(self._device_control.set_mode(0))
 
-    def _refresh(self, device: Command) -> None:
+    def _refresh(self, device: Command, write_ha: bool = True) -> None:
         """Refresh the purifier data."""
-        super()._refresh(device)
-
         # Caching of air purifier control and purifier object
         self._device_control = device.air_purifier_control
         self._device_data = device.air_purifier_control.air_purifiers[0]
+        super()._refresh(device, write_ha=write_ha)

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -34,8 +34,7 @@ async def async_setup_entry(
     purifiers = [dev for dev in devices if dev.has_air_purifier_control]
     if purifiers:
         async_add_entities(
-            TradfriAirPurifierFan(hass, purifier, api, gateway_id)
-            for purifier in purifiers
+            TradfriAirPurifierFan(purifier, api, gateway_id) for purifier in purifiers
         )
 
 
@@ -61,13 +60,12 @@ class TradfriAirPurifierFan(TradfriBaseDevice, FanEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         device: Command,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize a switch."""
-        super().__init__(hass, device, api, gateway_id)
+        super().__init__(device, api, gateway_id)
         self._attr_unique_id = f"{gateway_id}-{device.id}"
 
     @property

--- a/homeassistant/components/tradfri/light.py
+++ b/homeassistant/components/tradfri/light.py
@@ -51,14 +51,10 @@ async def async_setup_entry(
 
     lights = [dev for dev in devices if dev.has_light_control]
     if lights:
-        async_add_entities(
-            TradfriLight(hass, light, api, gateway_id) for light in lights
-        )
+        async_add_entities(TradfriLight(light, api, gateway_id) for light in lights)
 
     if config_entry.data[CONF_IMPORT_GROUPS] and (groups := tradfri_data[GROUPS]):
-        async_add_entities(
-            TradfriGroup(hass, group, api, gateway_id) for group in groups
-        )
+        async_add_entities(TradfriGroup(group, api, gateway_id) for group in groups)
 
 
 class TradfriGroup(TradfriBaseClass, LightEntity):
@@ -68,13 +64,12 @@ class TradfriGroup(TradfriBaseClass, LightEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         device: Command,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize a Group."""
-        super().__init__(hass, device, api, gateway_id)
+        super().__init__(device, api, gateway_id)
 
         self._attr_unique_id = f"group-{gateway_id}-{device.id}"
         self._attr_should_poll = True
@@ -121,13 +116,12 @@ class TradfriLight(TradfriBaseDevice, LightEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         device: Command,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize a Light."""
-        super().__init__(hass, device, api, gateway_id)
+        super().__init__(device, api, gateway_id)
         self._attr_unique_id = f"light-{gateway_id}-{device.id}"
         self._hs_color = None
 

--- a/homeassistant/components/tradfri/sensor.py
+++ b/homeassistant/components/tradfri/sensor.py
@@ -37,9 +37,7 @@ async def async_setup_entry(
         and not dev.has_air_purifier_control
     )
     if sensors:
-        async_add_entities(
-            TradfriSensor(hass, sensor, api, gateway_id) for sensor in sensors
-        )
+        async_add_entities(TradfriSensor(sensor, api, gateway_id) for sensor in sensors)
 
 
 class TradfriSensor(TradfriBaseDevice, SensorEntity):
@@ -50,13 +48,12 @@ class TradfriSensor(TradfriBaseDevice, SensorEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         device: Command,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize the device."""
-        super().__init__(hass, device, api, gateway_id)
+        super().__init__(device, api, gateway_id)
         self._attr_unique_id = f"{gateway_id}-{device.id}"
 
     @property

--- a/homeassistant/components/tradfri/sensor.py
+++ b/homeassistant/components/tradfri/sensor.py
@@ -37,7 +37,9 @@ async def async_setup_entry(
         and not dev.has_air_purifier_control
     )
     if sensors:
-        async_add_entities(TradfriSensor(sensor, api, gateway_id) for sensor in sensors)
+        async_add_entities(
+            TradfriSensor(hass, sensor, api, gateway_id) for sensor in sensors
+        )
 
 
 class TradfriSensor(TradfriBaseDevice, SensorEntity):
@@ -48,12 +50,13 @@ class TradfriSensor(TradfriBaseDevice, SensorEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         device: Command,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize the device."""
-        super().__init__(device, api, gateway_id)
+        super().__init__(hass, device, api, gateway_id)
         self._attr_unique_id = f"{gateway_id}-{device.id}"
 
     @property

--- a/homeassistant/components/tradfri/switch.py
+++ b/homeassistant/components/tradfri/switch.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
     switches = [dev for dev in devices if dev.has_socket_control]
     if switches:
         async_add_entities(
-            TradfriSwitch(hass, switch, api, gateway_id) for switch in switches
+            TradfriSwitch(switch, api, gateway_id) for switch in switches
         )
 
 
@@ -38,13 +38,12 @@ class TradfriSwitch(TradfriBaseDevice, SwitchEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         device: Command,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize a switch."""
-        super().__init__(hass, device, api, gateway_id)
+        super().__init__(device, api, gateway_id)
         self._attr_unique_id = f"{gateway_id}-{device.id}"
 
     def _refresh(self, device: Command, write_ha: bool = True) -> None:

--- a/homeassistant/components/tradfri/switch.py
+++ b/homeassistant/components/tradfri/switch.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
     switches = [dev for dev in devices if dev.has_socket_control]
     if switches:
         async_add_entities(
-            TradfriSwitch(switch, api, gateway_id) for switch in switches
+            TradfriSwitch(hass, switch, api, gateway_id) for switch in switches
         )
 
 
@@ -38,21 +38,21 @@ class TradfriSwitch(TradfriBaseDevice, SwitchEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         device: Command,
         api: Callable[[Command | list[Command]], Any],
         gateway_id: str,
     ) -> None:
         """Initialize a switch."""
-        super().__init__(device, api, gateway_id)
+        super().__init__(hass, device, api, gateway_id)
         self._attr_unique_id = f"{gateway_id}-{device.id}"
 
-    def _refresh(self, device: Command) -> None:
+    def _refresh(self, device: Command, write_ha: bool = True) -> None:
         """Refresh the switch data."""
-        super()._refresh(device)
-
         # Caching of switch control and switch object
         self._device_control = device.socket_control
         self._device_data = device.socket_control.sockets[0]
+        super()._refresh(device, write_ha=write_ha)
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It was detected when a device goes offline, but _attr_available was not set. 

In a number of places _attr variables was changed without calling async_write_ha_state()



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Would be nice if this could make it into 2021.11

There seems to be another problem with the IKEA Gateway goes offline, but that is for another PR, since it is very different changes.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
