### PR TITLE
Handle accessories without a serial number in homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -12,7 +12,7 @@ from aiohomekit.model import Accessories
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
-from homeassistant.const import ATTR_IDENTIFIERS, ATTR_VIA_DEVICE
+from homeassistant.const import ATTR_VIA_DEVICE
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
@@ -24,6 +24,8 @@ from .const import (
     DOMAIN,
     ENTITY_MAP,
     HOMEKIT_ACCESSORY_DISPATCH,
+    IDENTIFIER_ACCESSORY_ID,
+    IDENTIFIER_SERIAL_NUMBER,
 )
 from .device_trigger import async_fire_triggers, async_setup_triggers_for_entry
 
@@ -207,33 +209,40 @@ class HKDevice:
                 service_type=ServicesTypes.ACCESSORY_INFORMATION,
             )
 
-            device_info = DeviceInfo(
-                identifiers={
+            serial_number = info.value(CharacteristicsTypes.SERIAL_NUMBER)
+
+            if serial_number:
+                identifiers = {(DOMAIN, IDENTIFIER_SERIAL_NUMBER, serial_number)}
+            else:
+                # Some accessories do not have a serial number
+                identifiers = {
                     (
                         DOMAIN,
-                        "serial-number",
-                        info.value(CharacteristicsTypes.SERIAL_NUMBER),
+                        IDENTIFIER_ACCESSORY_ID,
+                        f"{self.unique_id}_{accessory.aid}",
                     )
-                },
+                }
+
+            if accessory.aid == 1:
+                # Accessory 1 is the root device (sometimes the only device, sometimes a bridge)
+                # Link the root device to the pairing id for the connection.
+                identifiers.add((DOMAIN, IDENTIFIER_ACCESSORY_ID, self.unique_id))
+
+            device_info = DeviceInfo(
+                identifiers=identifiers,
                 name=info.value(CharacteristicsTypes.NAME),
                 manufacturer=info.value(CharacteristicsTypes.MANUFACTURER, ""),
                 model=info.value(CharacteristicsTypes.MODEL, ""),
                 sw_version=info.value(CharacteristicsTypes.FIRMWARE_REVISION, ""),
             )
 
-            if accessory.aid == 1:
-                # Accessory 1 is the root device (sometimes the only device, sometimes a bridge)
-                # Link the root device to the pairing id for the connection.
-                device_info[ATTR_IDENTIFIERS].add(
-                    (DOMAIN, "accessory-id", self.unique_id)
-                )
-            else:
+            if accessory.aid != 1:
                 # Every pairing has an accessory 1
                 # It *doesn't* have a via_device, as it is the device we are connecting to
                 # Every other accessory should use it as its via device.
                 device_info[ATTR_VIA_DEVICE] = (
                     DOMAIN,
-                    "serial-number",
+                    IDENTIFIER_SERIAL_NUMBER,
                     self.connection_info["serial-number"],
                 )
 

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -11,6 +11,10 @@ TRIGGERS = f"{DOMAIN}-triggers"
 HOMEKIT_DIR = ".homekit"
 PAIRING_FILE = "pairing.json"
 
+IDENTIFIER_SERIAL_NUMBER = "serial-number"
+IDENTIFIER_ACCESSORY_ID = "accessory-id"
+
+
 # Mapping from Homekit type to component.
 HOMEKIT_ACCESSORY_DISPATCH = {
     "lightbulb": "light",

--- a/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
@@ -41,8 +41,33 @@ async def test_ryse_smart_bridge_setup(hass):
     assert device.model == "RYSE Shade"
     assert device.sw_version == "3.0.8"
 
-    bridge = device = device_registry.async_get(device.via_device_id)
+    bridge = device_registry.async_get(device.via_device_id)
     assert bridge.manufacturer == "RYSE Inc."
     assert bridge.name == "RYSE SmartBridge"
     assert bridge.model == "RYSE SmartBridge"
     assert bridge.sw_version == "1.3.0"
+
+    # Check that the cover.ryse_smartshade is correctly found and set up
+    cover_id = "cover.ryse_smartshade"
+    cover = entity_registry.async_get(cover_id)
+    assert cover.unique_id == "homekit-00:00:00:00:00:00-3-48"
+
+    cover_helper = Helper(
+        hass,
+        cover_id,
+        pairing,
+        accessories[0],
+        config_entry,
+    )
+
+    cover_state = await cover_helper.poll_and_get_state()
+    assert cover_state.attributes["friendly_name"] == "RYSE SmartShade"
+    assert cover_state.state == "open"
+
+    device_registry = dr.async_get(hass)
+
+    device = device_registry.async_get(cover.device_id)
+    assert device.manufacturer == "RYSE Inc."
+    assert device.name == "RYSE SmartShade"
+    assert device.model == "RYSE Shade"
+    assert device.sw_version == ""

--- a/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_ryse_smart_bridge.py
@@ -1,0 +1,48 @@
+"""Test against characteristics captured from a ryse smart bridge platforms."""
+
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.components.homekit_controller.common import (
+    Helper,
+    setup_accessories_from_file,
+    setup_test_accessories,
+)
+
+
+async def test_ryse_smart_bridge_setup(hass):
+    """Test that a Ryse smart bridge can be correctly setup in HA."""
+    accessories = await setup_accessories_from_file(hass, "ryse_smart_bridge.json")
+    config_entry, pairing = await setup_test_accessories(hass, accessories)
+
+    entity_registry = er.async_get(hass)
+
+    # Check that the cover.master_bath_south is correctly found and set up
+    cover_id = "cover.master_bath_south"
+    cover = entity_registry.async_get(cover_id)
+    assert cover.unique_id == "homekit-1.0.0-48"
+
+    cover_helper = Helper(
+        hass,
+        cover_id,
+        pairing,
+        accessories[0],
+        config_entry,
+    )
+
+    cover_state = await cover_helper.poll_and_get_state()
+    assert cover_state.attributes["friendly_name"] == "Master Bath South"
+    assert cover_state.state == "closed"
+
+    device_registry = dr.async_get(hass)
+
+    device = device_registry.async_get(cover.device_id)
+    assert device.manufacturer == "RYSE Inc."
+    assert device.name == "Master Bath South"
+    assert device.model == "RYSE Shade"
+    assert device.sw_version == "3.0.8"
+
+    bridge = device = device_registry.async_get(device.via_device_id)
+    assert bridge.manufacturer == "RYSE Inc."
+    assert bridge.name == "RYSE SmartBridge"
+    assert bridge.model == "RYSE SmartBridge"
+    assert bridge.sw_version == "1.3.0"

--- a/tests/fixtures/homekit_controller/ryse_smart_bridge.json
+++ b/tests/fixtures/homekit_controller/ryse_smart_bridge.json
@@ -1,0 +1,596 @@
+[
+    {
+        "aid": 1,
+        "services": [
+            {
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291",
+                "primary": false,
+                "hidden": false,
+                "linked": [],
+                "characteristics": [
+                    {
+                        "iid": 2,
+                        "type": "00000014-0000-1000-8000-0026BB765291",
+                        "format": "bool",
+                        "perms": [
+                            "pw"
+                        ]
+                    },
+                    {
+                        "iid": 3,
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE Inc.",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 4,
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE SmartBridge",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 5,
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE SmartBridge",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 6,
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "0101.3521.0436",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 7,
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "1.3.0",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 8,
+                        "type": "00000053-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "0101.3521.0436",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 9,
+                        "type": "34AB8811-AC7F-4340-BAC3-FD6A85F9943B",
+                        "format": "string",
+                        "value": "4.1;3fac0fb4",
+                        "perms": [
+                            "pr",
+                            "hd"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 10,
+                        "type": "220",
+                        "format": "data",
+                        "value": "Yhl9CmseEb8=",
+                        "perms": [
+                            "pr",
+                            "hd"
+                        ],
+                        "ev": false,
+                        "maxDataLen": 8
+                    }
+                ]
+            },
+            {
+                "iid": 16,
+                "type": "000000A2-0000-1000-8000-0026BB765291",
+                "primary": false,
+                "hidden": false,
+                "linked": [],
+                "characteristics": [
+                    {
+                        "iid": 18,
+                        "type": "00000037-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "1.1.0",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "aid": 2,
+        "services": [
+            {
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291",
+                "primary": false,
+                "hidden": false,
+                "linked": [],
+                "characteristics": [
+                    {
+                        "iid": 2,
+                        "type": "00000014-0000-1000-8000-0026BB765291",
+                        "format": "bool",
+                        "perms": [
+                            "pw"
+                        ]
+                    },
+                    {
+                        "iid": 3,
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE Inc.",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 4,
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE Shade",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 5,
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "Master Bath South",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 6,
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "1.0.0",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 7,
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "3.0.8",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 8,
+                        "type": "00000053-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "1.0.0",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 11,
+                        "type": "000000A6-0000-1000-8000-0026BB765291",
+                        "format": "uint32",
+                        "value": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": false,
+                        "minValue": 0,
+                        "maxValue": 1,
+                        "minStep": 1
+                    }
+                ]
+            },
+            {
+                "iid": 48,
+                "type": "0000008C-0000-1000-8000-0026BB765291",
+                "primary": true,
+                "hidden": false,
+                "linked": [
+                    64
+                ],
+                "characteristics": [
+                    {
+                        "iid": 52,
+                        "type": "0000007C-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 0,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "ev": true,
+                        "unit": "percentage",
+                        "minValue": 0,
+                        "maxValue": 100,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 53,
+                        "type": "0000006D-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": true,
+                        "unit": "percentage",
+                        "minValue": 0,
+                        "maxValue": 100,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 54,
+                        "type": "00000072-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 2,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": true,
+                        "minValue": 0,
+                        "maxValue": 2,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 50,
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE Shade",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 55,
+                        "type": "00000024-0000-1000-8000-0026BB765291",
+                        "format": "bool",
+                        "value": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": true
+                    }
+                ]
+            },
+            {
+                "iid": 64,
+                "type": "00000096-0000-1000-8000-0026BB765291",
+                "primary": false,
+                "hidden": false,
+                "linked": [],
+                "characteristics": [
+                    {
+                        "iid": 67,
+                        "type": "00000068-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 100,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": true,
+                        "unit": "percentage",
+                        "minValue": 0,
+                        "maxValue": 100,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 68,
+                        "type": "0000008F-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 2,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": true,
+                        "minValue": 0,
+                        "maxValue": 2,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 70,
+                        "type": "00000079-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": true,
+                        "minValue": 0,
+                        "maxValue": 1,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 66,
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE Shade",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "aid": 3,
+        "services": [
+            {
+                "iid": 1,
+                "type": "0000003E-0000-1000-8000-0026BB765291",
+                "primary": false,
+                "hidden": false,
+                "linked": [],
+                "characteristics": [
+                    {
+                        "iid": 2,
+                        "type": "00000014-0000-1000-8000-0026BB765291",
+                        "format": "bool",
+                        "perms": [
+                            "pw"
+                        ]
+                    },
+                    {
+                        "iid": 3,
+                        "type": "00000020-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE Inc.",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 4,
+                        "type": "00000021-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE Shade",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 5,
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE SmartShade",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 6,
+                        "type": "00000030-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 7,
+                        "type": "00000052-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 8,
+                        "type": "00000053-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 11,
+                        "type": "000000A6-0000-1000-8000-0026BB765291",
+                        "format": "uint32",
+                        "value": 1,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": false,
+                        "minValue": 0,
+                        "maxValue": 1,
+                        "minStep": 1
+                    }
+                ]
+            },
+            {
+                "iid": 48,
+                "type": "0000008C-0000-1000-8000-0026BB765291",
+                "primary": true,
+                "hidden": false,
+                "linked": [
+                    64
+                ],
+                "characteristics": [
+                    {
+                        "iid": 52,
+                        "type": "0000007C-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 100,
+                        "perms": [
+                            "pr",
+                            "pw",
+                            "ev"
+                        ],
+                        "ev": false,
+                        "unit": "percentage",
+                        "minValue": 0,
+                        "maxValue": 100,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 53,
+                        "type": "0000006D-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 100,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": false,
+                        "unit": "percentage",
+                        "minValue": 0,
+                        "maxValue": 100,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 54,
+                        "type": "00000072-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 2,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": false,
+                        "minValue": 0,
+                        "maxValue": 2,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 50,
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE Shade",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    },
+                    {
+                        "iid": 55,
+                        "type": "00000024-0000-1000-8000-0026BB765291",
+                        "format": "bool",
+                        "value": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": false
+                    }
+                ]
+            },
+            {
+                "iid": 64,
+                "type": "00000096-0000-1000-8000-0026BB765291",
+                "primary": false,
+                "hidden": false,
+                "linked": [],
+                "characteristics": [
+                    {
+                        "iid": 67,
+                        "type": "00000068-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 100,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": false,
+                        "unit": "percentage",
+                        "minValue": 0,
+                        "maxValue": 100,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 68,
+                        "type": "0000008F-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 2,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": false,
+                        "minValue": 0,
+                        "maxValue": 2,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 70,
+                        "type": "00000079-0000-1000-8000-0026BB765291",
+                        "format": "uint8",
+                        "value": 0,
+                        "perms": [
+                            "pr",
+                            "ev"
+                        ],
+                        "ev": false,
+                        "minValue": 0,
+                        "maxValue": 1,
+                        "minStep": 1
+                    },
+                    {
+                        "iid": 66,
+                        "type": "00000023-0000-1000-8000-0026BB765291",
+                        "format": "string",
+                        "value": "RYSE Shade",
+                        "perms": [
+                            "pr"
+                        ],
+                        "ev": false
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Handle accessories without a serial number in homekit_controller.... and yes the device this fixes is somehow certified 😢 

Fixes:
```
            {
                "config_entries": [
                    "b4fd4f4d94378ac67f1e2cc5779c20c2"
                ],
                "connections": [],
                "identifiers": [
                    [
                        "homekit_controller",
                        "serial-number",
                        ""
                    ]
                ],
                "manufacturer": "RYSE Inc.",
                "model": "RYSE Shade",
                "name": "RYSE SmartShade",
                "sw_version": "",
                "entry_type": null,
                "id": "cfc23551c84c416476afe9bd6eb45007",
                "via_device_id": "44f86498995c935bede06372f44f2c3d",
                "area_id": null,
                "name_by_user": "Master Bath North",
                "disabled_by": null,
                "configuration_url": null
            },
```

There are still some more things to be sorted out with identifiers that are outside the scope of this PR.

1. Identifiers are now typed to two element tuples.  
2. Using the serial number as an identifier needs to be prefixed with the unique id of the pairing since serial numbers are not globally unique and may be the same for different devices/manufacturers.
3. Maybe it would be safer to always use `f"{self._accessory.unique_id}_{self._aid}"`?


The above two will need to be addressed in a future PR with a migration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
