### PR TITLE
Fix min_humidity and max_humidity in homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -14,8 +14,6 @@ from aiohomekit.model.services import ServicesTypes
 from aiohomekit.utils import clamp_enum_to_char
 
 from homeassistant.components.climate import (
-    DEFAULT_MAX_HUMIDITY,
-    DEFAULT_MIN_HUMIDITY,
     ClimateEntity,
 )
 from homeassistant.components.climate.const import (
@@ -487,14 +485,18 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
     @property
     def min_humidity(self):
         """Return the minimum humidity."""
-        char = self.service[CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET]
-        return char.minValue or DEFAULT_MIN_HUMIDITY
+        min_humidity = self.service[CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET].minValue
+        if min_humidity is not None:
+            return min_humidity
+        return super().min_humidity
 
     @property
     def max_humidity(self):
         """Return the maximum humidity."""
-        char = self.service[CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET]
-        return char.maxValue or DEFAULT_MAX_HUMIDITY
+        max_humidity = self.service[CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET].maxValue
+        if max_humidity is not None:
+            return super().max_humidity
+        return super().max_humidity
 
     @property
     def hvac_action(self):

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -13,9 +13,7 @@ from aiohomekit.model.characteristics import (
 from aiohomekit.model.services import ServicesTypes
 from aiohomekit.utils import clamp_enum_to_char
 
-from homeassistant.components.climate import (
-    ClimateEntity,
-)
+from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
     ATTR_TARGET_TEMP_HIGH,
@@ -485,7 +483,9 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
     @property
     def min_humidity(self):
         """Return the minimum humidity."""
-        min_humidity = self.service[CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET].minValue
+        min_humidity = self.service[
+            CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET
+        ].minValue
         if min_humidity is not None:
             return min_humidity
         return super().min_humidity
@@ -493,7 +493,9 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
     @property
     def max_humidity(self):
         """Return the maximum humidity."""
-        max_humidity = self.service[CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET].maxValue
+        max_humidity = self.service[
+            CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET
+        ].maxValue
         if max_humidity is not None:
             return max_humidity
         return super().max_humidity

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -495,7 +495,7 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
         """Return the maximum humidity."""
         max_humidity = self.service[CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET].maxValue
         if max_humidity is not None:
-            return super().max_humidity
+            return max_humidity
         return super().max_humidity
 
     @property


### PR DESCRIPTION
min_humidity and max_humidity were always returning the HA default values even when the device was sending it's own min and max humidity target values

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
