### PR TITLE
Return the real MAC address for LIFX bulbs with newer firmware

### DIFF
--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -457,21 +457,23 @@ class LIFXLight(LightEntity):
         self.postponed_update = None
         self.lock = asyncio.Lock()
 
+    def get_mac_addr(self):
+        """Increment the last byte of the mac address by one for FW>3.70."""
+        real_mac_addr = self.bulb.mac_addr
+        if AwesomeVersion(self.bulb.host_firmware_version) >= AwesomeVersion("3.70"):
+            octets = [int(octet, 16) for octet in self.bulb.mac_addr.split(":")]
+            octets[5] = (octets[5] + 1) % 256
+            real_mac_addr = ":".join(f"{octet:02x}" for octet in octets)
+        return real_mac_addr
+
     @property
     def device_info(self) -> DeviceInfo:
         """Return information about the device."""
         _map = aiolifx().products.product_map
 
-        # The last byte of the bulb MAC address is incremented by 1 in FW3.70 and higher
-        # In the case where the last byte is "ff", it rolls back to 00
-        if AwesomeVersion(self.bulb.host_firmware_version) >= AwesomeVersion("3.70"):
-            octets = [int(octet, 16) for octet in self.bulb.mac_addr.split(":")]
-            octets[5] = (octets[5] + 1) % 256
-            self.real_mac_addr = ":".join(f"{octet:02x}" for octet in octets)
-
         info = DeviceInfo(
             identifiers={(LIFX_DOMAIN, self.unique_id)},
-            connections={(dr.CONNECTION_NETWORK_MAC, self.real_mac_addr)},
+            connections={(dr.CONNECTION_NETWORK_MAC, self.get_mac_addr())},
             manufacturer="LIFX",
             name=self.name,
         )

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -67,6 +67,8 @@ MESSAGE_TIMEOUT = 1.0
 MESSAGE_RETRIES = 8
 UNAVAILABLE_GRACE = 90
 
+FIX_MAC_FW = AwesomeVersion("3.70")
+
 SERVICE_LIFX_SET_STATE = "set_state"
 
 ATTR_INFRARED = "infrared"
@@ -460,7 +462,10 @@ class LIFXLight(LightEntity):
     def get_mac_addr(self):
         """Increment the last byte of the mac address by one for FW>3.70."""
         real_mac_addr = self.bulb.mac_addr
-        if AwesomeVersion(self.bulb.host_firmware_version) >= AwesomeVersion("3.70"):
+        if (
+            self.bulb.host_firmware_version
+            and AwesomeVersion(self.bulb.host_firmware_version) >= FIX_MAC_FW
+        ):
             octets = [int(octet, 16) for octet in self.bulb.mac_addr.split(":")]
             octets[5] = (octets[5] + 1) % 256
             real_mac_addr = ":".join(f"{octet:02x}" for octet in octets)

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -453,7 +453,6 @@ class LIFXLight(LightEntity):
     def __init__(self, bulb, effects_conductor):
         """Initialize the light."""
         self.bulb = bulb
-        self.real_mac_addr = self.bulb.mac_addr
         self.effects_conductor = effects_conductor
         self.registered = True
         self.postponed_update = None
@@ -461,15 +460,14 @@ class LIFXLight(LightEntity):
 
     def get_mac_addr(self):
         """Increment the last byte of the mac address by one for FW>3.70."""
-        real_mac_addr = self.bulb.mac_addr
         if (
             self.bulb.host_firmware_version
             and AwesomeVersion(self.bulb.host_firmware_version) >= FIX_MAC_FW
         ):
             octets = [int(octet, 16) for octet in self.bulb.mac_addr.split(":")]
             octets[5] = (octets[5] + 1) % 256
-            real_mac_addr = ":".join(f"{octet:02x}" for octet in octets)
-        return real_mac_addr
+            return ":".join(f"{octet:02x}" for octet in octets)
+        return self.bulb.mac_addr
 
     @property
     def device_info(self) -> DeviceInfo:


### PR DESCRIPTION
Signed-off-by: Avi Miller <me@dje.li>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
LIFX introduced a change in firmware 3.70 that resulted in the serial number used by the LIFX LAN protocol no longer being the mac address. This broke the connection between integrations that use MAC address identifiers. This PR fixes that by calculating the correct mac address for bulbs running firmware 3.70 or higher for the bulb's entry in the device registry. 

Also resolves a bug introduced in #58312 which made all LIFX
bulbs get the the model name "True".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #57457
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
