### PR TITLE
A few RFLink tests 

### DIFF
--- a/tests/components/rflink/test_init.py
+++ b/tests/components/rflink/test_init.py
@@ -10,13 +10,20 @@ from homeassistant.components.rflink import (
     CONF_KEEPALIVE_IDLE,
     CONF_RECONNECT_INTERVAL,
     DATA_ENTITY_LOOKUP,
+    DOMAIN as RFLINK_DOMAIN,
     EVENT_KEY_COMMAND,
     EVENT_KEY_SENSOR,
     SERVICE_SEND_COMMAND,
     TMP_ENTITY,
     RflinkCommand,
 )
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_STOP_COVER, SERVICE_TURN_OFF
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_HOST,
+    CONF_PORT,
+    SERVICE_STOP_COVER,
+    SERVICE_TURN_OFF,
+)
 
 
 async def mock_rflink(
@@ -386,11 +393,11 @@ async def test_not_connected(hass, monkeypatch):
 async def test_keepalive(hass, monkeypatch, caplog):
     """Validate negative keepalive values."""
     keepalive_value = -3
-    domain = "rflink"
+    domain = RFLINK_DOMAIN
     config = {
-        "rflink": {
-            "host": "10.10.0.1",
-            "port": 1234,
+        RFLINK_DOMAIN: {
+            CONF_HOST: "10.10.0.1",
+            CONF_PORT: 1234,
             CONF_KEEPALIVE_IDLE: keepalive_value,
         }
     }
@@ -406,11 +413,11 @@ async def test_keepalive(hass, monkeypatch, caplog):
 async def test2_keepalive(hass, monkeypatch, caplog):
     """Validate very short keepalive values."""
     keepalive_value = 30
-    domain = "rflink"
+    domain = RFLINK_DOMAIN
     config = {
-        "rflink": {
-            "host": "10.10.0.1",
-            "port": 1234,
+        RFLINK_DOMAIN: {
+            CONF_HOST: "10.10.0.1",
+            CONF_PORT: 1234,
             CONF_KEEPALIVE_IDLE: keepalive_value,
         }
     }
@@ -425,8 +432,10 @@ async def test2_keepalive(hass, monkeypatch, caplog):
 
 async def test3_keepalive(hass, monkeypatch, caplog):
     """Validate keepalive=0 value."""
-    domain = "rflink"
-    config = {"rflink": {"host": "10.10.0.1", "port": 1234, CONF_KEEPALIVE_IDLE: 0}}
+    domain = RFLINK_DOMAIN
+    config = {
+        RFLINK_DOMAIN: {CONF_HOST: "10.10.0.1", CONF_PORT: 1234, CONF_KEEPALIVE_IDLE: 0}
+    }
 
     # setup mocking rflink module
     _, _, _, _ = await mock_rflink(hass, config, domain, monkeypatch)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add a few tests for full coverage of RFLink integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
It would be great to be able to access to the `keepalive` connection's value, but 
It would have been great to access to the `keepalive` connection's value, but I haven't been able to get it. Any help in this regard would be welcome.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
