### PR TITLE
Add srp_energy cost sensor

### DIFF
--- a/homeassistant/components/srp_energy/__init__.py
+++ b/homeassistant/components/srp_energy/__init__.py
@@ -32,26 +32,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from ex
 
     # This creates each HA object for each platform your device requires.
-    # It's done by calling the `async_setup_entry` function in each platform module.
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in PLATFORMS
-            ]
-        )
-    )
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    # unload srp client
+    hass.data[DOMAIN] = None
+    # Remove config entry
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/srp_energy/__init__.py
+++ b/homeassistant/components/srp_energy/__init__.py
@@ -1,4 +1,5 @@
 """The SRP Energy integration."""
+import asyncio
 import logging
 
 from srpenergy.client import SrpEnergyClient
@@ -8,7 +9,7 @@ from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import SRP_ENERGY_DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,26 +19,39 @@ PLATFORMS = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the SRP Energy component from a config entry."""
-    # Store an SrpEnergyClient object for your srp_energy to access
+    hass.data.setdefault(DOMAIN, {})
     try:
         srp_energy_client = SrpEnergyClient(
             entry.data.get(CONF_ID),
             entry.data.get(CONF_USERNAME),
             entry.data.get(CONF_PASSWORD),
         )
-        hass.data[SRP_ENERGY_DOMAIN] = srp_energy_client
+        hass.data[DOMAIN][entry.entry_id] = srp_energy_client
     except (Exception) as ex:
         _LOGGER.error("Unable to connect to Srp Energy: %s", str(ex))
         raise ConfigEntryNotReady from ex
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    # This creates each HA object for each platform your device requires.
+    # It's done by calling the `async_setup_entry` function in each platform module.
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    # unload srp client
-    hass.data[SRP_ENERGY_DOMAIN] = None
-    # Remove config entry
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/srp_energy/config_flow.py
+++ b/homeassistant/components/srp_energy/config_flow.py
@@ -7,12 +7,12 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 
-from .const import CONF_IS_TOU, DEFAULT_NAME, SRP_ENERGY_DOMAIN
+from .const import CONF_IS_TOU, DEFAULT_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class ConfigFlow(config_entries.ConfigFlow, domain=SRP_ENERGY_DOMAIN):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for SRP Energy."""
 
     VERSION = 1

--- a/homeassistant/components/srp_energy/const.py
+++ b/homeassistant/components/srp_energy/const.py
@@ -1,7 +1,15 @@
 """Constants for the SRP Energy integration."""
 from datetime import timedelta
 
-SRP_ENERGY_DOMAIN = "srp_energy"
+from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING
+from homeassistant.const import (
+    CURRENCY_DOLLAR,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_MONETARY,
+    ENERGY_KILO_WATT_HOUR,
+)
+
+DOMAIN = "srp_energy"
 DEFAULT_NAME = "SRP Energy"
 
 CONF_IS_TOU = "is_tou"
@@ -9,7 +17,31 @@ CONF_IS_TOU = "is_tou"
 ATTRIBUTION = "Powered by SRP Energy"
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1440)
 
-SENSOR_NAME = "Usage"
-SENSOR_TYPE = "usage"
+SOURCE_TYPE_USAGE = "usage"
+SOURCE_TYPE_COST = "cost"
 
-ICON = "mdi:flash"
+SENSOR_TYPE_THIS_DAY = "thisDay"
+SENSOR_TYPE_THIS_WEEK = "thisWeek"
+
+SENSORS_INFO = [
+    {
+        "name": f"{DEFAULT_NAME} Costs",
+        "device_class": DEVICE_CLASS_MONETARY,
+        "unit_of_measurement": CURRENCY_DOLLAR,
+        "source_type": SOURCE_TYPE_COST,
+        "sensor_type": SENSOR_TYPE_THIS_DAY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+        "icon": "mdi:cash",
+        "precision": 3,
+    },
+    {
+        "name": f"{DEFAULT_NAME} Usage",
+        "device_class": DEVICE_CLASS_ENERGY,
+        "unit_of_measurement": ENERGY_KILO_WATT_HOUR,
+        "source_type": SOURCE_TYPE_USAGE,
+        "sensor_type": SENSOR_TYPE_THIS_DAY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+        "icon": "mdi:flash",
+        "precision": 3,
+    },
+]

--- a/homeassistant/components/srp_energy/manifest.json
+++ b/homeassistant/components/srp_energy/manifest.json
@@ -3,7 +3,7 @@
   "name": "SRP Energy",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/srp_energy",
-  "requirements": ["srpenergy==1.3.2"],
+  "requirements": ["srpenergy==1.3.5"],
   "codeowners": ["@briglx"],
   "iot_class": "cloud_polling",
   "loggers": ["srpenergy"]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2272,7 +2272,7 @@ spotipy==2.19.0
 sqlalchemy==1.4.27
 
 # homeassistant.components.srp_energy
-srpenergy==1.3.2
+srpenergy==1.3.5
 
 # homeassistant.components.starline
 starline==0.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1405,7 +1405,7 @@ spotipy==2.19.0
 sqlalchemy==1.4.27
 
 # homeassistant.components.srp_energy
-srpenergy==1.3.2
+srpenergy==1.3.5
 
 # homeassistant.components.starline
 starline==0.1.5

--- a/tests/components/srp_energy/__init__.py
+++ b/tests/components/srp_energy/__init__.py
@@ -35,7 +35,7 @@ async def init_integration(
         options = ENTRY_OPTIONS
 
     config_entry = MockConfigEntry(
-        domain=srp_energy.SRP_ENERGY_DOMAIN,
+        domain=srp_energy.DOMAIN,
         source=source,
         data=config,
         options=options,

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -2,7 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.srp_energy.const import CONF_IS_TOU, SRP_ENERGY_DOMAIN
+from homeassistant.components.srp_energy.const import CONF_IS_TOU, DOMAIN
 
 from . import ENTRY_CONFIG, init_integration
 
@@ -11,7 +11,7 @@ async def test_form(hass):
     """Test user config."""
     # First get the form
     result = await hass.config_entries.flow.async_init(
-        SRP_ENERGY_DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
@@ -40,7 +40,7 @@ async def test_form(hass):
 async def test_form_invalid_auth(hass):
     """Test user config with invalid auth."""
     result = await hass.config_entries.flow.async_init(
-        SRP_ENERGY_DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
@@ -58,7 +58,7 @@ async def test_form_invalid_auth(hass):
 async def test_form_value_error(hass):
     """Test user config that throws a value error."""
     result = await hass.config_entries.flow.async_init(
-        SRP_ENERGY_DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
@@ -76,7 +76,7 @@ async def test_form_value_error(hass):
 async def test_form_unknown_exception(hass):
     """Test user config that throws an unknown exception."""
     result = await hass.config_entries.flow.async_init(
-        SRP_ENERGY_DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
@@ -100,7 +100,7 @@ async def test_config(hass):
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
-            SRP_ENERGY_DOMAIN,
+            DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},
             data=ENTRY_CONFIG,
         )
@@ -114,7 +114,7 @@ async def test_integration_already_configured(hass):
     """Test integration is already configured."""
     await init_integration(hass)
     result = await hass.config_entries.flow.async_init(
-        SRP_ENERGY_DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "single_instance_allowed"

--- a/tests/components/srp_energy/test_init.py
+++ b/tests/components/srp_energy/test_init.py
@@ -1,27 +1,26 @@
 """Tests for Srp Energy component Init."""
-from homeassistant import config_entries
 from homeassistant.components import srp_energy
 
 from tests.components.srp_energy import init_integration
 
 
-async def test_setup_entry(hass):
-    """Test setup entry fails if deCONZ is not available."""
+async def test_setup(hass):
+    """Test for successfully setting up the platform."""
     config_entry = await init_integration(hass)
-    assert config_entry.state == config_entries.ConfigEntryState.LOADED
-    assert hass.data[srp_energy.SRP_ENERGY_DOMAIN]
+    assert srp_energy.DOMAIN in hass.config.components
+    assert config_entry.entry_id in hass.data[srp_energy.DOMAIN]
 
 
 async def test_unload_entry(hass):
     """Test being able to unload an entry."""
     config_entry = await init_integration(hass)
-    assert hass.data[srp_energy.SRP_ENERGY_DOMAIN]
+    assert hass.data[srp_energy.DOMAIN]
 
     assert await srp_energy.async_unload_entry(hass, config_entry)
-    assert not hass.data[srp_energy.SRP_ENERGY_DOMAIN]
+    assert not hass.data[srp_energy.DOMAIN]
 
 
 async def test_async_setup_entry_with_exception(hass):
     """Test exception when SrpClient can't load."""
     await init_integration(hass, side_effect=Exception())
-    assert srp_energy.SRP_ENERGY_DOMAIN not in hass.data
+    assert hass.data[srp_energy.DOMAIN] == {}

--- a/tests/components/srp_energy/test_sensor.py
+++ b/tests/components/srp_energy/test_sensor.py
@@ -1,136 +1,187 @@
 """Tests for the srp_energy sensor platform."""
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.components.srp_energy.const import (
-    ATTRIBUTION,
-    DEFAULT_NAME,
-    ICON,
-    SENSOR_NAME,
-    SENSOR_TYPE,
-    SRP_ENERGY_DOMAIN,
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    STATE_CLASS_TOTAL_INCREASING,
 )
-from homeassistant.components.srp_energy.sensor import SrpEntity, async_setup_entry
-from homeassistant.const import ATTR_ATTRIBUTION, ENERGY_KILO_WATT_HOUR
+from homeassistant.components.srp_energy.const import CONF_IS_TOU, DOMAIN, SENSORS_INFO
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_ID,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CURRENCY_DOLLAR,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_MONETARY,
+    ENERGY_KILO_WATT_HOUR,
+)
+
+from tests.common import MockConfigEntry
+
+sample_usage = [
+    ("9/19/2018", "12:00 AM", "2018-09-19T00:00:00-7:00", "1.2", "0.17"),
+    ("9/19/2018", "1:00 AM", "2018-09-19T01:00:00-7:00", "2.1", "0.30"),
+    ("9/19/2018", "2:00 AM", "2018-09-19T02:00:00-7:00", "1.5", "0.23"),
+    ("9/19/2018", "9:00 PM", "2018-09-19T21:00:00-7:00", "1.2", "0.19"),
+    ("9/19/2018", "10:00 PM", "2018-09-19T22:00:00-7:00", "1.1", "0.18"),
+    ("9/19/2018", "11:00 PM", "2018-09-19T23:00:00-7:00", "0.4", "0.09"),
+]
 
 
-async def test_async_setup_entry(hass):
-    """Test the sensor."""
-    fake_async_add_entities = MagicMock()
-    fake_srp_energy_client = MagicMock()
-    fake_srp_energy_client.usage.return_value = [{1, 2, 3, 1.999, 4}]
-    fake_config = MagicMock(
-        data={
-            "name": "SRP Energy",
-            "is_tou": False,
-            "id": "0123456789",
-            "username": "testuser@example.com",
-            "password": "mypassword",
-        }
-    )
-    hass.data[SRP_ENERGY_DOMAIN] = fake_srp_energy_client
+async def test_setup_entry(hass):
+    """Test for successfully setting up the platform."""
+    with patch(
+        "srpenergy.client.SrpEnergyClient.usage", return_value=sample_usage
+    ), patch(
+        "homeassistant.components.srp_energy.SrpEnergyClient.usage",
+        return_value=sample_usage,
+    ):
 
-    await async_setup_entry(hass, fake_config, fake_async_add_entities)
+        hass.config.components.add(DOMAIN)
+        config_entry = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="userId",
+            data={
+                CONF_NAME: "Test",
+                CONF_ID: "123456789",
+                CONF_USERNAME: "abba",
+                CONF_PASSWORD: "ana",
+                CONF_IS_TOU: False,
+            },
+            source="test",
+        )
+        config_entry.add_to_hass(hass)
+
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert DOMAIN in hass.config.components
+
+        # Assert data is loaded for usage
+        current_usage = hass.states.get("sensor.srp_energy_usage")
+        assert current_usage.state == "7.5"
+        assert current_usage.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_ENERGY
+        assert (
+            current_usage.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            == ENERGY_KILO_WATT_HOUR
+        )
+        assert (
+            current_usage.attributes.get(ATTR_STATE_CLASS)
+            == STATE_CLASS_TOTAL_INCREASING
+        )
+        assert current_usage.attributes.get(ATTR_FRIENDLY_NAME) == "SRP Energy Usage"
+        assert current_usage.attributes.get(ATTR_ICON) == "mdi:flash"
+
+        # Assert data is loaded for cost
+        current_costs = hass.states.get("sensor.srp_energy_costs")
+        assert current_costs.state == "1.16"
+        assert current_costs.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_MONETARY
+        assert current_costs.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == CURRENCY_DOLLAR
+        assert (
+            current_costs.attributes.get(ATTR_STATE_CLASS)
+            == STATE_CLASS_TOTAL_INCREASING
+        )
+        assert current_costs.attributes.get(ATTR_FRIENDLY_NAME) == "SRP Energy Costs"
+        assert current_costs.attributes.get(ATTR_ICON) == "mdi:cash"
 
 
 async def test_async_setup_entry_timeout_error(hass):
     """Test fetching usage data. Failed the first time because was too get response."""
-    fake_async_add_entities = MagicMock()
-    fake_srp_energy_client = MagicMock()
-    fake_srp_energy_client.usage.return_value = [{1, 2, 3, 1.999, 4}]
-    fake_config = MagicMock(
-        data={
-            "name": "SRP Energy",
-            "is_tou": False,
-            "id": "0123456789",
-            "username": "testuser@example.com",
-            "password": "mypassword",
-        }
-    )
-    hass.data[SRP_ENERGY_DOMAIN] = fake_srp_energy_client
-    fake_srp_energy_client.usage.side_effect = TimeoutError()
+    with patch(
+        "srpenergy.client.SrpEnergyClient.usage", side_effect=TimeoutError()
+    ), patch(
+        "homeassistant.components.srp_energy.SrpEnergyClient.usage",
+        side_effect=TimeoutError(),
+    ):
+        hass.config.components.add(DOMAIN)
+        config_entry = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="userId",
+            data={
+                CONF_NAME: "Test",
+                CONF_ID: "123456789",
+                CONF_USERNAME: "abba",
+                CONF_PASSWORD: "ana",
+                CONF_IS_TOU: False,
+            },
+            source="test",
+        )
+        config_entry.add_to_hass(hass)
 
-    await async_setup_entry(hass, fake_config, fake_async_add_entities)
-    assert not fake_async_add_entities.call_args[0][0][
-        0
-    ].coordinator.last_update_success
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert DOMAIN in hass.config.components
 
 
 async def test_async_setup_entry_connect_error(hass):
     """Test fetching usage data. Failed the first time because was too get response."""
-    fake_async_add_entities = MagicMock()
-    fake_srp_energy_client = MagicMock()
-    fake_srp_energy_client.usage.return_value = [{1, 2, 3, 1.999, 4}]
-    fake_config = MagicMock(
-        data={
-            "name": "SRP Energy",
-            "is_tou": False,
-            "id": "0123456789",
-            "username": "testuser@example.com",
-            "password": "mypassword",
-        }
-    )
-    hass.data[SRP_ENERGY_DOMAIN] = fake_srp_energy_client
-    fake_srp_energy_client.usage.side_effect = ValueError()
+    with patch(
+        "srpenergy.client.SrpEnergyClient.usage", side_effect=ValueError()
+    ), patch(
+        "homeassistant.components.srp_energy.SrpEnergyClient.usage",
+        side_effect=ValueError(),
+    ):
+        hass.config.components.add(DOMAIN)
+        config_entry = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="userId",
+            data={
+                CONF_NAME: "SRP Energy Test",
+                CONF_ID: "123456789",
+                CONF_USERNAME: "abba",
+                CONF_PASSWORD: "ana",
+                CONF_IS_TOU: False,
+            },
+            source="test",
+        )
+        config_entry.add_to_hass(hass)
 
-    await async_setup_entry(hass, fake_config, fake_async_add_entities)
-    assert not fake_async_add_entities.call_args[0][0][
-        0
-    ].coordinator.last_update_success
-
-
-async def test_srp_entity(hass):
-    """Test the SrpEntity."""
-    fake_coordinator = MagicMock(data=1.99999999999)
-    srp_entity = SrpEntity(fake_coordinator)
-    srp_entity.hass = hass
-
-    assert srp_entity is not None
-    assert srp_entity.name == f"{DEFAULT_NAME} {SENSOR_NAME}"
-    assert srp_entity.unique_id == SENSOR_TYPE
-    assert srp_entity.state is None
-    assert srp_entity.unit_of_measurement == ENERGY_KILO_WATT_HOUR
-    assert srp_entity.icon == ICON
-    assert srp_entity.usage == "2.00"
-    assert srp_entity.should_poll is False
-    assert srp_entity.extra_state_attributes[ATTR_ATTRIBUTION] == ATTRIBUTION
-    assert srp_entity.available is not None
-    assert srp_entity.device_class is SensorDeviceClass.ENERGY
-    assert srp_entity.state_class is SensorStateClass.TOTAL_INCREASING
-
-    await srp_entity.async_added_to_hass()
-    assert srp_entity.state is not None
-    assert fake_coordinator.async_add_listener.called
-    assert not fake_coordinator.async_add_listener.data.called
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert DOMAIN in hass.config.components
 
 
-async def test_srp_entity_no_data(hass):
-    """Test the SrpEntity."""
-    fake_coordinator = MagicMock(data=False)
-    srp_entity = SrpEntity(fake_coordinator)
-    srp_entity.hass = hass
-    assert srp_entity.extra_state_attributes is None
+async def test_srp_entity_missing_type(hass):
+    """Test the SrpEntity when type is missing."""
+    with patch("srpenergy.client.SrpEnergyClient.usage"):
+        SENSORS_INFO.append(
+            {
+                "name": "Test Costs",
+                "device_class": DEVICE_CLASS_MONETARY,
+                "unit_of_measurement": CURRENCY_DOLLAR,
+                "source_type": "Abba",
+                "sensor_type": "Dabba",
+                "state_class": STATE_CLASS_TOTAL_INCREASING,
+                "icon": "mdi:cash",
+                "precision": 3,
+            }
+        )
+        hass.config.components.add(DOMAIN)
+        config_entry = MockConfigEntry(
+            version=1,
+            domain=DOMAIN,
+            title="userId",
+            data={
+                CONF_NAME: "Test",
+                CONF_ID: "123456789",
+                CONF_USERNAME: "abba",
+                CONF_PASSWORD: "ana",
+                CONF_IS_TOU: False,
+            },
+            source="test",
+        )
+        config_entry.add_to_hass(hass)
 
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert DOMAIN in hass.config.components
 
-async def test_srp_entity_no_coord_data(hass):
-    """Test the SrpEntity."""
-    fake_coordinator = MagicMock(data=False)
-    srp_entity = SrpEntity(fake_coordinator)
-    srp_entity.hass = hass
-
-    assert srp_entity.usage is None
-
-
-async def test_srp_entity_async_update(hass):
-    """Test the SrpEntity."""
-
-    async def async_magic():
-        pass
-
-    MagicMock.__await__ = lambda x: async_magic().__await__()
-    fake_coordinator = MagicMock(data=False)
-    srp_entity = SrpEntity(fake_coordinator)
-    srp_entity.hass = hass
-
-    await srp_entity.async_update()
-    assert fake_coordinator.async_request_refresh.called
+        current_costs = hass.states.get("sensor.test_costs")
+        assert current_costs.state == "unavailable"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Renamed sensor to be more descriptive between the usage sensor and the cost sensor.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Create a new cost sensor for the srp_energy integration.
Fulfills feature request https://github.com/home-assistant/home-assistant.io/issues/19598

Change energy sensor `state_class` to `total_increasing` and aggregate data starting from the beginning of the month.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

Updated dependency srpenergy  from 1.3.2 to 1.3.5

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] 
https://github.com/home-assistant/home-assistant.io/pull/20023

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
