### PR TITLE
Bump hatasmota to 0.3.0

### DIFF
--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     websocket_api.async_register_command(hass, websocket_remove_device)
     hass.data[DATA_UNSUB] = []
 
-    def _publish(
+    async def _publish(
         topic: str,
         payload: mqtt.PublishPayloadType,
         qos: int | None = None,
@@ -75,9 +75,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     device_registry = await hass.helpers.device_registry.async_get_registry()
 
-    def async_discover_device(config: TasmotaDeviceConfig, mac: str) -> None:
+    async def async_discover_device(config: TasmotaDeviceConfig, mac: str) -> None:
         """Discover and add a Tasmota device."""
-        async_setup_device(hass, mac, config, entry, tasmota_mqtt, device_registry)
+        await async_setup_device(
+            hass, mac, config, entry, tasmota_mqtt, device_registry
+        )
 
     async def async_device_removed(event: Event) -> None:
         """Handle the removal of a device."""
@@ -92,7 +94,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         macs = [c[1] for c in device.connections if c[0] == CONNECTION_NETWORK_MAC]
         for mac in macs:
-            clear_discovery_topic(mac, entry.data[CONF_DISCOVERY_PREFIX], tasmota_mqtt)
+            await clear_discovery_topic(
+                mac, entry.data[CONF_DISCOVERY_PREFIX], tasmota_mqtt
+            )
 
     hass.data[DATA_UNSUB].append(
         hass.bus.async_listen(EVENT_DEVICE_REGISTRY_UPDATED, async_device_removed)
@@ -143,7 +147,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-def _remove_device(
+async def _remove_device(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     mac: str,
@@ -158,7 +162,9 @@ def _remove_device(
 
     _LOGGER.debug("Removing tasmota device %s", mac)
     device_registry.async_remove_device(device.id)
-    clear_discovery_topic(mac, config_entry.data[CONF_DISCOVERY_PREFIX], tasmota_mqtt)
+    await clear_discovery_topic(
+        mac, config_entry.data[CONF_DISCOVERY_PREFIX], tasmota_mqtt
+    )
 
 
 def _update_device(
@@ -180,7 +186,7 @@ def _update_device(
     )
 
 
-def async_setup_device(
+async def async_setup_device(
     hass: HomeAssistant,
     mac: str,
     config: TasmotaDeviceConfig,
@@ -190,7 +196,7 @@ def async_setup_device(
 ) -> None:
     """Set up the Tasmota device."""
     if not config:
-        _remove_device(hass, config_entry, mac, tasmota_mqtt, device_registry)
+        await _remove_device(hass, config_entry, mac, tasmota_mqtt, device_registry)
     else:
         _update_device(hass, config_entry, config, device_registry)
 

--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -52,14 +52,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def _publish(
         topic: str,
         payload: mqtt.PublishPayloadType,
-        qos: int | None = None,
-        retain: bool | None = None,
+        qos: int | None,
+        retain: bool | None,
     ) -> None:
-        if qos is None:
-            qos = 0
-        if retain is None:
-            retain = False
-        hass.async_create_task(mqtt.async_publish(hass, topic, payload, qos, retain))
+        await mqtt.async_publish(hass, topic, payload, qos, retain)
 
     async def _subscribe_topics(sub_state: dict | None, topics: dict) -> dict:
         # Optionally mark message handlers as callback

--- a/homeassistant/components/tasmota/cover.py
+++ b/homeassistant/components/tasmota/cover.py
@@ -111,17 +111,17 @@ class TasmotaCover(
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        self._tasmota_entity.open()
+        await self._tasmota_entity.open()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        self._tasmota_entity.close()
+        await self._tasmota_entity.close()
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position = kwargs[cover.ATTR_POSITION]
-        self._tasmota_entity.set_position(position)
+        await self._tasmota_entity.set_position(position)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        self._tasmota_entity.stop()
+        await self._tasmota_entity.stop()

--- a/homeassistant/components/tasmota/discovery.py
+++ b/homeassistant/components/tasmota/discovery.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable
+from typing import Awaitable, Callable
 
 from hatasmota.discovery import (
     TasmotaDiscovery,
@@ -34,7 +34,7 @@ TASMOTA_DISCOVERY_ENTITY_NEW = "tasmota_discovery_entity_new_{}"
 TASMOTA_DISCOVERY_ENTITY_UPDATED = "tasmota_discovery_entity_updated_{}_{}_{}_{}"
 TASMOTA_DISCOVERY_INSTANCE = "tasmota_discovery_instance"
 
-SetupDeviceCallback = Callable[[TasmotaDeviceConfig, str], None]
+SetupDeviceCallback = Callable[[TasmotaDeviceConfig, str], Awaitable[None]]
 
 
 def clear_discovery_hash(
@@ -119,7 +119,7 @@ async def async_start(
 
         _LOGGER.debug("Received discovery data for tasmota device: %s", mac)
         tasmota_device_config = tasmota_get_device_config(payload)
-        setup_device(tasmota_device_config, mac)
+        await setup_device(tasmota_device_config, mac)
 
         if not payload:
             return

--- a/homeassistant/components/tasmota/fan.py
+++ b/homeassistant/components/tasmota/fan.py
@@ -109,7 +109,7 @@ class TasmotaFan(
             tasmota_speed = percentage_to_ordered_list_item(
                 ORDERED_NAMED_FAN_SPEEDS, percentage
             )
-            self._tasmota_entity.set_speed(tasmota_speed)
+            await self._tasmota_entity.set_speed(tasmota_speed)
 
     async def async_turn_on(
         self,
@@ -129,4 +129,4 @@ class TasmotaFan(
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
-        self._tasmota_entity.set_speed(tasmota_const.FAN_SPEED_OFF)
+        await self._tasmota_entity.set_speed(tasmota_const.FAN_SPEED_OFF)

--- a/homeassistant/components/tasmota/light.py
+++ b/homeassistant/components/tasmota/light.py
@@ -275,7 +275,7 @@ class TasmotaLight(
         if ATTR_EFFECT in kwargs:
             attributes["effect"] = kwargs[ATTR_EFFECT]
 
-        self._tasmota_entity.set_state(True, attributes)
+        await self._tasmota_entity.set_state(True, attributes)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
@@ -284,4 +284,4 @@ class TasmotaLight(
         if ATTR_TRANSITION in kwargs:
             attributes["transition"] = kwargs[ATTR_TRANSITION]
 
-        self._tasmota_entity.set_state(False, attributes)
+        await self._tasmota_entity.set_state(False, attributes)

--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.2.21"],
+  "requirements": ["hatasmota==0.3.0"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"],

--- a/homeassistant/components/tasmota/mixins.py
+++ b/homeassistant/components/tasmota/mixins.py
@@ -123,10 +123,9 @@ class TasmotaAvailability(TasmotaEntity):
         )
         await super().async_added_to_hass()
 
-    @callback
-    def availability_updated(self, available: bool) -> None:
+    async def availability_updated(self, available: bool) -> None:
         """Handle updated availability."""
-        self._tasmota_entity.poll_status()
+        await self._tasmota_entity.poll_status()
         self._available = available
         self.async_write_ha_state()
 

--- a/homeassistant/components/tasmota/switch.py
+++ b/homeassistant/components/tasmota/switch.py
@@ -58,8 +58,8 @@ class TasmotaSwitch(
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        self._tasmota_entity.set_state(True)
+        await self._tasmota_entity.set_state(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        self._tasmota_entity.set_state(False)
+        await self._tasmota_entity.set_state(False)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -786,7 +786,7 @@ hass-nabucasa==0.50.0
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.2.21
+hatasmota==0.3.0
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -482,7 +482,7 @@ hangups==0.4.14
 hass-nabucasa==0.50.0
 
 # homeassistant.components.tasmota
-hatasmota==0.2.21
+hatasmota==0.3.0
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.4

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -56,6 +56,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -121,6 +122,7 @@ async def test_controlling_state_via_mqtt_switchname(hass, mqtt_mock, setup_tasm
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.custom_name")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -179,6 +181,7 @@ async def test_pushon_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota)
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)

--- a/tests/components/tasmota/test_common.py
+++ b/tests/components/tasmota/test_common.py
@@ -130,7 +130,7 @@ async def help_test_availability_when_connection_lost(
         get_topic_tele_will(config),
         config_get_state_online(config),
     )
-
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state.state != STATE_UNAVAILABLE
 
@@ -158,6 +158,7 @@ async def help_test_availability_when_connection_lost(
         get_topic_tele_will(config),
         config_get_state_online(config),
     )
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state.state != STATE_UNAVAILABLE
 
@@ -196,7 +197,7 @@ async def help_test_availability(
         get_topic_tele_will(config),
         config_get_state_online(config),
     )
-
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state.state != STATE_UNAVAILABLE
 
@@ -205,7 +206,7 @@ async def help_test_availability(
         get_topic_tele_will(config),
         config_get_state_offline(config),
     )
-
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state.state == STATE_UNAVAILABLE
 
@@ -258,10 +259,12 @@ async def help_test_availability_discovery_update(
     assert state.state == STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, availability_topic1, online1)
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state.state != STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, availability_topic1, offline1)
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state.state == STATE_UNAVAILABLE
 
@@ -273,11 +276,13 @@ async def help_test_availability_discovery_update(
     async_fire_mqtt_message(hass, availability_topic1, online1)
     async_fire_mqtt_message(hass, availability_topic1, online2)
     async_fire_mqtt_message(hass, availability_topic2, online1)
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state.state == STATE_UNAVAILABLE
 
     # Verify we are subscribing to the new topic
     async_fire_mqtt_message(hass, availability_topic2, online2)
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state.state != STATE_UNAVAILABLE
 
@@ -575,10 +580,12 @@ async def help_test_entity_id_update_discovery_update(
         await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, topic, config_get_state_online(config))
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state.state != STATE_UNAVAILABLE
 
     async_fire_mqtt_message(hass, topic, config_get_state_offline(config))
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.{entity_id}")
     assert state.state == STATE_UNAVAILABLE
 
@@ -597,5 +604,6 @@ async def help_test_entity_id_update_discovery_update(
 
     topic = get_topic_tele_will(config)
     async_fire_mqtt_message(hass, topic, config_get_state_online(config))
+    await hass.async_block_till_done()
     state = hass.states.get(f"{domain}.milk")
     assert state.state != STATE_UNAVAILABLE

--- a/tests/components/tasmota/test_cover.py
+++ b/tests/components/tasmota/test_cover.py
@@ -53,6 +53,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == STATE_UNKNOWN
     assert (
@@ -215,6 +216,7 @@ async def test_controlling_state_via_mqtt_inverted(hass, mqtt_mock, setup_tasmot
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("cover.tasmota_cover_1")
     assert state.state == STATE_UNKNOWN
     assert (
@@ -383,6 +385,7 @@ async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("cover.test_cover_1")
     assert state.state == STATE_UNKNOWN
     await hass.async_block_till_done()
@@ -446,6 +449,7 @@ async def test_sending_mqtt_commands_inverted(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("cover.test_cover_1")
     assert state.state == STATE_UNKNOWN
     await hass.async_block_till_done()

--- a/tests/components/tasmota/test_fan.py
+++ b/tests/components/tasmota/test_fan.py
@@ -50,6 +50,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_OFF
     assert state.attributes["percentage"] is None
@@ -101,6 +102,7 @@ async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()
@@ -167,6 +169,7 @@ async def test_invalid_fan_speed_percentage(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()

--- a/tests/components/tasmota/test_light.py
+++ b/tests/components/tasmota/test_light.py
@@ -46,6 +46,7 @@ async def test_attributes_on_off(hass, mqtt_mock, setup_tasmota):
     )
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"POWER":"ON"}')
 
     state = hass.states.get("light.test")
@@ -72,6 +73,7 @@ async def test_attributes_dimmer_tuya(hass, mqtt_mock, setup_tasmota):
     )
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"POWER":"ON"}')
 
     state = hass.states.get("light.test")
@@ -97,6 +99,7 @@ async def test_attributes_dimmer(hass, mqtt_mock, setup_tasmota):
     )
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"POWER":"ON"}')
 
     state = hass.states.get("light.test")
@@ -122,6 +125,7 @@ async def test_attributes_ct(hass, mqtt_mock, setup_tasmota):
     )
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"POWER":"ON"}')
 
     state = hass.states.get("light.test")
@@ -148,6 +152,7 @@ async def test_attributes_ct_reduced(hass, mqtt_mock, setup_tasmota):
     )
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"POWER":"ON"}')
 
     state = hass.states.get("light.test")
@@ -173,6 +178,7 @@ async def test_attributes_rgb(hass, mqtt_mock, setup_tasmota):
     )
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"POWER":"ON"}')
 
     state = hass.states.get("light.test")
@@ -207,6 +213,7 @@ async def test_attributes_rgbw(hass, mqtt_mock, setup_tasmota):
     )
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"POWER":"ON"}')
 
     state = hass.states.get("light.test")
@@ -241,6 +248,7 @@ async def test_attributes_rgbww(hass, mqtt_mock, setup_tasmota):
     )
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"POWER":"ON"}')
 
     state = hass.states.get("light.test")
@@ -276,6 +284,7 @@ async def test_attributes_rgbww_reduced(hass, mqtt_mock, setup_tasmota):
     )
     await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/STATE", '{"POWER":"ON"}')
 
     state = hass.states.get("light.test")
@@ -316,6 +325,7 @@ async def test_controlling_state_via_mqtt_on_off(hass, mqtt_mock, setup_tasmota)
     assert "color_mode" not in state.attributes
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -364,6 +374,7 @@ async def test_controlling_state_via_mqtt_ct(hass, mqtt_mock, setup_tasmota):
     assert "color_mode" not in state.attributes
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -426,6 +437,7 @@ async def test_controlling_state_via_mqtt_rgbw(hass, mqtt_mock, setup_tasmota):
     assert "color_mode" not in state.attributes
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -524,6 +536,7 @@ async def test_controlling_state_via_mqtt_rgbww(hass, mqtt_mock, setup_tasmota):
     assert "color_mode" not in state.attributes
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -625,6 +638,7 @@ async def test_controlling_state_via_mqtt_rgbww_tuya(hass, mqtt_mock, setup_tasm
     assert "color_mode" not in state.attributes
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -729,6 +743,7 @@ async def test_sending_mqtt_commands_on_off(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()
@@ -770,6 +785,7 @@ async def test_sending_mqtt_commands_rgbww_tuya(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()
@@ -817,6 +833,7 @@ async def test_sending_mqtt_commands_rgbw_legacy(hass, mqtt_mock, setup_tasmota)
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()
@@ -923,6 +940,7 @@ async def test_sending_mqtt_commands_rgbw(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()
@@ -1029,6 +1047,7 @@ async def test_sending_mqtt_commands_rgbww(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()
@@ -1114,6 +1133,7 @@ async def test_sending_mqtt_commands_power_unlinked(hass, mqtt_mock, setup_tasmo
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()
@@ -1164,6 +1184,7 @@ async def test_transition(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()
@@ -1345,6 +1366,7 @@ async def test_transition_fixed(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("light.test")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -155,6 +155,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert entry.entity_category is None
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("sensor.tasmota_dht11_temperature")
     assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -200,6 +201,7 @@ async def test_nested_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("sensor.tasmota_tx23_speed_act")
     assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -245,6 +247,7 @@ async def test_indexed_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("sensor.tasmota_energy_totaltariff_1")
     assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -293,6 +296,7 @@ async def test_indexed_sensor_state_via_mqtt2(hass, mqtt_mock, setup_tasmota):
     )
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("sensor.tasmota_energy_total")
     assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -343,6 +347,7 @@ async def test_indexed_sensor_state_via_mqtt3(hass, mqtt_mock, setup_tasmota):
     )
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("sensor.tasmota_energy_total_1")
     assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -396,6 +401,7 @@ async def test_bad_indexed_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota)
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("sensor.tasmota_energy_apparentpower_0")
     assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -507,6 +513,7 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("sensor.tasmota_status")
     assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -566,6 +573,7 @@ async def test_single_shot_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_t
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("sensor.tasmota_status")
     assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -650,6 +658,7 @@ async def test_restart_time_status_sensor_state_via_mqtt(
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("sensor.tasmota_status")
     assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -863,6 +872,7 @@ async def test_enable_status_sensor(hass, mqtt_mock, setup_tasmota):
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("sensor.tasmota_signal")
     assert state.state == STATE_UNKNOWN
     assert not state.attributes.get(ATTR_ASSUMED_STATE)

--- a/tests/components/tasmota/test_switch.py
+++ b/tests/components/tasmota/test_switch.py
@@ -48,6 +48,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("switch.test")
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
@@ -87,6 +88,7 @@ async def test_sending_mqtt_commands(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/LWT", "Online")
+    await hass.async_block_till_done()
     state = hass.states.get("switch.test")
     assert state.state == STATE_OFF
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump hatasmota from 0.2.21 to 0.3.0

This adapts hatasmota to the changed `mqtt.async_publish`, so some adjustments are needed in core too.

Changes:

- 0.3.0 (https://github.com/emontnemery/hatasmota/releases/tag/0.3.0)
   - Adapt to changed mqtt.async_publish in HA core 2021.12 [#122](https://github.com/emontnemery/hatasmota/pull/122)

Git compare: https://github.com/emontnemery/hatasmota/compare/0.2.21..0.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
