### PR TITLE
Add unique_id configuration variable to command_line integration

### DIFF
--- a/homeassistant/components/command_line/binary_sensor.py
+++ b/homeassistant/components/command_line/binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PAYLOAD_OFF,
     CONF_PAYLOAD_ON,
+    CONF_UNIQUE_ID,
     CONF_VALUE_TEMPLATE,
 )
 import homeassistant.helpers.config_validation as cv
@@ -38,6 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_COMMAND_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
 )
 
@@ -54,6 +56,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     device_class = config.get(CONF_DEVICE_CLASS)
     value_template = config.get(CONF_VALUE_TEMPLATE)
     command_timeout = config.get(CONF_COMMAND_TIMEOUT)
+    unique_id = config.get(CONF_UNIQUE_ID)
     if value_template is not None:
         value_template.hass = hass
     data = CommandSensorData(hass, command, command_timeout)
@@ -61,7 +64,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(
         [
             CommandBinarySensor(
-                hass, data, name, device_class, payload_on, payload_off, value_template
+                hass,
+                data,
+                name,
+                device_class,
+                payload_on,
+                payload_off,
+                value_template,
+                unique_id,
             )
         ],
         True,
@@ -72,7 +82,15 @@ class CommandBinarySensor(BinarySensorEntity):
     """Representation of a command line binary sensor."""
 
     def __init__(
-        self, hass, data, name, device_class, payload_on, payload_off, value_template
+        self,
+        hass,
+        data,
+        name,
+        device_class,
+        payload_on,
+        payload_off,
+        value_template,
+        unique_id,
     ):
         """Initialize the Command line binary sensor."""
         self._hass = hass
@@ -83,6 +101,7 @@ class CommandBinarySensor(BinarySensorEntity):
         self._payload_on = payload_on
         self._payload_off = payload_off
         self._value_template = value_template
+        self._attr_unique_id = unique_id
 
     @property
     def name(self):

--- a/homeassistant/components/command_line/cover.py
+++ b/homeassistant/components/command_line/cover.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     CONF_COMMAND_STOP,
     CONF_COVERS,
     CONF_FRIENDLY_NAME,
+    CONF_UNIQUE_ID,
     CONF_VALUE_TEMPLATE,
 )
 import homeassistant.helpers.config_validation as cv
@@ -30,6 +31,7 @@ COVER_SCHEMA = vol.Schema(
         vol.Optional(CONF_FRIENDLY_NAME): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_COMMAND_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
 )
 
@@ -61,6 +63,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 device_config.get(CONF_COMMAND_STATE),
                 value_template,
                 device_config[CONF_COMMAND_TIMEOUT],
+                device_config.get(CONF_UNIQUE_ID),
             )
         )
 
@@ -84,6 +87,7 @@ class CommandCover(CoverEntity):
         command_state,
         value_template,
         timeout,
+        unique_id,
     ):
         """Initialize the cover."""
         self._hass = hass
@@ -95,6 +99,7 @@ class CommandCover(CoverEntity):
         self._command_state = command_state
         self._value_template = value_template
         self._timeout = timeout
+        self._attr_unique_id = unique_id
 
     def _move_cover(self, command):
         """Execute the actual commands."""

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.const import (
     CONF_COMMAND,
     CONF_NAME,
+    CONF_UNIQUE_ID,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_TEMPLATE,
     STATE_UNKNOWN,
@@ -38,6 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
 )
 
@@ -52,13 +54,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     unit = config.get(CONF_UNIT_OF_MEASUREMENT)
     value_template = config.get(CONF_VALUE_TEMPLATE)
     command_timeout = config.get(CONF_COMMAND_TIMEOUT)
+    unique_id = config.get(CONF_UNIQUE_ID)
     if value_template is not None:
         value_template.hass = hass
     json_attributes = config.get(CONF_JSON_ATTRIBUTES)
     data = CommandSensorData(hass, command, command_timeout)
 
     add_entities(
-        [CommandSensor(hass, data, name, unit, value_template, json_attributes)], True
+        [
+            CommandSensor(
+                hass, data, name, unit, value_template, json_attributes, unique_id
+            )
+        ],
+        True,
     )
 
 
@@ -66,7 +74,14 @@ class CommandSensor(SensorEntity):
     """Representation of a sensor that is using shell commands."""
 
     def __init__(
-        self, hass, data, name, unit_of_measurement, value_template, json_attributes
+        self,
+        hass,
+        data,
+        name,
+        unit_of_measurement,
+        value_template,
+        json_attributes,
+        unique_id,
     ):
         """Initialize the sensor."""
         self._hass = hass
@@ -77,6 +92,7 @@ class CommandSensor(SensorEntity):
         self._state = None
         self._unit_of_measurement = unit_of_measurement
         self._value_template = value_template
+        self._attr_unique_id = unique_id
 
     @property
     def name(self):

--- a/homeassistant/components/command_line/switch.py
+++ b/homeassistant/components/command_line/switch.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_COMMAND_STATE,
     CONF_FRIENDLY_NAME,
     CONF_SWITCHES,
+    CONF_UNIQUE_ID,
     CONF_VALUE_TEMPLATE,
 )
 import homeassistant.helpers.config_validation as cv
@@ -32,6 +33,7 @@ SWITCH_SCHEMA = vol.Schema(
         vol.Optional(CONF_FRIENDLY_NAME): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_COMMAND_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
 )
 
@@ -64,6 +66,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 device_config.get(CONF_COMMAND_STATE),
                 value_template,
                 device_config[CONF_COMMAND_TIMEOUT],
+                device_config.get(CONF_UNIQUE_ID),
             )
         )
 
@@ -87,6 +90,7 @@ class CommandSwitch(SwitchEntity):
         command_state,
         value_template,
         timeout,
+        unique_id,
     ):
         """Initialize the switch."""
         self._hass = hass
@@ -98,6 +102,7 @@ class CommandSwitch(SwitchEntity):
         self._command_state = command_state
         self._value_template = value_template
         self._timeout = timeout
+        self._attr_unique_id = unique_id
 
     def _switch(self, command):
         """Execute the actual commands."""

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -7,6 +7,7 @@ from homeassistant import setup
 from homeassistant.components.binary_sensor import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry
 
 
 async def setup_test_entity(hass: HomeAssistant, config_dict: dict[str, Any]) -> None:
@@ -65,3 +66,47 @@ async def test_sensor_off(hass: HomeAssistant) -> None:
     )
     entity_state = hass.states.get("binary_sensor.test")
     assert entity_state.state == STATE_OFF
+
+
+async def test_unique_id(hass):
+    """Test unique_id option and if it only creates one binary sensor per id."""
+    assert await setup.async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: [
+                {
+                    "platform": "command_line",
+                    "unique_id": "unique",
+                    "command": "echo 0",
+                },
+                {
+                    "platform": "command_line",
+                    "unique_id": "not-so-unique-anymore",
+                    "command": "echo 1",
+                },
+                {
+                    "platform": "command_line",
+                    "unique_id": "not-so-unique-anymore",
+                    "command": "echo 2",
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 2
+
+    ent_reg = entity_registry.async_get(hass)
+
+    assert len(ent_reg.entities) == 2
+    assert (
+        ent_reg.async_get_entity_id("binary_sensor", "command_line", "unique")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(
+            "binary_sensor", "command_line", "not-so-unique-anymore"
+        )
+        is not None
+    )

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     SERVICE_STOP_COVER,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
@@ -164,3 +165,41 @@ async def test_move_cover_failure(caplog: Any, hass: HomeAssistant) -> None:
         DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: "cover.test"}, blocking=True
     )
     assert "Command failed" in caplog.text
+
+
+async def test_unique_id(hass):
+    """Test unique_id option and if it only creates one cover per id."""
+    await setup_test_entity(
+        hass,
+        {
+            "unique": {
+                "command_open": "echo open",
+                "command_close": "echo close",
+                "command_stop": "echo stop",
+                "unique_id": "unique",
+            },
+            "not_unique_1": {
+                "command_open": "echo open",
+                "command_close": "echo close",
+                "command_stop": "echo stop",
+                "unique_id": "not-so-unique-anymore",
+            },
+            "not_unique_2": {
+                "command_open": "echo open",
+                "command_close": "echo close",
+                "command_stop": "echo stop",
+                "unique_id": "not-so-unique-anymore",
+            },
+        },
+    )
+
+    assert len(hass.states.async_all()) == 2
+
+    ent_reg = entity_registry.async_get(hass)
+
+    assert len(ent_reg.entities) == 2
+    assert ent_reg.async_get_entity_id("cover", "command_line", "unique") is not None
+    assert (
+        ent_reg.async_get_entity_id("cover", "command_line", "not-so-unique-anymore")
+        is not None
+    )

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
@@ -370,3 +371,38 @@ async def test_no_switches(caplog: Any, hass: HomeAssistant) -> None:
 
     await setup_test_entity(hass, {})
     assert "No switches" in caplog.text
+
+
+async def test_unique_id(hass):
+    """Test unique_id option and if it only creates one switch per id."""
+    await setup_test_entity(
+        hass,
+        {
+            "unique": {
+                "command_on": "echo on",
+                "command_off": "echo off",
+                "unique_id": "unique",
+            },
+            "not_unique_1": {
+                "command_on": "echo on",
+                "command_off": "echo off",
+                "unique_id": "not-so-unique-anymore",
+            },
+            "not_unique_2": {
+                "command_on": "echo on",
+                "command_off": "echo off",
+                "unique_id": "not-so-unique-anymore",
+            },
+        },
+    )
+
+    assert len(hass.states.async_all()) == 2
+
+    ent_reg = entity_registry.async_get(hass)
+
+    assert len(ent_reg.entities) == 2
+    assert ent_reg.async_get_entity_id("switch", "command_line", "unique") is not None
+    assert (
+        ent_reg.async_get_entity_id("switch", "command_line", "not-so-unique-anymore")
+        is not None
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds unique_id as configuration variable to the command_line platform,
allowing to customize entities trough the UI.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20031

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
