### PR TITLE
Switch to update coordinator, and bump venstarcolortouch to 0.15

### DIFF
--- a/homeassistant/components/venstar/__init__.py
+++ b/homeassistant/components/venstar/__init__.py
@@ -137,7 +137,7 @@ class VenstarEntity(CoordinatorEntity):
     @property
     def unique_id(self):
         """Set unique_id for this entity."""
-        return f"{self._config.entry_id}_{self._client.name}"
+        return f"{self._config.entry_id}"
 
     @property
     def device_info(self):

--- a/homeassistant/components/venstar/__init__.py
+++ b/homeassistant/components/venstar/__init__.py
@@ -1,5 +1,6 @@
 """The venstar component."""
 import asyncio
+from datetime import timedelta
 
 from requests import RequestException
 from venstarcolortouch import VenstarColorTouch
@@ -11,8 +12,9 @@ from homeassistant.const import (
     CONF_SSL,
     CONF_USERNAME,
 )
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.entity import Entity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import update_coordinator
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import _LOGGER, DOMAIN, VENSTAR_TIMEOUT
 
@@ -37,11 +39,13 @@ async def async_setup_entry(hass, config):
         proto=protocol,
     )
 
-    try:
-        await hass.async_add_executor_job(client.update_info)
-    except (OSError, RequestException) as ex:
-        raise ConfigEntryNotReady(f"Unable to connect to the thermostat: {ex}") from ex
-    hass.data.setdefault(DOMAIN, {})[config.entry_id] = client
+    venstar_data_coordinator = VenstarDataUpdateCoordinator(
+        hass,
+        venstar_connection=client,
+    )
+    await venstar_data_coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})[config.entry_id] = venstar_data_coordinator
     hass.config_entries.async_setup_platforms(config, PLATFORMS)
 
     return True
@@ -55,35 +59,69 @@ async def async_unload_entry(hass, config):
     return unload_ok
 
 
-class VenstarEntity(Entity):
-    """Get the latest data and update."""
+class VenstarDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
+    """Class to manage fetching Venstar data."""
 
-    def __init__(self, config, client):
-        """Initialize the data object."""
-        self._config = config
-        self._client = client
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        venstar_connection: VenstarColorTouch,
+    ) -> None:
+        """Initialize global Venstar data updater."""
+        self._client = venstar_connection
 
-    async def async_update(self):
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=60),
+        )
+
+    def _get_client(self):
+        """Return the client."""
+        return self._client
+
+    async def _async_update_data(self) -> None:
         """Update the state."""
         try:
-            info_success = await self.hass.async_add_executor_job(
-                self._client.update_info
-            )
+            await self.hass.async_add_executor_job(self._client.update_info)
         except (OSError, RequestException) as ex:
-            _LOGGER.error("Exception during info update: %s", ex)
+            raise update_coordinator.UpdateFailed(
+                f"Exception during Venstar info update: {ex}"
+            ) from ex
 
         # older venstars sometimes cannot handle rapid sequential connections
         await asyncio.sleep(3)
 
         try:
-            sensor_success = await self.hass.async_add_executor_job(
-                self._client.update_sensors
-            )
+            await self.hass.async_add_executor_job(self._client.update_sensors)
         except (OSError, RequestException) as ex:
-            _LOGGER.error("Exception during sensor update: %s", ex)
+            raise update_coordinator.UpdateFailed(
+                f"Exception during Venstar sensor update: {ex}"
+            ) from ex
+        return None
 
-        if not info_success or not sensor_success:
-            _LOGGER.error("Failed to update data")
+
+class VenstarEntity(CoordinatorEntity):
+    """Representation of a Venstar entity."""
+
+    def __init__(self, venstar_data_coordinator, config):
+        """Initialize the data object."""
+        super().__init__(venstar_data_coordinator)
+        self._config = config
+        self._update_attr()
+        self._client = venstar_data_coordinator._get_client()
+
+    @callback
+    def _update_attr(self) -> None:
+        """Update the state and attributes."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_attr()
+        self.async_write_ha_state()
 
     @property
     def name(self):
@@ -93,17 +131,17 @@ class VenstarEntity(Entity):
     @property
     def unique_id(self):
         """Set unique_id for this entity."""
-        return f"{self._config.entry_id}"
+        return f"{self._config.entry_id}_{self._client.name}"
 
     @property
     def device_info(self):
         """Return the device information for this entity."""
+        ven_type = self._client.get_type()
+        ven_apiver = self._client.get_api_ver()
         return {
             "identifiers": {(DOMAIN, self._config.entry_id)},
             "name": self._client.name,
             "manufacturer": "Venstar",
-            # pylint: disable=protected-access
-            "model": f"{self._client.model}-{self._client._type}",
-            # pylint: disable=protected-access
-            "sw_version": self._client._api_ver,
+            "model": f"{self._client.model}-{ven_type}",
+            "sw_version": ven_apiver,
         }

--- a/homeassistant/components/venstar/__init__.py
+++ b/homeassistant/components/venstar/__init__.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from requests import RequestException
 from venstarcolortouch import VenstarColorTouch
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -106,7 +107,11 @@ class VenstarDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
 class VenstarEntity(CoordinatorEntity):
     """Representation of a Venstar entity."""
 
-    def __init__(self, venstar_data_coordinator, config):
+    def __init__(
+        self,
+        venstar_data_coordinator: VenstarDataUpdateCoordinator,
+        config: ConfigEntry,
+    ) -> None:
         """Initialize the data object."""
         super().__init__(venstar_data_coordinator)
         self._config = config
@@ -136,12 +141,10 @@ class VenstarEntity(CoordinatorEntity):
     @property
     def device_info(self):
         """Return the device information for this entity."""
-        ven_type = self._client.get_type()
-        ven_apiver = self._client.get_api_ver()
         return {
             "identifiers": {(DOMAIN, self._config.entry_id)},
             "name": self._client.name,
             "manufacturer": "Venstar",
-            "model": f"{self._client.model}-{ven_type}",
-            "sw_version": ven_apiver,
+            "model": f"{self._client.model}-{self._client.get_type()}",
+            "sw_version": self._client.get_api_ver(),
         }

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -321,7 +321,7 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set a new target fan mode."""
-        await self.hass.async_add_executor_job(partial(self._set_fan_mode, fan_mode))
+        await self.hass.async_add_executor_job(self._set_fan_mode, fan_mode)
         self.async_write_ha_state()
 
     def _set_fan_mode(self, fan_mode):
@@ -336,7 +336,7 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set a new target operation mode."""
-        await self.hass.async_add_executor_job(partial(self._set_hvac_mode, hvac_mode))
+        await self.hass.async_add_executor_job(self._set_hvac_mode, hvac_mode)
         self.async_write_ha_state()
 
     def _set_hvac_mode(self, hvac_mode):
@@ -345,7 +345,7 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
 
     async def async_set_humidity(self, humidity: int) -> None:
         """Set a new target humidity."""
-        await self.hass.async_add_executor_job(partial(self._set_humidity, humidity))
+        await self.hass.async_add_executor_job(self._set_humidity, humidity)
         self.async_write_ha_state()
 
     def _set_humidity(self, humidity):
@@ -357,9 +357,7 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the hold mode."""
-        await self.hass.async_add_executor_job(
-            partial(self._set_preset_mode, preset_mode)
-        )
+        await self.hass.async_add_executor_job(self._set_preset_mode, preset_mode)
         self.async_write_ha_state()
 
     def _set_preset_mode(self, preset_mode):

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -24,7 +24,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
-from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_HOST,
@@ -38,9 +38,11 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import VenstarEntity
+from . import VenstarDataUpdateCoordinator, VenstarEntity
 from .const import (
     _LOGGER,
     ATTR_FAN_STATE,
@@ -68,7 +70,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up the Venstar thermostat."""
     venstar_data_coordinator = hass.data[DOMAIN][config_entry.entry_id]
     async_add_entities(
@@ -103,7 +109,11 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
 class VenstarThermostat(VenstarEntity, ClimateEntity):
     """Representation of a Venstar thermostat."""
 
-    def __init__(self, venstar_data_coordinator, config):
+    def __init__(
+        self,
+        venstar_data_coordinator: VenstarDataUpdateCoordinator,
+        config: ConfigEntry,
+    ) -> None:
         """Initialize the thermostat."""
         super().__init__(venstar_data_coordinator, config)
         self._mode_map = {

--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -70,8 +70,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Venstar thermostat."""
-    client = hass.data[DOMAIN][config_entry.entry_id]
-    async_add_entities([VenstarThermostat(config_entry, client)], True)
+    venstar_data_coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        [
+            VenstarThermostat(
+                venstar_data_coordinator,
+                config_entry,
+            )
+        ],
+        True,
+    )
 
 
 async def async_setup_platform(hass, config, add_entities, discovery_info=None):
@@ -95,9 +103,9 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
 class VenstarThermostat(VenstarEntity, ClimateEntity):
     """Representation of a Venstar thermostat."""
 
-    def __init__(self, config, client):
+    def __init__(self, venstar_data_coordinator, config):
         """Initialize the thermostat."""
-        super().__init__(config, client)
+        super().__init__(venstar_data_coordinator, config)
         self._mode_map = {
             HVAC_MODE_HEAT: self._client.MODE_HEAT,
             HVAC_MODE_COOL: self._client.MODE_COOL,

--- a/homeassistant/components/venstar/manifest.json
+++ b/homeassistant/components/venstar/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/venstar",
   "requirements": [
-    "venstarcolortouch==0.14"
+    "venstarcolortouch==0.15"
   ],
   "codeowners": ["@garbled1"],
   "iot_class": "local_polling"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2363,7 +2363,7 @@ vallox-websocket-api==2.8.1
 velbus-aio==2021.10.6
 
 # homeassistant.components.venstar
-venstarcolortouch==0.14
+venstarcolortouch==0.15
 
 # homeassistant.components.vilfo
 vilfo-api-client==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1367,7 +1367,7 @@ uvcclient==0.11.0
 velbus-aio==2021.10.6
 
 # homeassistant.components.venstar
-venstarcolortouch==0.14
+venstarcolortouch==0.15
 
 # homeassistant.components.vilfo
 vilfo-api-client==0.3.2


### PR DESCRIPTION
The library bump uses the new accessor functions to get the api version
and the type, instead of protected class members.
For the coordinator, there is really no functional change, because we still
use the accessor functions in the library (which do not make calls to the
api, they access internal class variables).  The benefit is soley that when
new platforms are added, we will not make multiple API calls to the thermostat.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The library bump uses the new accessor functions to get the api version
and the type, instead of protected class members.

For the coordinator, there is really no functional change, because we still
use the accessor functions in the library (which do not make calls to the
api, they access internal class variables).  The benefit is soley that when
new platforms are added, we will not make multiple API calls to the thermostat.

Differences between 0.14 and 0.15:
https://github.com/hpeyerl/venstar_colortouch/compare/9e63eb4...55beae8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
