### PR TITLE
Fix uncaught exception in sense and retry later

### DIFF
--- a/homeassistant/components/sense/const.py
+++ b/homeassistant/components/sense/const.py
@@ -1,8 +1,10 @@
 """Constants for monitoring a Sense energy sensor."""
 
 import asyncio
+import socket
 
 from sense_energy import SenseAPITimeoutException
+from sense_energy.sense_exceptions import SenseWebsocketException
 
 DOMAIN = "sense"
 DEFAULT_TIMEOUT = 10
@@ -37,6 +39,7 @@ SOLAR_POWERED_ID = "solar_powered"
 ICON = "mdi:flash"
 
 SENSE_TIMEOUT_EXCEPTIONS = (asyncio.TimeoutError, SenseAPITimeoutException)
+SENSE_EXCEPTIONS = (socket.gaierror, SenseWebsocketException)
 
 MDI_ICONS = {
     "ac": "air-conditioner",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix uncaught exception in sense and retry later
- Improve sense error reporting

Fixes #57486 Part 1

Part 2 - https://github.com/home-assistant/core/pull/58626

```
2021-10-27 01:24:00 ERROR (MainThread) [homeassistant.components.sense] Error requesting Sense Trends 81@koston.org data: Cannot connect to host api.sense.com:443 ssl:default [Try again]                    
2021-10-27 01:24:00 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved                                                                        
Traceback (most recent call last):                                                                                                                                                
  File "/usr/src/homeassistant/homeassistant/components/sense/__init__.py", line 113, in async_sense_update                                                                       
    await gateway.update_realtime()                                                                                                                                           
  File "/usr/local/lib/python3.9/site-packages/sense_energy/asyncsenseable.py", line 73, in update_realtime                                                                      
    await self.async_realtime_stream(single=True)                                                                                                                                                             
  File "/usr/local/lib/python3.9/site-packages/sense_energy/asyncsenseable.py", line 79, in async_realtime_stream                                                  
    async with websockets.connect(url, ssl=self.ssl_context) as ws:                                                                                                                             
  File "/usr/local/lib/python3.9/site-packages/websockets/legacy/client.py", line 604, in __aenter__                                                                 
    return await self                                                                                                                                     
  File "/usr/local/lib/python3.9/site-packages/websockets/legacy/client.py", line 622, in __await_impl__                                                                                                  
    transport, protocol = await self._create_connection()                                                                                                      
  File "/usr/local/lib/python3.9/asyncio/base_events.py", line 1017, in create_connection                                                                                                                     
    infos = await self._ensure_resolved(                                                                                                                                       
  File "/usr/local/lib/python3.9/asyncio/base_events.py", line 1396, in _ensure_resolved                                                                                  
    return await loop.getaddrinfo(host, port, family=family, type=type,                                                                                                         
  File "/usr/local/lib/python3.9/asyncio/base_events.py", line 856, in getaddrinfo                                                                                                              
    return await self.run_in_executor(                                                                                                                                                                        
  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 52, in run                                                                                                     
    result = self.fn(*self.args, **self.kwargs)                                                                                                                                                               
  File "/usr/local/lib/python3.9/socket.py", line 954, in getaddrinfo                                                                                                                                         
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):                                                                                                                                   
socket.gaierror: [Errno -3] Try again    
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
