### PR TITLE
Migrate Tuya unique IDs for switches & lights

### DIFF
--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -14,9 +14,11 @@ from tuya_iot import (
     TuyaOpenMQ,
 )
 
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import (
@@ -33,6 +35,7 @@ from .const import (
     PLATFORMS,
     TUYA_DISCOVERY_NEW,
     TUYA_HA_SIGNAL_UPDATE_ENTITY,
+    DPCode,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -115,6 +118,9 @@ async def _init_tuya_sdk(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.async_add_executor_job(home_manager.update_device_cache)
     await cleanup_device_registry(hass, device_manager)
 
+    # Migrate old unique_ids to the new format
+    async_migrate_entities_unique_ids(hass, entry, device_manager)
+
     # Register known device IDs
     device_registry = dr.async_get(hass)
     for device in device_manager.device_map.values():
@@ -141,6 +147,74 @@ async def cleanup_device_registry(
             if DOMAIN == item[0] and item[1] not in device_manager.device_map:
                 device_registry.async_remove_device(dev_id)
                 break
+
+
+@callback
+def async_migrate_entities_unique_ids(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_manager: TuyaDeviceManager
+) -> None:
+    """Migrate unique_ids in the entity registry to the new format."""
+    entity_registry = er.async_get(hass)
+    registry_entries = er.async_entries_for_config_entry(
+        entity_registry, config_entry.entry_id
+    )
+    entries = {entry.unique_id: entry for entry in registry_entries}
+
+    for device in device_manager.device_map.values():
+        # Old lights where in `tuya.{device_id}` format, now the DPCode is added.
+        #
+        # If the device is a previously supported light category and still has
+        # the old format for the unique ID, migrate it to the new format.
+        #
+        # Previously only devices providing the SWITCH_LED DPCode were supported,
+        # thus this can be added to those existing IDs.
+        #
+        # `tuya.{device_id}` -> `tuya.{device_id}{SWITCH_LED}`
+        if (
+            device.category in ("dc", "dd", "dj", "fs", "fwl", "jsq", "xdd", "xxj")
+            and (entry := entries.get(f"tuya.{device.id}"))
+            and entry.platform == LIGHT_DOMAIN
+        ):
+            entity_registry.async_update_entity(
+                entry.entity_id, new_unique_id=f"tuya.{device.id}{DPCode.SWITCH_LED}"
+            )
+
+        # Old switches has different formats for the unique ID, but is mappable.
+        #
+        # If the device is a previously supported switch category and still has
+        # the old format for the unique ID, migrate it to the new format.
+        #
+        # `tuya.{device_id}` -> `tuya.{device_id}{SWITCH}`
+        # `tuya.{device_id}_1` -> `tuya.{device_id}{SWITCH_1}`
+        # ...
+        # `tuya.{device_id}_6` -> `tuya.{device_id}{SWITCH_6}`
+        # `tuya.{device_id}_usb1` -> `tuya.{device_id}{SWITCH_USB1}`
+        # ...
+        # `tuya.{device_id}_usb6` -> `tuya.{device_id}{SWITCH_USB6}`
+        #
+        # In all other cases, the unique ID is not changed.
+        if device.category in ("bh", "cwysj", "cz", "dlq", "kg", "kj", "pc", "xxj"):
+            for postfix, dpcode in [
+                ("", DPCode.SWITCH),
+                ("_1", DPCode.SWITCH_1),
+                ("_2", DPCode.SWITCH_2),
+                ("_3", DPCode.SWITCH_3),
+                ("_4", DPCode.SWITCH_4),
+                ("_5", DPCode.SWITCH_5),
+                ("_6", DPCode.SWITCH_6),
+                ("_usb1", DPCode.SWITCH_USB1),
+                ("_usb2", DPCode.SWITCH_USB2),
+                ("_usb3", DPCode.SWITCH_USB3),
+                ("_usb4", DPCode.SWITCH_USB4),
+                ("_usb5", DPCode.SWITCH_USB5),
+                ("_usb6", DPCode.SWITCH_USB6),
+            ]:
+                if (
+                    entry := entries.get(f"tuya.{device.id}{postfix}")
+                ) and entry.platform == SWITCH_DOMAIN:
+                    entity_registry.async_update_entity(
+                        entry.entity_id, new_unique_id=f"tuya.{device.id}{dpcode}"
+                    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The current refactoring of the Tuya integration causes a breaking change.
This PR mitigates that breaking change, making it non-breaking.

If the new unique ID already exists, it will just skip it. This prevents breaking changes in the current beta and also prevents the integration from not loading because of it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
