### PR TITLE
Reorganize Guardian services

### DIFF
--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -55,12 +55,14 @@ SERVICE_NAME_UPGRADE_FIRMWARE = "upgrade_firmware"
 
 SERVICE_PAIR_UNPAIR_SENSOR_SCHEMA = vol.Schema(
     {
+        vol.Required(CONF_DEVICE_ID): cv.string,
         vol.Required(CONF_UID): cv.string,
     }
 )
 
 SERVICE_UPGRADE_FIRMWARE_SCHEMA = vol.Schema(
     {
+        vol.Required(CONF_DEVICE_ID): cv.string,
         vol.Optional(CONF_URL): cv.url,
         vol.Optional(CONF_PORT): cv.port,
         vol.Optional(CONF_FILENAME): cv.string,

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -53,6 +53,16 @@ SERVICE_NAME_RESET_VALVE_DIAGNOSTICS = "reset_valve_diagnostics"
 SERVICE_NAME_UNPAIR_SENSOR = "unpair_sensor"
 SERVICE_NAME_UPGRADE_FIRMWARE = "upgrade_firmware"
 
+SERVICES = (
+    SERVICE_NAME_DISABLE_AP,
+    SERVICE_NAME_ENABLE_AP,
+    SERVICE_NAME_PAIR_SENSOR,
+    SERVICE_NAME_REBOOT,
+    SERVICE_NAME_RESET_VALVE_DIAGNOSTICS,
+    SERVICE_NAME_UNPAIR_SENSOR,
+    SERVICE_NAME_UPGRADE_FIRMWARE,
+)
+
 SERVICE_PAIR_UNPAIR_SENSOR_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_DEVICE_ID): cv.string,
@@ -252,15 +262,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if len(loaded_entries) == 1:
         # If this is the last loaded instance of Guardian, deregister any services
         # defined during integration setup:
-        for service_name in (
-            SERVICE_NAME_DISABLE_AP,
-            SERVICE_NAME_ENABLE_AP,
-            SERVICE_NAME_PAIR_SENSOR,
-            SERVICE_NAME_REBOOT,
-            SERVICE_NAME_RESET_VALVE_DIAGNOSTICS,
-            SERVICE_NAME_UNPAIR_SENSOR,
-            SERVICE_NAME_UPGRADE_FIRMWARE,
-        ):
+        for service_name in SERVICES:
             hass.services.async_remove(DOMAIN, service_name)
 
     return unload_ok

--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -244,8 +244,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
 
-    entries = hass.config_entries.async_entries(DOMAIN)
-    if len(entries) == 1 and entries[0].state == ConfigEntryState.LOADED:
+    loaded_entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state == ConfigEntryState.LOADED
+    ]
+    if len(loaded_entries) == 1:
         # If this is the last loaded instance of Guardian, deregister any services
         # defined during integration setup:
         for service_name in (

--- a/homeassistant/components/guardian/const.py
+++ b/homeassistant/components/guardian/const.py
@@ -17,6 +17,5 @@ CONF_UID = "uid"
 DATA_CLIENT = "client"
 DATA_COORDINATOR = "coordinator"
 DATA_COORDINATOR_PAIRED_SENSOR = "coordinator_paired_sensor"
-DATA_PAIRED_SENSOR_MANAGER = "paired_sensor_manager"
 
 SIGNAL_PAIRED_SENSOR_COORDINATOR_ADDED = "guardian_paired_sensor_coordinator_added_{0}"

--- a/homeassistant/components/guardian/services.yaml
+++ b/homeassistant/components/guardian/services.yaml
@@ -2,25 +2,36 @@
 disable_ap:
   name: Disable AP
   description: Disable the device's onboard access point.
-  target:
-    entity:
-      integration: guardian
-      domain: switch
+  fields:
+    device_id:
+      name: Valve Controller
+      description: The valve controller whose AP should be disabled
+      required: true
+      selector:
+        device:
+          integration: guardian
 enable_ap:
   name: Enable AP
   description: Enable the device's onboard access point.
-  target:
-    entity:
-      integration: guardian
-      domain: switch
-pair_sensor:
-  name: Pair sensor
-  description: Add a new paired sensor to the valve controller.
-  target:
-    entity:
-      integration: guardian
-      domain: switch
   fields:
+    device_id:
+      name: Valve Controller
+      description: The valve controller whose AP should be enabled
+      required: true
+      selector:
+        device:
+          integration: guardian
+pair_sensor:
+  name: Pair Sensor
+  description: Add a new paired sensor to the valve controller.
+  fields:
+    device_id:
+      name: Valve Controller
+      description: The valve controller to add the sensor to
+      required: true
+      selector:
+        device:
+          integration: guardian
     uid:
       name: UID
       description: The UID of the paired sensor
@@ -31,25 +42,36 @@ pair_sensor:
 reboot:
   name: Reboot
   description: Reboot the device.
-  target:
-    entity:
-      integration: guardian
-      domain: switch
-reset_valve_diagnostics:
-  name: Reset valve diagnostics
-  description: Fully (and irrecoverably) reset all valve diagnostics.
-  target:
-    entity:
-      integration: guardian
-      domain: switch
-unpair_sensor:
-  name: Unpair sensor
-  description: Remove a paired sensor from the valve controller.
-  target:
-    entity:
-      integration: guardian
-      domain: switch
   fields:
+    device_id:
+      name: Valve Controller
+      description: The valve controller to reboot
+      required: true
+      selector:
+        device:
+          integration: guardian
+reset_valve_diagnostics:
+  name: Reset Valve Diagnostics
+  description: Fully (and irrecoverably) reset all valve diagnostics.
+  fields:
+    device_id:
+      name: Valve Controller
+      description: The valve controller whose diagnostics should be reset
+      required: true
+      selector:
+        device:
+          integration: guardian
+unpair_sensor:
+  name: Unpair Sensor
+  description: Remove a paired sensor from the valve controller.
+  fields:
+    device_id:
+      name: Valve Controller
+      description: The valve controller to remove the sensor from
+      required: true
+      selector:
+        device:
+          integration: guardian
     uid:
       name: UID
       description: The UID of the paired sensor
@@ -60,11 +82,14 @@ unpair_sensor:
 upgrade_firmware:
   name: Upgrade firmware
   description: Upgrade the device firmware.
-  target:
-    entity:
-      integration: guardian
-      domain: switch
   fields:
+    device_id:
+      name: Valve Controller
+      description: The valve controller whose firmware should be upgraded
+      required: true
+      selector:
+        device:
+          integration: guardian
     url:
       name: URL
       description: The URL of the server hosting the firmware file.
@@ -76,7 +101,9 @@ upgrade_firmware:
       description: The port on which the firmware file is served.
       example: 443
       selector:
-        text:
+        number:
+          min: 1
+          max: 65535
     filename:
       name: Filename
       description: The firmware filename.

--- a/homeassistant/components/guardian/switch.py
+++ b/homeassistant/components/guardian/switch.py
@@ -5,39 +5,20 @@ from typing import Any
 
 from aioguardian import Client
 from aioguardian.errors import GuardianError
-import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_FILENAME, CONF_PORT, CONF_URL
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import ValveControllerEntity
-from .const import (
-    API_VALVE_STATUS,
-    CONF_UID,
-    DATA_CLIENT,
-    DATA_COORDINATOR,
-    DATA_PAIRED_SENSOR_MANAGER,
-    DOMAIN,
-    LOGGER,
-)
+from .const import API_VALVE_STATUS, DATA_CLIENT, DATA_COORDINATOR, DOMAIN, LOGGER
 
 ATTR_AVG_CURRENT = "average_current"
 ATTR_INST_CURRENT = "instantaneous_current"
 ATTR_INST_CURRENT_DDT = "instantaneous_current_ddt"
 ATTR_TRAVEL_COUNT = "travel_count"
-
-SERVICE_DISABLE_AP = "disable_ap"
-SERVICE_ENABLE_AP = "enable_ap"
-SERVICE_PAIR_SENSOR = "pair_sensor"
-SERVICE_REBOOT = "reboot"
-SERVICE_RESET_VALVE_DIAGNOSTICS = "reset_valve_diagnostics"
-SERVICE_UNPAIR_SENSOR = "unpair_sensor"
-SERVICE_UPGRADE_FIRMWARE = "upgrade_firmware"
 
 SWITCH_KIND_VALVE = "valve"
 
@@ -52,31 +33,6 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Guardian switches based on a config entry."""
-    platform = entity_platform.async_get_current_platform()
-
-    for service_name, schema, method in (
-        (SERVICE_DISABLE_AP, {}, "async_disable_ap"),
-        (SERVICE_ENABLE_AP, {}, "async_enable_ap"),
-        (SERVICE_PAIR_SENSOR, {vol.Required(CONF_UID): cv.string}, "async_pair_sensor"),
-        (SERVICE_REBOOT, {}, "async_reboot"),
-        (SERVICE_RESET_VALVE_DIAGNOSTICS, {}, "async_reset_valve_diagnostics"),
-        (
-            SERVICE_UPGRADE_FIRMWARE,
-            {
-                vol.Optional(CONF_URL): cv.url,
-                vol.Optional(CONF_PORT): cv.port,
-                vol.Optional(CONF_FILENAME): cv.string,
-            },
-            "async_upgrade_firmware",
-        ),
-        (
-            SERVICE_UNPAIR_SENSOR,
-            {vol.Required(CONF_UID): cv.string},
-            "async_unpair_sensor",
-        ),
-    ):
-        platform.async_register_entity_service(service_name, schema, method)
-
     async_add_entities(
         [
             ValveControllerSwitch(
@@ -134,78 +90,6 @@ class ValveControllerSwitch(ValveControllerEntity, SwitchEntity):
                 ],
             }
         )
-
-    async def async_disable_ap(self) -> None:
-        """Disable the device's onboard access point."""
-        try:
-            async with self._client:
-                await self._client.wifi.disable_ap()
-        except GuardianError as err:
-            LOGGER.error("Error while disabling valve controller AP: %s", err)
-
-    async def async_enable_ap(self) -> None:
-        """Enable the device's onboard access point."""
-        try:
-            async with self._client:
-                await self._client.wifi.enable_ap()
-        except GuardianError as err:
-            LOGGER.error("Error while enabling valve controller AP: %s", err)
-
-    async def async_pair_sensor(self, *, uid: str) -> None:
-        """Add a new paired sensor."""
-        try:
-            async with self._client:
-                await self._client.sensor.pair_sensor(uid)
-        except GuardianError as err:
-            LOGGER.error("Error while adding paired sensor: %s", err)
-            return
-
-        await self.hass.data[DOMAIN][self._entry.entry_id][
-            DATA_PAIRED_SENSOR_MANAGER
-        ].async_pair_sensor(uid)
-
-    async def async_reboot(self) -> None:
-        """Reboot the device."""
-        try:
-            async with self._client:
-                await self._client.system.reboot()
-        except GuardianError as err:
-            LOGGER.error("Error while rebooting valve controller: %s", err)
-
-    async def async_reset_valve_diagnostics(self) -> None:
-        """Fully reset system motor diagnostics."""
-        try:
-            async with self._client:
-                await self._client.valve.reset()
-        except GuardianError as err:
-            LOGGER.error("Error while resetting valve diagnostics: %s", err)
-
-    async def async_unpair_sensor(self, *, uid: str) -> None:
-        """Add a new paired sensor."""
-        try:
-            async with self._client:
-                await self._client.sensor.unpair_sensor(uid)
-        except GuardianError as err:
-            LOGGER.error("Error while removing paired sensor: %s", err)
-            return
-
-        await self.hass.data[DOMAIN][self._entry.entry_id][
-            DATA_PAIRED_SENSOR_MANAGER
-        ].async_unpair_sensor(uid)
-
-    async def async_upgrade_firmware(
-        self, *, url: str, port: int, filename: str
-    ) -> None:
-        """Upgrade the device firmware."""
-        try:
-            async with self._client:
-                await self._client.system.upgrade_firmware(
-                    url=url,
-                    port=port,
-                    filename=filename,
-                )
-        except GuardianError as err:
-            LOGGER.error("Error while upgrading firmware: %s", err)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the valve off (closed)."""

--- a/homeassistant/components/guardian/translations/en.json
+++ b/homeassistant/components/guardian/translations/en.json
@@ -15,9 +15,6 @@
                     "port": "Port"
                 },
                 "description": "Configure a local Elexa Guardian device."
-            },
-            "zeroconf_confirm": {
-                "description": "Do you want to set up this Guardian device?"
             }
         }
     }


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Guardian services have been reorganized and now utilize a Home Assistant selector (device ID) instead of using a Guardian entity. Use of the `entity_id` parameter in service calls is deprecated and will be removed at a later date.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Guardian's services currently use targets, which doesn't make sense, as the services are really focused on the device itself (rather than any of its entities). This PR reorganizes things so that the services use selectors instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] (**not needed**)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
