### PR TITLE
Use DeviceEntryType in non-typechecked code too

### DIFF
--- a/homeassistant/components/climacell/__init__.py
+++ b/homeassistant/components/climacell/__init__.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -358,7 +359,7 @@ class ClimaCellEntity(CoordinatorEntity):
     def device_info(self) -> DeviceInfo:
         """Return device registry information."""
         return DeviceInfo(
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self._config_entry.data[CONF_API_KEY])},
             manufacturer="ClimaCell",
             name="ClimaCell",

--- a/homeassistant/components/coinbase/sensor.py
+++ b/homeassistant/components/coinbase/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
 )
 from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import (
@@ -112,7 +113,7 @@ class AccountSensor(SensorEntity):
         self._attr_state_class = STATE_CLASS_TOTAL
         self._attr_device_info = DeviceInfo(
             configuration_url="https://www.coinbase.com/settings/api",
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self._coinbase_data.user_id)},
             manufacturer="Coinbase.com",
             name=f"Coinbase {self._coinbase_data.user_id[-4:]}",
@@ -185,7 +186,7 @@ class ExchangeRateSensor(SensorEntity):
         self._attr_state_class = STATE_CLASS_MEASUREMENT
         self._attr_device_info = DeviceInfo(
             configuration_url="https://www.coinbase.com/settings/api",
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self._coinbase_data.user_id)},
             manufacturer="Coinbase.com",
             name=f"Coinbase {self._coinbase_data.user_id[-4:]}",

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -156,7 +156,7 @@ class DeconzGateway:
         device_registry.async_get_or_create(
             config_entry_id=self.config_entry.entry_id,
             configuration_url=configuration_url,
-            entry_type="service",
+            entry_type=dr.DeviceEntryType.SERVICE,
             identifiers={(DECONZ_DOMAIN, self.api.config.bridge_id)},
             manufacturer="Dresden Elektronik",
             model=self.api.config.model_id,

--- a/homeassistant/components/eafm/sensor.py
+++ b/homeassistant/components/eafm/sensor.py
@@ -8,6 +8,7 @@ import async_timeout
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import ATTR_ATTRIBUTION, LENGTH_METERS
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -123,7 +124,7 @@ class Measurement(CoordinatorEntity, SensorEntity):
     def device_info(self):
         """Return the device info."""
         return DeviceInfo(
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, "measure-id", self.station_id)},
             manufacturer="https://environment.data.gov.uk/",
             model=self.parameter_name,

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -19,7 +19,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_MANUFACTURER,
     ATTR_NAME,
-    ATTR_SERVICE,
     EVENT_CORE_CONFIG_UPDATE,
     SERVICE_HOMEASSISTANT_RESTART,
     SERVICE_HOMEASSISTANT_STOP,
@@ -27,7 +26,11 @@ from homeassistant.const import (
 from homeassistant.core import DOMAIN as HASS_DOMAIN, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, recorder
-from homeassistant.helpers.device_registry import DeviceRegistry, async_get_registry
+from homeassistant.helpers.device_registry import (
+    DeviceEntryType,
+    DeviceRegistry,
+    async_get_registry,
+)
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -660,7 +663,7 @@ def async_register_addons_in_dev_reg(
             model=SupervisorEntityModel.ADDON,
             sw_version=addon[ATTR_VERSION],
             name=addon[ATTR_NAME],
-            entry_type=ATTR_SERVICE,
+            entry_type=DeviceEntryType.SERVICE,
             configuration_url=f"homeassistant://hassio/addon/{addon[ATTR_SLUG]}",
         )
         if manufacturer := addon.get(ATTR_REPOSITORY) or addon.get(ATTR_URL):
@@ -679,7 +682,7 @@ def async_register_os_in_dev_reg(
         model=SupervisorEntityModel.OS,
         sw_version=os_dict[ATTR_VERSION],
         name="Home Assistant Operating System",
-        entry_type=ATTR_SERVICE,
+        entry_type=DeviceEntryType.SERVICE,
     )
     dev_reg.async_get_or_create(config_entry_id=entry_id, **params)
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -766,7 +766,7 @@ class HomeKit:
             manufacturer=MANUFACTURER,
             name=accessory_friendly_name(self._entry_title, self.driver.accessory),
             model=f"HomeKit {hk_mode_name}",
-            entry_type="service",
+            entry_type=device_registry.DeviceEntryType.SERVICE,
         )
 
     @callback

--- a/homeassistant/components/met_eireann/weather.py
+++ b/homeassistant/components/met_eireann/weather.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     SPEED_MILES_PER_HOUR,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -187,7 +188,7 @@ class MetEireannWeather(CoordinatorEntity, WeatherEntity):
         """Device info."""
         return DeviceInfo(
             default_name="Forecast",
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN,)},
             manufacturer="Met Éireann",
             model="Forecast",

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -96,7 +97,7 @@ class MeteoFranceSensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         return DeviceInfo(
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self.platform.config_entry.unique_id)},
             manufacturer=MANUFACTURER,
             model=MODEL,

--- a/homeassistant/components/meteo_france/weather.py
+++ b/homeassistant/components/meteo_france/weather.py
@@ -15,6 +15,7 @@ from homeassistant.components.weather import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MODE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -90,7 +91,7 @@ class MeteoFranceWeather(CoordinatorEntity, WeatherEntity):
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         return DeviceInfo(
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self.platform.config_entry.unique_id)},
             manufacturer=MANUFACTURER,
             model=MODEL,

--- a/homeassistant/components/meteoclimatic/sensor.py
+++ b/homeassistant/components/meteoclimatic/sensor.py
@@ -3,6 +3,7 @@ from homeassistant.components.sensor import SensorEntity, SensorEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -43,7 +44,7 @@ class MeteoclimaticSensor(CoordinatorEntity, SensorEntity):
     def device_info(self):
         """Return the device info."""
         return DeviceInfo(
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self.platform.config_entry.unique_id)},
             manufacturer=MANUFACTURER,
             model=MODEL,

--- a/homeassistant/components/meteoclimatic/weather.py
+++ b/homeassistant/components/meteoclimatic/weather.py
@@ -5,6 +5,7 @@ from homeassistant.components.weather import WeatherEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -57,7 +58,7 @@ class MeteoclimaticWeather(CoordinatorEntity, WeatherEntity):
     def device_info(self):
         """Return the device info."""
         return DeviceInfo(
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self.platform.config_entry.unique_id)},
             manufacturer=MANUFACTURER,
             model=MODEL,

--- a/homeassistant/components/nightscout/__init__.py
+++ b/homeassistant/components/nightscout/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         manufacturer="Nightscout Foundation",
         name=status.name,
         sw_version=status.version,
-        entry_type="service",
+        entry_type=dr.DeviceEntryType.SERVICE,
     )
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import debounce
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -172,7 +173,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 def device_info(latitude, longitude) -> DeviceInfo:
     """Return device registry information."""
     return DeviceInfo(
-        entry_type="service",
+        entry_type=DeviceEntryType.SERVICE,
         identifiers={(DOMAIN, base_unique_id(latitude, longitude))},
         manufacturer="National Weather Service",
         name=f"NWS: {latitude}, {longitude}",

--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import (
@@ -112,7 +113,7 @@ class OVOEnergyDeviceEntity(OVOEnergyEntity):
     def device_info(self) -> DeviceInfo:
         """Return device information about this OVO Energy instance."""
         return DeviceInfo(
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self._client.account_id)},
             manufacturer="OVO Energy",
             name=self._client.username,

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -23,6 +23,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.const import STATE_IDLE, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -533,7 +534,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
                 name="Plex Client Service",
                 manufacturer="Plex",
                 model="Plex Clients",
-                entry_type="service",
+                entry_type=DeviceEntryType.SERVICE,
             )
 
         return DeviceInfo(

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -53,6 +53,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utc_from_timestamp
@@ -267,7 +268,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
             manufacturer="Spotify AB",
             model=model,
             name=self._name,
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             configuration_url="https://open.spotify.com",
         )
 

--- a/homeassistant/components/unifi/switch.py
+++ b/homeassistant/components/unifi/switch.py
@@ -17,6 +17,7 @@ from aiounifi.events import (
 from homeassistant.components.switch import DOMAIN, SwitchEntity
 from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
@@ -370,7 +371,7 @@ class UniFiDPIRestrictionSwitch(UniFiBase, SwitchEntity):
     def device_info(self) -> DeviceInfo:
         """Return a service description for device registry."""
         return DeviceInfo(
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, f"unifi_controller_{self._item.site_id}")},
             manufacturer=ATTR_MANUFACTURER,
             model="UniFi Controller",

--- a/homeassistant/components/xbox/base_sensor.py
+++ b/homeassistant/components/xbox/base_sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from yarl import URL
 
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -70,7 +71,7 @@ class XboxBaseSensorEntity(CoordinatorEntity):
     def device_info(self) -> DeviceInfo:
         """Return a device description for device registry."""
         return DeviceInfo(
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, "xbox_live")},
             manufacturer="Microsoft",
             model="Xbox Live",

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -36,7 +36,7 @@ async def test_list_devices(hass, client, registry):
         manufacturer="manufacturer",
         model="model",
         via_device=("bridgeid", "0123"),
-        entry_type="service",
+        entry_type=helpers_dr.DeviceEntryType.SERVICE,
     )
 
     await client.send_json({"id": 5, "type": "config/device_registry/list"})
@@ -68,7 +68,7 @@ async def test_list_devices(hass, client, registry):
             "model": "model",
             "name": None,
             "sw_version": None,
-            "entry_type": "service",
+            "entry_type": helpers_dr.DeviceEntryType.SERVICE,
             "via_device_id": dev1,
             "area_id": None,
             "name_by_user": None,

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -176,7 +176,7 @@ async def test_gateway_setup(hass, aioclient_mock):
     )
 
     assert gateway_entry.configuration_url == f"http://{HOST}:{PORT}"
-    assert gateway_entry.entry_type == "service"
+    assert gateway_entry.entry_type is dr.DeviceEntryType.SERVICE
 
 
 async def test_gateway_device_configuration_url_when_addon(hass, aioclient_mock):

--- a/tests/components/kraken/test_sensor.py
+++ b/tests/components/kraken/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.kraken.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START
+from homeassistant.helpers.device_registry import DeviceEntryType
 import homeassistant.util.dt as dt_util
 
 from .const import (
@@ -253,7 +254,7 @@ async def test_sensors_available_after_restart(hass):
             identifiers={(DOMAIN, "XBT_USD")},
             name="XBT USD",
             manufacturer="Kraken.com",
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
         )
         entry.add_to_hass(hass)
 

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     DEVICE_CLASS_TIMESTAMP,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.util import dt
 
 from tests.common import (
@@ -390,7 +391,7 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         )
         assert picnic_service.model == DEFAULT_USER_RESPONSE["user_id"]
         assert picnic_service.name == "Picnic: Commonstreet 123a"
-        assert picnic_service.entry_type == "service"
+        assert picnic_service.entry_type is DeviceEntryType.SERVICE
 
     async def test_auth_token_is_saved_on_update(self):
         """Test that auth-token changes in the session object are reflected by the config entry."""

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -179,7 +179,7 @@ async def test_loading_from_storage(hass, hass_storage):
                     "model": "model",
                     "name": "name",
                     "sw_version": "version",
-                    "entry_type": "service",
+                    "entry_type": device_registry.DeviceEntryType.SERVICE,
                     "area_id": "12345A",
                     "name_by_user": "Test Friendly Name",
                     "disabled_by": device_registry.DISABLED_USER,
@@ -212,7 +212,7 @@ async def test_loading_from_storage(hass, hass_storage):
     assert entry.id == "abcdefghijklm"
     assert entry.area_id == "12345A"
     assert entry.name_by_user == "Test Friendly Name"
-    assert entry.entry_type == "service"
+    assert entry.entry_type is device_registry.DeviceEntryType.SERVICE
     assert entry.disabled_by == device_registry.DISABLED_USER
     assert isinstance(entry.config_entries, set)
     assert isinstance(entry.connections, set)

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -839,7 +839,7 @@ async def test_device_info_called(hass):
                         "name": "test-name",
                         "sw_version": "test-sw",
                         "suggested_area": "Heliport",
-                        "entry_type": "service",
+                        "entry_type": dr.DeviceEntryType.SERVICE,
                         "via_device": ("hue", "via-id"),
                     },
                 ),
@@ -863,7 +863,7 @@ async def test_device_info_called(hass):
     assert device.identifiers == {("hue", "1234")}
     assert device.configuration_url == "http://192.168.0.100/config"
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, "abcd")}
-    assert device.entry_type == "service"
+    assert device.entry_type is dr.DeviceEntryType.SERVICE
     assert device.manufacturer == "test-manuf"
     assert device.model == "test-model"
     assert device.name == "test-name"


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

~Make device entry type an enum. This is a quite large PR, but should be an easy review.~

~If this incompatibility is seen too much out of the blue, we could try limited compat deprecation period, like keeping `DeviceInfo` and  `device_registry.async_get_or_create` working when passed a `str` still for a bit. But it wouldn't be full compatibility though as the `entry_type` would no longer be a `str` after initialization, nor might it help too much with possibilities to split this PR to smaller pieces as getting typechecks to pass could get complicated. Thoughts? Filing as one big blob anyway for now to see how the tests fare.~

Here go remaining `entry_type` `str` usages converted to DeviceEntryType.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/548, #59940
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
