### PR TITLE
Avoid circular import in network integration

### DIFF
--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -4,22 +4,12 @@ from __future__ import annotations
 from ipaddress import IPv4Address, IPv6Address, ip_interface
 import logging
 
-import voluptuous as vol
-
-from homeassistant.components import websocket_api
-from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
 from . import util
-from .const import (
-    ATTR_ADAPTERS,
-    ATTR_CONFIGURED_ADAPTERS,
-    DOMAIN,
-    IPV4_BROADCAST_ADDR,
-    NETWORK_CONFIG_SCHEMA,
-)
+from .const import DOMAIN, IPV4_BROADCAST_ADDR
 from .models import Adapter
 from .network import Network
 
@@ -107,50 +97,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     _LOGGER.debug("Adapters: %s", network.adapters)
 
-    websocket_api.async_register_command(hass, websocket_network_adapters)
-    websocket_api.async_register_command(hass, websocket_network_adapters_configure)
+    # Avoid circular issue: http->network->websocket_api->http
+    from .websocket import (  # pylint: disable=import-outside-toplevel
+        async_register_websocket_commands,
+    )
+
+    async_register_websocket_commands(hass)
 
     return True
-
-
-@websocket_api.require_admin
-@websocket_api.websocket_command({vol.Required("type"): "network"})
-@websocket_api.async_response
-async def websocket_network_adapters(
-    hass: HomeAssistant,
-    connection: ActiveConnection,
-    msg: dict,
-) -> None:
-    """Return network preferences."""
-    network: Network = hass.data[DOMAIN]
-    connection.send_result(
-        msg["id"],
-        {
-            ATTR_ADAPTERS: network.adapters,
-            ATTR_CONFIGURED_ADAPTERS: network.configured_adapters,
-        },
-    )
-
-
-@websocket_api.require_admin
-@websocket_api.websocket_command(
-    {
-        vol.Required("type"): "network/configure",
-        vol.Required("config", default={}): NETWORK_CONFIG_SCHEMA,
-    }
-)
-@websocket_api.async_response
-async def websocket_network_adapters_configure(
-    hass: HomeAssistant,
-    connection: ActiveConnection,
-    msg: dict,
-) -> None:
-    """Update network config."""
-    network: Network = hass.data[DOMAIN]
-
-    await network.async_reconfig(msg["config"])
-
-    connection.send_result(
-        msg["id"],
-        {ATTR_CONFIGURED_ADAPTERS: network.configured_adapters},
-    )

--- a/homeassistant/components/network/websocket.py
+++ b/homeassistant/components/network/websocket.py
@@ -1,0 +1,66 @@
+"""The Network Configuration integration websocket commands."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.components.websocket_api.connection import ActiveConnection
+from homeassistant.core import HomeAssistant, callback
+
+from .const import (
+    ATTR_ADAPTERS,
+    ATTR_CONFIGURED_ADAPTERS,
+    DOMAIN,
+    NETWORK_CONFIG_SCHEMA,
+)
+from .network import Network
+
+
+@callback
+def async_register_websocket_commands(hass: HomeAssistant) -> None:
+    """Register network websocket commands."""
+    websocket_api.async_register_command(hass, websocket_network_adapters)
+    websocket_api.async_register_command(hass, websocket_network_adapters_configure)
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required("type"): "network"})
+@websocket_api.async_response
+async def websocket_network_adapters(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict,
+) -> None:
+    """Return network preferences."""
+    network: Network = hass.data[DOMAIN]
+    connection.send_result(
+        msg["id"],
+        {
+            ATTR_ADAPTERS: network.adapters,
+            ATTR_CONFIGURED_ADAPTERS: network.configured_adapters,
+        },
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "network/configure",
+        vol.Required("config", default={}): NETWORK_CONFIG_SCHEMA,
+    }
+)
+@websocket_api.async_response
+async def websocket_network_adapters_configure(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict,
+) -> None:
+    """Update network config."""
+    network: Network = hass.data[DOMAIN]
+
+    await network.async_reconfig(msg["config"])
+
+    connection.send_result(
+        msg["id"],
+        {ATTR_CONFIGURED_ADAPTERS: network.configured_adapters},
+    )


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid circular import in network integration

- This prepares the network integration to be usable in http


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
