### PR TITLE
Update light turn_on schema to coerce colors to tuple before asserting sequence type

### DIFF
--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections import Counter
 import itertools
+import logging
 from typing import Any, Set, cast
 
 import voluptuous as vol
@@ -65,6 +66,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 SUPPORT_GROUP_LIGHT = (
     SUPPORT_EFFECT | SUPPORT_FLASH | SUPPORT_TRANSITION | SUPPORT_WHITE_VALUE
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_platform(
@@ -151,6 +154,8 @@ class LightGroup(GroupEntity, light.LightEntity):
             key: value for key, value in kwargs.items() if key in FORWARDED_ATTRIBUTES
         }
         data[ATTR_ENTITY_ID] = self._entity_ids
+
+        _LOGGER.debug("Forwarded turn_on command: %s", data)
 
         await self.hass.services.async_call(
             light.DOMAIN,

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -202,13 +202,13 @@ LIGHT_TURN_ON_SCHEMA = {
     ),
     vol.Exclusive(ATTR_KELVIN, COLOR_GROUP): cv.positive_int,
     vol.Exclusive(ATTR_HS_COLOR, COLOR_GROUP): vol.All(
+        vol.Coerce(tuple),
         vol.ExactSequence(
             (
                 vol.All(vol.Coerce(float), vol.Range(min=0, max=360)),
                 vol.All(vol.Coerce(float), vol.Range(min=0, max=100)),
             )
         ),
-        vol.Coerce(tuple),
     ),
     vol.Exclusive(ATTR_RGB_COLOR, COLOR_GROUP): vol.All(
         vol.Coerce(tuple), vol.ExactSequence((cv.byte,) * 3)

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -211,16 +211,16 @@ LIGHT_TURN_ON_SCHEMA = {
         vol.Coerce(tuple),
     ),
     vol.Exclusive(ATTR_RGB_COLOR, COLOR_GROUP): vol.All(
-        vol.ExactSequence((cv.byte,) * 3), vol.Coerce(tuple)
+        vol.Coerce(tuple), vol.ExactSequence((cv.byte,) * 3)
     ),
     vol.Exclusive(ATTR_RGBW_COLOR, COLOR_GROUP): vol.All(
-        vol.ExactSequence((cv.byte,) * 4), vol.Coerce(tuple)
+        vol.Coerce(tuple), vol.ExactSequence((cv.byte,) * 4)
     ),
     vol.Exclusive(ATTR_RGBWW_COLOR, COLOR_GROUP): vol.All(
-        vol.ExactSequence((cv.byte,) * 5), vol.Coerce(tuple)
+        vol.Coerce(tuple), vol.ExactSequence((cv.byte,) * 5)
     ),
     vol.Exclusive(ATTR_XY_COLOR, COLOR_GROUP): vol.All(
-        vol.ExactSequence((cv.small_float, cv.small_float)), vol.Coerce(tuple)
+        vol.Coerce(tuple), vol.ExactSequence((cv.small_float, cv.small_float))
     ),
     vol.Exclusive(ATTR_WHITE, COLOR_GROUP): VALID_BRIGHTNESS,
     ATTR_WHITE_VALUE: vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -196,7 +196,7 @@ class GamutType:
     blue: XYPoint = attr.ib()
 
 
-def color_name_to_rgb(color_name: str) -> tuple[int, int, int]:
+def color_name_to_rgb(color_name: str) -> RGBColor:
     """Convert color name to RGB hex value."""
     # COLORS map has no spaces in it, so make the color_name have no
     # spaces in it as well for matching purposes
@@ -204,7 +204,7 @@ def color_name_to_rgb(color_name: str) -> tuple[int, int, int]:
     if not hex_value:
         raise ValueError("Unknown color")
 
-    return tuple(hex_value)  # type: ignore[return-value]
+    return hex_value
 
 
 # pylint: disable=invalid-name

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -196,7 +196,7 @@ class GamutType:
     blue: XYPoint = attr.ib()
 
 
-def color_name_to_rgb(color_name: str) -> RGBColor:
+def color_name_to_rgb(color_name: str) -> tuple[int, int, int]:
     """Convert color name to RGB hex value."""
     # COLORS map has no spaces in it, so make the color_name have no
     # spaces in it as well for matching purposes
@@ -204,7 +204,7 @@ def color_name_to_rgb(color_name: str) -> RGBColor:
     if not hex_value:
         raise ValueError("Unknown color")
 
-    return hex_value
+    return tuple(hex_value)  # type: ignore[return-value]
 
 
 # pylint: disable=invalid-name

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -3,12 +3,15 @@ from os import path
 import unittest.mock
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from homeassistant import config as hass_config
 from homeassistant.components.group import DOMAIN, SERVICE_RELOAD
 import homeassistant.components.group.light as group
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
+    ATTR_COLOR_NAME,
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_EFFECT_LIST,
@@ -28,6 +31,7 @@ from homeassistant.components.light import (
     COLOR_MODE_COLOR_TEMP,
     COLOR_MODE_HS,
     COLOR_MODE_ONOFF,
+    COLOR_MODE_RGB,
     COLOR_MODE_RGBW,
     COLOR_MODE_RGBWW,
     COLOR_MODE_WHITE,
@@ -258,6 +262,77 @@ async def test_color_hs(hass, enable_custom_integrations):
     assert state.attributes[ATTR_COLOR_MODE] == "hs"
     assert state.attributes[ATTR_HS_COLOR] == (0, 50)
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs"]
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+
+
+async def test_color_rgb(hass, enable_custom_integrations):
+    """Test rgbw color reporting."""
+    platform = getattr(hass.components, "test.light")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
+
+    entity0 = platform.ENTITIES[0]
+    entity0.supported_color_modes = {COLOR_MODE_RGB}
+    entity0.color_mode = COLOR_MODE_RGB
+    entity0.brightness = 255
+    entity0.rgb_color = (0, 64, 128)
+
+    entity1 = platform.ENTITIES[1]
+    entity1.supported_color_modes = {COLOR_MODE_RGB}
+    entity1.color_mode = COLOR_MODE_RGB
+    entity1.brightness = 255
+    entity1.rgb_color = (255, 128, 64)
+
+    assert await async_setup_component(
+        hass,
+        LIGHT_DOMAIN,
+        {
+            LIGHT_DOMAIN: [
+                {"platform": "test"},
+                {
+                    "platform": DOMAIN,
+                    "entities": ["light.test1", "light.test2"],
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.light_group")
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_COLOR_MODE] == "rgb"
+    assert state.attributes[ATTR_RGB_COLOR] == (0, 64, 128)
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": [entity1.entity_id]},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("light.light_group")
+    assert state.attributes[ATTR_COLOR_MODE] == "rgb"
+    assert state.attributes[ATTR_RGB_COLOR] == (127, 96, 96)
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+
+    await hass.services.async_call(
+        "light",
+        "turn_off",
+        {"entity_id": [entity0.entity_id]},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("light.light_group")
+    assert state.attributes[ATTR_COLOR_MODE] == "rgb"
+    assert state.attributes[ATTR_RGB_COLOR] == (255, 128, 64)
+    assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
@@ -1039,14 +1114,40 @@ async def test_supported_features(hass):
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 40
 
 
-async def test_service_calls(hass):
+@pytest.mark.parametrize("supported_color_modes", [COLOR_MODE_HS, COLOR_MODE_RGB])
+async def test_service_calls(hass, enable_custom_integrations, supported_color_modes):
     """Test service calls."""
+    platform = getattr(hass.components, "test.light")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(platform.MockLight("bed_light", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("ceiling_lights", STATE_OFF))
+    platform.ENTITIES.append(platform.MockLight("kitchen_lights", STATE_OFF))
+
+    entity0 = platform.ENTITIES[0]
+    entity0.supported_color_modes = {supported_color_modes}
+    entity0.color_mode = supported_color_modes
+    entity0.brightness = 255
+    entity0.rgb_color = (0, 64, 128)
+
+    entity1 = platform.ENTITIES[1]
+    entity1.supported_color_modes = {supported_color_modes}
+    entity1.color_mode = supported_color_modes
+    entity1.brightness = 255
+    entity1.rgb_color = (255, 128, 64)
+
+    entity2 = platform.ENTITIES[2]
+    entity2.supported_color_modes = {supported_color_modes}
+    entity2.color_mode = supported_color_modes
+    entity2.brightness = 255
+    entity2.rgb_color = (255, 128, 64)
+
     await async_setup_component(
         hass,
         LIGHT_DOMAIN,
         {
             LIGHT_DOMAIN: [
-                {"platform": "demo"},
+                {"platform": "test"},
                 {
                     "platform": DOMAIN,
                     "entities": [
@@ -1062,14 +1163,16 @@ async def test_service_calls(hass):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.get("light.light_group").state == STATE_ON
+    group_state = hass.states.get("light.light_group")
+    assert group_state.state == STATE_ON
+    assert group_state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [supported_color_modes]
+
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TOGGLE,
         {ATTR_ENTITY_ID: "light.light_group"},
         blocking=True,
     )
-
     assert hass.states.get("light.bed_light").state == STATE_OFF
     assert hass.states.get("light.ceiling_lights").state == STATE_OFF
     assert hass.states.get("light.kitchen_lights").state == STATE_OFF
@@ -1095,6 +1198,84 @@ async def test_service_calls(hass):
     assert hass.states.get("light.bed_light").state == STATE_OFF
     assert hass.states.get("light.ceiling_lights").state == STATE_OFF
     assert hass.states.get("light.kitchen_lights").state == STATE_OFF
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.light_group",
+            ATTR_BRIGHTNESS: 128,
+            ATTR_RGB_COLOR: (42, 255, 255),
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("light.bed_light")
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_RGB_COLOR] == (42, 255, 255)
+
+    state = hass.states.get("light.ceiling_lights")
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_RGB_COLOR] == (42, 255, 255)
+
+    state = hass.states.get("light.kitchen_lights")
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_RGB_COLOR] == (42, 255, 255)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.light_group",
+            ATTR_BRIGHTNESS: 128,
+            ATTR_COLOR_NAME: "red",
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("light.bed_light")
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_RGB_COLOR] == (255, 0, 0)
+
+    state = hass.states.get("light.ceiling_lights")
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_RGB_COLOR] == (255, 0, 0)
+
+    state = hass.states.get("light.kitchen_lights")
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_RGB_COLOR] == (255, 0, 0)
+
+
+async def test_service_call_effect(hass):
+    """Test service calls."""
+    await async_setup_component(
+        hass,
+        LIGHT_DOMAIN,
+        {
+            LIGHT_DOMAIN: [
+                {"platform": "demo"},
+                {
+                    "platform": DOMAIN,
+                    "entities": [
+                        "light.bed_light",
+                        "light.ceiling_lights",
+                        "light.kitchen_lights",
+                    ],
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.light_group").state == STATE_ON
 
     await hass.services.async_call(
         LIGHT_DOMAIN,

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.exceptions import Unauthorized
 from homeassistant.setup import async_setup_component
+import homeassistant.util.color as color_util
 
 from tests.common import async_mock_service
 
@@ -1587,6 +1588,83 @@ async def test_light_service_call_color_conversion(hass, enable_custom_integrati
     _, data = entity6.last_call("turn_on")
     # The midpoint the the white channels is warm, compensated by adding green + blue
     assert data == {"brightness": 128, "rgbww_color": (0, 75, 140, 255, 255)}
+
+
+async def test_light_service_call_color_conversion_named_tuple(
+    hass, enable_custom_integrations
+):
+    """Test a named tuple (RGBColor) is handled correctly."""
+    platform = getattr(hass.components, "test.light")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(platform.MockLight("Test_hs", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_rgb", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_xy", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_all", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_legacy", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_rgbw", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_rgbww", STATE_ON))
+
+    entity0 = platform.ENTITIES[0]
+    entity0.supported_color_modes = {light.COLOR_MODE_HS}
+
+    entity1 = platform.ENTITIES[1]
+    entity1.supported_color_modes = {light.COLOR_MODE_RGB}
+
+    entity2 = platform.ENTITIES[2]
+    entity2.supported_color_modes = {light.COLOR_MODE_XY}
+
+    entity3 = platform.ENTITIES[3]
+    entity3.supported_color_modes = {
+        light.COLOR_MODE_HS,
+        light.COLOR_MODE_RGB,
+        light.COLOR_MODE_XY,
+    }
+
+    entity4 = platform.ENTITIES[4]
+    entity4.supported_features = light.SUPPORT_COLOR
+
+    entity5 = platform.ENTITIES[5]
+    entity5.supported_color_modes = {light.COLOR_MODE_RGBW}
+
+    entity6 = platform.ENTITIES[6]
+    entity6.supported_color_modes = {light.COLOR_MODE_RGBWW}
+
+    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [
+                entity0.entity_id,
+                entity1.entity_id,
+                entity2.entity_id,
+                entity3.entity_id,
+                entity4.entity_id,
+                entity5.entity_id,
+                entity6.entity_id,
+            ],
+            "brightness_pct": 50,
+            "rgb_color": color_util.RGBColor(128, 0, 0),
+        },
+        blocking=True,
+    )
+    _, data = entity0.last_call("turn_on")
+    assert data == {"brightness": 128, "hs_color": (0.0, 100.0)}
+    _, data = entity1.last_call("turn_on")
+    assert data == {"brightness": 128, "rgb_color": (128, 0, 0)}
+    _, data = entity2.last_call("turn_on")
+    assert data == {"brightness": 128, "xy_color": (0.701, 0.299)}
+    _, data = entity3.last_call("turn_on")
+    assert data == {"brightness": 128, "rgb_color": (128, 0, 0)}
+    _, data = entity4.last_call("turn_on")
+    assert data == {"brightness": 128, "hs_color": (0.0, 100.0)}
+    _, data = entity5.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbw_color": (128, 0, 0, 0)}
+    _, data = entity6.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbww_color": (128, 0, 0, 0, 0)}
 
 
 async def test_light_service_call_color_temp_emulation(

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1646,25 +1646,25 @@ async def test_light_service_call_color_conversion_named_tuple(
                 entity5.entity_id,
                 entity6.entity_id,
             ],
-            "brightness_pct": 50,
+            "brightness_pct": 25,
             "rgb_color": color_util.RGBColor(128, 0, 0),
         },
         blocking=True,
     )
     _, data = entity0.last_call("turn_on")
-    assert data == {"brightness": 128, "hs_color": (0.0, 100.0)}
+    assert data == {"brightness": 64, "hs_color": (0.0, 100.0)}
     _, data = entity1.last_call("turn_on")
-    assert data == {"brightness": 128, "rgb_color": (128, 0, 0)}
+    assert data == {"brightness": 64, "rgb_color": (128, 0, 0)}
     _, data = entity2.last_call("turn_on")
-    assert data == {"brightness": 128, "xy_color": (0.701, 0.299)}
+    assert data == {"brightness": 64, "xy_color": (0.701, 0.299)}
     _, data = entity3.last_call("turn_on")
-    assert data == {"brightness": 128, "rgb_color": (128, 0, 0)}
+    assert data == {"brightness": 64, "rgb_color": (128, 0, 0)}
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 128, "hs_color": (0.0, 100.0)}
+    assert data == {"brightness": 64, "hs_color": (0.0, 100.0)}
     _, data = entity5.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbw_color": (128, 0, 0, 0)}
+    assert data == {"brightness": 64, "rgbw_color": (128, 0, 0, 0)}
     _, data = entity6.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbww_color": (128, 0, 0, 0, 0)}
+    assert data == {"brightness": 64, "rgbww_color": (128, 0, 0, 0, 0)}
 
 
 async def test_light_service_call_color_temp_emulation(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update light `turn_on` schema to coerce colors to tuple before asserting sequence type
Without it, this throws when the rgb color is a named tuple `RGBColor`
```py
    vol.Exclusive(ATTR_RGB_COLOR, COLOR_GROUP): vol.All(
        vol.ExactSequence((cv.byte,) * 3), vol.Coerce(tuple)
    ),
```

More precisely, this fails:
```
    async def test_exactsequence():
>       vol.ExactSequence((int,)*3)(color_util.RGBColor(1, 2, 3))

tests/components/group/test_light.py:1312:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = ExactSequence([<class 'int'>, <class 'int'>, <class 'int'>]), v = RGBColor(r=1, g=2, b=3)

    def __call__(self, v):
        if not isinstance(v, (list, tuple)) or len(v) != len(self._schemas):
            raise ExactSequenceInvalid(self.msg)
        try:
>           v = type(v)(schema(x) for x, schema in zip(v, self._schemas))
E           TypeError: __new__() missing 2 required positional arguments: 'g' and 'b'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/57614

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
