### PR TITLE
Add zeroconf ATTR constants

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -207,7 +207,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.bridge = bridge
         return await self.async_step_link()
 
-    async def async_step_zeroconf(self, discovery_info: dict[str, Any]):
+    async def async_step_zeroconf(self, discovery_info: dict[str, Any]) -> FlowResult:
         """Handle a discovered Hue bridge.
 
         This flow is triggered by the Zeroconf component. It will check if the

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.const import CONF_HOST, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .bridge import authenticate_bridge
 from .const import (
@@ -207,7 +208,9 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.bridge = bridge
         return await self.async_step_link()
 
-    async def async_step_zeroconf(self, discovery_info: dict[str, Any]) -> FlowResult:
+    async def async_step_zeroconf(
+        self, discovery_info: DiscoveryInfoType
+    ) -> FlowResult:
         """Handle a discovered Hue bridge.
 
         This flow is triggered by the Zeroconf component. It will check if the

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -11,7 +11,7 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries, core
-from homeassistant.components import ssdp
+from homeassistant.components import ssdp, zeroconf
 from homeassistant.const import CONF_HOST, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
@@ -207,14 +207,15 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.bridge = bridge
         return await self.async_step_link()
 
-    async def async_step_zeroconf(self, discovery_info):
+    async def async_step_zeroconf(self, discovery_info: dict[str, Any]):
         """Handle a discovered Hue bridge.
 
         This flow is triggered by the Zeroconf component. It will check if the
         host is already configured and delegate to the import step if not.
         """
         bridge = self._async_get_bridge(
-            discovery_info["host"], discovery_info["properties"]["bridgeid"]
+            discovery_info[zeroconf.ATTR_HOST],
+            discovery_info[zeroconf.ATTR_PROPERTIES]["bridgeid"],
         )
 
         await self.async_set_unique_id(bridge.id)

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -63,11 +63,8 @@ MAX_NAME_LEN = 63
 
 # Attributes for HaServiceInfo
 ATTR_HOST: Final = "host"
-ATTR_HOSTNAME: Final = "hostname"
 ATTR_NAME: Final = "name"
-ATTR_PORT: Final = "port"
 ATTR_PROPERTIES: Final = "properties"
-ATTR_TYPE: Final = "type"
 
 
 CONFIG_SCHEMA = vol.Schema(

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -8,7 +8,7 @@ from ipaddress import IPv4Address, IPv6Address, ip_address
 import logging
 import socket
 import sys
-from typing import Any, TypedDict, cast
+from typing import Any, Final, TypedDict, cast
 
 import voluptuous as vol
 from zeroconf import InterfaceChoice, IPVersion, ServiceStateChange
@@ -60,6 +60,15 @@ MAX_PROPERTY_VALUE_LEN = 230
 
 # Dns label max length
 MAX_NAME_LEN = 63
+
+# Attributes for HaServiceInfo
+ATTR_HOST: Final = "host"
+ATTR_HOSTNAME: Final = "hostname"
+ATTR_NAME: Final = "name"
+ATTR_PORT: Final = "port"
+ATTR_PROPERTIES: Final = "properties"
+ATTR_TYPE: Final = "type"
+
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -349,7 +358,7 @@ class ZeroconfDiscovery:
 
         # If we can handle it as a HomeKit discovery, we do that here.
         if service_type in HOMEKIT_TYPES:
-            props = info["properties"]
+            props = info[ATTR_PROPERTIES]
             if domain := async_get_homekit_discovery_domain(self.homekit_models, props):
                 discovery_flow.async_create_flow(
                     self.hass, domain, {"source": config_entries.SOURCE_HOMEKIT}, info
@@ -371,18 +380,18 @@ class ZeroconfDiscovery:
                     # likely bad homekit data
                     return
 
-        if "name" in info:
-            lowercase_name: str | None = info["name"].lower()
+        if ATTR_NAME in info:
+            lowercase_name: str | None = info[ATTR_NAME].lower()
         else:
             lowercase_name = None
 
-        if "macaddress" in info["properties"]:
-            uppercase_mac: str | None = info["properties"]["macaddress"].upper()
+        if "macaddress" in info[ATTR_PROPERTIES]:
+            uppercase_mac: str | None = info[ATTR_PROPERTIES]["macaddress"].upper()
         else:
             uppercase_mac = None
 
-        if "manufacturer" in info["properties"]:
-            lowercase_manufacturer: str | None = info["properties"][
+        if "manufacturer" in info[ATTR_PROPERTIES]:
+            lowercase_manufacturer: str | None = info[ATTR_PROPERTIES][
                 "manufacturer"
             ].lower()
         else:
@@ -476,14 +485,14 @@ def info_from_service(service: AsyncServiceInfo) -> HaServiceInfo | None:
     if (host := _first_non_link_local_or_v6_address(addresses)) is None:
         return None
 
-    return {
-        "host": str(host),
-        "port": service.port,
-        "hostname": service.server,
-        "type": service.type,
-        "name": service.name,
-        "properties": properties,
-    }
+    return HaServiceInfo(
+        host=str(host),
+        port=service.port,
+        hostname=service.server,
+        type=service.type,
+        name=service.name,
+        properties=properties,
+    )
 
 
 def _first_non_link_local_or_v6_address(addresses: list[bytes]) -> str | None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `ATTR_*` constants to `zeroconf`, to be used by the various config flows.
Sample use in `hue`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
