### PR TITLE
Add zwave_js binary sensor entity category

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -156,12 +156,6 @@ NOTIFICATION_SENSOR_MAPPINGS: tuple[NotificationZWaveJSEntityDescription, ...] =
         device_class=DEVICE_CLASS_DOOR,
     ),
     NotificationZWaveJSEntityDescription(
-        # NotificationType 6: Access Control - State Id 17 (door/window closed)
-        key=NOTIFICATION_ACCESS_CONTROL,
-        states=("23",),
-        entity_registry_enabled_default=False,
-    ),
-    NotificationZWaveJSEntityDescription(
         # NotificationType 7: Home Security - State Id's 1, 2 (intrusion)
         key=NOTIFICATION_HOME_SECURITY,
         states=("1", "2"),

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -149,9 +149,10 @@ NOTIFICATION_SENSOR_MAPPINGS: tuple[NotificationZWaveJSEntityDescription, ...] =
         device_class=DEVICE_CLASS_LOCK,
     ),
     NotificationZWaveJSEntityDescription(
-        # NotificationType 6: Access Control - State Id 16 (door/window open)
+        # NotificationType 6: Access Control - State Id 22 (door/window open)
         key=NOTIFICATION_ACCESS_CONTROL,
-        states=("22",),
+        off_state="23",
+        states=("22", "23"),
         device_class=DEVICE_CLASS_DOOR,
     ),
     NotificationZWaveJSEntityDescription(

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -23,11 +23,13 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_SAFETY,
     DEVICE_CLASS_SMOKE,
     DEVICE_CLASS_SOUND,
+    DEVICE_CLASS_TAMPER,
     DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -166,7 +168,8 @@ NOTIFICATION_SENSOR_MAPPINGS: tuple[NotificationZWaveJSEntityDescription, ...] =
         # NotificationType 7: Home Security - State Id's 3, 4, 9 (tampering)
         key=NOTIFICATION_HOME_SECURITY,
         states=("3", "4", "9"),
-        device_class=DEVICE_CLASS_SAFETY,
+        device_class=DEVICE_CLASS_TAMPER,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     NotificationZWaveJSEntityDescription(
         # NotificationType 7: Home Security - State Id's 5, 6 (glass breakage)
@@ -179,6 +182,14 @@ NOTIFICATION_SENSOR_MAPPINGS: tuple[NotificationZWaveJSEntityDescription, ...] =
         key=NOTIFICATION_HOME_SECURITY,
         states=("7", "8"),
         device_class=DEVICE_CLASS_MOTION,
+    ),
+    NotificationZWaveJSEntityDescription(
+        # NotificationType 8: Power Management -
+        # State Id's 10, 11, 17 (Battery maintenance status)
+        key=NOTIFICATION_POWER_MANAGEMENT,
+        states=("10", "11", "17"),
+        device_class=DEVICE_CLASS_BATTERY,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     NotificationZWaveJSEntityDescription(
         # NotificationType 9: System - State Id's 1, 2, 6, 7
@@ -228,6 +239,7 @@ BOOLEAN_SENSOR_MAPPINGS: dict[str, BinarySensorEntityDescription] = {
     CommandClass.BATTERY: BinarySensorEntityDescription(
         key=str(CommandClass.BATTERY),
         device_class=DEVICE_CLASS_BATTERY,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
 }
 

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -1,6 +1,9 @@
 """Provide common test tools for Z-Wave JS."""
 AIR_TEMPERATURE_SENSOR = "sensor.multisensor_6_air_temperature"
 BATTERY_SENSOR = "sensor.multisensor_6_battery_level"
+TAMPER_SENSOR = (
+    "binary_sensor.multisensor_6_home_security_tampering_product_cover_removed"
+)
 HUMIDITY_SENSOR = "sensor.multisensor_6_humidity"
 POWER_SENSOR = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed"
 ENERGY_SENSOR = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed_2"

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -1,11 +1,19 @@
 """Test the Z-Wave JS binary sensor platform."""
 from zwave_js_server.event import Event
+from zwave_js_server.model.node import Node
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_TAMPER,
 )
-from homeassistant.const import DEVICE_CLASS_BATTERY, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    DEVICE_CLASS_BATTERY,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import (
@@ -14,7 +22,10 @@ from .common import (
     LOW_BATTERY_BINARY_SENSOR,
     NOTIFICATION_MOTION_BINARY_SENSOR,
     PROPERTY_DOOR_STATUS_BINARY_SENSOR,
+    TAMPER_SENSOR,
 )
+
+from tests.common import MockConfigEntry
 
 
 async def test_low_battery_sensor(hass, multisensor_6, integration):
@@ -24,6 +35,12 @@ async def test_low_battery_sensor(hass, multisensor_6, integration):
     assert state
     assert state.state == STATE_OFF
     assert state.attributes["device_class"] == DEVICE_CLASS_BATTERY
+
+    registry = er.async_get(hass)
+    entity_entry = registry.async_get(LOW_BATTERY_BINARY_SENSOR)
+
+    assert entity_entry
+    assert entity_entry.entity_category == ENTITY_CATEGORY_DIAGNOSTIC
 
 
 async def test_enabled_legacy_sensor(hass, ecolink_door_sensor, integration):
@@ -89,6 +106,50 @@ async def test_notification_sensor(hass, multisensor_6, integration):
     assert state
     assert state.state == STATE_ON
     assert state.attributes["device_class"] == DEVICE_CLASS_MOTION
+
+    state = hass.states.get(TAMPER_SENSOR)
+
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes["device_class"] == DEVICE_CLASS_TAMPER
+
+    registry = er.async_get(hass)
+    entity_entry = registry.async_get(TAMPER_SENSOR)
+
+    assert entity_entry
+    assert entity_entry.entity_category == ENTITY_CATEGORY_DIAGNOSTIC
+
+
+async def test_notification_off_state(
+    hass: HomeAssistant,
+    lock_popp_electric_strike_lock_control: Node,
+):
+    """Test the description off_state attribute of certain notification sensors."""
+    node = lock_popp_electric_strike_lock_control
+    # Remove all other values except the door state value.
+    node.values = {
+        value_id: value
+        for value_id, value in node.values.items()
+        if value_id == "62-113-0-Access Control-Door state"
+    }
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    door_states = [
+        state
+        for state in hass.states.async_all("binary_sensor")
+        if state.attributes.get("device_class") == DEVICE_CLASS_DOOR
+    ]
+
+    # Only one entity should be created for the Door state notification states.
+    assert len(door_states) == 1
+
+    state = door_states[0]
+    assert state
+    assert state.entity_id == "binary_sensor.node_62_access_control_window_door_is_open"
 
 
 async def test_property_sensor_door_status(hass, lock_august_pro, integration):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- Door state notification sensors will now be represented by a single binary sensor entity that changes state between open and closed representing the door state. The binary sensor notification entity that only represented the closed state has been removed. Please check and update your automations and scripts if you have any that targeted that kind of entity.
- The home security tamper binary sensor has changed device class from safety to tamper.
- Some entities have been marked as diagnostic, eg battery maintenance sensor, mains status sensor, tamper sensor and low battery sensor. Diagnostic entities:
  - Are, by default, not exposed to Google Assistant or Alexa.
  - Are shown on a separate card on the device configuration page.
  - Do not show up on the automatically generated Lovelace Dashboards.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add support for entity categories in the binary sensor platform.
- Add support for non idle notification sensors where the off state is not idle.
- Change device class to tamper for the tamper sensor, instead of safety.
- Add entity category examples for some cases.
- Remove door state entity that only represented the closed state. Now there's a single binary sensor entity that changes state between open and closed representing the door state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
