### PR TITLE
Get Litter-Robot to 100% code coverage and minor code cleanup

### DIFF
--- a/homeassistant/components/litterrobot/select.py
+++ b/homeassistant/components/litterrobot/select.py
@@ -23,14 +23,14 @@ async def async_setup_entry(
     """Set up Litter-Robot selects using config entry."""
     hub: LitterRobotHub = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities = [
-        LitterRobotSelect(
-            robot=robot, entity_type=TYPE_CLEAN_CYCLE_WAIT_TIME_MINUTES, hub=hub
-        )
-        for robot in hub.account.robots
-    ]
-
-    async_add_entities(entities)
+    async_add_entities(
+        [
+            LitterRobotSelect(
+                robot=robot, entity_type=TYPE_CLEAN_CYCLE_WAIT_TIME_MINUTES, hub=hub
+            )
+            for robot in hub.account.robots
+        ]
+    )
 
 
 class LitterRobotSelect(LitterRobotControlEntity, SelectEntity):

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -98,4 +98,4 @@ async def async_setup_entry(
                 )
             )
 
-    async_add_entities(entities, True)
+    async_add_entities(entities)

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -76,4 +76,4 @@ async def async_setup_entry(
         for switch_class, switch_type in ROBOT_SWITCHES:
             entities.append(switch_class(robot=robot, entity_type=switch_type, hub=hub))
 
-    async_add_entities(entities, True)
+    async_add_entities(entities)

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -47,13 +47,12 @@ async def async_setup_entry(
     """Set up Litter-Robot cleaner using config entry."""
     hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
 
-    entities = []
-    for robot in hub.account.robots:
-        entities.append(
+    async_add_entities(
+        [
             LitterRobotCleaner(robot=robot, entity_type=TYPE_LITTER_BOX, hub=hub)
-        )
-
-    async_add_entities(entities, True)
+            for robot in hub.account.robots
+        ]
+    )
 
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -17,7 +17,7 @@ from homeassistant.components.vacuum import (
     SUPPORT_STATUS,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
-    StateVacuumEntity,
+    VacuumEntity,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF
@@ -75,7 +75,7 @@ async def async_setup_entry(
     )
 
 
-class LitterRobotCleaner(LitterRobotControlEntity, StateVacuumEntity):
+class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
     """Litter-Robot "Vacuum" Cleaner."""
 
     @property

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -60,6 +60,12 @@ def mock_account_with_no_robots() -> MagicMock:
 
 
 @pytest.fixture
+def mock_account_with_sleeping_robot() -> MagicMock:
+    """Mock a Litter-Robot account with a sleeping robot."""
+    return create_mock_account({"sleepModeActive": "102:00:00"})
+
+
+@pytest.fixture
 def mock_account_with_error() -> MagicMock:
     """Mock a Litter-Robot account with error."""
     return create_mock_account({"unitStatus": "BR"})

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -1,5 +1,6 @@
 """Test the Litter-Robot vacuum entity."""
 from datetime import timedelta
+from unittest.mock import Mock
 
 import pytest
 from voluptuous.error import MultipleInvalid
@@ -10,6 +11,8 @@ from homeassistant.components.litterrobot.vacuum import (
     SERVICE_RESET_WASTE_DRAWER,
     SERVICE_SET_SLEEP_MODE,
     SERVICE_SET_WAIT_TIME,
+    TYPE_LITTER_BOX,
+    LitterRobotCleaner,
 )
 from homeassistant.components.vacuum import (
     DOMAIN as PLATFORM_DOMAIN,
@@ -24,7 +27,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
 from .common import VACUUM_ENTITY_ID
-from .conftest import setup_integration
+from .conftest import create_mock_robot, setup_integration
 
 from tests.common import async_fire_time_changed
 
@@ -44,6 +47,16 @@ async def test_vacuum(hass: HomeAssistant, mock_account):
     assert vacuum
     assert vacuum.state == STATE_DOCKED
     assert vacuum.attributes["is_sleeping"] is False
+
+
+async def test_vacuum_status_when_sleeping(hass):
+    """Tests the vacuum status when sleeping."""
+    robot = create_mock_robot({"sleepModeActive": "102:00:00"})
+    vacuum = LitterRobotCleaner(robot, TYPE_LITTER_BOX, Mock())
+    vacuum.hass = hass
+
+    assert vacuum
+    assert vacuum.status == "Ready (Sleeping)"
 
 
 async def test_no_robots(hass: HomeAssistant, mock_account_with_no_robots):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
100% code coverage and removed update_before_add=True from async_add_entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
