### PR TITLE
Reorganize SimpliSafe services

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -342,7 +342,7 @@ async def async_setup_entry(  # noqa: C901
                 {
                     prop: value
                     for prop, value in call.data.items()
-                    if prop != ATTR_SYSTEM_ID
+                    if prop != ATTR_DEVICE_ID
                 }
             )
         except SimplipyError as err:

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -247,7 +247,7 @@ def _async_register_base_station(
 def _async_get_system_for_service_call(
     hass: HomeAssistant, call: ServiceCall
 ) -> SystemV2 | SystemV3:
-    """Get the SimpliSafe manager object related to a service call (by device ID)."""
+    """Get the SimpliSafe system related to a service call (by device ID)."""
     device_id = call.data[ATTR_DEVICE_ID]
     device_registry = dr.async_get(hass)
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -267,9 +267,7 @@ def _async_get_system_for_service_call(
     raise ValueError(f"No controller for device ID: {device_id}")
 
 
-async def async_setup_entry(  # noqa: C901
-    hass: HomeAssistant, entry: ConfigEntry
-) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SimpliSafe as config entry."""
     _async_standardize_config_entry(hass, entry)
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -137,6 +137,14 @@ SERVICE_NAME_REMOVE_PIN = "remove_pin"
 SERVICE_NAME_SET_PIN = "set_pin"
 SERVICE_NAME_SET_SYSTEM_PROPERTIES = "set_system_properties"
 
+SERVICES = (
+    SERVICE_NAME_CLEAR_NOTIFICATIONS,
+    SERVICE_NAME_REMOVE_PIN,
+    SERVICE_NAME_SET_PIN,
+    SERVICE_NAME_SET_SYSTEM_PROPERTIES,
+)
+
+
 SERVICE_REMOVE_PIN_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_DEVICE_ID): cv.string,
@@ -408,12 +416,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if len(loaded_entries) == 1:
         # If this is the last loaded instance of SimpliSafe, deregister any services
         # defined during integration setup:
-        for service_name in (
-            SERVICE_NAME_CLEAR_NOTIFICATIONS,
-            SERVICE_NAME_REMOVE_PIN,
-            SERVICE_NAME_SET_PIN,
-            SERVICE_NAME_SET_SYSTEM_PROPERTIES,
-        ):
+        for service_name in SERVICES:
             hass.services.async_remove(DOMAIN, service_name)
 
     return unload_ok

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -400,8 +400,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
 
-    entries = hass.config_entries.async_entries(DOMAIN)
-    if len(entries) == 1 and entries[0].state == ConfigEntryState.LOADED:
+    loaded_entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state == ConfigEntryState.LOADED
+    ]
+    if len(loaded_entries) == 1:
         # If this is the last loaded instance of SimpliSafe, deregister any services
         # defined during integration setup:
         for service_name in (

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -252,6 +252,8 @@ def _async_get_system_for_service_call(
     device_registry = dr.async_get(hass)
 
     if alarm_control_panel_device_entry := device_registry.async_get(device_id):
+        if TYPE_CHECKING:
+            assert alarm_control_panel_device_entry.via_device_id
         if base_station_device_entry := device_registry.async_get(
             alarm_control_panel_device_entry.via_device_id
         ):

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Iterable
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from simplipy import API
 from simplipy.device import Device, DeviceTypes
@@ -262,7 +262,9 @@ def _async_get_system_for_service_call(
             for entry in hass.config_entries.async_entries(DOMAIN):
                 if entry.entry_id in alarm_control_panel_device_entry.config_entries:
                     simplisafe = hass.data[DOMAIN][entry.entry_id]
-                    return simplisafe.systems[system_id]
+                    return cast(
+                        Union[SystemV2, SystemV3], simplisafe.systems[system_id]
+                    )
 
     raise ValueError(f"No system for device ID: {device_id}")
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -49,6 +49,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_CODE,
     CONF_CODE,
+    CONF_DEVICE_ID,
     CONF_TOKEN,
     EVENT_HOMEASSISTANT_STOP,
 )

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -264,7 +264,7 @@ def _async_get_system_for_service_call(
                     simplisafe = hass.data[DOMAIN][entry.entry_id]
                     return simplisafe.systems[system_id]
 
-    raise ValueError(f"No controller for device ID: {device_id}")
+    raise ValueError(f"No system for device ID: {device_id}")
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/simplisafe/alarm_control_panel.py
+++ b/homeassistant/components/simplisafe/alarm_control_panel.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 from simplipy.errors import SimplipyError
 from simplipy.system import SystemStates
-from simplipy.system.v2 import SystemV2
 from simplipy.system.v3 import SystemV3
 from simplipy.websocket import (
     EVENT_ALARM_CANCELED,
@@ -58,6 +57,7 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
+from .typing import SystemType
 
 ATTR_BATTERY_BACKUP_POWER_LEVEL = "battery_backup_power_level"
 ATTR_GSM_STRENGTH = "gsm_strength"
@@ -119,7 +119,7 @@ async def async_setup_entry(
 class SimpliSafeAlarm(SimpliSafeEntity, AlarmControlPanelEntity):
     """Representation of a SimpliSafe alarm."""
 
-    def __init__(self, simplisafe: SimpliSafe, system: SystemV2 | SystemV3) -> None:
+    def __init__(self, simplisafe: SimpliSafe, system: SystemType) -> None:
         """Initialize the SimpliSafe alarm."""
         super().__init__(
             simplisafe,

--- a/homeassistant/components/simplisafe/services.yaml
+++ b/homeassistant/components/simplisafe/services.yaml
@@ -3,13 +3,14 @@ remove_pin:
   name: Remove PIN
   description: Remove a PIN by its label or value.
   fields:
-    system_id:
-      name: System ID
-      description: The SimpliSafe system ID to affect.
+    device_id:
+      name: System
+      description: The system to remove the PIN from
       required: true
-      example: 123987
       selector:
-        text:
+        device:
+          integration: simplisafe
+          model: alarm_control_panel
     label_or_pin:
       name: Label/PIN
       description: The label/value to remove.
@@ -21,13 +22,14 @@ set_pin:
   name: Set PIN
   description: Set/update a PIN
   fields:
-    system_id:
-      name: System ID
-      description: The SimpliSafe system ID to affect
+    device_id:
+      name: System
+      description: The system to set the PIN on
       required: true
-      example: 123987
       selector:
-        text:
+        device:
+          integration: simplisafe
+          model: alarm_control_panel
     label:
       name: Label
       description: The label of the PIN
@@ -47,8 +49,8 @@ set_system_properties:
   description: Set one or more system properties
   fields:
     device_id:
-      name: Valve Controller
-      description: The valve controller to remove the sensor from
+      name: System
+      description: The system whose properties should be set
       required: true
       selector:
         device:

--- a/homeassistant/components/simplisafe/services.yaml
+++ b/homeassistant/components/simplisafe/services.yaml
@@ -46,6 +46,14 @@ set_system_properties:
   name: Set system properties
   description: Set one or more system properties
   fields:
+    device_id:
+      name: Valve Controller
+      description: The valve controller to remove the sensor from
+      required: true
+      selector:
+        device:
+          integration: simplisafe
+          model: alarm_control_panel
     alarm_duration:
       name: Alarm duration
       description: The length of a triggered alarm

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -19,8 +19,25 @@
                 "description": "Input the authorization code from the SimpliSafe web app URL:",
                 "title": "Finish Authorization"
             },
+            "mfa": {
+                "description": "Check your email for a link from SimpliSafe. After verifying the link, return here to complete the installation of the integration.",
+                "title": "SimpliSafe Multi-Factor Authentication"
+            },
+            "reauth_confirm": {
+                "data": {
+                    "password": "Password"
+                },
+                "description": "Your access has expired or been revoked. Enter your password to re-link your account.",
+                "title": "Reauthenticate Integration"
+            },
             "user": {
-                "description": "Starting in 2021, SimpliSafe has moved to a new authentication mechanism via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. When the process is complete, return here and click Submit."
+                "data": {
+                    "code": "Code (used in Home Assistant UI)",
+                    "password": "Password",
+                    "username": "Email"
+                },
+                "description": "Starting in 2021, SimpliSafe has moved to a new authentication mechanism via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. When the process is complete, return here and click Submit.",
+                "title": "Fill in your information."
             }
         }
     },

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -19,25 +19,8 @@
                 "description": "Input the authorization code from the SimpliSafe web app URL:",
                 "title": "Finish Authorization"
             },
-            "mfa": {
-                "description": "Check your email for a link from SimpliSafe. After verifying the link, return here to complete the installation of the integration.",
-                "title": "SimpliSafe Multi-Factor Authentication"
-            },
-            "reauth_confirm": {
-                "data": {
-                    "password": "Password"
-                },
-                "description": "Your access has expired or been revoked. Enter your password to re-link your account.",
-                "title": "Reauthenticate Integration"
-            },
             "user": {
-                "data": {
-                    "code": "Code (used in Home Assistant UI)",
-                    "password": "Password",
-                    "username": "Email"
-                },
-                "description": "Starting in 2021, SimpliSafe has moved to a new authentication mechanism via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. When the process is complete, return here and click Submit.",
-                "title": "Fill in your information."
+                "description": "Starting in 2021, SimpliSafe has moved to a new authentication mechanism via its web app. Due to technical limitations, there is a manual step at the end of this process; please ensure that you read the [documentation](http://home-assistant.io/integrations/simplisafe#getting-an-authorization-code) before starting.\n\nWhen you are ready, click [here]({url}) to open the SimpliSafe web app and input your credentials. When the process is complete, return here and click Submit."
             }
         }
     },

--- a/homeassistant/components/simplisafe/typing.py
+++ b/homeassistant/components/simplisafe/typing.py
@@ -1,0 +1,7 @@
+"""Define typing helpers for SimpliSafe."""
+from typing import Union
+
+from simplipy.system.v2 import SystemV2
+from simplipy.system.v3 import SystemV3
+
+SystemType = Union[SystemV2, SystemV3]


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
SimpliSafe services have been reorganized and now utilize a Home Assistant selector (device ID) instead of using a SimpliSafe system ID. Use of the `system_id` parameter in service calls is deprecated and will be removed at a later date.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SimpliSafe's services currently use SimpliSafe system IDs, which isn't necessary now that we can use selectors and device IDs. This PR reorganizes things so that the services use selectors instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20066

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (**not needed**)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
