### PR TITLE
Add events and device triggers to LCN

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -10,6 +10,7 @@ import pypck
 from homeassistant import config_entries
 from homeassistant.const import (
     CONF_ADDRESS,
+    CONF_DEVICE_ID,
     CONF_DOMAIN,
     CONF_IP_ADDRESS,
     CONF_NAME,
@@ -183,7 +184,7 @@ def host_input_received(
     # fire event: lcn_transmitter, lcn_transponder or lcn_fingerprint
     if isinstance(inp, pypck.inputs.ModStatusAccessControl):
         event_data = {
-            "device_id": device.id,
+            CONF_DEVICE_ID: device.id,
             "segment_id": address[0],
             "module_id": address[1],
             "code": inp.code,
@@ -207,7 +208,7 @@ def host_input_received(
                 if not selected:
                     continue
                 event_data = {
-                    "device_id": device.id,
+                    CONF_DEVICE_ID: device.id,
                     "segment_id": address[0],
                     "module_id": address[1],
                     "key": pypck.lcn_defs.Key(table * 8 + key).name.lower(),
@@ -249,7 +250,7 @@ class LcnEntity(Entity):
     def device_info(self) -> DeviceInfo | None:
         """Return device specific attributes."""
         address = f"{'g' if self.address[2] else 'm'}{self.address[0]:03d}{self.address[1]:03d}"
-        model = f"LCN {get_device_model(self.config[CONF_DOMAIN], self.config[CONF_DOMAIN_DATA])}"
+        model = f"LCN resource ({get_device_model(self.config[CONF_DOMAIN], self.config[CONF_DOMAIN_DATA])})"
 
         return {
             "identifiers": {(DOMAIN, self.unique_id)},

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -178,17 +178,16 @@ def host_input_received(
     identifiers = {(DOMAIN, generate_unique_id(config_entry.entry_id, address))}
     device = device_registry.async_get_device(identifiers, set())
 
-    if not device:
-        return
-
     # fire event: lcn_transmitter, lcn_transponder or lcn_fingerprint
     if isinstance(inp, pypck.inputs.ModStatusAccessControl):
         event_data = {
-            CONF_DEVICE_ID: device.id,
             "segment_id": address[0],
             "module_id": address[1],
             "code": inp.code,
         }
+
+        if device is not None:
+            event_data.update({CONF_DEVICE_ID: device.id})
 
         if inp.periphery == pypck.lcn_defs.AccessControlPeriphery.TRANSMITTER:
             event_data.update(
@@ -208,12 +207,15 @@ def host_input_received(
                 if not selected:
                     continue
                 event_data = {
-                    CONF_DEVICE_ID: device.id,
                     "segment_id": address[0],
                     "module_id": address[1],
                     "key": pypck.lcn_defs.Key(table * 8 + key).name.lower(),
                     "action": action.name.lower(),
                 }
+
+                if device is not None:
+                    event_data.update({CONF_DEVICE_ID: device.id})
+
                 hass.bus.async_fire("lcn_sendkeys", event_data)
 
 

--- a/homeassistant/components/lcn/const.py
+++ b/homeassistant/components/lcn/const.py
@@ -183,6 +183,35 @@ RELVARREF = ["CURRENT", "PROG"]
 
 SENDKEYCOMMANDS = ["HIT", "MAKE", "BREAK", "DONTSEND"]
 
+SENDKEYS = [
+    "A1",
+    "A2",
+    "A3",
+    "A4",
+    "A5",
+    "A6",
+    "A7",
+    "A8",
+    "B1",
+    "B2",
+    "B3",
+    "B4",
+    "B5",
+    "B6",
+    "B7",
+    "B8",
+    "C1",
+    "C2",
+    "C3",
+    "C4",
+    "C5",
+    "C6",
+    "C7",
+    "C8",
+]
+
+KEY_ACTIONS = ["HIT", "MAKE", "BREAK"]
+
 TIME_UNITS = [
     "SECONDS",
     "SECOND",

--- a/homeassistant/components/lcn/device_trigger.py
+++ b/homeassistant/components/lcn/device_trigger.py
@@ -1,0 +1,108 @@
+"""Provides device triggers for LCN."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.components.automation import (
+    AutomationActionType,
+    AutomationTriggerInfo,
+)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers import event
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from . import DOMAIN
+from .const import KEY_ACTIONS, SENDKEYS
+
+TRIGGER_TYPES = {"transmitter", "transponder", "fingerprint", "sendkeys"}
+
+LCN_DEVICE_TRIGGER_BASE_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES)}
+)
+
+ACCESS_CONTROL_SCHEMA = {vol.Optional("code"): vol.All(vol.Lower, cv.string)}
+TRANSMITTER_SCHEMA = {
+    **ACCESS_CONTROL_SCHEMA,
+    vol.Optional("level"): cv.positive_int,
+    vol.Optional("key"): cv.positive_int,
+    vol.Optional("action"): vol.In([action.lower() for action in KEY_ACTIONS]),
+}
+
+SENDKEYS_SCHEMA = {
+    vol.Optional("key"): vol.In([key.lower() for key in SENDKEYS]),
+    vol.Optional("action"): vol.In([action.lower() for action in KEY_ACTIONS]),
+}
+
+TRIGGER_SCHEMA = vol.Any(
+    LCN_DEVICE_TRIGGER_BASE_SCHEMA.extend(ACCESS_CONTROL_SCHEMA),
+    LCN_DEVICE_TRIGGER_BASE_SCHEMA.extend(TRANSMITTER_SCHEMA),
+    LCN_DEVICE_TRIGGER_BASE_SCHEMA.extend(SENDKEYS_SCHEMA),
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict]:
+    """List device triggers for LCN devices."""
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get(device_id)
+
+    triggers: list[dict] = []
+    if device.model.startswith("group"):
+        return triggers
+
+    base_trigger = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DOMAIN,
+        CONF_DEVICE_ID: device_id,
+    }
+
+    triggers.append({**base_trigger, CONF_TYPE: "transmitter"})
+    triggers.append({**base_trigger, CONF_TYPE: "transponder"})
+    triggers.append({**base_trigger, CONF_TYPE: "fingerprint"})
+    triggers.append({**base_trigger, CONF_TYPE: "sendkeys"})
+
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: AutomationTriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    event_data = {CONF_DEVICE_ID: config[CONF_DEVICE_ID]}
+    event_data.update(
+        {
+            key: config[key]
+            for key in ("code", "level", "key", "action")
+            if key in config
+        }
+    )
+
+    event_config = event.TRIGGER_SCHEMA(
+        {
+            event.CONF_PLATFORM: "event",
+            event.CONF_EVENT_TYPE: f"lcn_{config[CONF_TYPE]}",
+            event.CONF_EVENT_DATA: event_data,
+        }
+    )
+
+    return await event.async_attach_trigger(
+        hass, event_config, action, automation_info, platform_type="device"
+    )
+
+
+async def async_get_trigger_capabilities(hass: HomeAssistant, config: dict) -> dict:
+    """List trigger capabilities."""
+    if config[CONF_TYPE] == "transmitter":
+        return {"extra_fields": vol.Schema(TRANSMITTER_SCHEMA)}
+    elif config[CONF_TYPE] == "transponder":
+        return {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)}
+    elif config[CONF_TYPE] == "fingerprint":
+        return {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)}
+    elif config[CONF_TYPE] == "sendkeys":
+        return {"extra_fields": vol.Schema(SENDKEYS_SCHEMA)}
+    return {}

--- a/homeassistant/components/lcn/device_trigger.py
+++ b/homeassistant/components/lcn/device_trigger.py
@@ -11,7 +11,7 @@ from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEM
 from homeassistant.components.homeassistant.triggers import event
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
 from . import DOMAIN
@@ -45,11 +45,11 @@ TRIGGER_SCHEMA = vol.Any(
 
 async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict]:
     """List device triggers for LCN devices."""
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(device_id)
 
     triggers: list[dict] = []
-    if device.model.startswith("group"):
+    if device.model.startswith(("LCN host", "LCN group", "LCN resource")):  # type: ignore[union-attr]
         return triggers
 
     base_trigger = {

--- a/homeassistant/components/lcn/device_trigger.py
+++ b/homeassistant/components/lcn/device_trigger.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.typing import ConfigType
 from . import DOMAIN
 from .const import KEY_ACTIONS, SENDKEYS
 
-TRIGGER_TYPES = {"transmitter", "transponder", "fingerprint", "sendkeys"}
+TRIGGER_TYPES = {"transmitter", "transponder", "fingerprint", "send_keys"}
 
 LCN_DEVICE_TRIGGER_BASE_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES)}
@@ -52,9 +52,8 @@ async def async_get_triggers(
     device_registry = dr.async_get(hass)
     device = device_registry.async_get(device_id)
 
-    triggers: list[dict] = []
     if device.model.startswith(("LCN host", "LCN group", "LCN resource")):  # type: ignore[union-attr]
-        return triggers
+        return []
 
     base_trigger = {
         CONF_PLATFORM: "device",
@@ -62,12 +61,7 @@ async def async_get_triggers(
         CONF_DEVICE_ID: device_id,
     }
 
-    triggers.append({**base_trigger, CONF_TYPE: "transmitter"})
-    triggers.append({**base_trigger, CONF_TYPE: "transponder"})
-    triggers.append({**base_trigger, CONF_TYPE: "fingerprint"})
-    triggers.append({**base_trigger, CONF_TYPE: "sendkeys"})
-
-    return triggers
+    return [{**base_trigger, CONF_TYPE: type_} for type_ in TRIGGER_TYPES]
 
 
 async def async_attach_trigger(

--- a/homeassistant/components/lcn/device_trigger.py
+++ b/homeassistant/components/lcn/device_trigger.py
@@ -1,6 +1,8 @@
 """Provides device triggers for LCN."""
 from __future__ import annotations
 
+from typing import Any
+
 import voluptuous as vol
 
 from homeassistant.components.automation import (
@@ -43,7 +45,9 @@ TRIGGER_SCHEMA = vol.Any(
 )
 
 
-async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict]:
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, Any]]:
     """List device triggers for LCN devices."""
     device_registry = dr.async_get(hass)
     device = device_registry.async_get(device_id)
@@ -93,16 +97,3 @@ async def async_attach_trigger(
     return await event.async_attach_trigger(
         hass, event_config, action, automation_info, platform_type="device"
     )
-
-
-async def async_get_trigger_capabilities(hass: HomeAssistant, config: dict) -> dict:
-    """List trigger capabilities."""
-    if config[CONF_TYPE] == "transmitter":
-        return {"extra_fields": vol.Schema(TRANSMITTER_SCHEMA)}
-    elif config[CONF_TYPE] == "transponder":
-        return {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)}
-    elif config[CONF_TYPE] == "fingerprint":
-        return {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)}
-    elif config[CONF_TYPE] == "sendkeys":
-        return {"extra_fields": vol.Schema(SENDKEYS_SCHEMA)}
-    return {}

--- a/homeassistant/components/lcn/device_trigger.py
+++ b/homeassistant/components/lcn/device_trigger.py
@@ -71,14 +71,14 @@ async def async_attach_trigger(
     automation_info: AutomationTriggerInfo,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
-    event_data = {CONF_DEVICE_ID: config[CONF_DEVICE_ID]}
-    event_data.update(
-        {
+    event_data = {
+        CONF_DEVICE_ID: config[CONF_DEVICE_ID],
+        **{
             key: config[key]
             for key in ("code", "level", "key", "action")
             if key in config
-        }
-    )
+        },
+    }
 
     event_config = event.TRIGGER_SCHEMA(
         {
@@ -95,12 +95,10 @@ async def async_attach_trigger(
 
 async def async_get_trigger_capabilities(hass: HomeAssistant, config: dict) -> dict:
     """List trigger capabilities."""
-    if config[CONF_TYPE] == "transmitter":
-        return {"extra_fields": vol.Schema(TRANSMITTER_SCHEMA)}
-    if config[CONF_TYPE] == "transponder":
-        return {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)}
-    if config[CONF_TYPE] == "fingerprint":
-        return {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)}
-    if config[CONF_TYPE] == "send_keys":
-        return {"extra_fields": vol.Schema(SENDKEYS_SCHEMA)}
-    return {}
+    TYPE_SCHEMAS = {
+        "transmitter": {"extra_fields": vol.Schema(TRANSMITTER_SCHEMA)},
+        "transponder": {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)},
+        "fingerprint": {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)},
+        "send_keys": {"extra_fields": vol.Schema(SENDKEYS_SCHEMA)},
+    }
+    return TYPE_SCHEMAS.get(config[CONF_TYPE], {})

--- a/homeassistant/components/lcn/device_trigger.py
+++ b/homeassistant/components/lcn/device_trigger.py
@@ -44,6 +44,13 @@ TRIGGER_SCHEMA = vol.Any(
     LCN_DEVICE_TRIGGER_BASE_SCHEMA.extend(SENDKEYS_SCHEMA),
 )
 
+TYPE_SCHEMAS = {
+    "transmitter": {"extra_fields": vol.Schema(TRANSMITTER_SCHEMA)},
+    "transponder": {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)},
+    "fingerprint": {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)},
+    "send_keys": {"extra_fields": vol.Schema(SENDKEYS_SCHEMA)},
+}
+
 
 async def async_get_triggers(
     hass: HomeAssistant, device_id: str
@@ -95,10 +102,4 @@ async def async_attach_trigger(
 
 async def async_get_trigger_capabilities(hass: HomeAssistant, config: dict) -> dict:
     """List trigger capabilities."""
-    TYPE_SCHEMAS = {
-        "transmitter": {"extra_fields": vol.Schema(TRANSMITTER_SCHEMA)},
-        "transponder": {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)},
-        "fingerprint": {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)},
-        "send_keys": {"extra_fields": vol.Schema(SENDKEYS_SCHEMA)},
-    }
     return TYPE_SCHEMAS.get(config[CONF_TYPE], {})

--- a/homeassistant/components/lcn/device_trigger.py
+++ b/homeassistant/components/lcn/device_trigger.py
@@ -91,3 +91,16 @@ async def async_attach_trigger(
     return await event.async_attach_trigger(
         hass, event_config, action, automation_info, platform_type="device"
     )
+
+
+async def async_get_trigger_capabilities(hass: HomeAssistant, config: dict) -> dict:
+    """List trigger capabilities."""
+    if config[CONF_TYPE] == "transmitter":
+        return {"extra_fields": vol.Schema(TRANSMITTER_SCHEMA)}
+    if config[CONF_TYPE] == "transponder":
+        return {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)}
+    if config[CONF_TYPE] == "fingerprint":
+        return {"extra_fields": vol.Schema(ACCESS_CONTROL_SCHEMA)}
+    if config[CONF_TYPE] == "send_keys":
+        return {"extra_fields": vol.Schema(SENDKEYS_SCHEMA)}
+    return {}

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -256,7 +256,7 @@ def register_lcn_host_device(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         identifiers={(DOMAIN, config_entry.entry_id)},
         manufacturer="Issendorff",
         name=config_entry.title,
-        model="PCHK",
+        model=f"LCN host ({config_entry.data[CONF_IP_ADDRESS]}:{config_entry.data[CONF_PORT]})",
     )
 
 

--- a/homeassistant/components/lcn/manifest.json
+++ b/homeassistant/components/lcn/manifest.json
@@ -3,7 +3,7 @@
   "name": "LCN",
   "config_flow": false,
   "documentation": "https://www.home-assistant.io/integrations/lcn",
-  "requirements": ["pypck==0.7.10"],
+  "requirements": ["pypck==0.7.11"],
   "codeowners": ["@alengwenus"],
   "iot_class": "local_push"
 }

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -1,0 +1,10 @@
+{
+  "device_automation": {
+    "trigger_type": {
+      "transmitter": "transmitter code received",
+      "transponder": "transpoder code received",
+      "fingerprint": "fingerprint code received",
+      "sendkeys": "sent key received"
+    }
+  }
+}

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -4,7 +4,7 @@
       "transmitter": "transmitter code received",
       "transponder": "transpoder code received",
       "fingerprint": "fingerprint code received",
-      "sendkeys": "sent key received"
+      "send_keys": "sent key received"
     }
   }
 }

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -4,7 +4,7 @@
       "transmitter": "transmitter code received",
       "transponder": "transpoder code received",
       "fingerprint": "fingerprint code received",
-      "send_keys": "sent key received"
+      "send_keys": "send keys received"
     }
   }
 }

--- a/homeassistant/components/lcn/translations/en.json
+++ b/homeassistant/components/lcn/translations/en.json
@@ -1,0 +1,10 @@
+{
+    "device_automation": {
+        "trigger_type": {
+            "fingerprint": "fingerprint code received",
+            "sendkeys": "sent key received",
+            "transmitter": "transmitter code received",
+            "transponder": "transpoder code received"
+        }
+    }
+}

--- a/homeassistant/components/lcn/translations/en.json
+++ b/homeassistant/components/lcn/translations/en.json
@@ -2,7 +2,7 @@
     "device_automation": {
         "trigger_type": {
             "fingerprint": "fingerprint code received",
-            "sendkeys": "sent key received",
+            "send_keys": "sent key received",
             "transmitter": "transmitter code received",
             "transponder": "transpoder code received"
         }

--- a/homeassistant/components/lcn/translations/en.json
+++ b/homeassistant/components/lcn/translations/en.json
@@ -2,7 +2,7 @@
     "device_automation": {
         "trigger_type": {
             "fingerprint": "fingerprint code received",
-            "send_keys": "sent key received",
+            "send_keys": "send keys received",
             "transmitter": "transmitter code received",
             "transponder": "transpoder code received"
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1714,7 +1714,7 @@ pyownet==0.10.0.post1
 pypca==0.0.7
 
 # homeassistant.components.lcn
-pypck==0.7.10
+pypck==0.7.11
 
 # homeassistant.components.pjlink
 pypjlink2==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1036,7 +1036,7 @@ pyowm==3.2.0
 pyownet==0.10.0.post1
 
 # homeassistant.components.lcn
-pypck==0.7.10
+pypck==0.7.11
 
 # homeassistant.components.plaato
 pyplaato==0.0.15

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -41,6 +41,13 @@ class MockGroupConnection(GroupConnection):
 class MockPchkConnectionManager(PchkConnectionManager):
     """Fake connection handler."""
 
+    return_value = None
+
+    def __init__(self, *args, **kwargs):
+        """Initialize MockPchkCOnnectionManager."""
+        super().__init__(*args, **kwargs)
+        self.__class__.return_value = self
+
     async def async_connect(self, timeout=30):
         """Mock establishing a connection to PCHK."""
         self.authentication_completed_future.set_result(True)

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -1,6 +1,6 @@
 """Test configuration and mocks for LCN component."""
 import json
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pypck
 from pypck.connection import PchkConnectionManager
@@ -57,7 +57,6 @@ class MockPchkConnectionManager(PchkConnectionManager):
         return super().get_address_conn(addr, request_serials=False)
 
     send_command = AsyncMock()
-    register_for_inputs = Mock()
 
 
 def create_config_entry(name):

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -1,0 +1,241 @@
+"""Tests for LCN device triggers."""
+from unittest.mock import patch
+
+from homeassistant.components import automation
+from homeassistant.components.lcn.const import DOMAIN
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+
+from .conftest import MockPchkConnectionManager, get_device, init_integration
+
+from tests.common import assert_lists_same, async_get_device_automations
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_get_triggers_module_device(hass, entry):
+    """Test we get the expected triggers from a LCN module device."""
+    await init_integration(hass, entry)
+    device = get_device(hass, entry, (0, 7, False))
+
+    expected_triggers = [
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: device.id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: "transmitter",
+        },
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: device.id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: "transponder",
+        },
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: device.id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: "fingerprint",
+        },
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: device.id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: "sendkeys",
+        },
+    ]
+
+    triggers = await async_get_device_automations(hass, "trigger", device.id)
+
+    assert_lists_same(triggers, expected_triggers)
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_get_triggers_non_module_device(hass, entry):
+    """Test we get the expected triggers from a LCN non-module device."""
+    not_included_types = ("transmitter", "transponder", "fingerprint", "sendkeys")
+
+    await init_integration(hass, entry)
+    device_registry = dr.async_get(hass)
+    for device_id in device_registry.devices:
+        device = device_registry.async_get(device_id)
+        if device.model.startswith(("LCN host", "LCN group", "LCN resource")):
+            triggers = await async_get_device_automations(hass, "trigger", device_id)
+            for trigger in triggers:
+                assert trigger[CONF_TYPE] not in not_included_types
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_transponder_event_triggers_module_device(hass, calls, entry):
+    """Test we get the expected triggers from a LCN non-module device."""
+    await init_integration(hass, entry)
+    device = get_device(hass, entry, (0, 7, False))
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device.id,
+                        CONF_TYPE: "transponder",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "test": "test_trigger_transponder",
+                            "code": "{{ trigger.event.data.code }}",
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    event_data = {CONF_DEVICE_ID: device.id, "code": "aabbcc"}
+    hass.bus.async_fire("lcn_transponder", event_data)
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data["test"] == "test_trigger_transponder"
+    assert calls[0].data["code"] == "aabbcc"
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_fingerprint_event_triggers_module_device(hass, calls, entry):
+    """Test we get the expected triggers from a LCN non-module device."""
+    await init_integration(hass, entry)
+    device = get_device(hass, entry, (0, 7, False))
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device.id,
+                        CONF_TYPE: "fingerprint",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "test": "test_trigger_fingerprint",
+                            "code": "{{ trigger.event.data.code }}",
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    event_data = {CONF_DEVICE_ID: device.id, "code": "aabbcc"}
+    hass.bus.async_fire("lcn_fingerprint", event_data)
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data["test"] == "test_trigger_fingerprint"
+    assert calls[0].data["code"] == "aabbcc"
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_transmitter_event_triggers_module_device(hass, calls, entry):
+    """Test we get the expected triggers from a LCN non-module device."""
+    await init_integration(hass, entry)
+    device = get_device(hass, entry, (0, 7, False))
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device.id,
+                        CONF_TYPE: "transmitter",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "test": "test_trigger_transmitter",
+                            "code": "{{ trigger.event.data.code }}",
+                            "level": "{{ trigger.event.data.level }}",
+                            "key": "{{ trigger.event.data.key }}",
+                            "action": "{{ trigger.event.data.action }}",
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    event_data = {
+        CONF_DEVICE_ID: device.id,
+        "code": "aabbcc",
+        "level": 0,
+        "key": 0,
+        "action": "hit",
+    }
+
+    hass.bus.async_fire("lcn_transmitter", event_data)
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data["test"] == "test_trigger_transmitter"
+    assert calls[0].data["code"] == "aabbcc"
+    assert calls[0].data["level"] == 0
+    assert calls[0].data["key"] == 0
+    assert calls[0].data["action"] == "hit"
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_sendkeys_event_triggers_module_device(hass, calls, entry):
+    """Test we get the expected triggers from a LCN non-module device."""
+    await init_integration(hass, entry)
+    device = get_device(hass, entry, (0, 7, False))
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device.id,
+                        CONF_TYPE: "sendkeys",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "test": "test_trigger_sendkeys",
+                            "key": "{{ trigger.event.data.key }}",
+                            "action": "{{ trigger.event.data.action }}",
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    event_data = {
+        CONF_DEVICE_ID: device.id,
+        "key": "a1",
+        "action": "hit",
+    }
+
+    hass.bus.async_fire("lcn_sendkeys", event_data)
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data["test"] == "test_trigger_sendkeys"
+    assert calls[0].data["key"] == "a1"
+    assert calls[0].data["action"] == "hit"

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -8,7 +8,7 @@ import voluptuous_serialize
 
 from homeassistant.components import automation
 from homeassistant.components.lcn import device_trigger
-from homeassistant.components.lcn.const import CONNECTION, DOMAIN, KEY_ACTIONS, SENDKEYS
+from homeassistant.components.lcn.const import DOMAIN, KEY_ACTIONS, SENDKEYS
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.setup import async_setup_component
@@ -107,7 +107,7 @@ async def test_if_fires_on_transponder_event(hass, calls, entry):
         code="aabbcc",
     )
 
-    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -155,7 +155,7 @@ async def test_if_fires_on_fingerprint_event(hass, calls, entry):
         code="aabbcc",
     )
 
-    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -209,7 +209,7 @@ async def test_if_fires_on_transmitter_event(hass, calls, entry):
         action=KeyAction.HIT,
     )
 
-    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -261,7 +261,7 @@ async def test_if_fires_on_send_keys_event(hass, calls, entry):
         keys=[True, False, False, False, False, False, False, False],
     )
 
-    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -21,32 +21,31 @@ async def test_get_triggers_module_device(hass, entry):
     expected_triggers = [
         {
             CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: DOMAIN,
             CONF_TYPE: "transmitter",
+            CONF_DEVICE_ID: device.id,
         },
         {
             CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: DOMAIN,
             CONF_TYPE: "transponder",
+            CONF_DEVICE_ID: device.id,
         },
         {
             CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: DOMAIN,
             CONF_TYPE: "fingerprint",
+            CONF_DEVICE_ID: device.id,
         },
         {
             CONF_PLATFORM: "device",
-            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: DOMAIN,
             CONF_TYPE: "sendkeys",
+            CONF_DEVICE_ID: device.id,
         },
     ]
 
     triggers = await async_get_device_automations(hass, "trigger", device.id)
-
     assert_lists_same(triggers, expected_triggers)
 
 
@@ -66,8 +65,8 @@ async def test_get_triggers_non_module_device(hass, entry):
 
 
 @patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
-async def test_transponder_event_triggers_module_device(hass, calls, entry):
-    """Test we get the expected triggers from a LCN non-module device."""
+async def test_if_fires_on_transponder_event(hass, calls, entry):
+    """Test for transponder event triggers firing."""
     await init_integration(hass, entry)
     device = get_device(hass, entry, (0, 7, False))
 
@@ -100,13 +99,15 @@ async def test_transponder_event_triggers_module_device(hass, calls, entry):
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert calls[0].data["test"] == "test_trigger_transponder"
-    assert calls[0].data["code"] == "aabbcc"
+    assert calls[0].data == {
+        "test": "test_trigger_transponder",
+        "code": "aabbcc",
+    }
 
 
 @patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
-async def test_fingerprint_event_triggers_module_device(hass, calls, entry):
-    """Test we get the expected triggers from a LCN non-module device."""
+async def test_if_fires_on_fingerprint_event(hass, calls, entry):
+    """Test for fingerprint event triggers firing."""
     await init_integration(hass, entry)
     device = get_device(hass, entry, (0, 7, False))
 
@@ -139,13 +140,15 @@ async def test_fingerprint_event_triggers_module_device(hass, calls, entry):
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert calls[0].data["test"] == "test_trigger_fingerprint"
-    assert calls[0].data["code"] == "aabbcc"
+    assert calls[0].data == {
+        "test": "test_trigger_fingerprint",
+        "code": "aabbcc",
+    }
 
 
 @patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
-async def test_transmitter_event_triggers_module_device(hass, calls, entry):
-    """Test we get the expected triggers from a LCN non-module device."""
+async def test_if_fires_on_transmitter_event(hass, calls, entry):
+    """Test for transmitter event triggers firing."""
     await init_integration(hass, entry)
     device = get_device(hass, entry, (0, 7, False))
 
@@ -188,16 +191,18 @@ async def test_transmitter_event_triggers_module_device(hass, calls, entry):
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert calls[0].data["test"] == "test_trigger_transmitter"
-    assert calls[0].data["code"] == "aabbcc"
-    assert calls[0].data["level"] == 0
-    assert calls[0].data["key"] == 0
-    assert calls[0].data["action"] == "hit"
+    assert calls[0].data == {
+        "test": "test_trigger_transmitter",
+        "code": "aabbcc",
+        "level": 0,
+        "key": 0,
+        "action": "hit",
+    }
 
 
 @patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
-async def test_sendkeys_event_triggers_module_device(hass, calls, entry):
-    """Test we get the expected triggers from a LCN non-module device."""
+async def test_if_fires_on_sendkeys_event(hass, calls, entry):
+    """Test for sendkeys event triggers firing."""
     await init_integration(hass, entry)
     device = get_device(hass, entry, (0, 7, False))
 
@@ -236,6 +241,8 @@ async def test_sendkeys_event_triggers_module_device(hass, calls, entry):
     await hass.async_block_till_done()
 
     assert len(calls) == 1
-    assert calls[0].data["test"] == "test_trigger_sendkeys"
-    assert calls[0].data["key"] == "a1"
-    assert calls[0].data["action"] == "hit"
+    assert calls[0].data == {
+        "test": "test_trigger_sendkeys",
+        "key": "a1",
+        "action": "hit",
+    }

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -44,7 +44,7 @@ async def test_get_triggers_module_device(hass, entry):
         {
             CONF_PLATFORM: "device",
             CONF_DOMAIN: DOMAIN,
-            CONF_TYPE: "sendkeys",
+            CONF_TYPE: "send_keys",
             CONF_DEVICE_ID: device.id,
         },
     ]
@@ -56,7 +56,7 @@ async def test_get_triggers_module_device(hass, entry):
 @patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_get_triggers_non_module_device(hass, entry):
     """Test we get the expected triggers from a LCN non-module device."""
-    not_included_types = ("transmitter", "transponder", "fingerprint", "sendkeys")
+    not_included_types = ("transmitter", "transponder", "fingerprint", "send_keys")
 
     await init_integration(hass, entry)
     device_registry = dr.async_get(hass)
@@ -222,8 +222,8 @@ async def test_if_fires_on_transmitter_event(hass, calls, entry):
 
 
 @patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
-async def test_if_fires_on_sendkeys_event(hass, calls, entry):
-    """Test for sendkeys event triggers firing."""
+async def test_if_fires_on_send_keys_event(hass, calls, entry):
+    """Test for send_keys event triggers firing."""
     await init_integration(hass, entry)
     address = (0, 7, False)
     device = get_device(hass, entry, address)
@@ -238,12 +238,12 @@ async def test_if_fires_on_sendkeys_event(hass, calls, entry):
                         CONF_PLATFORM: "device",
                         CONF_DOMAIN: DOMAIN,
                         CONF_DEVICE_ID: device.id,
-                        CONF_TYPE: "sendkeys",
+                        CONF_TYPE: "send_keys",
                     },
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "test": "test_trigger_sendkeys",
+                            "test": "test_trigger_send_keys",
                             "key": "{{ trigger.event.data.key }}",
                             "action": "{{ trigger.event.data.action }}",
                         },
@@ -265,7 +265,7 @@ async def test_if_fires_on_sendkeys_event(hass, calls, entry):
 
     assert len(calls) == 1
     assert calls[0].data == {
-        "test": "test_trigger_sendkeys",
+        "test": "test_trigger_send_keys",
         "key": "a1",
         "action": "hit",
     }

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -1,0 +1,117 @@
+"""Tests for LCN events."""
+from unittest.mock import patch
+
+from pypck.inputs import ModSendKeysHost, ModStatusAccessControl
+from pypck.lcn_addr import LcnAddr
+from pypck.lcn_defs import AccessControlPeriphery, KeyAction, SendKeyCommand
+
+from homeassistant.components.lcn import host_input_received
+from homeassistant.helpers import device_registry as dr
+
+from .conftest import MockPchkConnectionManager, init_integration
+
+from tests.common import async_capture_events
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_fire_transponder_event(hass, entry):
+    """Test the transponder event is fired."""
+    await init_integration(hass, entry)
+    device_registry = dr.async_get(hass)
+
+    events = async_capture_events(hass, "lcn_transponder")
+
+    inp = ModStatusAccessControl(
+        LcnAddr(0, 7, False),
+        periphery=AccessControlPeriphery.TRANSPONDER,
+        code="aabbcc",
+    )
+
+    host_input_received(hass, entry, device_registry, inp)
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].event_type == "lcn_transponder"
+    assert events[0].data["code"] == "aabbcc"
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_fire_fingerprint_event(hass, entry):
+    """Test the fingerprint event is fired."""
+    await init_integration(hass, entry)
+    device_registry = dr.async_get(hass)
+
+    events = async_capture_events(hass, "lcn_fingerprint")
+
+    inp = ModStatusAccessControl(
+        LcnAddr(0, 7, False),
+        periphery=AccessControlPeriphery.FINGERPRINT,
+        code="aabbcc",
+    )
+
+    host_input_received(hass, entry, device_registry, inp)
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].event_type == "lcn_fingerprint"
+    assert events[0].data["code"] == "aabbcc"
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_fire_transmitter_event(hass, entry):
+    """Test the transmitter event is fired."""
+    await init_integration(hass, entry)
+    device_registry = dr.async_get(hass)
+
+    events = async_capture_events(hass, "lcn_transmitter")
+
+    inp = ModStatusAccessControl(
+        LcnAddr(0, 7, False),
+        periphery=AccessControlPeriphery.TRANSMITTER,
+        code="aabbcc",
+        level=0,
+        key=0,
+        action=KeyAction.HIT,
+    )
+
+    host_input_received(hass, entry, device_registry, inp)
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].event_type == "lcn_transmitter"
+    assert events[0].data["code"] == "aabbcc"
+    assert events[0].data["level"] == 0
+    assert events[0].data["key"] == 0
+    assert events[0].data["action"] == "hit"
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_fire_sendkeys_event(hass, entry):
+    """Test the sendkeys event is fired."""
+    await init_integration(hass, entry)
+    device_registry = dr.async_get(hass)
+
+    events = async_capture_events(hass, "lcn_sendkeys")
+
+    inp = ModSendKeysHost(
+        LcnAddr(0, 7, False),
+        actions=[SendKeyCommand.HIT, SendKeyCommand.MAKE, SendKeyCommand.DONTSEND],
+        keys=[True, True, False, False, False, False, False, False],
+    )
+
+    host_input_received(hass, entry, device_registry, inp)
+    await hass.async_block_till_done()
+
+    assert len(events) == 4
+    assert events[0].event_type == "lcn_sendkeys"
+    assert events[0].data["key"] == "a1"
+    assert events[0].data["action"] == "hit"
+    assert events[1].event_type == "lcn_sendkeys"
+    assert events[1].data["key"] == "a2"
+    assert events[1].data["action"] == "hit"
+    assert events[2].event_type == "lcn_sendkeys"
+    assert events[2].data["key"] == "b1"
+    assert events[2].data["action"] == "make"
+    assert events[3].event_type == "lcn_sendkeys"
+    assert events[3].data["key"] == "b2"
+    assert events[3].data["action"] == "make"

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -134,3 +134,22 @@ async def test_dont_fire_on_non_module_input(hass, entry):
         await lcn_connection.async_process_input(inp)
         await hass.async_block_till_done()
         assert len(events) == 0
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_dont_fire_on_unknown_module(hass, entry):
+    """Test for no event is fired if an input from an unknown module is received."""
+    await init_integration(hass, entry)
+
+    inp = ModStatusAccessControl(
+        LcnAddr(0, 10, False),  # unknown module
+        periphery=AccessControlPeriphery.FINGERPRINT,
+        code="aabbcc",
+    )
+
+    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+
+    events = async_capture_events(hass, "lcn_transmitter")
+    await lcn_connection.async_process_input(inp)
+    await hass.async_block_till_done()
+    assert len(events) == 0

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -86,10 +86,10 @@ async def test_fire_transmitter_event(hass, entry):
 
 @patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
 async def test_fire_sendkeys_event(hass, entry):
-    """Test the sendkeys event is fired."""
+    """Test the send_keys event is fired."""
     await init_integration(hass, entry)
 
-    events = async_capture_events(hass, "lcn_sendkeys")
+    events = async_capture_events(hass, "lcn_send_keys")
 
     inp = ModSendKeysHost(
         LcnAddr(0, 7, False),
@@ -102,16 +102,16 @@ async def test_fire_sendkeys_event(hass, entry):
     await hass.async_block_till_done()
 
     assert len(events) == 4
-    assert events[0].event_type == "lcn_sendkeys"
+    assert events[0].event_type == "lcn_send_keys"
     assert events[0].data["key"] == "a1"
     assert events[0].data["action"] == "hit"
-    assert events[1].event_type == "lcn_sendkeys"
+    assert events[1].event_type == "lcn_send_keys"
     assert events[1].data["key"] == "a2"
     assert events[1].data["action"] == "hit"
-    assert events[2].event_type == "lcn_sendkeys"
+    assert events[2].event_type == "lcn_send_keys"
     assert events[2].data["key"] == "b1"
     assert events[2].data["action"] == "make"
-    assert events[3].event_type == "lcn_sendkeys"
+    assert events[3].event_type == "lcn_send_keys"
     assert events[3].data["key"] == "b2"
     assert events[3].data["action"] == "make"
 
@@ -128,7 +128,7 @@ async def test_dont_fire_on_non_module_input(hass, entry):
         "lcn_transponder",
         "lcn_fingerprint",
         "lcn_transmitter",
-        "lcn_sendkeys",
+        "lcn_send_keys",
     ):
         events = async_capture_events(hass, event_name)
         await lcn_connection.async_process_input(inp)

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -1,7 +1,7 @@
 """Tests for LCN events."""
 from unittest.mock import patch
 
-from pypck.inputs import ModSendKeysHost, ModStatusAccessControl
+from pypck.inputs import Input, ModSendKeysHost, ModStatusAccessControl
 from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import AccessControlPeriphery, KeyAction, SendKeyCommand
 
@@ -115,3 +115,18 @@ async def test_fire_sendkeys_event(hass, entry):
     assert events[3].event_type == "lcn_sendkeys"
     assert events[3].data["key"] == "b2"
     assert events[3].data["action"] == "make"
+
+
+@patch("pypck.connection.PchkConnectionManager", MockPchkConnectionManager)
+async def test_dont_fire_on_non_module_input(hass, entry):
+    """Test for no event is fired if a non-module input is received."""
+    await init_integration(hass, entry)
+    device_registry = dr.async_get(hass)
+
+    inp = Input()
+
+    with patch.object(hass.bus, "async_fire") as async_fire:
+        host_input_received(hass, entry, device_registry, inp)
+        await hass.async_block_till_done()
+
+    assert async_fire.called is False

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -5,8 +5,6 @@ from pypck.inputs import Input, ModSendKeysHost, ModStatusAccessControl
 from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import AccessControlPeriphery, KeyAction, SendKeyCommand
 
-from homeassistant.components.lcn.const import CONNECTION, DOMAIN
-
 from .conftest import MockPchkConnectionManager, init_integration
 
 from tests.common import async_capture_events
@@ -25,7 +23,7 @@ async def test_fire_transponder_event(hass, entry):
         code="aabbcc",
     )
 
-    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -47,7 +45,7 @@ async def test_fire_fingerprint_event(hass, entry):
         code="aabbcc",
     )
 
-    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -72,7 +70,7 @@ async def test_fire_transmitter_event(hass, entry):
         action=KeyAction.HIT,
     )
 
-    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -97,7 +95,7 @@ async def test_fire_sendkeys_event(hass, entry):
         keys=[True, True, False, False, False, False, False, False],
     )
 
-    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+    lcn_connection = MockPchkConnectionManager.return_value
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
@@ -122,7 +120,7 @@ async def test_dont_fire_on_non_module_input(hass, entry):
     await init_integration(hass, entry)
 
     inp = Input()
-    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+    lcn_connection = MockPchkConnectionManager.return_value
 
     for event_name in (
         "lcn_transponder",
@@ -147,7 +145,7 @@ async def test_dont_fire_on_unknown_module(hass, entry):
         code="aabbcc",
     )
 
-    lcn_connection = hass.data[DOMAIN][entry.entry_id][CONNECTION]
+    lcn_connection = MockPchkConnectionManager.return_value
 
     events = async_capture_events(hass, "lcn_transmitter")
     await lcn_connection.async_process_input(inp)

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -19,6 +19,7 @@ from .conftest import MockPchkConnectionManager, init_integration, setup_compone
 async def test_async_setup_entry(hass, entry):
     """Test a successful setup entry and unload of entry."""
     await init_integration(hass, entry)
+
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.state == ConfigEntryState.LOADED
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Within the LCN integration add support for some events:

- `lcn_transmitter`  (Button pressed on remote control)
- `lcn_transponder` (Transponder detected certain key)
- `lcn_fingerprint` (Fingerprint sensor detected certain fingerprint)
- `lcn_send_keys`  (Got info about physically connected buttons pressed)

All events originate from additional sensor devices connected to a LCN hardware module and can be related to the latter. The hardware modules are represented as DeviceEntities in HomeAssistant. Therefore also device triggers have been implemented for those DeviceEntities.

The new functionality also required a dependency upgrade (pypck==0.7.11):
Release notes: https://github.com/alengwenus/pypck/releases
Code changes: https://github.com/alengwenus/pypck/compare/0.7.10...0.7.11

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#20080

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
