### PR TITLE
ADS: add new options to sensor and switch (device_class / state_class) 

### DIFF
--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -19,8 +19,16 @@ from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
 )
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.sensor import (
+    CONF_STATE_CLASS,
+    DEVICE_CLASSES_SCHEMA as SENSOR_DEVICE_CLASSES_SCHEMA,
+    DOMAIN as SENSOR_DOMAIN,
+    STATE_CLASSES_SCHEMA as SENSOR_STATE_CLASSES_SCHEMA,
+)
+from homeassistant.components.switch import (
+    DEVICE_CLASSES_SCHEMA as SWITCH_DEVICE_CLASSES_SCHEMA,
+    DOMAIN as SWITCH_DOMAIN,
+)
 from homeassistant.const import (
     CONF_BINARY_SENSORS,
     CONF_COVERS,
@@ -127,6 +135,8 @@ SENSOR_SCHEMA = vol.Schema(
         ),
         vol.Optional(CONF_NAME, default=SENSOR_DEFAULT_NAME): cv.string,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT, default=""): cv.string,
+        vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_STATE_CLASS): SENSOR_STATE_CLASSES_SCHEMA,
     }
 )
 
@@ -134,6 +144,7 @@ SWITCH_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_ADS_VAR): cv.string,
         vol.Optional(CONF_NAME, default=SWITCH_DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_DEVICE_CLASS): SWITCH_DEVICE_CLASSES_SCHEMA,
     }
 )
 

--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -75,7 +75,9 @@ SERVICE_WRITE_DATA_BY_NAME = "write_data_by_name"
 
 BINARY_SENSOR_DEFAULT_NAME = "ADS binary sensor"
 COVER_DEFAULT_NAME = "ADS Cover"
+LIGHT_DEFAULT_NAME = "ADS Light"
 SENSOR_DEFAULT_NAME = "ADS sensor"
+SWITCH_DEFAULT_NAME = "ADS Switch"
 
 PLATFORMS = (
     (BINARY_SENSOR_DOMAIN, CONF_BINARY_SENSORS),
@@ -106,6 +108,14 @@ COVER_SCHEMA = vol.Schema(
     }
 )
 
+LIGHT_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ADS_VAR): cv.string,
+        vol.Optional(CONF_ADS_VAR_BRIGHTNESS): cv.string,
+        vol.Optional(CONF_NAME, default=LIGHT_DEFAULT_NAME): cv.string,
+    }
+)
+
 SENSOR_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_ADS_VAR): cv.string,
@@ -124,6 +134,13 @@ SENSOR_SCHEMA = vol.Schema(
     }
 )
 
+SWITCH_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ADS_VAR): cv.string,
+        vol.Optional(CONF_NAME, default=SWITCH_DEFAULT_NAME): cv.string,
+    }
+)
+
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
@@ -135,7 +152,9 @@ CONFIG_SCHEMA = vol.Schema(
                     cv.ensure_list, [BINARY_SENSOR_SCHEMA]
                 ),
                 vol.Optional(CONF_COVERS): vol.All(cv.ensure_list, [COVER_SCHEMA]),
+                vol.Optional(CONF_LIGHTS): vol.All(cv.ensure_list, [LIGHT_SCHEMA]),
                 vol.Optional(CONF_SENSORS): vol.All(cv.ensure_list, [SENSOR_SCHEMA]),
+                vol.Optional(CONF_SWITCHES): vol.All(cv.ensure_list, [SWITCH_SCHEMA]),
             }
         )
     },

--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -19,12 +19,8 @@ from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
 )
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.components.sensor import (  # CONF_STATE_CLASS,; DEVICE_CLASSES_SCHEMA as SENSOR_DEVICE_CLASSES_SCHEMA,; STATE_CLASSES_SCHEMA as SENSOR_STATE_CLASSES_SCHEMA,
-    DOMAIN as SENSOR_DOMAIN,
-)
-from homeassistant.components.switch import (  # DEVICE_CLASSES_SCHEMA as SWITCH_DEVICE_CLASSES_SCHEMA,
-    DOMAIN as SWITCH_DOMAIN,
-)
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     CONF_BINARY_SENSORS,
     CONF_COVERS,

--- a/homeassistant/components/ads/binary_sensor.py
+++ b/homeassistant/components/ads/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_BINARY_SENSORS, CONF_DEVICE_CLASS, CONF_NAM
 from . import CONF_ADS_VAR, DATA_ADS, STATE_KEY_STATE, AdsEntity
 
 
-def setup_platform(hass, config, add_entities, discovery_info):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Binary Sensor platform for ADS."""
     entities = []
 

--- a/homeassistant/components/ads/binary_sensor.py
+++ b/homeassistant/components/ads/binary_sensor.py
@@ -1,37 +1,29 @@
 """Support for ADS binary sensors."""
-import voluptuous as vol
-
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOVING,
-    DEVICE_CLASSES_SCHEMA,
-    PLATFORM_SCHEMA,
     BinarySensorEntity,
 )
-from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_BINARY_SENSORS, CONF_DEVICE_CLASS, CONF_NAME
 
 from . import CONF_ADS_VAR, DATA_ADS, STATE_KEY_STATE, AdsEntity
 
-DEFAULT_NAME = "ADS binary sensor"
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_ADS_VAR): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-    }
-)
 
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info):
     """Set up the Binary Sensor platform for ADS."""
+    entities = []
+
+    if discovery_info is None:  # pragma: no cover
+        return
+
     ads_hub = hass.data.get(DATA_ADS)
 
-    ads_var = config[CONF_ADS_VAR]
-    name = config[CONF_NAME]
-    device_class = config.get(CONF_DEVICE_CLASS)
+    for entry in discovery_info[CONF_BINARY_SENSORS]:
+        ads_var = entry.get(CONF_ADS_VAR)
+        name = entry.get(CONF_NAME)
+        device_class = entry.get(CONF_DEVICE_CLASS)
+        entities.append(AdsBinarySensor(ads_hub, name, ads_var, device_class))
 
-    ads_sensor = AdsBinarySensor(ads_hub, name, ads_var, device_class)
-    add_entities([ads_sensor])
+    add_entities(entities)
 
 
 class AdsBinarySensor(AdsEntity, BinarySensorEntity):

--- a/homeassistant/components/ads/cover.py
+++ b/homeassistant/components/ads/cover.py
@@ -1,64 +1,47 @@
 """Support for ADS covers."""
-import voluptuous as vol
-
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    DEVICE_CLASSES_SCHEMA,
-    PLATFORM_SCHEMA,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
     SUPPORT_STOP,
     CoverEntity,
 )
-from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_COVERS, CONF_DEVICE_CLASS, CONF_NAME
 
 from . import (
     CONF_ADS_VAR,
+    CONF_ADS_VAR_CLOSE,
+    CONF_ADS_VAR_OPEN,
     CONF_ADS_VAR_POSITION,
+    CONF_ADS_VAR_SET_POS,
+    CONF_ADS_VAR_STOP,
     DATA_ADS,
     STATE_KEY_POSITION,
     STATE_KEY_STATE,
     AdsEntity,
 )
 
-DEFAULT_NAME = "ADS Cover"
 
-CONF_ADS_VAR_SET_POS = "adsvar_set_position"
-CONF_ADS_VAR_OPEN = "adsvar_open"
-CONF_ADS_VAR_CLOSE = "adsvar_close"
-CONF_ADS_VAR_STOP = "adsvar_stop"
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_ADS_VAR): cv.string,
-        vol.Optional(CONF_ADS_VAR_POSITION): cv.string,
-        vol.Optional(CONF_ADS_VAR_SET_POS): cv.string,
-        vol.Optional(CONF_ADS_VAR_CLOSE): cv.string,
-        vol.Optional(CONF_ADS_VAR_OPEN): cv.string,
-        vol.Optional(CONF_ADS_VAR_STOP): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-    }
-)
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info):
     """Set up the cover platform for ADS."""
-    ads_hub = hass.data[DATA_ADS]
+    entities = []
 
-    ads_var_is_closed = config.get(CONF_ADS_VAR)
-    ads_var_position = config.get(CONF_ADS_VAR_POSITION)
-    ads_var_pos_set = config.get(CONF_ADS_VAR_SET_POS)
-    ads_var_open = config.get(CONF_ADS_VAR_OPEN)
-    ads_var_close = config.get(CONF_ADS_VAR_CLOSE)
-    ads_var_stop = config.get(CONF_ADS_VAR_STOP)
-    name = config[CONF_NAME]
-    device_class = config.get(CONF_DEVICE_CLASS)
+    if discovery_info is None:  # pragma: no cover
+        return
 
-    add_entities(
-        [
+    ads_hub = hass.data.get(DATA_ADS)
+
+    for entry in discovery_info[CONF_COVERS]:
+        ads_var_is_closed = entry.get(CONF_ADS_VAR)
+        ads_var_position = entry.get(CONF_ADS_VAR_POSITION)
+        ads_var_pos_set = entry.get(CONF_ADS_VAR_SET_POS)
+        ads_var_open = entry.get(CONF_ADS_VAR_OPEN)
+        ads_var_close = entry.get(CONF_ADS_VAR_CLOSE)
+        ads_var_stop = entry.get(CONF_ADS_VAR_STOP)
+        name = entry.get(CONF_NAME)
+        device_class = entry.get(CONF_DEVICE_CLASS)
+        entities.append(
             AdsCover(
                 ads_hub,
                 ads_var_is_closed,
@@ -70,8 +53,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 name,
                 device_class,
             )
-        ]
-    )
+        )
+
+    add_entities(entities)
 
 
 class AdsCover(AdsEntity, CoverEntity):

--- a/homeassistant/components/ads/cover.py
+++ b/homeassistant/components/ads/cover.py
@@ -23,7 +23,7 @@ from . import (
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the cover platform for ADS."""
     entities = []
 

--- a/homeassistant/components/ads/light.py
+++ b/homeassistant/components/ads/light.py
@@ -1,16 +1,12 @@
 """Support for ADS light sources."""
 from __future__ import annotations
 
-import voluptuous as vol
-
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    PLATFORM_SCHEMA,
     SUPPORT_BRIGHTNESS,
     LightEntity,
 )
-from homeassistant.const import CONF_NAME
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_LIGHTS, CONF_NAME
 
 from . import (
     CONF_ADS_VAR,
@@ -21,25 +17,23 @@ from . import (
     AdsEntity,
 )
 
-DEFAULT_NAME = "ADS Light"
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_ADS_VAR): cv.string,
-        vol.Optional(CONF_ADS_VAR_BRIGHTNESS): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    }
-)
 
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info):
     """Set up the light platform for ADS."""
+    entities = []
+
+    if discovery_info is None:  # pragma: no cover
+        return
+
     ads_hub = hass.data.get(DATA_ADS)
 
-    ads_var_enable = config[CONF_ADS_VAR]
-    ads_var_brightness = config.get(CONF_ADS_VAR_BRIGHTNESS)
-    name = config[CONF_NAME]
+    for entry in discovery_info[CONF_LIGHTS]:
+        ads_var_enable = entry.get(CONF_ADS_VAR)
+        ads_var_brightness = entry.get(CONF_ADS_VAR_BRIGHTNESS)
+        name = entry.get(CONF_NAME)
+        entities.append(AdsLight(ads_hub, ads_var_enable, ads_var_brightness, name))
 
-    add_entities([AdsLight(ads_hub, ads_var_enable, ads_var_brightness, name)])
+    add_entities(entities)
 
 
 class AdsLight(AdsEntity, LightEntity):

--- a/homeassistant/components/ads/light.py
+++ b/homeassistant/components/ads/light.py
@@ -18,7 +18,7 @@ from . import (
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the light platform for ADS."""
     entities = []
 

--- a/homeassistant/components/ads/sensor.py
+++ b/homeassistant/components/ads/sensor.py
@@ -1,7 +1,13 @@
 """Support for ADS sensors."""
 from homeassistant.components import ads
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import CONF_NAME, CONF_SENSORS, CONF_UNIT_OF_MEASUREMENT
+from homeassistant.components.sensor.const import CONF_STATE_CLASS
+from homeassistant.const import (
+    CONF_DEVICE_CLASS,
+    CONF_NAME,
+    CONF_SENSORS,
+    CONF_UNIT_OF_MEASUREMENT,
+)
 from homeassistant.helpers.typing import StateType
 
 from . import CONF_ADS_FACTOR, CONF_ADS_TYPE, CONF_ADS_VAR, STATE_KEY_STATE, AdsEntity
@@ -22,8 +28,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         name = entry.get(CONF_NAME)
         unit_of_measurement = entry.get(CONF_UNIT_OF_MEASUREMENT)
         factor = entry.get(CONF_ADS_FACTOR)
+        device_class = entry.get(CONF_DEVICE_CLASS)
+        state_class = entry.get(CONF_STATE_CLASS)
         entities.append(
-            AdsSensor(ads_hub, ads_var, ads_type, name, unit_of_measurement, factor)
+            AdsSensor(
+                ads_hub,
+                ads_var,
+                ads_type,
+                name,
+                unit_of_measurement,
+                factor,
+                device_class,
+                state_class,
+            )
         )
 
     add_entities(entities)
@@ -32,12 +49,24 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class AdsSensor(AdsEntity, SensorEntity):
     """Representation of an ADS sensor entity."""
 
-    def __init__(self, ads_hub, ads_var, ads_type, name, unit_of_measurement, factor):
+    def __init__(
+        self,
+        ads_hub,
+        ads_var,
+        ads_type,
+        name,
+        unit_of_measurement,
+        factor,
+        device_class,
+        state_class,
+    ):
         """Initialize AdsSensor entity."""
         super().__init__(ads_hub, name, ads_var)
         self._attr_native_unit_of_measurement = unit_of_measurement
         self._ads_type = ads_type
         self._factor = factor
+        self._attr_device_class = device_class
+        self._attr_state_class = state_class
 
     async def async_added_to_hass(self):
         """Register device notification."""

--- a/homeassistant/components/ads/sensor.py
+++ b/homeassistant/components/ads/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.typing import StateType
 from . import CONF_ADS_FACTOR, CONF_ADS_TYPE, CONF_ADS_VAR, STATE_KEY_STATE, AdsEntity
 
 
-def setup_platform(hass, config, add_entities, discovery_info):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up an ADS sensor device."""
     entities = []
 

--- a/homeassistant/components/ads/switch.py
+++ b/homeassistant/components/ads/switch.py
@@ -1,6 +1,6 @@
 """Support for ADS switch platform."""
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.const import CONF_NAME, CONF_SWITCHES
+from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_SWITCHES
 
 from . import CONF_ADS_VAR, DATA_ADS, STATE_KEY_STATE, AdsEntity
 
@@ -17,13 +17,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     for entry in discovery_info[CONF_SWITCHES]:
         ads_var = entry.get(CONF_ADS_VAR)
         name = entry.get(CONF_NAME)
-        entities.append(AdsSwitch(ads_hub, name, ads_var))
+        device_class = entry.get(CONF_DEVICE_CLASS)
+        entities.append(AdsSwitch(ads_hub, name, ads_var, device_class))
 
     add_entities(entities)
 
 
 class AdsSwitch(AdsEntity, SwitchEntity):
     """Representation of an ADS switch device."""
+
+    def __init__(self, ads_hub, name, ads_var, device_class):
+        """Initialize ADS switch device."""
+        super().__init__(ads_hub, name, ads_var)
+        self._attr_device_class = device_class
 
     async def async_added_to_hass(self):
         """Register device notification."""

--- a/homeassistant/components/ads/switch.py
+++ b/homeassistant/components/ads/switch.py
@@ -1,30 +1,25 @@
 """Support for ADS switch platform."""
-import voluptuous as vol
-
-from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
-from homeassistant.const import CONF_NAME
-import homeassistant.helpers.config_validation as cv
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import CONF_NAME, CONF_SWITCHES
 
 from . import CONF_ADS_VAR, DATA_ADS, STATE_KEY_STATE, AdsEntity
 
-DEFAULT_NAME = "ADS Switch"
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_ADS_VAR): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    }
-)
-
-
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info):
     """Set up switch platform for ADS."""
+    entities = []
+
+    if discovery_info is None:  # pragma: no cover
+        return
+
     ads_hub = hass.data.get(DATA_ADS)
 
-    name = config[CONF_NAME]
-    ads_var = config[CONF_ADS_VAR]
+    for entry in discovery_info[CONF_SWITCHES]:
+        ads_var = entry.get(CONF_ADS_VAR)
+        name = entry.get(CONF_NAME)
+        entities.append(AdsSwitch(ads_hub, name, ads_var))
 
-    add_entities([AdsSwitch(ads_hub, name, ads_var)])
+    add_entities(entities)
 
 
 class AdsSwitch(AdsEntity, SwitchEntity):

--- a/homeassistant/components/ads/switch.py
+++ b/homeassistant/components/ads/switch.py
@@ -5,7 +5,7 @@ from homeassistant.const import CONF_NAME, CONF_SWITCHES
 from . import CONF_ADS_VAR, DATA_ADS, STATE_KEY_STATE, AdsEntity
 
 
-def setup_platform(hass, config, add_entities, discovery_info):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up switch platform for ADS."""
     entities = []
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds new options to sensor and switch platformas of ADS integration:
Sensor: device_class and state_class 
Switch: device_class

Follow up of #58734

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/20084

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
