### PR TITLE
Switchbot "in memory" state for push mode switch

### DIFF
--- a/homeassistant/components/switchbot/switch.py
+++ b/homeassistant/components/switchbot/switch.py
@@ -131,7 +131,7 @@ class SwitchBotBotEntity(SwitchbotEntity, SwitchEntity, RestoreEntity):
             self._last_run_success = bool(
                 await self.hass.async_add_executor_job(self._device.turn_on)
             )
-            if not self.data["data"]["switchMode"] and self._last_run_success:
+            if self._last_run_success:
                 self._attr_is_on = True
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -142,7 +142,7 @@ class SwitchBotBotEntity(SwitchbotEntity, SwitchEntity, RestoreEntity):
             self._last_run_success = bool(
                 await self.hass.async_add_executor_job(self._device.turn_off)
             )
-            if not self.data["data"]["switchMode"] and self._last_run_success:
+            if self._last_run_success:
                 self._attr_is_on = False
 
     @property

--- a/homeassistant/components/switchbot/switch.py
+++ b/homeassistant/components/switchbot/switch.py
@@ -127,37 +127,23 @@ class SwitchBotBotEntity(SwitchbotEntity, SwitchEntity, RestoreEntity):
         """Turn device on."""
         _LOGGER.info("Turn Switchbot bot on %s", self._mac)
 
-        if not self.data["data"]["switchMode"]:
-            async with self.coordinator.api_lock:
-                self._last_run_success = bool(
-                    await self.hass.async_add_executor_job(self._device.press)
-                )
-
-            if self._last_run_success:
-                self._attr_is_on = True
-
         async with self.coordinator.api_lock:
             self._last_run_success = bool(
                 await self.hass.async_add_executor_job(self._device.turn_on)
             )
+            if not self.data["data"]["switchMode"] and self._last_run_success:
+                self._attr_is_on = True
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn device off."""
         _LOGGER.info("Turn Switchbot bot off %s", self._mac)
 
-        if not self.data["data"]["switchMode"]:
-            async with self.coordinator.api_lock:
-                self._last_run_success = bool(
-                    await self.hass.async_add_executor_job(self._device.press)
-                )
-
-            if self._last_run_success:
-                self._attr_is_on = False
-
         async with self.coordinator.api_lock:
             self._last_run_success = bool(
                 await self.hass.async_add_executor_job(self._device.turn_off)
             )
+            if not self.data["data"]["switchMode"] and self._last_run_success:
+                self._attr_is_on = False
 
     @property
     def assumed_state(self) -> bool:

--- a/homeassistant/components/switchbot/switch.py
+++ b/homeassistant/components/switchbot/switch.py
@@ -127,6 +127,15 @@ class SwitchBotBotEntity(SwitchbotEntity, SwitchEntity, RestoreEntity):
         """Turn device on."""
         _LOGGER.info("Turn Switchbot bot on %s", self._mac)
 
+        if not self.data["data"]["switchMode"]:
+            async with self.coordinator.api_lock:
+                self._last_run_success = bool(
+                    await self.hass.async_add_executor_job(self._device.press)
+                )
+
+            if self._last_run_success:
+                self._attr_is_on = True
+
         async with self.coordinator.api_lock:
             self._last_run_success = bool(
                 await self.hass.async_add_executor_job(self._device.turn_on)
@@ -135,6 +144,15 @@ class SwitchBotBotEntity(SwitchbotEntity, SwitchEntity, RestoreEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn device off."""
         _LOGGER.info("Turn Switchbot bot off %s", self._mac)
+
+        if not self.data["data"]["switchMode"]:
+            async with self.coordinator.api_lock:
+                self._last_run_success = bool(
+                    await self.hass.async_add_executor_job(self._device.press)
+                )
+
+            if self._last_run_success:
+                self._attr_is_on = False
 
         async with self.coordinator.api_lock:
             self._last_run_success = bool(
@@ -152,7 +170,7 @@ class SwitchBotBotEntity(SwitchbotEntity, SwitchEntity, RestoreEntity):
     def is_on(self) -> bool:
         """Return true if device is on."""
         if not self.data["data"]["switchMode"]:
-            return
+            return self._attr_is_on
         return self.data["data"]["isOn"]
 
     @property

--- a/homeassistant/components/switchbot/switch.py
+++ b/homeassistant/components/switchbot/switch.py
@@ -151,6 +151,8 @@ class SwitchBotBotEntity(SwitchbotEntity, SwitchEntity, RestoreEntity):
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
+        if not self.data["data"]["switchMode"]:
+            return
         return self.data["data"]["isOn"]
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Track state "in memory" for switchbot bot when in "push mode".

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #57446
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
