### PR TITLE
Add automation.stop service to stop an automation

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -101,6 +101,7 @@ ATTR_LAST_TRIGGERED = "last_triggered"
 ATTR_SOURCE = "source"
 ATTR_VARIABLES = "variables"
 SERVICE_TRIGGER = "trigger"
+SERVICE_STOP = "stop"
 
 _LOGGER = logging.getLogger(__name__)
 AutomationActionType = Callable[[HomeAssistant, TemplateVarsType], Awaitable[None]]
@@ -253,6 +254,7 @@ async def async_setup(hass, config):
         {vol.Optional(CONF_STOP_ACTIONS, default=DEFAULT_STOP_ACTIONS): cv.boolean},
         "async_turn_off",
     )
+    component.async_register_entity_service(SERVICE_STOP, {}, "async_stop")
 
     async def reload_service_handler(service_call):
         """Remove all automations and load new ones from config."""
@@ -568,6 +570,10 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             await self.action_script.async_stop()
 
         self.async_write_ha_state()
+
+    async def async_stop(self, **kwargs: Any) -> None:
+        """Stop execution of all actions of the automation."""
+        await self.action_script.async_stop()
 
     async def _async_attach_triggers(
         self, home_assistant_start: bool

--- a/homeassistant/components/automation/services.yaml
+++ b/homeassistant/components/automation/services.yaml
@@ -44,3 +44,10 @@ trigger:
 reload:
   name: Reload
   description: Reload the automation configuration.
+
+stop:
+  name: Stop
+  description: Stop currently running actions of an automation
+  target:
+    entity:
+      domain: automation

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -12,6 +12,7 @@ from homeassistant.components.automation import (
     DOMAIN,
     EVENT_AUTOMATION_RELOADED,
     EVENT_AUTOMATION_TRIGGERED,
+    SERVICE_STOP,
     SERVICE_TRIGGER,
 )
 from homeassistant.const import (
@@ -655,7 +656,9 @@ async def test_reload_config_handles_load_fails(hass, calls):
     assert len(calls) == 2
 
 
-@pytest.mark.parametrize("service", ["turn_off_stop", "turn_off_no_stop", "reload"])
+@pytest.mark.parametrize(
+    "service", ["turn_off_stop", "turn_off_no_stop", "reload", "stop"]
+)
 async def test_automation_stops(hass, calls, service):
     """Test that turning off / reloading stops any running actions as appropriate."""
     entity_id = "automation.hello"
@@ -698,6 +701,13 @@ async def test_automation_stops(hass, calls, service):
             automation.DOMAIN,
             SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: entity_id, automation.CONF_STOP_ACTIONS: False},
+            blocking=True,
+        )
+    elif service == "stop":
+        await hass.services.async_call(
+            automation.DOMAIN,
+            SERVICE_STOP,
+            {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
     else:


### PR DESCRIPTION
Add a new `automation.stop` service which stops all running actions of
an automation.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently it is only possible to stop a running automation by turning it off and on again, and thus invoking two services. This adds a new service, `automation.stop`, to stop an automation in one go.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#20085

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
