### PR TITLE
Add device_class for GEM power and voltage sensors

### DIFF
--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONF_SENSOR_TYPE,
     CONF_SENSORS,
     CONF_TEMPERATURE_UNIT,
+    DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
     ELECTRIC_POTENTIAL_VOLT,
     POWER_WATT,
@@ -173,6 +174,7 @@ class CurrentSensor(GEMSensor[greeneye.monitor.Channel]):
 
     _attr_icon = CURRENT_SENSOR_ICON
     _attr_native_unit_of_measurement = UNIT_WATTS
+    _attr_device_class = DEVICE_CLASS_POWER
 
     def __init__(
         self, monitor_serial_number: int, number: int, name: str, net_metering: bool

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -45,7 +45,6 @@ DATA_WATT_SECONDS = "watt_seconds"
 UNIT_WATTS = POWER_WATT
 
 COUNTER_ICON = "mdi:counter"
-CURRENT_SENSOR_ICON = "mdi:flash"
 
 
 async def async_setup_platform(

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -173,7 +173,6 @@ class GEMSensor(Generic[T], SensorEntity):
 class CurrentSensor(GEMSensor[greeneye.monitor.Channel]):
     """Entity showing power usage on one channel of the monitor."""
 
-    _attr_icon = CURRENT_SENSOR_ICON
     _attr_native_unit_of_measurement = UNIT_WATTS
     _attr_device_class = DEVICE_CLASS_POWER
 
@@ -316,7 +315,6 @@ class TemperatureSensor(GEMSensor[greeneye.monitor.TemperatureSensor]):
 class VoltageSensor(GEMSensor[greeneye.monitor.Monitor]):
     """Entity showing voltage."""
 
-    _attr_icon = VOLTAGE_ICON
     _attr_native_unit_of_measurement = ELECTRIC_POTENTIAL_VOLT
     _attr_device_class = DEVICE_CLASS_VOLTAGE
 

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -46,8 +46,6 @@ UNIT_WATTS = POWER_WATT
 
 COUNTER_ICON = "mdi:counter"
 CURRENT_SENSOR_ICON = "mdi:flash"
-TEMPERATURE_ICON = "mdi:thermometer"
-VOLTAGE_ICON = "mdi:current-ac"
 
 
 async def async_setup_platform(
@@ -283,7 +281,6 @@ class TemperatureSensor(GEMSensor[greeneye.monitor.TemperatureSensor]):
     """Entity showing temperature from one temperature sensor."""
 
     _attr_device_class = DEVICE_CLASS_TEMPERATURE
-    _attr_icon = TEMPERATURE_ICON
 
     def __init__(
         self, monitor_serial_number: int, number: int, name: str, unit: str

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_TEMPERATURE_UNIT,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLTAGE,
     ELECTRIC_POTENTIAL_VOLT,
     POWER_WATT,
     TIME_HOURS,
@@ -317,6 +318,7 @@ class VoltageSensor(GEMSensor[greeneye.monitor.Monitor]):
 
     _attr_icon = VOLTAGE_ICON
     _attr_native_unit_of_measurement = ELECTRIC_POTENTIAL_VOLT
+    _attr_device_class = DEVICE_CLASS_VOLTAGE
 
     def __init__(self, monitor_serial_number: int, number: int, name: str) -> None:
         """Construct the entity."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix device_class for the GEM current sensor to be type POWER and the voltage sensor to be type VOLTAGE

To fix the statistics error about the UOM of watts not matching device_class energy

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
