### PR TITLE
dlna_dmr: less eager discovery

### DIFF
--- a/homeassistant/components/dlna_dmr/config_flow.py
+++ b/homeassistant/components/dlna_dmr/config_flow.py
@@ -470,4 +470,20 @@ def _is_ignored_device(discovery_info: Mapping[str, Any]) -> bool:
     if discovery_info.get(ssdp.ATTR_UPNP_DEVICE_TYPE) not in DmrDevice.DEVICE_TYPES:
         return True
 
+    # Special cases for devices with other discovery methods (e.g. mDNS), or
+    # that advertise multiple unrelated (sent in separate discovery packets)
+    # UPnP devices.
+    manufacturer = discovery_info.get(ssdp.ATTR_UPNP_MANUFACTURER, "").lower()
+    model = discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME, "").lower()
+
+    if manufacturer.startswith("xbmc") or model == "kodi":
+        # kodi
+        return True
+    if manufacturer.startswith("samsung") and "tv" in model:
+        # samsungtv
+        return True
+    if manufacturer.startswith("lg") and "tv" in model:
+        # webostv
+        return True
+
     return False

--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -17,18 +17,6 @@
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3",
       "st": "urn:schemas-upnp-org:device:MediaRenderer:3"
-    },
-    {
-      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",
-      "nt": "urn:schemas-upnp-org:device:MediaRenderer:1"
-    },
-    {
-      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
-      "nt": "urn:schemas-upnp-org:device:MediaRenderer:2"
-    },
-    {
-      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3",
-      "nt": "urn:schemas-upnp-org:device:MediaRenderer:3"
     }
   ],
   "codeowners": ["@StevenLooman", "@chishm"],

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -95,18 +95,6 @@ SSDP = {
         {
             "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3",
             "st": "urn:schemas-upnp-org:device:MediaRenderer:3"
-        },
-        {
-            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",
-            "nt": "urn:schemas-upnp-org:device:MediaRenderer:1"
-        },
-        {
-            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
-            "nt": "urn:schemas-upnp-org:device:MediaRenderer:2"
-        },
-        {
-            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3",
-            "nt": "urn:schemas-upnp-org:device:MediaRenderer:3"
         }
     ],
     "fritz": [

--- a/tests/components/dlna_dmr/test_config_flow.py
+++ b/tests/components/dlna_dmr/test_config_flow.py
@@ -631,6 +631,22 @@ async def test_ssdp_ignore_device(hass: HomeAssistant) -> None:
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "alternative_integration"
 
+    for manufacturer, model in [
+        ("XBMC Foundation", "Kodi"),
+        ("Samsung", "Smart TV"),
+        ("LG Electronics.", "LG TV"),
+    ]:
+        discovery = dict(MOCK_DISCOVERY)
+        discovery[ssdp.ATTR_UPNP_MANUFACTURER] = manufacturer
+        discovery[ssdp.ATTR_UPNP_MODEL_NAME] = model
+        result = await hass.config_entries.flow.async_init(
+            DLNA_DOMAIN,
+            context={"source": config_entries.SOURCE_SSDP},
+            data=discovery,
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "alternative_integration"
+
 
 async def test_unignore_flow(hass: HomeAssistant, ssdp_scanner_mock: Mock) -> None:
     """Test a config flow started by unignoring a device."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Even less eager discovery for DLNA DMR. This adds special cases for devices that aren't ignored by the usual way of detecting multiple config flows.

I've added devices that I am aware of. There might be a few more that slip through, but hopefully not too many.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #56898
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
