### PR TITLE
Improve part metadata in stream

### DIFF
--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -707,9 +707,6 @@ async def test_durations(hass, record_worker_sync):
     running_metadata_duration = 0
     for segment in complete_segments:
         av_segment = av.open(io.BytesIO(segment.init + segment.get_data()))
-        print(
-            f"segment start time {av_segment.start_time} duration {av_segment.duration}"
-        )
         av_segment.close()
         for part_num, part in enumerate(segment.parts):
             av_part = av.open(io.BytesIO(segment.init + part.data))

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -677,6 +677,10 @@ async def test_worker_log(hass, caplog):
 
 async def test_durations(hass, record_worker_sync):
     """Test that the duration metadata matches the media."""
+
+    # Use a target part duration which has a slight mismatch
+    # with the incoming frame rate to better expose problems.
+    target_part_duration = TEST_PART_DURATION - 0.01
     await async_setup_component(
         hass,
         "stream",
@@ -684,12 +688,12 @@ async def test_durations(hass, record_worker_sync):
             "stream": {
                 CONF_LL_HLS: True,
                 CONF_SEGMENT_DURATION: SEGMENT_DURATION,
-                CONF_PART_DURATION: TEST_PART_DURATION,
+                CONF_PART_DURATION: target_part_duration,
             }
         },
     )
 
-    source = generate_h264_video()
+    source = generate_h264_video(duration=SEGMENT_DURATION + 1)
     stream = create_stream(hass, source, {})
 
     # use record_worker_sync to grab output segments
@@ -702,25 +706,40 @@ async def test_durations(hass, record_worker_sync):
     # check that the Part duration metadata matches the durations in the media
     running_metadata_duration = 0
     for segment in complete_segments:
-        for part in segment.parts:
+        av_segment = av.open(io.BytesIO(segment.init + segment.get_data()))
+        print(
+            f"segment start time {av_segment.start_time} duration {av_segment.duration}"
+        )
+        av_segment.close()
+        for part_num, part in enumerate(segment.parts):
             av_part = av.open(io.BytesIO(segment.init + part.data))
             running_metadata_duration += part.duration
-            # av_part.duration actually returns the dts of the first packet of
-            # the next av_part. When we normalize this by av.time_base we get
-            # the running duration of the media.
-            # The metadata duration is slightly different. The worker has
-            # some flexibility of where to set each metadata boundary, and
-            # when the media's duration is slightly too long, the metadata
-            # duration is adjusted down. This means that the running metadata
-            # duration may be up to one video frame duration smaller than the
-            # part duration.
-            assert running_metadata_duration < av_part.duration / av.time_base + 1e-6
-            assert (
-                running_metadata_duration
-                > av_part.duration / av.time_base
-                - 1 / av_part.streams.video[0].rate
-                - 1e-6
+            # av_part.duration actually returns the dts of the first packet of the next
+            # av_part. When we normalize this by av.time_base we get the running
+            # duration of the media.
+            # The metadata duration may differ slightly from the media duration.
+            # The worker has some flexibility of where to set each metadata boundary,
+            # and when the media's duration is slightly too long or too short, the
+            # metadata duration may be adjusted up or down.
+            # We check here that the divergence between the metadata duration and the
+            # media duration is not too large (2 frames seems reasonable here).
+            assert math.isclose(
+                (av_part.duration - av_part.start_time) / av.time_base,
+                part.duration,
+                abs_tol=2 / av_part.streams.video[0].rate + 1e-6,
             )
+            # Also check that the sum of the durations so far matches the last dts
+            # in the media.
+            assert math.isclose(
+                running_metadata_duration,
+                av_part.duration / av.time_base,
+                abs_tol=1e-6,
+            )
+            # And check that the metadata duration is between 0.85x and 1.0x of
+            # the part target duration
+            if not (part.has_keyframe or part_num == len(segment.parts) - 1):
+                assert part.duration > 0.85 * target_part_duration - 1e-6
+            assert part.duration < target_part_duration + 1e-6
             av_part.close()
     # check that the Part durations are consistent with the Segment durations
     for segment in complete_segments:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/pull/58036 corrects a mismatch between the EXT-X-PROGRAM-DATE-TIME and duration metadata in the HLS playlists in stream which helps Exoplayer playback. However, by resetting the timestamp to an adjusted timestamp on every segment, it allowed a timestamp drift to compound across segments. This drift results in mismatches in duration metadata and seems to cause playback issues in hls.js.
This PR:
- Keeps this drift from extending across segments by resetting the timestamps to the non-adjusted timestamps each segment
- Keeps `EXT-X-PROGRAM-DATE-TIME` consistent by incrementing `start_time` instead of relying on the reset timestamp
- Adjusts the `frag_duration` parameter passed to ffmpeg based on whether an audio track is present or not to try and keep the actual media fragments better bounded
- Enforces a floor in addition to the existing ceiling on part duration metadata
- Augments the duration test

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
