### PR TITLE
Add binary_sensor to venstar to track alerts

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1171,6 +1171,7 @@ omit =
     homeassistant/components/velbus/switch.py
     homeassistant/components/velux/*
     homeassistant/components/venstar/__init__.py
+    homeassistant/components/venstar/binary_sensor.py
     homeassistant/components/venstar/climate.py
     homeassistant/components/verisure/__init__.py
     homeassistant/components/verisure/alarm_control_panel.py

--- a/homeassistant/components/venstar/__init__.py
+++ b/homeassistant/components/venstar/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import _LOGGER, DOMAIN, VENSTAR_TIMEOUT
 
-PLATFORMS = ["climate"]
+PLATFORMS = ["climate", "binary_sensor"]
 
 
 async def async_setup_entry(hass, config):
@@ -96,6 +96,16 @@ class VenstarDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
         except (OSError, RequestException) as ex:
             raise update_coordinator.UpdateFailed(
                 f"Exception during Venstar sensor update: {ex}"
+            ) from ex
+
+        # older venstars sometimes cannot handle rapid sequential connections
+        await asyncio.sleep(3)
+
+        try:
+            await self.hass.async_add_executor_job(self.client.update_alerts)
+        except (OSError, RequestException) as ex:
+            raise update_coordinator.UpdateFailed(
+                f"Exception during Venstar alert update: {ex}"
             ) from ex
         return None
 

--- a/homeassistant/components/venstar/binary_sensor.py
+++ b/homeassistant/components/venstar/binary_sensor.py
@@ -1,6 +1,4 @@
 """Alarm sensors for the Venstar Thermostat."""
-from typing import List
-
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_PROBLEM,
     BinarySensorEntity,
@@ -16,10 +14,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
 
     if coordinator.client.alerts is None:
         return
-        sensors: List[VenstarBinarySensor] = [
-            VenstarBinarySensor(coordinator, config_entry, alert["name"])
-            for alert in coordinator.client.alerts
-        ]
+    sensors = [
+        VenstarBinarySensor(coordinator, config_entry, alert["name"])
+        for alert in coordinator.client.alerts
+    ]
 
     async_add_entities(sensors, True)
 

--- a/homeassistant/components/venstar/binary_sensor.py
+++ b/homeassistant/components/venstar/binary_sensor.py
@@ -1,0 +1,54 @@
+"""Alarm sensors for the Venstar Thermostat."""
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_PROBLEM,
+    BinarySensorEntity,
+)
+
+from . import VenstarEntity
+from .const import DOMAIN
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
+    """Set up Vensar device binary_sensors based on a config entry."""
+    sensors = []
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    if coordinator.client.alerts is not None:
+        for alert in coordinator.client.alerts:
+            sensors.append(
+                VenstarBinarySensor(coordinator, config_entry, alert["name"])
+            )
+
+    async_add_entities(sensors, True)
+
+
+class VenstarBinarySensor(VenstarEntity, BinarySensorEntity):
+    """Represent a Venstar alert."""
+
+    _attr_device_class = DEVICE_CLASS_PROBLEM
+
+    def __init__(self, coordinator, config, alert):
+        """Initialize the alert."""
+        super().__init__(coordinator, config)
+        self.alert = alert
+        self._config = config
+        self._unique_id = f"{self._config.entry_id}_{self.alert.replace(' ', '_')}"
+        self._name = f"{self._client.name} {self.alert}"
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        for alert in self._client.alerts:
+            if alert["name"] == self.alert:
+                return alert["active"]
+        return None

--- a/homeassistant/components/venstar/binary_sensor.py
+++ b/homeassistant/components/venstar/binary_sensor.py
@@ -1,4 +1,6 @@
 """Alarm sensors for the Venstar Thermostat."""
+from typing import List
+
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_PROBLEM,
     BinarySensorEntity,
@@ -14,7 +16,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
 
     if coordinator.client.alerts is None:
         return
-        sensors = [VenstarBinarySensor(coordinator, config_entry, alert["name"]) for alert in coordinator.client.alerts]
+        sensors: List[VenstarBinarySensor] = [
+            VenstarBinarySensor(coordinator, config_entry, alert["name"])
+            for alert in coordinator.client.alerts
+        ]
 
     async_add_entities(sensors, True)
 

--- a/homeassistant/components/venstar/binary_sensor.py
+++ b/homeassistant/components/venstar/binary_sensor.py
@@ -10,14 +10,11 @@ from .const import DOMAIN
 
 async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     """Set up Vensar device binary_sensors based on a config entry."""
-    sensors = []
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    if coordinator.client.alerts is not None:
-        for alert in coordinator.client.alerts:
-            sensors.append(
-                VenstarBinarySensor(coordinator, config_entry, alert["name"])
-            )
+    if coordinator.client.alerts is None:
+        return
+        sensors = [VenstarBinarySensor(coordinator, config_entry, alert["name"]) for alert in coordinator.client.alerts]
 
     async_add_entities(sensors, True)
 
@@ -51,4 +48,3 @@ class VenstarBinarySensor(VenstarEntity, BinarySensorEntity):
         for alert in self._client.alerts:
             if alert["name"] == self.alert:
                 return alert["active"]
-        return None

--- a/tests/components/venstar/test_init.py
+++ b/tests/components/venstar/test_init.py
@@ -33,6 +33,9 @@ async def test_setup_entry(hass: HomeAssistant):
     ), patch(
         "homeassistant.components.venstar.VenstarColorTouch.update_info",
         new=VenstarColorTouchMock.update_info,
+    ), patch(
+        "homeassistant.components.venstar.VenstarColorTouch.update_alerts",
+        new=VenstarColorTouchMock.update_alerts,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -64,6 +67,9 @@ async def test_setup_entry_exception(hass: HomeAssistant):
     ), patch(
         "homeassistant.components.venstar.VenstarColorTouch.update_info",
         new=VenstarColorTouchMock.broken_update_info,
+    ), patch(
+        "homeassistant.components.venstar.VenstarColorTouch.update_alerts",
+        new=VenstarColorTouchMock.update_alerts,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The venstar thermostat has simple binary alert states, such as "needs service" or "replace air filter". This adds support
for these sensors as problem sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20104

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
