### PR TITLE
Use zeroconf HaServiceInfo in tests (A-D)

### DIFF
--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -7,15 +7,16 @@ from pyatv.const import Protocol
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
+from homeassistant.components import zeroconf
 from homeassistant.components.apple_tv.const import CONF_START_OFF, DOMAIN
 
 from tests.common import MockConfigEntry
 
-DMAP_SERVICE = {
-    "type": "_touch-able._tcp.local.",
-    "name": "dmapid.something",
-    "properties": {"CtlN": "Apple TV"},
-}
+DMAP_SERVICE = zeroconf.HaServiceInfo(
+    type="_touch-able._tcp.local.",
+    name="dmapid.something",
+    properties={"CtlN": "Apple TV"},
+)
 
 
 @pytest.fixture(autouse=True)
@@ -399,10 +400,10 @@ async def test_zeroconf_unsupported_service_aborts(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data={
-            "type": "_dummy._tcp.local.",
-            "properties": {},
-        },
+        data=zeroconf.HaServiceInfo(
+            type="_dummy._tcp.local.",
+            properties={},
+        ),
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "unknown"
@@ -413,10 +414,10 @@ async def test_zeroconf_add_mrp_device(hass, mrp_device, pairing):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data={
-            "type": "_mediaremotetv._tcp.local.",
-            "properties": {"UniqueIdentifier": "mrpid", "Name": "Kitchen"},
-        },
+        data=zeroconf.HaServiceInfo(
+            type="_mediaremotetv._tcp.local.",
+            properties={"UniqueIdentifier": "mrpid", "Name": "Kitchen"},
+        ),
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["description_placeholders"] == {"name": "MRP Device"}

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -5,6 +5,7 @@ import pytest
 import respx
 
 from homeassistant import data_entry_flow
+from homeassistant.components import zeroconf
 from homeassistant.components.axis import config_flow
 from homeassistant.components.axis.const import (
     CONF_EVENTS,
@@ -292,17 +293,17 @@ async def test_reauth_flow_update_configuration(hass):
         ),
         (
             SOURCE_ZEROCONF,
-            {
-                "host": DEFAULT_HOST,
-                "port": 80,
-                "hostname": f"axis-{MAC.lower()}.local.",
-                "type": "_axis-video._tcp.local.",
-                "name": f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
-                "properties": {
+            zeroconf.HaServiceInfo(
+                host=DEFAULT_HOST,
+                port=80,
+                hostname=f"axis-{MAC.lower()}.local.",
+                type="_axis-video._tcp.local.",
+                name=f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
+                properties={
                     "_raw": {"macaddress": MAC.encode()},
                     "macaddress": MAC,
                 },
-            },
+            ),
         ),
     ],
 )
@@ -362,12 +363,12 @@ async def test_discovery_flow(hass, source: str, discovery_info: dict):
         ),
         (
             SOURCE_ZEROCONF,
-            {
-                CONF_HOST: DEFAULT_HOST,
-                CONF_PORT: 80,
-                "name": f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
-                "properties": {"macaddress": MAC},
-            },
+            zeroconf.HaServiceInfo(
+                host=DEFAULT_HOST,
+                port=80,
+                name=f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
+                properties={"macaddress": MAC},
+            ),
         ),
     ],
 )
@@ -410,12 +411,12 @@ async def test_discovered_device_already_configured(
         ),
         (
             SOURCE_ZEROCONF,
-            {
-                CONF_HOST: "2.3.4.5",
-                CONF_PORT: 8080,
-                "name": f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
-                "properties": {"macaddress": MAC},
-            },
+            zeroconf.HaServiceInfo(
+                host="2.3.4.5",
+                port=8080,
+                name=f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
+                properties={"macaddress": MAC},
+            ),
             8080,
         ),
     ],
@@ -478,12 +479,12 @@ async def test_discovery_flow_updated_configuration(
         ),
         (
             SOURCE_ZEROCONF,
-            {
-                CONF_HOST: "",
-                CONF_PORT: 0,
-                "name": "",
-                "properties": {"macaddress": "01234567890"},
-            },
+            zeroconf.HaServiceInfo(
+                host="",
+                port=0,
+                name="",
+                properties={"macaddress": "01234567890"},
+            ),
         ),
     ],
 )
@@ -516,12 +517,12 @@ async def test_discovery_flow_ignore_non_axis_device(
         ),
         (
             SOURCE_ZEROCONF,
-            {
-                CONF_HOST: "169.254.3.4",
-                CONF_PORT: 80,
-                "name": f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
-                "properties": {"macaddress": MAC},
-            },
+            zeroconf.HaServiceInfo(
+                host="169.254.3.4",
+                port=80,
+                name=f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
+                properties={"macaddress": MAC},
+            ),
         ),
     ],
 )

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, Mock, patch
 from aiohttp import ClientConnectionError, ClientResponseError
 
 from homeassistant import config_entries, core
+from homeassistant.components import zeroconf
 from homeassistant.components.bond.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
@@ -196,7 +197,9 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data={"name": "test-bond-id.some-other-tail-info", "host": "test-host"},
+        data=zeroconf.HaServiceInfo(
+            name="test-bond-id.some-other-tail-info", host="test-host"
+        ),
     )
     assert result["type"] == "form"
     assert result["errors"] == {}
@@ -226,7 +229,9 @@ async def test_zeroconf_form_token_unavailable(hass: core.HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data={"name": "test-bond-id.some-other-tail-info", "host": "test-host"},
+            data=zeroconf.HaServiceInfo(
+                name="test-bond-id.some-other-tail-info", host="test-host"
+            ),
         )
         await hass.async_block_till_done()
     assert result["type"] == "form"
@@ -259,7 +264,9 @@ async def test_zeroconf_form_with_token_available(hass: core.HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data={"name": "test-bond-id.some-other-tail-info", "host": "test-host"},
+            data=zeroconf.HaServiceInfo(
+                name="test-bond-id.some-other-tail-info", host="test-host"
+            ),
         )
         await hass.async_block_till_done()
     assert result["type"] == "form"
@@ -295,10 +302,10 @@ async def test_zeroconf_already_configured(hass: core.HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data={
-                "name": "already-registered-bond-id.some-other-tail-info",
-                "host": "updated-host",
-            },
+            data=zeroconf.HaServiceInfo(
+                name="already-registered-bond-id.some-other-tail-info",
+                host="updated-host",
+            ),
         )
 
     assert result["type"] == "abort"
@@ -336,10 +343,10 @@ async def test_zeroconf_already_configured_refresh_token(hass: core.HomeAssistan
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data={
-                "name": "already-registered-bond-id.some-other-tail-info",
-                "host": "updated-host",
-            },
+            data=zeroconf.HaServiceInfo(
+                name="already-registered-bond-id.some-other-tail-info",
+                host="updated-host",
+            ),
         )
         await hass.async_block_till_done()
 
@@ -369,10 +376,10 @@ async def test_zeroconf_already_configured_no_reload_same_host(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data={
-                "name": "already-registered-bond-id.some-other-tail-info",
-                "host": "stored-host",
-            },
+            data=zeroconf.HaServiceInfo(
+                name="already-registered-bond-id.some-other-tail-info",
+                host="stored-host",
+            ),
         )
         await hass.async_block_till_done()
 
@@ -386,10 +393,10 @@ async def test_zeroconf_form_unexpected_error(hass: core.HomeAssistant):
     await _help_test_form_unexpected_error(
         hass,
         source=config_entries.SOURCE_ZEROCONF,
-        initial_input={
-            "name": "test-bond-id.some-other-tail-info",
-            "host": "test-host",
-        },
+        initial_input=zeroconf.HaServiceInfo(
+            name="test-bond-id.some-other-tail-info",
+            host="test-host",
+        ),
         user_input={CONF_ACCESS_TOKEN: "test-token"},
         error=Exception(),
     )

--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -10,6 +10,7 @@ from boschshcpy.exceptions import (
 from boschshcpy.information import SHCInformation
 
 from homeassistant import config_entries
+from homeassistant.components import zeroconf
 from homeassistant.components.bosch_shc.config_flow import write_tls_asset
 from homeassistant.components.bosch_shc.const import CONF_SHC_CERT, CONF_SHC_KEY, DOMAIN
 
@@ -19,13 +20,13 @@ MOCK_SETTINGS = {
     "name": "Test name",
     "device": {"mac": "test-mac", "hostname": "test-host"},
 }
-DISCOVERY_INFO = {
-    "host": ["169.1.1.1", "1.1.1.1"],
-    "port": 0,
-    "hostname": "shc012345.local.",
-    "type": "_http._tcp.local.",
-    "name": "Bosch SHC [test-mac]._http._tcp.local.",
-}
+DISCOVERY_INFO = zeroconf.HaServiceInfo(
+    host=["169.1.1.1", "1.1.1.1"],
+    port=0,
+    hostname="shc012345.local.",
+    type="_http._tcp.local.",
+    name="Bosch SHC [test-mac]._http._tcp.local.",
+)
 
 
 async def test_form_user(hass, mock_zeroconf):
@@ -527,13 +528,13 @@ async def test_zeroconf_cannot_connect(hass, mock_zeroconf):
 
 async def test_zeroconf_link_local(hass, mock_zeroconf):
     """Test we get the form."""
-    DISCOVERY_INFO_LINK_LOCAL = {
-        "host": ["169.1.1.1"],
-        "port": 0,
-        "hostname": "shc012345.local.",
-        "type": "_http._tcp.local.",
-        "name": "Bosch SHC [test-mac]._http._tcp.local.",
-    }
+    DISCOVERY_INFO_LINK_LOCAL = zeroconf.HaServiceInfo(
+        host=["169.1.1.1"],
+        port=0,
+        hostname="shc012345.local.",
+        type="_http._tcp.local.",
+        name="Bosch SHC [test-mac]._http._tcp.local.",
+    )
 
     with patch(
         "boschshcpy.session.SHCSession.mdns_info", side_effect=SHCConnectionError
@@ -551,7 +552,7 @@ async def test_zeroconf_not_bosch_shc(hass, mock_zeroconf):
     """Test we filter out non-bosch_shc devices."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data={"host": "1.1.1.1", "name": "notboschshc"},
+        data=zeroconf.HaServiceInfo(host="1.1.1.1", name="notboschshc"),
         context={"source": config_entries.SOURCE_ZEROCONF},
     )
     assert result["type"] == "abort"

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from brother import SnmpError, UnsupportedModel
 
 from homeassistant import data_entry_flow
+from homeassistant.components import zeroconf
 from homeassistant.components.brother.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_TYPE
@@ -143,7 +144,9 @@ async def test_zeroconf_snmp_error(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data={"hostname": "example.local.", "name": "Brother Printer"},
+            data=zeroconf.HaServiceInfo(
+                hostname="example.local.", name="Brother Printer"
+            ),
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -156,11 +159,11 @@ async def test_zeroconf_unsupported_model(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data={
-                "hostname": "example.local.",
-                "name": "Brother Printer",
-                "properties": {"product": "MFC-8660DN"},
-            },
+            data=zeroconf.HaServiceInfo(
+                hostname="example.local.",
+                name="Brother Printer",
+                properties={"product": "MFC-8660DN"},
+            ),
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -181,7 +184,9 @@ async def test_zeroconf_device_exists_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data={"hostname": "example.local.", "name": "Brother Printer"},
+            data=zeroconf.HaServiceInfo(
+                hostname="example.local.", name="Brother Printer"
+            ),
         )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -196,7 +201,7 @@ async def test_zeroconf_no_probe_existing_device(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data={"hostname": "localhost", "name": "Brother Printer"},
+            data=zeroconf.HaServiceInfo(hostname="localhost", name="Brother Printer"),
         )
         await hass.async_block_till_done()
 
@@ -215,7 +220,9 @@ async def test_zeroconf_confirm_create_entry(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data={"hostname": "example.local.", "name": "Brother Printer"},
+            data=zeroconf.HaServiceInfo(
+                hostname="example.local.", name="Brother Printer"
+            ),
         )
 
         assert result["step_id"] == "zeroconf_confirm"

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -7,6 +7,7 @@ from aiohttp import ClientError, web_exceptions
 from pydaikin.exceptions import DaikinException
 import pytest
 
+from homeassistant.components import zeroconf
 from homeassistant.components.daikin.const import KEY_MAC
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PASSWORD
@@ -119,7 +120,7 @@ async def test_api_password_abort(hass):
 @pytest.mark.parametrize(
     "source, data, unique_id",
     [
-        (SOURCE_ZEROCONF, {CONF_HOST: HOST}, MAC),
+        (SOURCE_ZEROCONF, zeroconf.HaServiceInfo(host=HOST), MAC),
     ],
 )
 async def test_discovery_zeroconf(

--- a/tests/components/devolo_home_control/const.py
+++ b/tests/components/devolo_home_control/const.py
@@ -1,12 +1,14 @@
 """Constants used for mocking data."""
 
-DISCOVERY_INFO = {
-    "host": "192.168.0.1",
-    "port": 14791,
-    "hostname": "test.local.",
-    "type": "_dvl-deviceapi._tcp.local.",
-    "name": "dvl-deviceapi",
-    "properties": {
+from homeassistant.components import zeroconf
+
+DISCOVERY_INFO = zeroconf.HaServiceInfo(
+    host="192.168.0.1",
+    port=14791,
+    hostname="test.local.",
+    type="_dvl-deviceapi._tcp.local.",
+    name="dvl-deviceapi",
+    properties={
         "Path": "/deviceapi",
         "Version": "v0",
         "Features": "",
@@ -15,8 +17,8 @@ DISCOVERY_INFO = {
         "FirmwareVersion": "8.90.4",
         "PlcMacAddress": "AA:BB:CC:DD:EE:FF",
     },
-}
+)
 
-DISCOVERY_INFO_WRONG_DEVOLO_DEVICE = {"properties": {"MT": "2700"}}
+DISCOVERY_INFO_WRONG_DEVOLO_DEVICE = zeroconf.HaServiceInfo(properties={"MT": "2700"})
 
-DISCOVERY_INFO_WRONG_DEVICE = {"properties": {"Features": ""}}
+DISCOVERY_INFO_WRONG_DEVICE = zeroconf.HaServiceInfo(properties={"Features": ""})

--- a/tests/components/devolo_home_network/const.py
+++ b/tests/components/devolo_home_network/const.py
@@ -1,5 +1,7 @@
 """Constants used for mocking data."""
 
+from homeassistant.components import zeroconf
+
 IP = "1.1.1.1"
 
 CONNECTED_STATIONS = {
@@ -14,13 +16,13 @@ CONNECTED_STATIONS = {
     ],
 }
 
-DISCOVERY_INFO = {
-    "host": IP,
-    "port": 14791,
-    "hostname": "test.local.",
-    "type": "_dvl-deviceapi._tcp.local.",
-    "name": "dLAN pro 1200+ WiFi ac._dvl-deviceapi._tcp.local.",
-    "properties": {
+DISCOVERY_INFO = zeroconf.HaServiceInfo(
+    host=IP,
+    port=14791,
+    hostname="test.local.",
+    type="_dvl-deviceapi._tcp.local.",
+    name="dLAN pro 1200+ WiFi ac._dvl-deviceapi._tcp.local.",
+    properties={
         "Path": "abcdefghijkl/deviceapi",
         "Version": "v0",
         "Product": "dLAN pro 1200+ WiFi ac",
@@ -32,9 +34,9 @@ DISCOVERY_INFO = {
         "PS": "",
         "PlcMacAddress": "AA:BB:CC:DD:EE:FF",
     },
-}
+)
 
-DISCOVERY_INFO_WRONG_DEVICE = {"properties": {"MT": "2600"}}
+DISCOVERY_INFO_WRONG_DEVICE = zeroconf.HaServiceInfo(properties={"MT": "2600"})
 
 NEIGHBOR_ACCESS_POINTS = {
     "neighbor_aps": [

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 
 from homeassistant import config_entries, data_entry_flow
+from homeassistant.components import zeroconf
 from homeassistant.components.doorbird.const import CONF_EVENTS, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 
@@ -81,11 +82,11 @@ async def test_form_zeroconf_wrong_oui(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data={
-            "properties": {"macaddress": "notdoorbirdoui"},
-            "host": "192.168.1.8",
-            "name": "Doorstation - abc123._axis-video._tcp.local.",
-        },
+        data=zeroconf.HaServiceInfo(
+            properties={"macaddress": "notdoorbirdoui"},
+            host="192.168.1.8",
+            name="Doorstation - abc123._axis-video._tcp.local.",
+        ),
     )
     assert result["type"] == "abort"
     assert result["reason"] == "not_doorbird_device"
@@ -97,11 +98,11 @@ async def test_form_zeroconf_link_local_ignored(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data={
-            "properties": {"macaddress": "1CCAE3DOORBIRD"},
-            "host": "169.254.103.61",
-            "name": "Doorstation - abc123._axis-video._tcp.local.",
-        },
+        data=zeroconf.HaServiceInfo(
+            properties={"macaddress": "1CCAE3DOORBIRD"},
+            host="169.254.103.61",
+            name="Doorstation - abc123._axis-video._tcp.local.",
+        ),
     )
     assert result["type"] == "abort"
     assert result["reason"] == "link_local_address"
@@ -120,11 +121,11 @@ async def test_form_zeroconf_correct_oui(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data={
-                "properties": {"macaddress": "1CCAE3DOORBIRD"},
-                "name": "Doorstation - abc123._axis-video._tcp.local.",
-                "host": "192.168.1.5",
-            },
+            data=zeroconf.HaServiceInfo(
+                properties={"macaddress": "1CCAE3DOORBIRD"},
+                name="Doorstation - abc123._axis-video._tcp.local.",
+                host="192.168.1.5",
+            ),
         )
         await hass.async_block_till_done()
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -179,11 +180,11 @@ async def test_form_zeroconf_correct_oui_wrong_device(hass, doorbell_state_side_
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data={
-                "properties": {"macaddress": "1CCAE3DOORBIRD"},
-                "name": "Doorstation - abc123._axis-video._tcp.local.",
-                "host": "192.168.1.5",
-            },
+            data=zeroconf.HaServiceInfo(
+                properties={"macaddress": "1CCAE3DOORBIRD"},
+                name="Doorstation - abc123._axis-video._tcp.local.",
+                host="192.168.1.5",
+            ),
         )
         await hass.async_block_till_done()
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use zeroconf `HaServiceInfo` in tests (A-D)
Follow-up to #58835

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
