### PR TITLE
Handle `None` values in Xiaomi Miio integration

### DIFF
--- a/homeassistant/components/xiaomi_miio/binary_sensor.py
+++ b/homeassistant/components/xiaomi_miio/binary_sensor.py
@@ -134,7 +134,7 @@ def _setup_vacuum_sensors(hass, config_entry, async_add_entities):
                 device,
                 config_entry,
                 f"{sensor}_{config_entry.unique_id}",
-                hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR],
+                coordinator,
                 description,
             )
         )

--- a/homeassistant/components/xiaomi_miio/binary_sensor.py
+++ b/homeassistant/components/xiaomi_miio/binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
+from homeassistant.core import callback
 
 from . import VacuumCoordinatorDataAttributes
 from .const import (
@@ -168,16 +169,19 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class XiaomiGenericBinarySensor(XiaomiCoordinatedMiioEntity, BinarySensorEntity):
     """Representation of a Xiaomi Humidifier binary sensor."""
 
+    entity_description: XiaomiMiioBinarySensorDescription
+
     def __init__(self, name, device, entry, unique_id, coordinator, description):
         """Initialize the entity."""
         super().__init__(name, device, entry, unique_id, coordinator)
 
-        self.entity_description: XiaomiMiioBinarySensorDescription = description
+        self.entity_description = description
         self._attr_entity_registry_enabled_default = (
             description.entity_registry_enabled_default
         )
         self._attr_is_on = self._determine_native_value()
 
+    @callback
     def _handle_coordinator_update(self) -> None:
         self._attr_is_on = self._determine_native_value()
 

--- a/homeassistant/components/xiaomi_miio/binary_sensor.py
+++ b/homeassistant/components/xiaomi_miio/binary_sensor.py
@@ -176,10 +176,15 @@ class XiaomiGenericBinarySensor(XiaomiCoordinatedMiioEntity, BinarySensorEntity)
         self._attr_entity_registry_enabled_default = (
             description.entity_registry_enabled_default
         )
+        self._attr_is_on = self._determine_native_value()
 
-    @property
-    def is_on(self):
-        """Return true if the binary sensor is on."""
+    def _handle_coordinator_update(self) -> None:
+        self._attr_is_on = self._determine_native_value()
+
+        super()._handle_coordinator_update()
+
+    def _determine_native_value(self):
+        """Determine native value."""
         if self.entity_description.parent_key is not None:
             return self._extract_value_from_attribute(
                 getattr(self.coordinator.data, self.entity_description.parent_key),

--- a/homeassistant/components/xiaomi_miio/binary_sensor.py
+++ b/homeassistant/components/xiaomi_miio/binary_sensor.py
@@ -122,8 +122,8 @@ def _setup_vacuum_sensors(hass, config_entry, async_add_entities):
     for sensor, description in VACUUM_SENSORS.items():
         parent_key_data = getattr(coordinator.data, description.parent_key)
         if getattr(parent_key_data, description.key, None) is None:
-            _LOGGER.info(
-                "The %s device does not support the %s sensor",
+            _LOGGER.debug(
+                "It seems the %s does not support the %s as the initial value is None",
                 config_entry.data[CONF_MODEL],
                 description.key,
             )

--- a/homeassistant/components/xiaomi_miio/device.py
+++ b/homeassistant/components/xiaomi_miio/device.py
@@ -169,17 +169,6 @@ class XiaomiCoordinatedMiioEntity(CoordinatorEntity):
             return cls._parse_datetime_datetime(value)
         if isinstance(value, datetime.timedelta):
             return cls._parse_time_delta(value)
-        if isinstance(value, float):
-            return value
-        if isinstance(value, int):
-            return value
-
-        _LOGGER.warning(
-            "Could not determine how to parse state value of type %s for state %s and attribute %s",
-            type(value),
-            type(state),
-            attribute,
-        )
 
         return value
 

--- a/homeassistant/components/xiaomi_miio/device.py
+++ b/homeassistant/components/xiaomi_miio/device.py
@@ -169,6 +169,8 @@ class XiaomiCoordinatedMiioEntity(CoordinatorEntity):
             return cls._parse_datetime_datetime(value)
         if isinstance(value, datetime.timedelta):
             return cls._parse_time_delta(value)
+        if value is None:
+            _LOGGER.debug("Attribute %s is None, this is unexpected", attribute)
 
         return value
 

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -1,7 +1,6 @@
 """Support for Xiaomi Mi Air Purifier and Xiaomi Mi Air Humidifier."""
 from abc import abstractmethod
 import asyncio
-from enum import Enum
 import logging
 import math
 
@@ -362,14 +361,6 @@ class XiaomiGenericAirPurifier(XiaomiGenericDevice):
             return preset_mode if preset_mode in self._preset_modes else None
 
         return None
-
-    @staticmethod
-    def _extract_value_from_attribute(state, attribute):
-        value = getattr(state, attribute)
-        if isinstance(value, Enum):
-            return value.value
-
-        return value
 
     @callback
     def _handle_coordinator_update(self):

--- a/homeassistant/components/xiaomi_miio/humidifier.py
+++ b/homeassistant/components/xiaomi_miio/humidifier.py
@@ -1,5 +1,4 @@
 """Support for Xiaomi Mi Air Purifier and Xiaomi Mi Air Humidifier with humidifier entity."""
-from enum import Enum
 import logging
 import math
 
@@ -123,14 +122,6 @@ class XiaomiGenericHumidifier(XiaomiCoordinatedMiioEntity, HumidifierEntity):
     def is_on(self):
         """Return true if device is on."""
         return self._state
-
-    @staticmethod
-    def _extract_value_from_attribute(state, attribute):
-        value = getattr(state, attribute)
-        if isinstance(value, Enum):
-            return value.value
-
-        return value
 
     @property
     def mode(self):

--- a/homeassistant/components/xiaomi_miio/number.py
+++ b/homeassistant/components/xiaomi_miio/number.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.const import DEGREE, ENTITY_CATEGORY_CONFIG, TIME_MINUTES
@@ -284,14 +283,6 @@ class XiaomiNumberEntity(XiaomiCoordinatedMiioEntity, NumberEntity):
         ):
             return False
         return super().available
-
-    @staticmethod
-    def _extract_value_from_attribute(state, attribute):
-        value = getattr(state, attribute)
-        if isinstance(value, Enum):
-            return value.value
-
-        return value
 
     async def async_set_value(self, value):
         """Set an option of the miio device."""

--- a/homeassistant/components/xiaomi_miio/select.py
+++ b/homeassistant/components/xiaomi_miio/select.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
 
 from miio.airfresh import LedBrightness as AirfreshLedBrightness
 from miio.airhumidifier import LedBrightness as AirhumidifierLedBrightness
@@ -125,14 +124,6 @@ class XiaomiSelector(XiaomiCoordinatedMiioEntity, SelectEntity):
         super().__init__(name, device, entry, unique_id, coordinator)
         self._attr_options = list(description.options)
         self.entity_description = description
-
-    @staticmethod
-    def _extract_value_from_attribute(state, attribute):
-        value = getattr(state, attribute)
-        if isinstance(value, Enum):
-            return value.value
-
-        return value
 
 
 class XiaomiAirHumidifierSelector(XiaomiSelector):

--- a/homeassistant/components/xiaomi_miio/select.py
+++ b/homeassistant/components/xiaomi_miio/select.py
@@ -144,7 +144,7 @@ class XiaomiAirHumidifierSelector(XiaomiSelector):
         )
         # Sometimes (quite rarely) the device returns None as the LED brightness so we
         # check that the value is not None before updating the state.
-        if led_brightness:
+        if led_brightness is not None:
             self._current_led_brightness = led_brightness
             self.async_write_ha_state()
 

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -538,8 +538,8 @@ def _setup_vacuum_sensors(hass, config_entry, async_add_entities):
     for sensor, description in VACUUM_SENSORS.items():
         parent_key_data = getattr(coordinator.data, description.parent_key)
         if getattr(parent_key_data, description.key, None) is None:
-            _LOGGER.info(
-                "The %s device does not support the %s sensor",
+            _LOGGER.debug(
+                "It seems the %s does not support the %s as the initial value is None",
                 config_entry.data[CONF_MODEL],
                 description.key,
             )

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -676,7 +676,9 @@ class XiaomiGenericSensor(XiaomiCoordinatedMiioEntity, SensorEntity):
         # check that the value is not None before updating the state.
         if native_value is not None:
             self._attr_native_value = native_value
-            self._attr_extra_state_attributes = self._extract_attributes()
+            self._attr_extra_state_attributes = self._extract_attributes(
+                self.coordinator.data
+            )
             self.async_write_ha_state()
 
     def _determine_native_value(self):

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -656,14 +656,15 @@ class XiaomiGenericSensor(XiaomiCoordinatedMiioEntity, SensorEntity):
         self.entity_description = description
         self._attr_unique_id = unique_id
         self._attr_native_value = self._determine_native_value()
+        self._attr_extra_state_attributes = self._extract_attributes(coordinator.data)
 
-    @property
-    def extra_state_attributes(self):
-        """Return the state attributes."""
+    @callback
+    def _extract_attributes(self, data):
+        """Return state attributes with valid values."""
         return {
-            attr: self._extract_value_from_attribute(self.coordinator.data, attr)
+            attr: value
             for attr in self.entity_description.attributes
-            if hasattr(self.coordinator.data, attr)
+            if (value := self._extract_value_from_attribute(data, attr)) is not None
         }
 
     @callback
@@ -674,6 +675,7 @@ class XiaomiGenericSensor(XiaomiCoordinatedMiioEntity, SensorEntity):
         # check that the value is not None before updating the state.
         if native_value is not None:
             self._attr_native_value = native_value
+            self._attr_extra_state_attributes = self._extract_attributes()
             self.async_write_ha_state()
 
     def _determine_native_value(self):

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -651,20 +651,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class XiaomiGenericSensor(XiaomiCoordinatedMiioEntity, SensorEntity):
     """Representation of a Xiaomi generic sensor."""
 
-    def __init__(
-        self,
-        name,
-        device,
-        entry,
-        unique_id,
-        coordinator,
-        description: XiaomiMiioSensorDescription,
-    ):
+    entity_description: XiaomiMiioSensorDescription
+
+    def __init__(self, name, device, entry, unique_id, coordinator, description):
         """Initialize the entity."""
         super().__init__(name, device, entry, unique_id, coordinator)
+        self.entity_description = description
         self._attr_unique_id = unique_id
         self._attr_native_value = self._determine_native_value()
-        self.entity_description: XiaomiMiioSensorDescription = description
 
     @property
     def extra_state_attributes(self):

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -530,17 +530,14 @@ VACUUM_SENSORS = {
 
 
 def _setup_vacuum_sensors(hass, config_entry, async_add_entities):
+    """Set up the Xiaomi vacuum sensors."""
     device = hass.data[DOMAIN][config_entry.entry_id].get(KEY_DEVICE)
     coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
     entities = []
 
     for sensor, description in VACUUM_SENSORS.items():
-        if (
-            getattr(
-                getattr(coordinator.data, description.parent_key), description.key, None
-            )
-            is None
-        ):
+        parent_key_data = getattr(coordinator.data, description.parent_key)
+        if getattr(parent_key_data, description.key, None) is None:
             _LOGGER.info(
                 "The %s device does not support the %s sensor",
                 config_entry.data[CONF_MODEL],

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -664,7 +664,8 @@ class XiaomiGenericSensor(XiaomiCoordinatedMiioEntity, SensorEntity):
         return {
             attr: value
             for attr in self.entity_description.attributes
-            if (value := self._extract_value_from_attribute(data, attr)) is not None
+            if hasattr(data, attr)
+            and (value := self._extract_value_from_attribute(data, attr)) is not None
         }
 
     @callback

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from enum import Enum
 from functools import partial
 import logging
 
@@ -473,14 +472,6 @@ class XiaomiGenericCoordinatedSwitch(XiaomiCoordinatedMiioEntity, SwitchEntity):
         ):
             return False
         return super().available
-
-    @staticmethod
-    def _extract_value_from_attribute(state, attribute):
-        value = getattr(state, attribute)
-        if isinstance(value, Enum):
-            return value.value
-
-        return value
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on an option of the miio device."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is an extension of [this one](https://github.com/home-assistant/core/pull/57553). I opened a new PR due to problems with agreeing on what this fix should look like.

With this change:
- the integration will not create the vacuum sesnor and binary sensor entities if the initial value is `None` (currently we don't have the device -> features map)
- if the device returns value `None` for the sensor, binary sensor or select entity during runtime (it happens quite rarely for unknown reasons) the integration will skip it

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #57474
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
