### PR TITLE
Add authentication provider for Synology DSM users

### DIFF
--- a/homeassistant/auth/providers/synology.py
+++ b/homeassistant/auth/providers/synology.py
@@ -135,6 +135,7 @@ class SynologyAuthProvider(AuthProvider):
 
         # Create new credentials.
         credential_data = {k: flow_result[k] for k in flow_result.keys()}
+        credential_data.update({"username": account})
         return self.async_create_credentials(credential_data)
 
     async def async_user_meta_for_credentials(

--- a/homeassistant/auth/providers/synology.py
+++ b/homeassistant/auth/providers/synology.py
@@ -1,0 +1,220 @@
+"""Authentication provider to authenticate using Synology DSM."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+import logging
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.auth import AuthProvider
+from homeassistant.auth.models import Credentials, UserMeta
+from homeassistant.auth.providers import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend(
+    {
+        vol.Required("host"): str,
+        vol.Required("port"): int,
+        vol.Required("secure", default=False): bool,
+        vol.Optional("verify_cert", default=False): bool,
+        vol.Required("dsm_version"): int,
+    }
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SynologyAuthenticationError(HomeAssistantError):
+    """Error to indicate an error while authenticating to Synology DSM."""
+
+
+class SynologyConnectionError(SynologyAuthenticationError):
+    """Error to indicate an error with the connection to Synology DSM."""
+
+
+class SynologyLoginError(SynologyAuthenticationError):
+    """Error to indicate invalid credentials while logging in to Synology DSM.."""
+
+
+class Synology2FAError(SynologyLoginError):
+    """Error to indicate invalid or missing 2FA while logging in to Synology DSM.."""
+
+
+@AUTH_PROVIDERS.register("synology")
+class SynologyAuthProvider(AuthProvider):
+    """Auth provider for Synology DSM.
+
+    Based on https://global.download.synology.com/download/Document/Software/DeveloperGuide/Os/DSM/All/enu/DSM_Login_Web_API_Guide_enu.pdf
+    """
+
+    DEFAULT_TITLE = "Synology DSM authentication"
+
+    @property
+    def api_url(self) -> str:
+        """Return the API URL for the configured Synology DSM."""
+        protocol = "http"
+        if self.config["secure"]:
+            protocol = "https"
+        return (
+            f"{protocol}://{self.config['host']}:{self.config['port']}/webapi/entry.cgi"
+        )
+
+    async def async_login_flow(self, context: dict[str, Any] | None) -> LoginFlow:
+        """Provide Synology login flow."""
+        return SynologyLoginFlow(self)
+
+    async def async_validate_login(
+        self, username: str, password: str, otp_code: str
+    ) -> dict[str, Any]:
+        """Validate credentials with Synology DSM."""
+        session = async_get_clientsession(self.hass, self.config["verify_cert"])
+
+        try:
+            query_params = {
+                "api": "SYNO.API.Auth",
+                "version": 7,
+                "method": "login",
+                "format": "sid",
+                "account": username,
+                "passwd": password,
+            }
+            if otp_code != "":
+                query_params["otp_code"] = otp_code
+
+            login_response = await session.get(self.api_url, params=query_params)
+        except Exception as ex:
+            _LOGGER.error("Error connecting to Synology DSM: %s", ex)
+            raise SynologyConnectionError(ex) from ex
+
+        if not login_response.ok:
+            _LOGGER.error(
+                "Status code %s in authentication response not successful: %s",
+                login_response.status,
+                login_response.reason,
+            )
+            raise SynologyConnectionError(
+                f"Connection to Synology DSM did not succeed. Status code: {login_response.status}"
+            )
+
+        login_response_json = await login_response.json()
+        if not login_response_json["success"]:
+            _LOGGER.warn(
+                "Authentication failed with Synology error code %s",
+                login_response_json["error"]["code"],
+            )
+            if login_response_json["error"]["code"] < 400:
+                raise SynologyConnectionError(
+                    f"Connection to Synology DSM did not succeed. Synology error code: {login_response_json['error']['error']}"
+                )
+            if login_response_json["error"]["code"] in [403, 404, 406]:
+                raise Synology2FAError(
+                    f"2-factor authentication failed with code {login_response_json['error']['code']}"
+                )
+            raise SynologyLoginError(
+                f"Authentication failed with code {login_response_json['error']['code']}"
+            )
+        _LOGGER.info(
+            f"User {login_response_json['data']['account']} successfully authenticated to Synology DSM"
+        )
+        return cast(dict[str, Any], login_response_json["data"])
+
+    async def async_get_or_create_credentials(
+        self, flow_result: Mapping[str, str]
+    ) -> Credentials:
+        """Get credentials based on the flow result."""
+        account = flow_result["account"]
+
+        for credential in await self.async_credentials():
+            if credential.data["account"] == account:
+                return credential
+
+        # Create new credentials.
+        credential_data = {k: flow_result[k] for k in flow_result.keys()}
+        return self.async_create_credentials(credential_data)
+
+    async def async_user_meta_for_credentials(
+        self, credentials: Credentials
+    ) -> UserMeta:
+        """Provide user metadata for new users."""
+
+        session = async_get_clientsession(self.hass, self.config["verify_cert"])
+        query_params = {
+            "api": "SYNO.Core.NormalUser",
+            "version": 1,
+            "method": "get",
+            "_sid": credentials.data["sid"],
+        }
+        try:
+            apis_response = await session.get(self.api_url, params=query_params)
+            apis_response_json = await apis_response.json()
+            full_name = apis_response_json["data"]["fullname"]
+            username = apis_response_json["data"]["username"]
+            # email is available as well, but not used at the moment
+            return UserMeta(
+                full_name if full_name != "" else username,
+                True,
+            )
+        except Exception as ex:
+            _LOGGER.error("Error while retrieving user info: %s", ex)
+            raise SynologyAuthenticationError(ex) from ex
+
+
+class SynologyLoginFlow(LoginFlow):
+    """Login flow for Synology DSM."""
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> FlowResult:
+        """Show the corresponding UI."""
+        errors = {}
+
+        if user_input is not None:
+            username = (
+                user_input["username"].strip()
+                if user_input.get("username") is not None
+                else ""
+            )
+            if username == "":
+                errors["username"] = "empty_username"
+
+            password = (
+                user_input["password"].strip()
+                if user_input.get("password") is not None
+                else ""
+            )
+            if password == "":
+                errors["password"] = "empty_password"
+
+            otp_code = (
+                user_input["otp_code"].strip()
+                if user_input.get("otp_code") is not None
+                else ""
+            )
+
+            if len(errors) == 0:
+                try:
+                    data = await cast(
+                        SynologyAuthProvider, self._auth_provider
+                    ).async_validate_login(username, password, otp_code)
+                    return await self.async_finish(data)
+                except Synology2FAError:
+                    errors["otp_code"] = "otp_required"
+                except SynologyLoginError:
+                    errors["base"] = "invalid_auth"
+                except SynologyAuthenticationError:
+                    errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("username"): str,
+                    vol.Required("password"): str,
+                    vol.Optional("otp_code"): str,
+                }
+            ),
+            errors=errors,
+        )

--- a/homeassistant/auth/providers/synology.py
+++ b/homeassistant/auth/providers/synology.py
@@ -88,7 +88,7 @@ class SynologyAuthProvider(AuthProvider):
             _LOGGER.error("Error connecting to Synology DSM: %s", ex)
             raise SynologyConnectionError(ex) from ex
 
-        if not login_response.ok:
+        if login_response.status != 200:
             _LOGGER.error(
                 "Status code %s in authentication response not successful: %s",
                 login_response.status,

--- a/homeassistant/auth/providers/synology.py
+++ b/homeassistant/auth/providers/synology.py
@@ -52,7 +52,7 @@ class SynologyAuthProvider(AuthProvider):
     DEFAULT_TITLE = "Synology DSM authentication"
 
     @property
-    def api_url(self) -> str:
+    def _api_url(self) -> str:
         """Return the API URL for the configured Synology DSM."""
         protocol = "http"
         if self.config["secure"]:
@@ -83,7 +83,7 @@ class SynologyAuthProvider(AuthProvider):
             if otp_code != "":
                 query_params["otp_code"] = otp_code
 
-            login_response = await session.get(self.api_url, params=query_params)
+            login_response = await session.get(self._api_url, params=query_params)
         except Exception as ex:
             _LOGGER.error("Error connecting to Synology DSM: %s", ex)
             raise SynologyConnectionError(ex) from ex
@@ -151,7 +151,7 @@ class SynologyAuthProvider(AuthProvider):
             "_sid": credentials.data["sid"],
         }
         try:
-            apis_response = await session.get(self.api_url, params=query_params)
+            apis_response = await session.get(self._api_url, params=query_params)
             apis_response_json = await apis_response.json()
             full_name = apis_response_json["data"]["fullname"]
             username = apis_response_json["data"]["username"]

--- a/homeassistant/auth/providers/synology.py
+++ b/homeassistant/auth/providers/synology.py
@@ -90,9 +90,8 @@ class SynologyAuthProvider(AuthProvider):
 
         if login_response.status != 200:
             _LOGGER.error(
-                "Status code %s in authentication response not successful: %s",
+                "Status code %s in authentication response not successful",
                 login_response.status,
-                login_response.reason,
             )
             raise SynologyConnectionError(
                 f"Connection to Synology DSM did not succeed. Status code: {login_response.status}"
@@ -106,7 +105,7 @@ class SynologyAuthProvider(AuthProvider):
             )
             if login_response_json["error"]["code"] < 400:
                 raise SynologyConnectionError(
-                    f"Connection to Synology DSM did not succeed. Synology error code: {login_response_json['error']['error']}"
+                    f"Connection to Synology DSM did not succeed. Synology error code: {login_response_json['error']['code']}"
                 )
             if login_response_json["error"]["code"] in [403, 404, 406]:
                 raise Synology2FAError(

--- a/homeassistant/auth/providers/synology.py
+++ b/homeassistant/auth/providers/synology.py
@@ -20,7 +20,6 @@ CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend(
         vol.Required("port"): int,
         vol.Required("secure", default=False): bool,
         vol.Optional("verify_cert", default=False): bool,
-        vol.Required("dsm_version"): int,
     }
 )
 

--- a/homeassistant/auth/providers/synology.py
+++ b/homeassistant/auth/providers/synology.py
@@ -119,7 +119,10 @@ class SynologyAuthProvider(AuthProvider):
         _LOGGER.info(
             f"User {login_response_json['data']['account']} successfully authenticated to Synology DSM"
         )
-        return cast(dict[str, Any], login_response_json["data"])
+        return {
+            k: login_response_json["data"][k]
+            for k in login_response_json["data"].keys()
+        }
 
     async def async_get_or_create_credentials(
         self, flow_result: Mapping[str, str]

--- a/homeassistant/auth/providers/synology.py
+++ b/homeassistant/auth/providers/synology.py
@@ -135,7 +135,7 @@ class SynologyAuthProvider(AuthProvider):
 
         # Create new credentials.
         credential_data = {k: flow_result[k] for k in flow_result.keys()}
-        credential_data.update({"username": account})
+        credential_data.update({"username": account.lower()})
         return self.async_create_credentials(credential_data)
 
     async def async_user_meta_for_credentials(

--- a/homeassistant/auth/providers/synology.py
+++ b/homeassistant/auth/providers/synology.py
@@ -100,7 +100,7 @@ class SynologyAuthProvider(AuthProvider):
 
         login_response_json = await login_response.json()
         if not login_response_json["success"]:
-            _LOGGER.warn(
+            _LOGGER.warning(
                 "Authentication failed with Synology error code %s",
                 login_response_json["error"]["code"],
             )
@@ -116,7 +116,8 @@ class SynologyAuthProvider(AuthProvider):
                 f"Authentication failed with code {login_response_json['error']['code']}"
             )
         _LOGGER.info(
-            f"User {login_response_json['data']['account']} successfully authenticated to Synology DSM"
+            "User %s successfully authenticated to Synology DSM",
+            login_response_json["data"]["account"],
         )
         return {
             k: login_response_json["data"][k]

--- a/tests/auth/providers/test_synology.py
+++ b/tests/auth/providers/test_synology.py
@@ -1,6 +1,5 @@
 """Unit tests for Synology DSM authentication provider."""
 from unittest.mock import AsyncMock
-import uuid
 
 import pytest
 
@@ -9,6 +8,56 @@ from homeassistant.auth.auth_store import AuthStore
 from homeassistant.auth.providers import synology
 from homeassistant.auth.providers.synology import SynologyAuthProvider
 from homeassistant.core import HomeAssistant
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+@pytest.fixture(autouse=True)
+def mock_synology_api(aioclient_mock: AiohttpClientMocker):
+    """Mock all API requests used by tests below."""
+
+    aioclient_mock.get(
+        "http://dummy:5000/webapi/entry.cgi",
+        params={
+            "api": "SYNO.API.Auth",
+            "version": "7",
+            "method": "login",
+            "account": "test-user",
+            "passwd": "password",
+            "otp_code": "123",
+            "format": "sid",
+        },
+        json={
+            "success": True,
+        },
+    )
+
+    aioclient_mock.get(
+        "http://dummy:5000/webapi/entry.cgi",
+        params={
+            "api": "SYNO.API.Auth",
+            "version": "7",
+            "method": "login",
+            "account": "test-user",
+            "passwd": "password",
+            "format": "sid",
+        },
+        json={"success": True, "data": {"account": "test-user"}},
+    )
+
+    aioclient_mock.get(
+        "http://dummy:5000/webapi/entry.cgi",
+        params={
+            "api": "SYNO.Core.NormalUser",
+            "version": 1,
+            "method": "get",
+            "_sid": "secure-session",
+        },
+        json={
+            "success": True,
+            "data": {"username": "test-user", "fullname": "Test Name"},
+        },
+    )
 
 
 @pytest.fixture
@@ -25,7 +74,7 @@ def provider(hass: HomeAssistant, store: AuthStore) -> SynologyAuthProvider:
         store,
         {
             "type": "synology",
-            "host": "localhost",
+            "host": "dummy",
             "port": 5000,
             "secure": False,
             "verify_cert": False,
@@ -55,7 +104,7 @@ async def test_create_new_credential(provider: SynologyAuthProvider):
 async def test_match_existing_credentials(provider: SynologyAuthProvider):
     """See if we match existing users."""
     existing = auth_models.Credentials(
-        id=uuid.uuid4(),
+        id="dummy-user-existing",
         auth_provider_type="synology",
         auth_provider_id=None,
         data={"account": "user-test"},
@@ -109,7 +158,19 @@ async def test_login_flow_empty_otp(provider: SynologyAuthProvider):
     step = await flow.async_step_init(
         {"username": "test-user", "password": "password", "otp_code": " "}
     )
-    assert step["type"] == "form"
-    assert step["step_id"] == "init"
-    assert len(step["errors"]) == 0
+    assert step["type"] == "create_entry"
     # OTP is optional, so no error should be raised
+
+
+async def test_create_new_user_with_meta(manager: AuthManager):
+    """See if we can create new users from credentials with metadata."""
+    credential = auth_models.Credentials(
+        id="dummy-id-user-with-meta",
+        auth_provider_type="synology",
+        auth_provider_id=None,
+        data={"account": "user-test", "sid": "secure-session"},
+        is_new=True,
+    )
+    user = await manager.async_get_or_create_user(credential)
+    assert user.is_active
+    assert user.name == "Test Name"

--- a/tests/auth/providers/test_synology.py
+++ b/tests/auth/providers/test_synology.py
@@ -1,0 +1,44 @@
+"""Unit tests for Synology DSM authentication provider."""
+import pytest
+
+from homeassistant.auth import AuthManager, auth_store
+from homeassistant.auth.providers import synology
+
+
+@pytest.fixture
+def store(hass):
+    """Mock store."""
+    return auth_store.AuthStore(hass)
+
+
+@pytest.fixture
+def provider(hass, store):
+    """Mock provider."""
+    return synology.SynologyAuthProvider(
+        hass,
+        store,
+        {
+            "type": "synology",
+            "host": "localhost",
+            "port": 5000,
+            "secure": False,
+            "verify_cert": False,
+        },
+    )
+
+
+@pytest.fixture
+def manager(hass, store, provider):
+    """Mock manager."""
+    return AuthManager(hass, store, {(provider.type, provider.id): provider}, {})
+
+
+async def test_create_new_credential(manager, provider):
+    """Test that we create a new credential."""
+    credentials = await provider.async_get_or_create_credentials(
+        {
+            "account": "test-user",
+        }
+    )
+    assert credentials.is_new is True
+    assert credentials.data["account"] == "test-user"

--- a/tests/auth/providers/test_synology.py
+++ b/tests/auth/providers/test_synology.py
@@ -1,7 +1,10 @@
 """Unit tests for Synology DSM authentication provider."""
+from unittest.mock import AsyncMock
+import uuid
+
 import pytest
 
-from homeassistant.auth import AuthManager, auth_store
+from homeassistant.auth import AuthManager, auth_store, models as auth_models
 from homeassistant.auth.providers import synology
 
 
@@ -42,3 +45,19 @@ async def test_create_new_credential(manager, provider):
     )
     assert credentials.is_new is True
     assert credentials.data["account"] == "test-user"
+
+
+async def test_match_existing_credentials(store, provider):
+    """See if we match existing users."""
+    existing = auth_models.Credentials(
+        id=uuid.uuid4(),
+        auth_provider_type="synology",
+        auth_provider_id=None,
+        data={"account": "user-test"},
+        is_new=False,
+    )
+    provider.async_credentials = AsyncMock(return_value=[existing])
+    credentials = await provider.async_get_or_create_credentials(
+        {"account": "user-test"}
+    )
+    assert credentials is existing

--- a/tests/auth/providers/test_synology.py
+++ b/tests/auth/providers/test_synology.py
@@ -63,7 +63,7 @@ async def test_match_existing_credentials(store, provider):
     assert credentials is existing
 
 
-async def test_login_flow(manager, provider):
+async def test_login_flow(provider):
     """Test the login flow UI."""
 
     flow = await provider.async_login_flow(None)

--- a/tests/auth/providers/test_synology.py
+++ b/tests/auth/providers/test_synology.py
@@ -6,7 +6,13 @@ import pytest
 from homeassistant.auth import AuthManager, auth_store, models as auth_models
 from homeassistant.auth.auth_store import AuthStore
 from homeassistant.auth.providers import synology
-from homeassistant.auth.providers.synology import SynologyAuthProvider
+from homeassistant.auth.providers.synology import (
+    Synology2FAError,
+    SynologyAuthenticationError,
+    SynologyAuthProvider,
+    SynologyConnectionError,
+    SynologyLoginError,
+)
 from homeassistant.core import HomeAssistant
 
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -27,9 +33,73 @@ def mock_synology_api(aioclient_mock: AiohttpClientMocker):
             "otp_code": "123",
             "format": "sid",
         },
-        json={
-            "success": True,
+        json={"success": True, "data": {"account": "test-user"}},
+    )
+
+    aioclient_mock.get(
+        "https://dummy:5000/webapi/entry.cgi",
+        params={
+            "api": "SYNO.API.Auth",
+            "version": "7",
+            "method": "login",
+            "account": "test-user",
+            "passwd": "password",
+            "format": "sid",
         },
+        json={"success": True, "data": {"account": "succeeded-https"}},
+    )
+
+    aioclient_mock.get(
+        "http://dummy:5000/webapi/entry.cgi",
+        params={
+            "api": "SYNO.API.Auth",
+            "version": "7",
+            "method": "login",
+            "account": "test-user",
+            "passwd": "password",
+            "otp_code": "456",
+            "format": "sid",
+        },
+        json={"success": False, "error": {"code": 403}},
+    )
+
+    aioclient_mock.get(
+        "http://dummy:5000/webapi/entry.cgi",
+        params={
+            "api": "SYNO.API.Auth",
+            "version": "7",
+            "method": "login",
+            "account": "bad-connection-to-dsm",
+            "passwd": "password",
+            "format": "sid",
+        },
+        json={"success": False, "error": {"code": 399}},
+    )
+
+    aioclient_mock.get(
+        "http://dummy:5000/webapi/entry.cgi",
+        params={
+            "api": "SYNO.API.Auth",
+            "version": "7",
+            "method": "login",
+            "account": "other-login-error",
+            "passwd": "password",
+            "format": "sid",
+        },
+        json={"success": False, "error": {"code": 500}},
+    )
+
+    aioclient_mock.get(
+        "http://dummy:5000/webapi/entry.cgi",
+        params={
+            "api": "SYNO.API.Auth",
+            "version": "7",
+            "method": "login",
+            "account": "http-error",
+            "passwd": "password",
+            "format": "sid",
+        },
+        status=500,
     )
 
     aioclient_mock.get(
@@ -56,6 +126,20 @@ def mock_synology_api(aioclient_mock: AiohttpClientMocker):
         json={
             "success": True,
             "data": {"username": "test-user", "fullname": "Test Name"},
+        },
+    )
+
+    aioclient_mock.get(
+        "http://dummy:5000/webapi/entry.cgi",
+        params={
+            "api": "SYNO.Core.NormalUser",
+            "version": 1,
+            "method": "get",
+            "_sid": "test-error",
+        },
+        json={
+            "success": True,
+            "data": {"invalid-key": "dummy"},
         },
     )
 
@@ -159,7 +243,7 @@ async def test_login_flow_empty_otp(provider: SynologyAuthProvider):
         {"username": "test-user", "password": "password", "otp_code": " "}
     )
     assert step["type"] == "create_entry"
-    # OTP is optional, so no error should be raised
+    # OTP is optional, so we don't get an error
 
 
 async def test_create_new_user_with_meta(manager: AuthManager):
@@ -174,3 +258,77 @@ async def test_create_new_user_with_meta(manager: AuthManager):
     user = await manager.async_get_or_create_user(credential)
     assert user.is_active
     assert user.name == "Test Name"
+
+
+async def test_async_validate_login_with_https(hass: HomeAssistant, store: AuthStore):
+    """Test login validation with HTTPS connection."""
+    provider = synology.SynologyAuthProvider(
+        hass,
+        store,
+        {
+            "type": "synology",
+            "host": "dummy",
+            "port": 5000,
+            "secure": True,
+            "verify_cert": False,
+        },
+    )
+    validation_result = await provider.async_validate_login(
+        username="test-user", password="password", otp_code=""
+    )
+    assert validation_result is not None
+    assert validation_result.get("account") == "succeeded-https"
+
+
+async def test_async_validate_login_with_otp_valid(provider: SynologyAuthProvider):
+    """Test login validation with usage of valid OTP."""
+    validation_result = await provider.async_validate_login(
+        username="test-user", password="password", otp_code="123"
+    )
+    assert validation_result is not None
+    assert validation_result.get("account") == "test-user"
+
+
+async def test_async_validate_login_with_otp_invalid(provider: SynologyAuthProvider):
+    """Test login validation with usage of invalid OTP."""
+    with pytest.raises(Synology2FAError):
+        await provider.async_validate_login(
+            username="test-user", password="password", otp_code="456"
+        )
+
+
+async def test_async_validate_login_bad_connection(provider: SynologyAuthProvider):
+    """Test login validation with bad connection."""
+    with pytest.raises(SynologyConnectionError):
+        await provider.async_validate_login(
+            username="bad-connection-to-dsm", password="password", otp_code=""
+        )
+
+
+async def test_async_validate_login_other_error(provider: SynologyAuthProvider):
+    """Test login validation with other login error."""
+    with pytest.raises(SynologyLoginError):
+        await provider.async_validate_login(
+            username="other-login-error", password="password", otp_code=""
+        )
+
+
+async def test_async_validate_login_http_error(provider: SynologyAuthProvider):
+    """Test login validation with HTTP error."""
+    with pytest.raises(SynologyConnectionError):
+        await provider.async_validate_login(
+            username="http-error", password="password", otp_code=""
+        )
+
+
+async def test_async_user_meta_for_credentials_error(provider: SynologyAuthProvider):
+    """Test credential matching with meta throwing an error."""
+    credentials = auth_models.Credentials(
+        id="dummy-user",
+        auth_provider_type="synology",
+        auth_provider_id=None,
+        data={"sid": "test-error"},
+        is_new=False,
+    )
+    with pytest.raises(SynologyAuthenticationError):
+        await provider.async_user_meta_for_credentials(credentials)

--- a/tests/auth/providers/test_synology.py
+++ b/tests/auth/providers/test_synology.py
@@ -68,7 +68,7 @@ async def test_match_existing_credentials(provider: SynologyAuthProvider):
     assert credentials is existing
 
 
-async def test_login_flow(provider: SynologyAuthProvider):
+async def test_login_flow_without_input(provider: SynologyAuthProvider):
     """Test the login flow UI."""
 
     flow = await provider.async_login_flow(None)
@@ -78,3 +78,38 @@ async def test_login_flow(provider: SynologyAuthProvider):
     assert len(step["errors"]) == 0
     schema_keys = list(step["data_schema"].schema)
     assert schema_keys == ["username", "password", "otp_code"]
+
+
+async def test_login_flow_empty_password(provider: SynologyAuthProvider):
+    """Test the login flow with an empty password."""
+
+    flow = await provider.async_login_flow(None)
+    step = await flow.async_step_init({"username": "test-user", "password": " "})
+    assert step["type"] == "form"
+    assert step["step_id"] == "init"
+    assert len(step["errors"]) == 1
+    assert step["errors"]["password"] == "empty_password"
+
+
+async def test_login_flow_empty_username(provider: SynologyAuthProvider):
+    """Test the login flow with an empty username."""
+
+    flow = await provider.async_login_flow(None)
+    step = await flow.async_step_init({"username": " ", "password": "password"})
+    assert step["type"] == "form"
+    assert step["step_id"] == "init"
+    assert len(step["errors"]) == 1
+    assert step["errors"]["username"] == "empty_username"
+
+
+async def test_login_flow_empty_otp(provider: SynologyAuthProvider):
+    """Test the login flow with an empty otp code."""
+
+    flow = await provider.async_login_flow(None)
+    step = await flow.async_step_init(
+        {"username": "test-user", "password": "password", "otp_code": " "}
+    )
+    assert step["type"] == "form"
+    assert step["step_id"] == "init"
+    assert len(step["errors"]) == 0
+    # OTP is optional, so no error should be raised

--- a/tests/auth/providers/test_synology.py
+++ b/tests/auth/providers/test_synology.py
@@ -61,3 +61,15 @@ async def test_match_existing_credentials(store, provider):
         {"account": "user-test"}
     )
     assert credentials is existing
+
+
+async def test_login_flow(manager, provider):
+    """Test the login flow UI."""
+
+    flow = await provider.async_login_flow(None)
+    step = await flow.async_step_init()
+    assert step["type"] == "form"
+    assert step["step_id"] == "init"
+    assert len(step["errors"]) == 0
+    schema_keys = list(step["data_schema"].schema)
+    assert schema_keys == ["username", "password", "otp_code"]

--- a/tests/auth/providers/test_synology.py
+++ b/tests/auth/providers/test_synology.py
@@ -5,17 +5,20 @@ import uuid
 import pytest
 
 from homeassistant.auth import AuthManager, auth_store, models as auth_models
+from homeassistant.auth.auth_store import AuthStore
 from homeassistant.auth.providers import synology
+from homeassistant.auth.providers.synology import SynologyAuthProvider
+from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture
-def store(hass):
+def store(hass: HomeAssistant) -> AuthStore:
     """Mock store."""
     return auth_store.AuthStore(hass)
 
 
 @pytest.fixture
-def provider(hass, store):
+def provider(hass: HomeAssistant, store: AuthStore) -> SynologyAuthProvider:
     """Mock provider."""
     return synology.SynologyAuthProvider(
         hass,
@@ -31,12 +34,14 @@ def provider(hass, store):
 
 
 @pytest.fixture
-def manager(hass, store, provider):
+def manager(
+    hass: HomeAssistant, store: AuthStore, provider: SynologyAuthProvider
+) -> AuthManager:
     """Mock manager."""
     return AuthManager(hass, store, {(provider.type, provider.id): provider}, {})
 
 
-async def test_create_new_credential(manager, provider):
+async def test_create_new_credential(provider: SynologyAuthProvider):
     """Test that we create a new credential."""
     credentials = await provider.async_get_or_create_credentials(
         {
@@ -47,7 +52,7 @@ async def test_create_new_credential(manager, provider):
     assert credentials.data["account"] == "test-user"
 
 
-async def test_match_existing_credentials(store, provider):
+async def test_match_existing_credentials(provider: SynologyAuthProvider):
     """See if we match existing users."""
     existing = auth_models.Credentials(
         id=uuid.uuid4(),
@@ -63,7 +68,7 @@ async def test_match_existing_credentials(store, provider):
     assert credentials is existing
 
 
-async def test_login_flow(provider):
+async def test_login_flow(provider: SynologyAuthProvider):
     """Test the login flow UI."""
 
     flow = await provider.async_login_flow(None)


### PR DESCRIPTION
## Proposed change
This PR adds an authentication provider to allow users to authenticate using a Synology NAS.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
I probably have to add some strings somewhere, but I cannot find where.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

https://github.com/home-assistant/home-assistant.io/pull/20108

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
