### PR TITLE
Aurora abb defer unique_id assignment during yaml import

### DIFF
--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -42,6 +42,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         except AuroraError as error:
             if "No response after" in str(error):
                 raise ConfigEntryNotReady("No response (could be dark)") from error
+            else:
+                raise error
         else:
             # If we got here, the device is now communicating (maybe after
             # being in darkness). But there's a small risk that the user has

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -61,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     return False
             hass.config_entries.async_update_entry(entry, unique_id=new_id)
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = serclient
+    hass.data.setdefault(DOMAIN, {})[entry.unique_id] = serclient
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
@@ -74,6 +74,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     # It should not be necessary to close the serial port because we close
     # it after every use in sensor.py, i.e. no need to do entry["client"].close()
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.unique_id)
 
     return unload_ok

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     comport = entry.data[CONF_PORT]
     address = entry.data[CONF_ADDRESS]
-    ser_client = AuroraSerialClient(address, comport, parity="N", timeout=1)
+    serclient = AuroraSerialClient(address, comport, parity="N", timeout=1)
     # To handle yaml import attempts in darkeness, (re)try connecting only if
     # unique_id not yet assigned.
     if entry.unique_id is None:
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             if "No response after" in str(error):
                 raise ConfigEntryNotReady("No response (could be dark)") from error
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = ser_client
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = serclient
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -12,7 +12,6 @@ import logging
 
 from aurorapy.client import AuroraError, AuroraSerialClient
 
-from homeassistant import data_entry_flow
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -53,7 +52,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             # Check if this unique_id has already been used
             for existing_entry in hass.config_entries.async_entries(DOMAIN):
                 if existing_entry.unique_id == new_id:
-                    raise data_entry_flow.AbortFlow("already_configured")
+                    _LOGGER.debug(
+                        "Remove already configured config entry for id %s", new_id
+                    )
+                    hass.async_create_task(
+                        hass.config_entries.async_remove(entry.entry_id)
+                    )
+                    return False
             entry.unique_id = new_id
             hass.config_entries.async_update_entry(entry, unique_id=new_id)
 

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -53,9 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 if existing_entry.unique_id == new_id:
                     raise data_entry_flow.AbortFlow("already_configured")
             entry.unique_id = new_id
-            hass.config_entries.async_update_entry(
-                entry, unique_id=res[ATTR_SERIAL_NUMBER]
-            )
+            hass.config_entries.async_update_entry(entry, unique_id=new_id)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = serclient
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -41,7 +41,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         except AuroraError as error:
             if "No response after" in str(error):
                 raise ConfigEntryNotReady("No response (could be dark)") from error
-            raise error
+            raise ConfigEntryNotReady(
+                "Failed to connect to inverter: %s" % error
+            ) from error
+        except OSError as error:
+            if error.errno == 19:  # No such device.
+                raise ConfigEntryNotReady(
+                    "Failed to connect to inverter: no such COM port"
+                ) from error
+            raise ConfigEntryNotReady(
+                "Failed to connect to inverter: %s" % error
+            ) from error
         else:
             # If we got here, the device is now communicating (maybe after
             # being in darkness). But there's a small risk that the user has

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -41,8 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         except AuroraError as error:
             if "No response after" in str(error):
                 raise ConfigEntryNotReady("No response (could be dark)") from error
-            else:
-                raise error
+            raise error
         else:
             # If we got here, the device is now communicating (maybe after
             # being in darkness). But there's a small risk that the user has

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -41,17 +41,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         except AuroraError as error:
             if "No response after" in str(error):
                 raise ConfigEntryNotReady("No response (could be dark)") from error
-            raise ConfigEntryNotReady(
-                "Failed to connect to inverter: %s" % error
-            ) from error
+            _LOGGER.error("Failed to connect to inverter: %s", error)
+            return False
         except OSError as error:
             if error.errno == 19:  # No such device.
-                raise ConfigEntryNotReady(
-                    "Failed to connect to inverter: no such COM port"
-                ) from error
-            raise ConfigEntryNotReady(
-                "Failed to connect to inverter: %s" % error
-            ) from error
+                _LOGGER.error("Failed to connect to inverter: no such COM port")
+                return False
+            _LOGGER.error("Failed to connect to inverter: %s", error)
+            return False
         else:
             # If we got here, the device is now communicating (maybe after
             # being in darkness). But there's a small risk that the user has

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -28,10 +28,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     comport = entry.data[CONF_PORT]
     address = entry.data[CONF_ADDRESS]
-    serclient = AuroraSerialClient(address, comport, parity="N", timeout=1)
+    ser_client = AuroraSerialClient(address, comport, parity="N", timeout=1)
+    # To handle yaml import attempts in darkeness, (re)try connecting only if
+    # unique_id not yet assigned.
+    if entry.unique_id is None:
+        try:
+            res = await hass.async_add_executor_job(
+                validate_and_connect, hass, entry.data
+            )
+            entry.unique_id = res[ATTR_SERIAL_NUMBER]
+        except AuroraError as error:
+            if "No response after" in str(error):
+                raise ConfigEntryNotReady("No response (could be dark)") from error
 
-    hass.data.setdefault(DOMAIN, {})[entry.unique_id] = serclient
-
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = ser_client
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
@@ -44,6 +54,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     # It should not be necessary to close the serial port because we close
     # it after every use in sensor.py, i.e. no need to do entry["client"].close()
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.unique_id)
+        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -59,7 +59,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                         hass.config_entries.async_remove(entry.entry_id)
                     )
                     return False
-            entry.unique_id = new_id
             hass.config_entries.async_update_entry(entry, unique_id=new_id)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = serclient

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -38,10 +38,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             res = await hass.async_add_executor_job(
                 validate_and_connect, hass, entry.data
             )
-            entry.unique_id = res[ATTR_SERIAL_NUMBER]
         except AuroraError as error:
             if "No response after" in str(error):
                 raise ConfigEntryNotReady("No response (could be dark)") from error
+        else:
+            hass.config_entries.async_update_entry(
+                entry, unique_id=res[ATTR_SERIAL_NUMBER]
+            )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = serclient
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -10,13 +10,15 @@
 
 import logging
 
-from aurorapy.client import AuroraSerialClient
+from aurorapy.client import AuroraError, AuroraSerialClient
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
+from .config_flow import validate_and_connect
+from .const import ATTR_SERIAL_NUMBER, DOMAIN
 
 PLATFORMS = ["sensor"]
 

--- a/homeassistant/components/aurora_abb_powerone/aurora_device.py
+++ b/homeassistant/components/aurora_abb_powerone/aurora_device.py
@@ -1,4 +1,6 @@
 """Top level class for AuroraABBPowerOneSolarPV inverters and sensors."""
+from __future__ import annotations
+
 import logging
 
 from aurorapy.client import AuroraSerialClient
@@ -29,9 +31,11 @@ class AuroraDevice(Entity):
         self._available = True
 
     @property
-    def unique_id(self) -> str:
+    def unique_id(self) -> str | None:
         """Return the unique id for this device."""
-        serial = self._data[ATTR_SERIAL_NUMBER]
+        serial = self._data.get(ATTR_SERIAL_NUMBER)
+        if serial is None:
+            return None
         return f"{serial}_{self.entity_description.key}"
 
     @property

--- a/homeassistant/components/aurora_abb_powerone/config_flow.py
+++ b/homeassistant/components/aurora_abb_powerone/config_flow.py
@@ -81,15 +81,9 @@ class AuroraABBConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="already_setup")
 
         conf = {}
-        conf[ATTR_SERIAL_NUMBER] = "sn_unknown_yaml"
-        conf[ATTR_MODEL] = "model_unknown_yaml"
-        conf[ATTR_FIRMWARE] = "fw_unknown_yaml"
         conf[CONF_PORT] = config["device"]
         conf[CONF_ADDRESS] = config["address"]
         # config["name"] from yaml is ignored.
-
-        await self.async_set_unique_id(self.flow_id)
-        self._abort_if_unique_id_configured()
 
         return self.async_create_entry(title=DEFAULT_INTEGRATION_TITLE, data=conf)
 

--- a/homeassistant/components/aurora_abb_powerone/sensor.py
+++ b/homeassistant/components/aurora_abb_powerone/sensor.py
@@ -84,7 +84,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     """Set up aurora_abb_powerone sensor based on a config entry."""
     entities = []
 
-    client = hass.data[DOMAIN][config_entry.entry_id]
+    client = hass.data[DOMAIN][config_entry.unique_id]
     data = config_entry.data
 
     for sens in SENSOR_TYPES:

--- a/homeassistant/components/aurora_abb_powerone/sensor.py
+++ b/homeassistant/components/aurora_abb_powerone/sensor.py
@@ -84,7 +84,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     """Set up aurora_abb_powerone sensor based on a config entry."""
     entities = []
 
-    client = hass.data[DOMAIN][config_entry.unique_id]
+    client = hass.data[DOMAIN][config_entry.entry_id]
     data = config_entry.data
 
     for sens in SENSOR_TYPES:

--- a/tests/components/aurora_abb_powerone/test_config_flow.py
+++ b/tests/components/aurora_abb_powerone/test_config_flow.py
@@ -188,6 +188,7 @@ async def test_import_day(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["data"][CONF_PORT] == "/dev/ttyUSB7"
     assert result["data"][CONF_ADDRESS] == 3
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -241,6 +242,7 @@ async def test_import_night(hass):
 
         assert len(mock_connect.mock_calls) == 1
         assert hass.states.get("sensor.power_output").state == "45.7"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
 async def test_import_night_then_user(hass):
@@ -299,6 +301,7 @@ async def test_import_night_then_user(hass):
         )
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
 
     # Now retry yaml - it should fail with duplicate
     with patch("aurorapy.client.AuroraSerialClient.connect", return_value=None,), patch(
@@ -318,3 +321,4 @@ async def test_import_night_then_user(hass):
         async_fire_time_changed(hass, utcnow() + timedelta(seconds=6))
         await hass.async_block_till_done()
         assert entry.state == ConfigEntryState.NOT_LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1

--- a/tests/components/aurora_abb_powerone/test_config_flow.py
+++ b/tests/components/aurora_abb_powerone/test_config_flow.py
@@ -180,9 +180,6 @@ async def test_import_day(hass):
     ), patch(
         "aurorapy.client.AuroraSerialClient.firmware",
         return_value="1.234",
-    ), patch(
-        "homeassistant.components.aurora_abb_powerone.async_setup_entry",
-        return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=TEST_DATA
@@ -236,8 +233,8 @@ async def test_import_night(hass):
         "aurorapy.client.AuroraSerialClient.measure",
         side_effect=_simulated_returns,
     ):
-        # Wait >5mins for the config to auto retry.
-        async_fire_time_changed(hass, utcnow() + timedelta(minutes=6))
+        # Wait >5seconds for the config to auto retry.
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=6))
         await hass.async_block_till_done()
         assert entry.state == ConfigEntryState.LOADED
         assert entry.unique_id

--- a/tests/components/aurora_abb_powerone/test_config_flow.py
+++ b/tests/components/aurora_abb_powerone/test_config_flow.py
@@ -241,3 +241,80 @@ async def test_import_night(hass):
 
         assert len(mock_connect.mock_calls) == 1
         assert hass.states.get("sensor.power_output").state == "45.7"
+
+
+async def test_import_night_then_user(hass):
+    """Attempt yaml import and fail (dark), but user sets up manually before auto retry."""
+    TEST_DATA = {"device": "/dev/ttyUSB7", "address": 3, "name": "MyAuroraPV"}
+
+    # First time round, no response.
+    with patch(
+        "aurorapy.client.AuroraSerialClient.connect",
+        side_effect=AuroraError("No response after"),
+    ) as mock_connect:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=TEST_DATA
+        )
+
+    configs = hass.config_entries.async_entries(DOMAIN)
+    assert len(configs) == 1
+    entry = configs[0]
+    assert not entry.unique_id
+    assert entry.state == ConfigEntryState.SETUP_RETRY
+
+    assert len(mock_connect.mock_calls) == 1
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"][CONF_PORT] == "/dev/ttyUSB7"
+    assert result["data"][CONF_ADDRESS] == 3
+
+    # Failed once, now simulate the user initiating config flow with valid settings.
+    fakecomports = []
+    fakecomports.append(list_ports_common.ListPortInfo("/dev/ttyUSB7"))
+    with patch(
+        "serial.tools.list_ports.comports",
+        return_value=fakecomports,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch("aurorapy.client.AuroraSerialClient.connect", return_value=None,), patch(
+        "aurorapy.client.AuroraSerialClient.serial_number",
+        return_value="9876543",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.version",
+        return_value="9.8.7.6",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.pn",
+        return_value="A.B.C",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.firmware",
+        return_value="1.234",
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_PORT: "/dev/ttyUSB7", CONF_ADDRESS: 7},
+        )
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    # Now retry yaml - it should fail with duplicate
+    with patch("aurorapy.client.AuroraSerialClient.connect", return_value=None,), patch(
+        "aurorapy.client.AuroraSerialClient.serial_number",
+        return_value="9876543",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.version",
+        return_value="9.8.7.6",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.pn",
+        return_value="A.B.C",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.firmware",
+        return_value="1.234",
+    ):
+        # Wait >5seconds for the config to auto retry.
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=6))
+        await hass.async_block_till_done()
+        assert entry.state == ConfigEntryState.NOT_LOADED

--- a/tests/components/aurora_abb_powerone/test_init.py
+++ b/tests/components/aurora_abb_powerone/test_init.py
@@ -19,6 +19,18 @@ async def test_unload_entry(hass):
     with patch("aurorapy.client.AuroraSerialClient.connect", return_value=None), patch(
         "homeassistant.components.aurora_abb_powerone.sensor.AuroraSensor.update",
         return_value=None,
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.serial_number",
+        return_value="9876543",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.version",
+        return_value="9.8.7.6",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.pn",
+        return_value="A.B.C",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.firmware",
+        return_value="1.234",
     ):
         mock_entry = MockConfigEntry(
             domain=DOMAIN,

--- a/tests/components/aurora_abb_powerone/test_sensor.py
+++ b/tests/components/aurora_abb_powerone/test_sensor.py
@@ -65,6 +65,18 @@ async def test_setup_platform_valid_config(hass):
         "aurorapy.client.AuroraSerialClient.measure",
         side_effect=_simulated_returns,
     ), patch(
+        "aurorapy.client.AuroraSerialClient.serial_number",
+        return_value="9876543",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.version",
+        return_value="9.8.7.6",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.pn",
+        return_value="A.B.C",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.firmware",
+        return_value="1.234",
+    ), patch(
         "aurorapy.client.AuroraSerialClient.cumulated_energy",
         side_effect=_simulated_returns,
     ), assert_setup_component(
@@ -95,6 +107,18 @@ async def test_sensors(hass):
         "aurorapy.client.AuroraSerialClient.measure",
         side_effect=_simulated_returns,
     ), patch(
+        "aurorapy.client.AuroraSerialClient.serial_number",
+        return_value="9876543",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.version",
+        return_value="9.8.7.6",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.pn",
+        return_value="A.B.C",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.firmware",
+        return_value="1.234",
+    ), patch(
         "aurorapy.client.AuroraSerialClient.cumulated_energy",
         side_effect=_simulated_returns,
     ):
@@ -123,6 +147,18 @@ async def test_sensor_dark(hass):
     # sun is up
     with patch("aurorapy.client.AuroraSerialClient.connect", return_value=None), patch(
         "aurorapy.client.AuroraSerialClient.measure", side_effect=_simulated_returns
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.serial_number",
+        return_value="9876543",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.version",
+        return_value="9.8.7.6",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.pn",
+        return_value="A.B.C",
+    ), patch(
+        "aurorapy.client.AuroraSerialClient.firmware",
+        return_value="1.234",
     ):
         mock_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(mock_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As implemented in #58504, the yaml import now allows the unique_id to be left as `None` until the setup can complete properly.  This is preferred over the old solution of assigning an arbitrary unique_id.

It also means that serial numbers, FW versions etc can be assigned correctly etc rather than using dummy values.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
