### PR TITLE
Add healthcheck for http component

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -120,7 +120,7 @@ class ConfData(TypedDict, total=False):
     ip_ban_enabled: bool
     ssl_profile: str
     healthcheck_enabled: bool
-    healthcheck_interval: int
+    healtcheck_threshold: int
 
 
 @bind_hass

--- a/homeassistant/components/http/healthcheck.py
+++ b/homeassistant/components/http/healthcheck.py
@@ -1,0 +1,63 @@
+"""Healthcheck logic for HTTP component."""
+from __future__ import annotations
+
+import logging
+from aiohttp.web import json_response
+from datetime import timedelta
+
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util import dt as dt_util
+
+_LOGGER: Final = logging.getLogger(__name__)
+
+KEY_HEALTHCHECK_THRESHOLD = "ha_healthcheck_threshold"
+KEY_HEALTHCHECK_LAST_SUCCESS = "ha_healthcheck_last_success"
+
+HEALTHCHECK_ENDPOINT = "/healthcheck"
+HEALTHCHECK_EVENT = "healthcheck_event"
+HEALTHCHECK_INTERVAL = 10
+
+
+def setup_healthcheck(
+    hass: HomeAssistant, app: Application, healthcheck_threshold: int
+) -> None:
+    app[KEY_HEALTHCHECK_THRESHOLD] = healthcheck_threshold
+    app[KEY_HEALTHCHECK_LAST_SUCCESS] = dt_util.utcnow()
+
+    app.router.add_route("GET", HEALTHCHECK_ENDPOINT, handle_healthcheck_request)
+
+    async def fire_healthcheck_event(now):
+        event_data = {
+            "now": now,
+        }
+        _LOGGER.debug(f"Firing healthcheck event")
+        hass.bus.async_fire(HEALTHCHECK_EVENT, event_data)
+
+    async def handle_healthcheck_event(event):
+        if event.data.get("now") is not None:
+            _LOGGER.debug(f"Received healthcheck event")
+            app[KEY_HEALTHCHECK_LAST_SUCCESS] = event.data.get("now")
+
+    hass.bus.async_listen(HEALTHCHECK_EVENT, handle_healthcheck_event)
+
+    async_track_time_interval(
+        hass, fire_healthcheck_event, timedelta(seconds=HEALTHCHECK_INTERVAL)
+    )
+
+
+async def handle_healthcheck_request(request: web.Request) -> web.Response:
+    healthcheck_last_success = request.app[KEY_HEALTHCHECK_LAST_SUCCESS]
+    healthcheck_threshold = request.app[KEY_HEALTHCHECK_THRESHOLD]
+
+    healthcheck_delta = dt_util.utcnow() - healthcheck_last_success
+
+    if healthcheck_delta < timedelta(
+        seconds=int(HEALTHCHECK_INTERVAL * healthcheck_threshold)
+    ):
+        return json_response({"healthy": True})
+    else:
+        healthcheck_delta_seconds = healthcheck_delta.total_seconds()
+        _LOGGER.error(
+            f"Home-Assistant is unhealthy, last healthcheck event was observed {healthcheck_delta_seconds} seconds ago"
+        )
+        return json_response({"healthy": False}, status=500)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Currently HomeAssistant dosnt expose any resonable healthcheck endpoint. This prevents k8s/docker/... from restarting failed service.
This change introduced new endpoint within `http` integration `/healthcheck`.

How it works:
Healthcheck code will fire `HEALTHCHECK_EVENT` every `HEALTHCHECK_INTERVAL` (10s by default), if we miss configurable threshold (3 by default), endpoint will report that HA is unhealthy.

Healthy response:
```
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Content-Length: 17
< Date: Mon, 01 Nov 2021 13:06:16 GMT
< Server: Python/3.9 aiohttp/3.7.4.post0
<
* Connection #0 to host localhost left intact
{"healthy": true}
```

Unhealthy response:
```
< HTTP/1.1 500 Internal Server Error
< Content-Type: application/json; charset=utf-8
< Content-Length: 18
< Date: Mon, 01 Nov 2021 13:07:11 GMT
< Server: Python/3.9 aiohttp/3.7.4.post0
<
* Connection #0 to host localhost left intact
{"healthy": false}
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
