### PR TITLE
Correct async_track_utc_time_change when leaving DST

### DIFF
--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -350,7 +350,9 @@ def find_next_time_expression_time(
             check_result = check_result.replace(fold=1)
 
             # Step 3: Check if check_result is in the future and earlier than result
-            if as_utc(check_result) > as_utc(now) and check_result < result:
+            if as_utc(check_result) > as_utc(now) and as_utc(check_result) < as_utc(
+                result
+            ):
                 return check_result
 
     return result

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -3399,9 +3399,19 @@ async def test_periodic_task_entering_dst(hass):
     dt_util.set_default_time_zone(timezone)
     specific_runs = []
 
-    now = dt_util.utcnow()
+    # DST starts early morning March 27th 2022
+    yy = 2022
+    mm = 3
+    dd = 27
+
+    # There's no 2022-03-27 02:30, the event should not fire until 2022-03-28 02:30
     time_that_will_not_match_right_away = datetime(
-        now.year + 1, 3, 25, 2, 31, 0, tzinfo=timezone
+        yy, mm, dd, 1, 28, 0, tzinfo=timezone, fold=0
+    )
+    # Make sure we enter DST during the test
+    assert (
+        time_that_will_not_match_right_away.utcoffset()
+        != (time_that_will_not_match_right_away + timedelta(hours=2)).utcoffset()
     )
 
     with patch(
@@ -3416,25 +3426,25 @@ async def test_periodic_task_entering_dst(hass):
         )
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 3, 25, 1, 50, 0, 999999, tzinfo=timezone)
+        hass, datetime(yy, mm, dd, 1, 50, 0, 999999, tzinfo=timezone)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 3, 25, 3, 50, 0, 999999, tzinfo=timezone)
+        hass, datetime(yy, mm, dd, 3, 50, 0, 999999, tzinfo=timezone)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 3, 26, 1, 50, 0, 999999, tzinfo=timezone)
+        hass, datetime(yy, mm, dd + 1, 1, 50, 0, 999999, tzinfo=timezone)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 3, 26, 2, 50, 0, 999999, tzinfo=timezone)
+        hass, datetime(yy, mm, dd + 1, 2, 50, 0, 999999, tzinfo=timezone)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
@@ -3448,12 +3458,19 @@ async def test_periodic_task_leaving_dst(hass):
     dt_util.set_default_time_zone(timezone)
     specific_runs = []
 
+    # DST ends early morning Ocotber 30th 2022
     yy = 2022
     mm = 10
     dd = 30
 
     time_that_will_not_match_right_away = datetime(
         yy, mm, dd, 2, 28, 0, tzinfo=timezone, fold=0
+    )
+
+    # Make sure we leave DST during the test
+    assert (
+        time_that_will_not_match_right_away.utcoffset()
+        != time_that_will_not_match_right_away.replace(fold=1).utcoffset()
     )
 
     with patch(
@@ -3521,12 +3538,18 @@ async def test_periodic_task_leaving_dst_2(hass):
     dt_util.set_default_time_zone(timezone)
     specific_runs = []
 
+    # DST ends early morning Ocotber 30th 2022
     yy = 2022
     mm = 10
     dd = 30
 
     time_that_will_not_match_right_away = datetime(
         yy, mm, dd, 2, 28, 0, tzinfo=timezone, fold=0
+    )
+    # Make sure we leave DST during the test
+    assert (
+        time_that_will_not_match_right_away.utcoffset()
+        != time_that_will_not_match_right_away.replace(fold=1).utcoffset()
     )
 
     with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correct async_track_utc_time_change when leaving DST

TODO:
 - Tests in `tests/util/tests_dt.py` need to be improved; they should have caught the broken behavior
 - Need to endure sure tests in `tests/helpers/test_event.py` actually test DST rollover

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
