### PR TITLE
Fix find_next_time_expression_time

### DIFF
--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -272,7 +272,8 @@ def find_next_time_expression_time(
             return None
         return arr[left]
 
-    result = now.replace(microsecond=0)
+    # Reset microseconds and fold; fold (for ambiguous DST times) will be handled later
+    result = now.replace(microsecond=0, fold=0)
 
     # Match next second
     if (next_second := _lower_bound(seconds, result.second)) is None:
@@ -309,40 +310,55 @@ def find_next_time_expression_time(
     result = result.replace(hour=next_hour)
 
     if result.tzinfo in (None, UTC):
+        # Using UTC, no DST checking needed
         return result
 
-    if _datetime_ambiguous(result):
-        # This happens when we're leaving daylight saving time and local
-        # clocks are rolled back. In this case, we want to trigger
-        # on both the DST and non-DST time. So when "now" is in the DST
-        # use the DST-on time, and if not, use the DST-off time.
-        fold = 1 if now.dst() else 0
-        if result.fold != fold:
-            result = result.replace(fold=fold)
-
     if not _datetime_exists(result):
-        # This happens when we're entering daylight saving time and local
-        # clocks are rolled forward, thus there are local times that do
-        # not exist. In this case, we want to trigger on the next time
-        # that *does* exist.
-        # In the worst case, this will run through all the seconds in the
-        # time shift, but that's max 3600 operations for once per year
+        # When entering DST and clocks are turned forward.
+        # There are wall clock times that don't "exist" (an hour is skipped).
+
+        # -> trigger on the next time that 1. matches the pattern and 2. does exist
+        # for example:
+        #   on 2021.03.28 02:00:00 in CET timezone clocks are turned forward an hour
+        #   with pattern "02:30", don't run on 28 mar (such a wall time does not exist on this day)
+        #   instead run at 02:30 the next day
+
+        # We solve this edge case by just iterating one second until the result exists
+        # (max. 3600 operations, which should be fine for an edge case that happens once a year)
         return find_next_time_expression_time(
             result + dt.timedelta(seconds=1), seconds, minutes, hours
         )
 
-    # Another edge-case when leaving DST:
-    # When now is in DST and ambiguous *and* the next trigger time we *should*
-    # trigger is ambiguous and outside DST, the excepts above won't catch it.
-    # For example: if triggering on 2:30 and now is 28.10.2018 2:30 (in DST)
-    # we should trigger next on 28.10.2018 2:30 (out of DST), but our
-    # algorithm above would produce 29.10.2018 2:30 (out of DST)
-    if _datetime_ambiguous(now):
+    # When leaving DST and clocks are turned backward.
+    # Then there are wall clock times that are ambiguous i.e. exist with DST and without DST
+    # The logic above does not take into account if a given pattern matches _twice_
+    # in a day.
+    # Example: on 2021.10.31 02:00:00 in CET timezone clocks are turned backward an hour
+
+    if _datetime_ambiguous(now) and _datetime_ambiguous(result):
+        # `now` and `result` are both ambiguous, so the next match happens
+        # _within_ the current fold.
+
+        # Examples:
+        #  1. 2021.10.31 02:00:00+02:00 with pattern 02:30 -> 2021.10.31 02:30:00+02:00
+        #  2. 2021.10.31 02:00:00+01:00 with pattern 02:30 -> 2021.10.31 02:30:00+01:00
+        return result.replace(fold=now.fold)
+
+    if _datetime_ambiguous(now) and now.fold == 0 and not _datetime_ambiguous(result):
+        # `now` is in the first fold, but result is not ambiguous (meaning it no longer matches
+        # within the fold).
+        # -> Check if result matches in the next fold. If so, emit that match
+
+        # Turn back the time by the DST offset, effectively run the algorithm on the first fold
+        # If it matches on the first fold, that means it will also match on the second one.
+
+        # Example: 2021.10.31 02:45:00+02:00 with pattern 02:30 -> 2021.10.31 02:30:00+01:00
+
         check_result = find_next_time_expression_time(
             now + _dst_offset_diff(now), seconds, minutes, hours
         )
         if _datetime_ambiguous(check_result):
-            return check_result
+            return check_result.replace(fold=1)
 
     return result
 

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -329,13 +329,16 @@ def find_next_time_expression_time(
             result + dt.timedelta(seconds=1), seconds, minutes, hours
         )
 
+    now_is_ambiguous = _datetime_ambiguous(now)
+    result_is_ambiguous = _datetime_ambiguous(result)
+
     # When leaving DST and clocks are turned backward.
     # Then there are wall clock times that are ambiguous i.e. exist with DST and without DST
     # The logic above does not take into account if a given pattern matches _twice_
     # in a day.
     # Example: on 2021.10.31 02:00:00 in CET timezone clocks are turned backward an hour
 
-    if _datetime_ambiguous(now) and _datetime_ambiguous(result):
+    if now_is_ambiguous and result_is_ambiguous:
         # `now` and `result` are both ambiguous, so the next match happens
         # _within_ the current fold.
 
@@ -344,7 +347,7 @@ def find_next_time_expression_time(
         #  2. 2021.10.31 02:00:00+01:00 with pattern 02:30 -> 2021.10.31 02:30:00+01:00
         return result.replace(fold=now.fold)
 
-    if _datetime_ambiguous(now) and now.fold == 0 and not _datetime_ambiguous(result):
+    if now_is_ambiguous and now.fold == 0 and not result_is_ambiguous:
         # `now` is in the first fold, but result is not ambiguous (meaning it no longer matches
         # within the fold).
         # -> Check if result matches in the next fold. If so, emit that match

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -3399,9 +3399,19 @@ async def test_periodic_task_entering_dst(hass):
     dt_util.set_default_time_zone(timezone)
     specific_runs = []
 
-    now = dt_util.utcnow()
+    # DST starts early morning March 27th 2022
+    yy = 2022
+    mm = 3
+    dd = 27
+
+    # There's no 2022-03-27 02:30, the event should not fire until 2022-03-28 02:30
     time_that_will_not_match_right_away = datetime(
-        now.year + 1, 3, 25, 2, 31, 0, tzinfo=timezone
+        yy, mm, dd, 1, 28, 0, tzinfo=timezone, fold=0
+    )
+    # Make sure we enter DST during the test
+    assert (
+        time_that_will_not_match_right_away.utcoffset()
+        != (time_that_will_not_match_right_away + timedelta(hours=2)).utcoffset()
     )
 
     with patch(
@@ -3416,25 +3426,25 @@ async def test_periodic_task_entering_dst(hass):
         )
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 3, 25, 1, 50, 0, 999999, tzinfo=timezone)
+        hass, datetime(yy, mm, dd, 1, 50, 0, 999999, tzinfo=timezone)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 3, 25, 3, 50, 0, 999999, tzinfo=timezone)
+        hass, datetime(yy, mm, dd, 3, 50, 0, 999999, tzinfo=timezone)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 3, 26, 1, 50, 0, 999999, tzinfo=timezone)
+        hass, datetime(yy, mm, dd + 1, 1, 50, 0, 999999, tzinfo=timezone)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 3, 26, 2, 50, 0, 999999, tzinfo=timezone)
+        hass, datetime(yy, mm, dd + 1, 2, 50, 0, 999999, tzinfo=timezone)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
@@ -3448,10 +3458,19 @@ async def test_periodic_task_leaving_dst(hass):
     dt_util.set_default_time_zone(timezone)
     specific_runs = []
 
-    now = dt_util.utcnow()
+    # DST ends early morning Ocotber 30th 2022
+    yy = 2022
+    mm = 10
+    dd = 30
 
     time_that_will_not_match_right_away = datetime(
-        now.year + 1, 10, 28, 2, 28, 0, tzinfo=timezone, fold=1
+        yy, mm, dd, 2, 28, 0, tzinfo=timezone, fold=0
+    )
+
+    # Make sure we leave DST during the test
+    assert (
+        time_that_will_not_match_right_away.utcoffset()
+        != time_that_will_not_match_right_away.replace(fold=1).utcoffset()
     )
 
     with patch(
@@ -3465,37 +3484,133 @@ async def test_periodic_task_leaving_dst(hass):
             second=0,
         )
 
+    # The task should not fire yet
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 10, 28, 2, 5, 0, 999999, tzinfo=timezone, fold=0)
+        hass, datetime(yy, mm, dd, 2, 28, 0, 999999, tzinfo=timezone, fold=0)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 0
 
+    # The task should fire
     async_fire_time_changed(
-        hass, datetime(now.year + 1, 10, 28, 2, 55, 0, 999999, tzinfo=timezone, fold=0)
+        hass, datetime(yy, mm, dd, 2, 30, 0, 999999, tzinfo=timezone, fold=0)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 1
 
+    # The task should not fire again
+    async_fire_time_changed(
+        hass, datetime(yy, mm, dd, 2, 55, 0, 999999, tzinfo=timezone, fold=0)
+    )
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 1
+
+    # DST has ended, the task should not fire yet
     async_fire_time_changed(
         hass,
-        datetime(now.year + 2, 10, 28, 2, 45, 0, 999999, tzinfo=timezone, fold=1),
+        datetime(yy, mm, dd, 2, 15, 0, 999999, tzinfo=timezone, fold=1),
+    )
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 1
+
+    # The task should fire
+    async_fire_time_changed(
+        hass,
+        datetime(yy, mm, dd, 2, 45, 0, 999999, tzinfo=timezone, fold=1),
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
+    # The task should not fire again
     async_fire_time_changed(
         hass,
-        datetime(now.year + 2, 10, 28, 2, 55, 0, 999999, tzinfo=timezone, fold=1),
+        datetime(yy, mm, dd, 2, 55, 0, 999999, tzinfo=timezone, fold=1),
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
 
+    # The task should fire again the next day
     async_fire_time_changed(
-        hass, datetime(now.year + 2, 10, 28, 2, 55, 0, 999999, tzinfo=timezone, fold=1)
+        hass, datetime(yy, mm, dd+1, 2, 55, 0, 999999, tzinfo=timezone, fold=1)
+    )
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 3
+
+    unsub()
+
+
+async def test_periodic_task_leaving_dst_2(hass):
+    """Test periodic task behavior when leaving dst."""
+    timezone = dt_util.get_time_zone("Europe/Vienna")
+    dt_util.set_default_time_zone(timezone)
+    specific_runs = []
+
+    # DST ends early morning Ocotber 30th 2022
+    yy = 2022
+    mm = 10
+    dd = 30
+
+    time_that_will_not_match_right_away = datetime(
+        yy, mm, dd, 2, 28, 0, tzinfo=timezone, fold=0
+    )
+    # Make sure we leave DST during the test
+    assert (
+        time_that_will_not_match_right_away.utcoffset()
+        != time_that_will_not_match_right_away.replace(fold=1).utcoffset()
+    )
+
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=time_that_will_not_match_right_away
+    ):
+        unsub = async_track_time_change(
+            hass,
+            callback(lambda x: specific_runs.append(x)),
+            minute=30,
+            second=0,
+        )
+
+    # The task should not fire yet
+    async_fire_time_changed(
+        hass, datetime(yy, mm, dd, 2, 28, 0, 999999, tzinfo=timezone, fold=0)
+    )
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 0
+
+    # The task should fire
+    async_fire_time_changed(
+        hass, datetime(yy, mm, dd, 2, 55, 0, 999999, tzinfo=timezone, fold=0)
+    )
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 1
+
+    # DST has ended, the task should not fire yet
+    async_fire_time_changed(
+        hass, datetime(yy, mm, dd, 2, 15, 0, 999999, tzinfo=timezone, fold=1)
+    )
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 1
+
+    # The task should fire
+    async_fire_time_changed(
+        hass, datetime(yy, mm, dd, 2, 45, 0, 999999, tzinfo=timezone, fold=1)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 2
+
+    # The task should not fire again
+    async_fire_time_changed(
+        hass,
+        datetime(yy, mm, dd, 2, 55, 0, 999999, tzinfo=timezone, fold=1),
+    )
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 2
+
+    # The task should fire again the next hour
+    async_fire_time_changed(
+        hass, datetime(yy, mm, dd, 3, 55, 0, 999999, tzinfo=timezone, fold=0)
+    )
+    await hass.async_block_till_done()
+    assert len(specific_runs) == 3
 
     unsub()
 

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -3531,7 +3531,7 @@ async def test_periodic_task_leaving_dst(hass):
 
     # The task should fire again the next day
     async_fire_time_changed(
-        hass, datetime(yy, mm, dd+1, 2, 55, 0, 999999, tzinfo=timezone, fold=1)
+        hass, datetime(yy, mm, dd + 1, 2, 55, 0, 999999, tzinfo=timezone, fold=1)
     )
     await hass.async_block_till_done()
     assert len(specific_runs) == 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix `find_next_time_expression_time` after https://github.com/home-assistant/core/pull/49643

The conversion introduced some bugs, like
- `fold` is the wrong value here (`is_dst == True` is equivalent to `fold == 0`, but that was the opposite here): https://github.com/home-assistant/core/pull/49643/files#diff-ebdd5e43e71f51f15950749ccba6701248317f7217663167de537455941e8d7dR319
- Setting `fold` to `1` here was missed: https://github.com/home-assistant/core/pull/49643/files#diff-ebdd5e43e71f51f15950749ccba6701248317f7217663167de537455941e8d7dR345 - thus all these edge cases would just generate times in the first fold
- and something else that I unfortunately couldn't track down

Additionally, there was an unwanted regression in the testing: the tests no longer checked if the `is_dst/fold` property is correct. This is due to a peculiar behavior of python's built-in `datetime` objects: The equality check doesn't consider the `fold` attribute (potentially a bug in the stdlib?). So all checks were passing even though the fold attribute was incorrect

```python3
>>> from datetime import datetime, timezone
>>> from zoneinfo import ZoneInfo
>>> tz=ZoneInfo("Europe/Vienna")
>>> dt1=datetime(2021, 10, 31, 2, 30, 0, fold=0, tzinfo=tz)
>>> dt2=datetime(2021, 10, 31, 2, 30, 0, fold=1, tzinfo=tz)
>>> dt1 == dt2
True
>>> dt1.astimezone(timezone.utc) == dt2.astimezone(timezone.utc)
False
# ¯\_(ツ)_/¯
```

Edit: that appears to be intentional behavior: https://www.python.org/dev/peps/pep-0495/#toc-entry-27

Fixes (at least part of) https://github.com/home-assistant/core/issues/58783

Because I couldn't get the old DST checks to work anymore, I took a look at my notes from when I initially implemented this feature, and I think I have simplified the checks somewhat. The main concern with leaving DST is that patterns like `02:30` should match _twice_. Once in the first fold, and after turning the clocks backwards. But we only need to consider two cases:

 - `now` and the matched `result` are both ambiguous (=in the same fold)
 - `now` is in the first fold, and the next matched event should be in the second fold.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
