### PR TITLE
2021.10.7

### DIFF
--- a/homeassistant/components/dlna_dmr/data.py
+++ b/homeassistant/components/dlna_dmr/data.py
@@ -39,7 +39,7 @@ class DlnaDmrData:
         """Initialize global data."""
         self.lock = asyncio.Lock()
         session = aiohttp_client.async_get_clientsession(hass, verify_ssl=False)
-        self.requester = AiohttpSessionRequester(session, with_sleep=False)
+        self.requester = AiohttpSessionRequester(session, with_sleep=True)
         self.upnp_factory = UpnpFactory(self.requester, non_strict=True)
         self.event_notifiers = {}
         self.event_notifier_refs = defaultdict(int)

--- a/homeassistant/components/fritz/config_flow.py
+++ b/homeassistant/components/fritz/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import socket
 from typing import Any
 from urllib.parse import ParseResult, urlparse
 
@@ -85,8 +86,16 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_check_configured_entry(self) -> ConfigEntry | None:
         """Check if entry is configured."""
+
+        current_host = await self.hass.async_add_executor_job(
+            socket.gethostbyname, self._host
+        )
+
         for entry in self._async_current_entries(include_ignore=False):
-            if entry.data[CONF_HOST] == self._host:
+            entry_host = await self.hass.async_add_executor_job(
+                socket.gethostbyname, entry.data[CONF_HOST]
+            )
+            if entry_host == current_host:
                 return entry
         return None
 

--- a/homeassistant/components/keenetic_ndms2/config_flow.py
+++ b/homeassistant/components/keenetic_ndms2/config_flow.py
@@ -118,6 +118,7 @@ class KeeneticFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
         await self.async_set_unique_id(discovery_info[ssdp.ATTR_UPNP_UDN])
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
 
         self._async_abort_entries_match({CONF_HOST: host})
 

--- a/homeassistant/components/mazda/manifest.json
+++ b/homeassistant/components/mazda/manifest.json
@@ -3,7 +3,7 @@
   "name": "Mazda Connected Services",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/mazda",
-  "requirements": ["pymazda==0.2.1"],
+  "requirements": ["pymazda==0.2.2"],
   "codeowners": ["@bdr99"],
   "quality_scale": "platinum",
   "iot_class": "cloud_polling"

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -142,7 +142,9 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         updated_data[CONF_PORT] = DEFAULT_PORT
         for model in MODELS_V2:
-            if discovery_info.get(ssdp.ATTR_UPNP_MODEL_NUMBER, "").startswith(model):
+            if discovery_info.get(ssdp.ATTR_UPNP_MODEL_NUMBER, "").startswith(
+                model
+            ) or discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME, "").startswith(model):
                 updated_data[CONF_PORT] = ORBI_PORT
 
         self.placeholders.update(updated_data)

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -199,6 +199,9 @@ class NetgearRouter:
         ntg_devices = await self.async_get_attached_devices()
         now = dt_util.utcnow()
 
+        if ntg_devices is None:
+            return
+
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug("Netgear scan result: \n%s", ntg_devices)
 

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -245,6 +245,7 @@ class SensorTemplate(TemplateEntity, SensorEntity):
 
         self._friendly_name_template = friendly_name_template
 
+        self._attr_name = None
         # Try to render the name as it can influence the entity ID
         if friendly_name_template:
             friendly_name_template.hass = hass

--- a/homeassistant/components/tuya/manifest.json
+++ b/homeassistant/components/tuya/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "tuya",
   "name": "Tuya",
-  "documentation": "https://github.com/tuya/tuya-home-assistant",
+  "documentation": "https://www.home-assistant.io/integrations/tuya",
   "requirements": ["tuya-iot-py-sdk==0.5.0"],
   "codeowners": ["@Tuya", "@zlinoliver", "@METISU"],
   "config_flow": true,

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -309,7 +309,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
     async def async_media_stop(self):
         """Send stop command."""
         if self._is_netusb:
-            await self.coordinator.musiccast.netusb_pause()
+            await self.coordinator.musiccast.netusb_stop()
         else:
             raise HomeAssistantError(
                 "Service stop is not supported for non NetUSB sources."

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 10
-PATCH_VERSION: Final = "6"
+PATCH_VERSION: Final = "7"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1619,7 +1619,7 @@ pymailgunner==1.4
 pymata-express==1.19
 
 # homeassistant.components.mazda
-pymazda==0.2.1
+pymazda==0.2.2
 
 # homeassistant.components.mediaroom
 pymediaroom==0.6.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -950,7 +950,7 @@ pymailgunner==1.4
 pymata-express==1.19
 
 # homeassistant.components.mazda
-pymazda==0.2.1
+pymazda==0.2.2
 
 # homeassistant.components.melcloud
 pymelcloud==2.5.4

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -41,6 +41,7 @@ ATTR_HOST = "host"
 ATTR_NEW_SERIAL_NUMBER = "NewSerialNumber"
 
 MOCK_HOST = "fake_host"
+MOCK_IP = "192.168.178.1"
 MOCK_SERIAL_NUMBER = "fake_serial_number"
 MOCK_FIRMWARE_INFO = [True, "1.1.1"]
 
@@ -51,7 +52,7 @@ MOCK_DEVICE_INFO = {
 }
 MOCK_IMPORT_CONFIG = {CONF_HOST: MOCK_HOST, CONF_USERNAME: "username"}
 MOCK_SSDP_DATA = {
-    ATTR_SSDP_LOCATION: "https://fake_host:12345/test",
+    ATTR_SSDP_LOCATION: f"https://{MOCK_IP}:12345/test",
     ATTR_UPNP_FRIENDLY_NAME: "fake_name",
     ATTR_UPNP_UDN: "uuid:only-a-test",
 }
@@ -81,7 +82,10 @@ async def test_user(hass: HomeAssistant, fc_class_mock, mock_get_source_ip):
         "requests.get"
     ) as mock_request_get, patch(
         "requests.post"
-    ) as mock_request_post:
+    ) as mock_request_post, patch(
+        "homeassistant.components.fritz.config_flow.socket.gethostbyname",
+        return_value=MOCK_IP,
+    ):
 
         mock_request_get.return_value.status_code = 200
         mock_request_get.return_value.content = MOCK_REQUEST
@@ -129,7 +133,10 @@ async def test_user_already_configured(
         "requests.get"
     ) as mock_request_get, patch(
         "requests.post"
-    ) as mock_request_post:
+    ) as mock_request_post, patch(
+        "homeassistant.components.fritz.config_flow.socket.gethostbyname",
+        return_value=MOCK_IP,
+    ):
 
         mock_request_get.return_value.status_code = 200
         mock_request_get.return_value.content = MOCK_REQUEST
@@ -319,7 +326,10 @@ async def test_ssdp_already_configured(
     with patch(
         "homeassistant.components.fritz.common.FritzConnection",
         side_effect=fc_class_mock,
-    ), patch("homeassistant.components.fritz.common.FritzStatus"):
+    ), patch("homeassistant.components.fritz.common.FritzStatus"), patch(
+        "homeassistant.components.fritz.config_flow.socket.gethostbyname",
+        return_value=MOCK_IP,
+    ):
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
@@ -343,7 +353,10 @@ async def test_ssdp_already_configured_host(
     with patch(
         "homeassistant.components.fritz.common.FritzConnection",
         side_effect=fc_class_mock,
-    ), patch("homeassistant.components.fritz.common.FritzStatus"):
+    ), patch("homeassistant.components.fritz.common.FritzStatus"), patch(
+        "homeassistant.components.fritz.config_flow.socket.gethostbyname",
+        return_value=MOCK_IP,
+    ):
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
@@ -367,7 +380,10 @@ async def test_ssdp_already_configured_host_uuid(
     with patch(
         "homeassistant.components.fritz.common.FritzConnection",
         side_effect=fc_class_mock,
-    ), patch("homeassistant.components.fritz.common.FritzStatus"):
+    ), patch("homeassistant.components.fritz.common.FritzStatus"), patch(
+        "homeassistant.components.fritz.config_flow.socket.gethostbyname",
+        return_value=MOCK_IP,
+    ):
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
@@ -436,7 +452,7 @@ async def test_ssdp(hass: HomeAssistant, fc_class_mock, mock_get_source_ip):
         )
 
         assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-        assert result["data"][CONF_HOST] == "fake_host"
+        assert result["data"][CONF_HOST] == MOCK_IP
         assert result["data"][CONF_PASSWORD] == "fake_pass"
         assert result["data"][CONF_USERNAME] == "fake_user"
 
@@ -482,7 +498,10 @@ async def test_import(hass: HomeAssistant, fc_class_mock, mock_get_source_ip):
         "requests.get"
     ) as mock_request_get, patch(
         "requests.post"
-    ) as mock_request_post:
+    ) as mock_request_post, patch(
+        "homeassistant.components.fritz.config_flow.socket.gethostbyname",
+        return_value=MOCK_IP,
+    ):
 
         mock_request_get.return_value.status_code = 200
         mock_request_get.return_value.content = MOCK_REQUEST

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -115,7 +115,7 @@ async def test_entity_picture_template(hass, start_ha):
 
 @pytest.mark.parametrize("count,domain", [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
-    "attribute,config",
+    "attribute,config,expected",
     [
         (
             "friendly_name",
@@ -130,6 +130,22 @@ async def test_entity_picture_template(hass, start_ha):
                     },
                 },
             },
+            ("It .", "It Works."),
+        ),
+        (
+            "friendly_name",
+            {
+                "sensor": {
+                    "platform": "template",
+                    "sensors": {
+                        "test_template_sensor": {
+                            "value_template": "{{ states.sensor.test_state.state }}",
+                            "friendly_name_template": "{{ 'It ' + states.sensor.test_state.state + '.'}}",
+                        }
+                    },
+                },
+            },
+            (None, "It Works."),
         ),
         (
             "friendly_name",
@@ -144,6 +160,7 @@ async def test_entity_picture_template(hass, start_ha):
                     },
                 },
             },
+            ("It .", "It Works."),
         ),
         (
             "test_attribute",
@@ -160,16 +177,17 @@ async def test_entity_picture_template(hass, start_ha):
                     },
                 },
             },
+            ("It .", "It Works."),
         ),
     ],
 )
-async def test_friendly_name_template(hass, attribute, start_ha):
+async def test_friendly_name_template(hass, attribute, expected, start_ha):
     """Test friendly_name template with an unknown value_template."""
-    assert hass.states.get(TEST_NAME).attributes.get(attribute) == "It ."
+    assert hass.states.get(TEST_NAME).attributes.get(attribute) == expected[0]
 
     hass.states.async_set("sensor.test_state", "Works")
     await hass.async_block_till_done()
-    assert hass.states.get(TEST_NAME).attributes[attribute] == "It Works."
+    assert hass.states.get(TEST_NAME).attributes[attribute] == expected[1]
 
 
 @pytest.mark.parametrize("count,domain", [(0, sensor.DOMAIN)])

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -224,55 +224,169 @@ def test_find_next_time_expression_time_dst():
     tz = dt_util.get_time_zone("Europe/Vienna")
     dt_util.set_default_time_zone(tz)
 
-    def find(dt, hour, minute, second):
+    def find(dt, hour, minute, second) -> datetime:
         """Call test_find_next_time_expression_time."""
         seconds = dt_util.parse_time_expression(second, 0, 59)
         minutes = dt_util.parse_time_expression(minute, 0, 59)
         hours = dt_util.parse_time_expression(hour, 0, 23)
 
-        return dt_util.find_next_time_expression_time(dt, seconds, minutes, hours)
+        local = dt_util.find_next_time_expression_time(dt, seconds, minutes, hours)
+        return dt_util.as_utc(local)
 
     # Entering DST, clocks are rolled forward
-    assert datetime(2018, 3, 26, 2, 30, 0, tzinfo=tz) == find(
+    assert dt_util.as_utc(datetime(2018, 3, 26, 2, 30, 0, tzinfo=tz)) == find(
         datetime(2018, 3, 25, 1, 50, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert datetime(2018, 3, 26, 2, 30, 0, tzinfo=tz) == find(
+    assert dt_util.as_utc(datetime(2018, 3, 26, 2, 30, 0, tzinfo=tz)) == find(
         datetime(2018, 3, 25, 3, 50, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert datetime(2018, 3, 26, 2, 30, 0, tzinfo=tz) == find(
+    assert dt_util.as_utc(datetime(2018, 3, 26, 2, 30, 0, tzinfo=tz)) == find(
         datetime(2018, 3, 26, 1, 50, 0, tzinfo=tz), 2, 30, 0
     )
 
     # Leaving DST, clocks are rolled back
-    assert datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=0) == find(
+    assert dt_util.as_utc(datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=0)) == find(
         datetime(2018, 10, 28, 2, 5, 0, tzinfo=tz, fold=0), 2, 30, 0
     )
 
-    assert datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=0) == find(
+    assert dt_util.as_utc(datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=0)) == find(
         datetime(2018, 10, 28, 2, 5, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=1) == find(
+    assert dt_util.as_utc(datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=1)) == find(
         datetime(2018, 10, 28, 2, 55, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=1) == find(
+    assert dt_util.as_utc(datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=1)) == find(
         datetime(2018, 10, 28, 2, 55, 0, tzinfo=tz, fold=0), 2, 30, 0
     )
 
-    assert datetime(2018, 10, 28, 4, 30, 0, tzinfo=tz, fold=0) == find(
+    assert dt_util.as_utc(datetime(2018, 10, 28, 4, 30, 0, tzinfo=tz, fold=0)) == find(
         datetime(2018, 10, 28, 2, 55, 0, tzinfo=tz, fold=1), 4, 30, 0
     )
 
-    assert datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=1) == find(
+    assert dt_util.as_utc(datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=1)) == find(
         datetime(2018, 10, 28, 2, 5, 0, tzinfo=tz, fold=1), 2, 30, 0
     )
 
-    assert datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=1) == find(
+    assert dt_util.as_utc(datetime(2018, 10, 28, 2, 30, 0, tzinfo=tz, fold=1)) == find(
         datetime(2018, 10, 28, 2, 55, 0, tzinfo=tz, fold=0), 2, 30, 0
     )
+
+
+# DST begins on 2021.03.28 2:00, clocks were turned forward 1h; 2:00-3:00 time does not exist
+@pytest.mark.parametrize(
+    "now_dt, expected_dt",
+    [
+        # 00:00 -> 2:30
+        (
+            datetime(2021, 3, 28, 0, 0, 0),
+            datetime(2021, 3, 29, 2, 30, 0),
+        ),
+    ],
+)
+def test_find_next_time_expression_entering_dst(now_dt, expected_dt):
+    """Test entering daylight saving time for find_next_time_expression_time."""
+    tz = dt_util.get_time_zone("Europe/Vienna")
+    dt_util.set_default_time_zone(tz)
+    # match on 02:30:00 every day
+    pattern_seconds = dt_util.parse_time_expression(0, 0, 59)
+    pattern_minutes = dt_util.parse_time_expression(30, 0, 59)
+    pattern_hours = dt_util.parse_time_expression(2, 0, 59)
+
+    now_dt = now_dt.replace(tzinfo=tz)
+    expected_dt = expected_dt.replace(tzinfo=tz)
+
+    res_dt = dt_util.find_next_time_expression_time(
+        now_dt, pattern_seconds, pattern_minutes, pattern_hours
+    )
+    assert dt_util.as_utc(res_dt) == dt_util.as_utc(expected_dt)
+
+
+# DST ends on 2021.10.31 2:00, clocks were turned backward 1h; 2:00-3:00 time is ambiguous
+@pytest.mark.parametrize(
+    "now_dt, expected_dt",
+    [
+        # 00:00 -> 2:30
+        (
+            datetime(2021, 10, 31, 0, 0, 0),
+            datetime(2021, 10, 31, 2, 30, 0, fold=0),
+        ),
+        # 02:00(0) -> 2:30(0)
+        (
+            datetime(2021, 10, 31, 2, 0, 0, fold=0),
+            datetime(2021, 10, 31, 2, 30, 0, fold=0),
+        ),
+        # 02:15(0) -> 2:30(0)
+        (
+            datetime(2021, 10, 31, 2, 15, 0, fold=0),
+            datetime(2021, 10, 31, 2, 30, 0, fold=0),
+        ),
+        # 02:30:00(0) -> 2:30(1)
+        (
+            datetime(2021, 10, 31, 2, 30, 0, fold=0),
+            datetime(2021, 10, 31, 2, 30, 0, fold=0),
+        ),
+        # 02:30:01(0) -> 2:30(1)
+        (
+            datetime(2021, 10, 31, 2, 30, 1, fold=0),
+            datetime(2021, 10, 31, 2, 30, 0, fold=1),
+        ),
+        # 02:45(0) -> 2:30(1)
+        (
+            datetime(2021, 10, 31, 2, 45, 0, fold=0),
+            datetime(2021, 10, 31, 2, 30, 0, fold=1),
+        ),
+        # 02:00(1) -> 2:30(1)
+        (
+            datetime(2021, 10, 31, 2, 0, 0, fold=1),
+            datetime(2021, 10, 31, 2, 30, 0, fold=1),
+        ),
+        # 02:15(1) -> 2:30(1)
+        (
+            datetime(2021, 10, 31, 2, 15, 0, fold=1),
+            datetime(2021, 10, 31, 2, 30, 0, fold=1),
+        ),
+        # 02:30:00(1) -> 2:30(1)
+        (
+            datetime(2021, 10, 31, 2, 30, 0, fold=1),
+            datetime(2021, 10, 31, 2, 30, 0, fold=1),
+        ),
+        # 02:30:01(1) -> 2:30 next day
+        (
+            datetime(2021, 10, 31, 2, 30, 1, fold=1),
+            datetime(2021, 11, 1, 2, 30, 0),
+        ),
+        # 02:45(1) -> 2:30 next day
+        (
+            datetime(2021, 10, 31, 2, 45, 0, fold=1),
+            datetime(2021, 11, 1, 2, 30, 0),
+        ),
+        # 08:00(1) -> 2:30 next day
+        (
+            datetime(2021, 10, 31, 8, 0, 1),
+            datetime(2021, 11, 1, 2, 30, 0),
+        ),
+    ],
+)
+def test_find_next_time_expression_exiting_dst(now_dt, expected_dt):
+    """Test exiting daylight saving time for find_next_time_expression_time."""
+    tz = dt_util.get_time_zone("Europe/Vienna")
+    dt_util.set_default_time_zone(tz)
+    # match on 02:30:00 every day
+    pattern_seconds = dt_util.parse_time_expression(0, 0, 59)
+    pattern_minutes = dt_util.parse_time_expression(30, 0, 59)
+    pattern_hours = dt_util.parse_time_expression(2, 0, 59)
+
+    now_dt = now_dt.replace(tzinfo=tz)
+    expected_dt = expected_dt.replace(tzinfo=tz)
+
+    res_dt = dt_util.find_next_time_expression_time(
+        now_dt, pattern_seconds, pattern_minutes, pattern_hours
+    )
+    assert dt_util.as_utc(res_dt) == dt_util.as_utc(expected_dt)
 
 
 def test_find_next_time_expression_time_dst_chicago():
@@ -280,64 +394,241 @@ def test_find_next_time_expression_time_dst_chicago():
     tz = dt_util.get_time_zone("America/Chicago")
     dt_util.set_default_time_zone(tz)
 
-    def find(dt, hour, minute, second):
+    def find(dt, hour, minute, second) -> datetime:
         """Call test_find_next_time_expression_time."""
         seconds = dt_util.parse_time_expression(second, 0, 59)
         minutes = dt_util.parse_time_expression(minute, 0, 59)
         hours = dt_util.parse_time_expression(hour, 0, 23)
 
-        return dt_util.find_next_time_expression_time(dt, seconds, minutes, hours)
+        local = dt_util.find_next_time_expression_time(dt, seconds, minutes, hours)
+        return dt_util.as_utc(local)
 
     # Entering DST, clocks are rolled forward
-    assert datetime(2021, 3, 15, 2, 30, 0, tzinfo=tz) == find(
+    assert dt_util.as_utc(datetime(2021, 3, 15, 2, 30, 0, tzinfo=tz)) == find(
         datetime(2021, 3, 14, 1, 50, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert datetime(2021, 3, 15, 2, 30, 0, tzinfo=tz) == find(
+    assert dt_util.as_utc(datetime(2021, 3, 15, 2, 30, 0, tzinfo=tz)) == find(
         datetime(2021, 3, 14, 3, 50, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert datetime(2021, 3, 15, 2, 30, 0, tzinfo=tz) == find(
+    assert dt_util.as_utc(datetime(2021, 3, 15, 2, 30, 0, tzinfo=tz)) == find(
         datetime(2021, 3, 14, 1, 50, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert datetime(2021, 3, 14, 3, 30, 0, tzinfo=tz) == find(
+    assert dt_util.as_utc(datetime(2021, 3, 14, 3, 30, 0, tzinfo=tz)) == find(
         datetime(2021, 3, 14, 1, 50, 0, tzinfo=tz), 3, 30, 0
     )
 
     # Leaving DST, clocks are rolled back
-    assert datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=0) == find(
+    assert dt_util.as_utc(datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=0)) == find(
         datetime(2021, 11, 7, 2, 5, 0, tzinfo=tz, fold=0), 2, 30, 0
     )
 
-    assert datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz) == find(
+    assert dt_util.as_utc(datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz)) == find(
         datetime(2021, 11, 7, 2, 5, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=0) == find(
+    assert dt_util.as_utc(datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=0)) == find(
         datetime(2021, 11, 7, 2, 5, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=1) == find(
+    assert dt_util.as_utc(datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=1)) == find(
         datetime(2021, 11, 7, 2, 10, 0, tzinfo=tz), 2, 30, 0
     )
 
-    assert datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=1) == find(
+    assert dt_util.as_utc(datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=1)) == find(
         datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=0), 2, 30, 0
     )
 
-    assert datetime(2021, 11, 8, 2, 30, 0, tzinfo=tz, fold=1) == find(
+    assert dt_util.as_utc(datetime(2021, 11, 8, 2, 30, 0, tzinfo=tz, fold=1)) == find(
         datetime(2021, 11, 7, 2, 55, 0, tzinfo=tz, fold=0), 2, 30, 0
     )
 
-    assert datetime(2021, 11, 7, 4, 30, 0, tzinfo=tz, fold=0) == find(
+    assert dt_util.as_utc(datetime(2021, 11, 7, 4, 30, 0, tzinfo=tz, fold=0)) == find(
         datetime(2021, 11, 7, 2, 55, 0, tzinfo=tz, fold=1), 4, 30, 0
     )
 
-    assert datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=1) == find(
+    assert dt_util.as_utc(datetime(2021, 11, 7, 2, 30, 0, tzinfo=tz, fold=1)) == find(
         datetime(2021, 11, 7, 2, 5, 0, tzinfo=tz, fold=1), 2, 30, 0
     )
 
-    assert datetime(2021, 11, 8, 2, 30, 0, tzinfo=tz) == find(
+    assert dt_util.as_utc(datetime(2021, 11, 8, 2, 30, 0, tzinfo=tz)) == find(
         datetime(2021, 11, 7, 2, 55, 0, tzinfo=tz, fold=0), 2, 30, 0
+    )
+
+
+def _get_matches(hours, minutes, seconds):
+    matching_hours = dt_util.parse_time_expression(hours, 0, 23)
+    matching_minutes = dt_util.parse_time_expression(minutes, 0, 59)
+    matching_seconds = dt_util.parse_time_expression(seconds, 0, 59)
+    return matching_hours, matching_minutes, matching_seconds
+
+
+def test_find_next_time_expression_day_before_dst_change_the_same_time():
+    """Test the day before DST to establish behavior without DST."""
+    tz = dt_util.get_time_zone("America/Chicago")
+    dt_util.set_default_time_zone(tz)
+
+    # Not in DST yet
+    hour_minute_second = (12, 30, 1)
+    test_time = datetime(2021, 10, 7, *hour_minute_second, tzinfo=tz, fold=0)
+    matching_hours, matching_minutes, matching_seconds = _get_matches(
+        *hour_minute_second
+    )
+    next_time = dt_util.find_next_time_expression_time(
+        test_time, matching_seconds, matching_minutes, matching_hours
+    )
+    assert next_time == datetime(2021, 10, 7, *hour_minute_second, tzinfo=tz, fold=0)
+    assert next_time.fold == 0
+    assert dt_util.as_utc(next_time) == datetime(
+        2021, 10, 7, 17, 30, 1, tzinfo=dt_util.UTC
+    )
+
+
+def test_find_next_time_expression_time_leave_dst_chicago_before_the_fold_30_s():
+    """Test leaving daylight saving time for find_next_time_expression_time 30s into the future."""
+    tz = dt_util.get_time_zone("America/Chicago")
+    dt_util.set_default_time_zone(tz)
+
+    # Leaving DST, clocks are rolled back
+
+    # Move ahead 30 seconds not folded yet
+    hour_minute_second = (1, 30, 31)
+    test_time = datetime(2021, 11, 7, 1, 30, 1, tzinfo=tz, fold=0)
+    matching_hours, matching_minutes, matching_seconds = _get_matches(
+        *hour_minute_second
+    )
+    next_time = dt_util.find_next_time_expression_time(
+        test_time, matching_seconds, matching_minutes, matching_hours
+    )
+    assert next_time == datetime(2021, 11, 7, 1, 30, 31, tzinfo=tz, fold=0)
+    assert dt_util.as_utc(next_time) == datetime(
+        2021, 11, 7, 6, 30, 31, tzinfo=dt_util.UTC
+    )
+    assert next_time.fold == 0
+
+
+def test_find_next_time_expression_time_leave_dst_chicago_before_the_fold_same_time():
+    """Test leaving daylight saving time for find_next_time_expression_time with the same time."""
+    tz = dt_util.get_time_zone("America/Chicago")
+    dt_util.set_default_time_zone(tz)
+
+    # Leaving DST, clocks are rolled back
+
+    # Move to the same time not folded yet
+    hour_minute_second = (0, 30, 1)
+    test_time = datetime(2021, 11, 7, *hour_minute_second, tzinfo=tz, fold=0)
+    matching_hours, matching_minutes, matching_seconds = _get_matches(
+        *hour_minute_second
+    )
+    next_time = dt_util.find_next_time_expression_time(
+        test_time, matching_seconds, matching_minutes, matching_hours
+    )
+    assert next_time == datetime(2021, 11, 7, *hour_minute_second, tzinfo=tz, fold=0)
+    assert dt_util.as_utc(next_time) == datetime(
+        2021, 11, 7, 5, 30, 1, tzinfo=dt_util.UTC
+    )
+    assert next_time.fold == 0
+
+
+def test_find_next_time_expression_time_leave_dst_chicago_into_the_fold_same_time():
+    """Test leaving daylight saving time for find_next_time_expression_time."""
+    tz = dt_util.get_time_zone("America/Chicago")
+    dt_util.set_default_time_zone(tz)
+
+    # Leaving DST, clocks are rolled back
+
+    # Find the same time inside the fold
+    hour_minute_second = (1, 30, 1)
+    test_time = datetime(2021, 11, 7, *hour_minute_second, tzinfo=tz, fold=0)
+    matching_hours, matching_minutes, matching_seconds = _get_matches(
+        *hour_minute_second
+    )
+
+    next_time = dt_util.find_next_time_expression_time(
+        test_time, matching_seconds, matching_minutes, matching_hours
+    )
+    assert next_time == datetime(2021, 11, 7, *hour_minute_second, tzinfo=tz, fold=1)
+    assert next_time.fold == 0
+    assert dt_util.as_utc(next_time) == datetime(
+        2021, 11, 7, 6, 30, 1, tzinfo=dt_util.UTC
+    )
+
+
+def test_find_next_time_expression_time_leave_dst_chicago_into_the_fold_ahead_1_hour_10_min():
+    """Test leaving daylight saving time for find_next_time_expression_time."""
+    tz = dt_util.get_time_zone("America/Chicago")
+    dt_util.set_default_time_zone(tz)
+
+    # Leaving DST, clocks are rolled back
+
+    # Find 1h 10m after into the fold
+    # Start at 01:30:01 fold=0
+    # Reach to 01:20:01 fold=1
+    hour_minute_second = (1, 20, 1)
+    test_time = datetime(2021, 11, 7, 1, 30, 1, tzinfo=tz, fold=0)
+    matching_hours, matching_minutes, matching_seconds = _get_matches(
+        *hour_minute_second
+    )
+
+    next_time = dt_util.find_next_time_expression_time(
+        test_time, matching_seconds, matching_minutes, matching_hours
+    )
+    assert next_time == datetime(2021, 11, 7, *hour_minute_second, tzinfo=tz, fold=1)
+    assert next_time.fold == 1  # time is ambiguous
+    assert dt_util.as_utc(next_time) == datetime(
+        2021, 11, 7, 7, 20, 1, tzinfo=dt_util.UTC
+    )
+
+
+def test_find_next_time_expression_time_leave_dst_chicago_inside_the_fold_ahead_10_min():
+    """Test leaving daylight saving time for find_next_time_expression_time."""
+    tz = dt_util.get_time_zone("America/Chicago")
+    dt_util.set_default_time_zone(tz)
+
+    # Leaving DST, clocks are rolled back
+
+    # Find 10m later while we are in the fold
+    # Start at 01:30:01 fold=0
+    # Reach to 01:40:01 fold=1
+    hour_minute_second = (1, 40, 1)
+    test_time = datetime(2021, 11, 7, 1, 30, 1, tzinfo=tz, fold=1)
+    matching_hours, matching_minutes, matching_seconds = _get_matches(
+        *hour_minute_second
+    )
+
+    next_time = dt_util.find_next_time_expression_time(
+        test_time, matching_seconds, matching_minutes, matching_hours
+    )
+    assert next_time == datetime(2021, 11, 7, *hour_minute_second, tzinfo=tz, fold=1)
+    assert next_time.fold == 1  # time is ambiguous
+    assert dt_util.as_utc(next_time) == datetime(
+        2021, 11, 7, 7, 40, 1, tzinfo=dt_util.UTC
+    )
+
+
+def test_find_next_time_expression_time_leave_dst_chicago_past_the_fold_ahead_2_hour_10_min():
+    """Test leaving daylight saving time for find_next_time_expression_time."""
+    tz = dt_util.get_time_zone("America/Chicago")
+    dt_util.set_default_time_zone(tz)
+
+    # Leaving DST, clocks are rolled back
+
+    # Find 1h 10m after into the fold
+    # Start at 01:30:01 fold=0
+    # Reach to 02:20:01 past the fold
+    hour_minute_second = (2, 20, 1)
+    test_time = datetime(2021, 11, 7, 1, 30, 1, tzinfo=tz, fold=0)
+    matching_hours, matching_minutes, matching_seconds = _get_matches(
+        *hour_minute_second
+    )
+
+    next_time = dt_util.find_next_time_expression_time(
+        test_time, matching_seconds, matching_minutes, matching_hours
+    )
+    assert next_time == datetime(2021, 11, 7, *hour_minute_second, tzinfo=tz, fold=1)
+    assert next_time.fold == 0  # Time is no longer ambiguous
+    assert dt_util.as_utc(next_time) == datetime(
+        2021, 11, 7, 8, 20, 1, tzinfo=dt_util.UTC
     )


### PR DESCRIPTION
- Fix Tuya documentation URL (@ludeeus - #57889)
- Fix netgear NoneType and discovery (@starkillerOG - #57904)
- Abort keenetic SSDP discovery if the unique id is already setup or ignored (@foxel - #58009)
- Fix Yamaha MusicCast media_stop (@micha91 - #58024)
- Sleep between device requests to detect socket closes (@chishm - #58087)
- Fix template sensor when name template doesn't render (@emontnemery - #58088)
- Bump pymazda to 0.2.2 (@bdr99 - #58113)
- Abort Fritz config flow for configured hostnames (@chemelli74 - #58140)
- Fix find_next_time_expression_time (@OttoWinter - #58894) 