### PR TITLE
Update volvooncall, add hybrid plug status

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -578,6 +578,7 @@ homeassistant/components/vizio/* @raman325
 homeassistant/components/vlc_telnet/* @rodripf @dmcc @MartinHjelmare
 homeassistant/components/volkszaehler/* @fabaff
 homeassistant/components/volumio/* @OnFreund
+homeassistant/components/volvooncall/* @molobrakos @decompil3d
 homeassistant/components/wake_on_lan/* @ntilley905
 homeassistant/components/wallbox/* @hesselonline
 homeassistant/components/waqi/* @andrey-git

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -156,7 +156,12 @@ async def async_setup(hass, config):
                     hass,
                     PLATFORMS[instrument.component],
                     DOMAIN,
-                    (vehicle.vin, instrument.component, instrument.attr),
+                    (
+                        vehicle.vin,
+                        instrument.component,
+                        instrument.attr,
+                        instrument.slug_attr,
+                    ),
                     config,
                 )
             )
@@ -192,7 +197,7 @@ class VolvoData:
         self.config = config[DOMAIN]
         self.names = self.config.get(CONF_NAME)
 
-    def instrument(self, vin, component, attr):
+    def instrument(self, vin, component, attr, slug_attr):
         """Return corresponding instrument."""
         return next(
             (
@@ -201,6 +206,7 @@ class VolvoData:
                 if instrument.vehicle.vin == vin
                 and instrument.component == component
                 and instrument.attr == attr
+                and instrument.slug_attr == slug_attr
             ),
             None,
         )
@@ -223,12 +229,13 @@ class VolvoData:
 class VolvoEntity(Entity):
     """Base class for all VOC entities."""
 
-    def __init__(self, data, vin, component, attribute):
+    def __init__(self, data, vin, component, attribute, slug_attr):
         """Initialize the entity."""
         self.data = data
         self.vin = vin
         self.component = component
         self.attribute = attribute
+        self.slug_attr = slug_attr
 
     async def async_added_to_hass(self):
         """Register update dispatcher."""
@@ -241,7 +248,9 @@ class VolvoEntity(Entity):
     @property
     def instrument(self):
         """Return corresponding instrument."""
-        return self.data.instrument(self.vin, self.component, self.attribute)
+        return self.data.instrument(
+            self.vin, self.component, self.attribute, self.slug_attr
+        )
 
     @property
     def icon(self):
@@ -287,4 +296,7 @@ class VolvoEntity(Entity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return f"{self.vin}-{self.component}-{self.attribute}"
+        slug_override = ""
+        if self.instrument.slug_override is not None:
+            slug_override = f"-{self.instrument.slug_override}"
+        return f"{self.vin}-{self.component}-{self.attribute}{slug_override}"

--- a/homeassistant/components/volvooncall/device_tracker.py
+++ b/homeassistant/components/volvooncall/device_tracker.py
@@ -11,9 +11,9 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     if discovery_info is None:
         return
 
-    vin, component, attr = discovery_info
+    vin, component, attr, slug_attr = discovery_info
     data = hass.data[DATA_KEY]
-    instrument = data.instrument(vin, component, attr)
+    instrument = data.instrument(vin, component, attr, slug_attr)
 
     async def see_vehicle():
         """Handle the reporting of the vehicle position."""

--- a/homeassistant/components/volvooncall/manifest.json
+++ b/homeassistant/components/volvooncall/manifest.json
@@ -2,7 +2,7 @@
   "domain": "volvooncall",
   "name": "Volvo On Call",
   "documentation": "https://www.home-assistant.io/integrations/volvooncall",
-  "requirements": ["volvooncall==0.8.12"],
-  "codeowners": [],
+  "requirements": ["volvooncall==0.9.1"],
+  "codeowners": ["@molobrakos", "@decompil3d"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2378,7 +2378,7 @@ vilfo-api-client==0.3.2
 volkszaehler==0.2.1
 
 # homeassistant.components.volvooncall
-volvooncall==0.8.12
+volvooncall==0.9.1
 
 # homeassistant.components.verisure
 vsure==1.7.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Prior versions of the `volvooncall` component represented hybrid vehicle charge state as a single binary sensor: `binary_sensor.<name>_battery_charging`. This was limiting, as Volvo's API expresses both plug status and battery charge status.

This release splits these into two binary sensors: `binary_sensor.<name>_battery_charging` and `binary_sensor.<name>_plug_status`. If you have existing automation and/or dashboards that use the `battery_charging` sensor, you may need/want to adjust to use one or both of the new sensors.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As described in the breaking change note above, this PR splits apart an existing binary sensor into two. It does so by first bumping the `volvooncall` package to `0.9.1` and then updating the consuming code in HA core to handle the new case of two sensors using the same underlying Volvo API attribute.

https://github.com/molobrakos/volvooncall/releases/tag/v0.9.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
