### PR TITLE
Address late review of motionEye media browser

### DIFF
--- a/homeassistant/components/motioneye/media_source.py
+++ b/homeassistant/components/motioneye/media_source.py
@@ -278,7 +278,7 @@ class MotionEyeMediaSource(MediaSource):
 
         parsed_path = PurePath(path)
         if path != "/":
-            base.title += " " + str(PurePath(*parsed_path.parts[1:]))
+            base.title += f" {PurePath(*parsed_path.parts[1:])}"
 
         base.children = []
 

--- a/homeassistant/components/motioneye/media_source.py
+++ b/homeassistant/components/motioneye/media_source.py
@@ -10,7 +10,6 @@ from motioneye_client.const import KEY_MEDIA_LIST, KEY_MIME_TYPE, KEY_PATH
 from homeassistant.components.media_player.const import (
     MEDIA_CLASS_DIRECTORY,
     MEDIA_CLASS_IMAGE,
-    MEDIA_CLASS_MOVIE,
     MEDIA_CLASS_VIDEO,
     MEDIA_TYPE_IMAGE,
     MEDIA_TYPE_VIDEO,
@@ -252,7 +251,7 @@ class MotionEyeMediaSource(MediaSource):
             can_play=False,
             can_expand=True,
             children_media_class=(
-                MEDIA_CLASS_MOVIE if kind == "movies" else MEDIA_CLASS_IMAGE
+                MEDIA_CLASS_VIDEO if kind == "movies" else MEDIA_CLASS_IMAGE
             ),
         )
 

--- a/homeassistant/components/motioneye/media_source.py
+++ b/homeassistant/components/motioneye/media_source.py
@@ -12,6 +12,8 @@ from homeassistant.components.media_player.const import (
     MEDIA_CLASS_IMAGE,
     MEDIA_CLASS_MOVIE,
     MEDIA_CLASS_VIDEO,
+    MEDIA_TYPE_IMAGE,
+    MEDIA_TYPE_VIDEO,
 )
 from homeassistant.components.media_source.error import MediaSourceError, Unresolvable
 from homeassistant.components.media_source.models import (
@@ -239,7 +241,9 @@ class MotionEyeMediaSource(MediaSource):
             domain=DOMAIN,
             identifier=f"{config.entry_id}#{device.id}#{kind}",
             media_class=MEDIA_CLASS_DIRECTORY,
-            media_content_type=MEDIA_CLASS_DIRECTORY,
+            media_content_type=(
+                MEDIA_TYPE_VIDEO if kind == "movies" else MEDIA_TYPE_IMAGE
+            ),
             title=(
                 f"{config.title} {device.name} {kind.title()}"
                 if full_title
@@ -339,7 +343,11 @@ class MotionEyeMediaSource(MediaSource):
                                     f"#{kind}#{full_child_path}"
                                 ),
                                 media_class=MEDIA_CLASS_DIRECTORY,
-                                media_content_type=MEDIA_CLASS_DIRECTORY,
+                                media_content_type=(
+                                    MEDIA_TYPE_VIDEO
+                                    if kind == "movies"
+                                    else MEDIA_TYPE_IMAGE
+                                ),
                                 title=display_child_path,
                                 can_play=False,
                                 can_expand=True,

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -159,7 +159,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
             {
                 "title": "Movies",
                 "media_class": "directory",
-                "media_content_type": "directory",
+                "media_content_type": "video",
                 "media_content_id": (
                     "media-source://motioneye"
                     f"/74565ad414754616000674c87bdc876c#{device.id}#movies"
@@ -172,7 +172,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
             {
                 "title": "Images",
                 "media_class": "directory",
-                "media_content_type": "directory",
+                "media_content_type": "image",
                 "media_content_id": (
                     "media-source://motioneye"
                     f"/74565ad414754616000674c87bdc876c#{device.id}#images"
@@ -193,7 +193,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
     assert media.as_dict() == {
         "title": "http://test:8766 Test Camera Movies",
         "media_class": "directory",
-        "media_content_type": "directory",
+        "media_content_type": "video",
         "media_content_id": (
             "media-source://motioneye"
             f"/74565ad414754616000674c87bdc876c#{device.id}#movies"
@@ -206,7 +206,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
             {
                 "title": "2021-04-25",
                 "media_class": "directory",
-                "media_content_type": "directory",
+                "media_content_type": "video",
                 "media_content_id": (
                     "media-source://motioneye"
                     f"/74565ad414754616000674c87bdc876c#{device.id}#movies#/2021-04-25"
@@ -227,7 +227,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
     assert media.as_dict() == {
         "title": "http://test:8766 Test Camera Movies 2021-04-25",
         "media_class": "directory",
-        "media_content_type": "directory",
+        "media_content_type": "video",
         "media_content_id": (
             "media-source://motioneye"
             f"/74565ad414754616000674c87bdc876c#{device.id}#movies"
@@ -305,7 +305,7 @@ async def test_async_browse_media_images_success(hass: HomeAssistant) -> None:
     assert media.as_dict() == {
         "title": "http://test:8766 Test Camera Images 2021-04-12",
         "media_class": "directory",
-        "media_content_type": "directory",
+        "media_content_type": "image",
         "media_content_id": (
             "media-source://motioneye"
             f"/74565ad414754616000674c87bdc876c#{device.id}#images"
@@ -469,7 +469,7 @@ async def test_async_resolve_media_failure(hass: HomeAssistant) -> None:
     assert media.as_dict() == {
         "title": "http://test:8766 Test Camera Movies 2021-04-25",
         "media_class": "directory",
-        "media_content_type": "directory",
+        "media_content_type": "video",
         "media_content_id": (
             f"media-source://motioneye"
             f"/74565ad414754616000674c87bdc876c#{device.id}#movies"

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -166,7 +166,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
                 ),
                 "can_play": False,
                 "can_expand": True,
-                "children_media_class": "movie",
+                "children_media_class": "video",
                 "thumbnail": None,
             },
             {
@@ -200,7 +200,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
         ),
         "can_play": False,
         "can_expand": True,
-        "children_media_class": "movie",
+        "children_media_class": "video",
         "thumbnail": None,
         "children": [
             {
@@ -234,7 +234,7 @@ async def test_async_browse_media_success(hass: HomeAssistant) -> None:
         ),
         "can_play": False,
         "can_expand": True,
-        "children_media_class": "movie",
+        "children_media_class": "video",
         "thumbnail": None,
         "children": [
             {
@@ -476,7 +476,7 @@ async def test_async_resolve_media_failure(hass: HomeAssistant) -> None:
         ),
         "can_play": False,
         "can_expand": True,
-        "children_media_class": "movie",
+        "children_media_class": "video",
         "thumbnail": None,
         "children": [],
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Post-merge fixes requested for the addition of motionEye media browsing (#53436).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #53436
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
