### PR TITLE
Switch channels via media browser and play_media service

### DIFF
--- a/homeassistant/components/frontier_silicon/browse_media.py
+++ b/homeassistant/components/frontier_silicon/browse_media.py
@@ -1,0 +1,218 @@
+"""Support for media browsing."""
+import asyncio
+import logging
+
+from homeassistant.components.media_player import BrowseError, BrowseMedia
+from homeassistant.components.media_player.const import (
+    MEDIA_CLASS_CHANNEL,
+    MEDIA_CLASS_DIRECTORY,
+    MEDIA_TYPE_CHANNEL,
+)
+
+CHILD_TYPE_MEDIA_CLASS = {
+    MEDIA_TYPE_CHANNEL: MEDIA_CLASS_CHANNEL,
+    "preset": MEDIA_CLASS_CHANNEL,
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class UnknownMediaType(BrowseError):
+    """Unknown media type."""
+
+
+async def build_item_response(media_library, payload, get_thumbnail_url=None):
+    """Create response payload for the provided media query."""
+    search_id = payload["search_id"]
+    search_type = payload["search_type"]
+
+    _, title, media = await get_media_info(media_library, search_id, search_type)
+    if get_thumbnail_url is not None:
+        thumbnail = await get_thumbnail_url(search_type, search_id)
+    else:
+        thumbnail = None
+
+    if media is None:
+        return None
+
+    children = await asyncio.gather(
+        *(item_payload(item, get_thumbnail_url) for item in media)
+    )
+
+    response = BrowseMedia(
+        media_class=MEDIA_CLASS_DIRECTORY,
+        media_content_id=search_id,
+        media_content_type=search_type,
+        title=title,
+        can_play=bool(search_id),
+        can_expand=True,
+        children=children,
+        thumbnail=thumbnail,
+    )
+    response.calculate_children_class()
+
+    return response
+
+
+async def item_payload(item, get_thumbnail_url=None):
+    """
+    Create response payload for a single media item.
+
+    Used by async_browse_media.
+    """
+    title = item["label"]
+
+    media_class = None
+
+    if "band" in item:
+        media_content_type = f"{item['type']}"
+        media_content_id = f"{item['band']}"
+        can_play = True
+        can_expand = False
+    else:
+        # this case is for the top folder of each type
+        # possible content types: album, artist, movie, library_music, tvshow, channel
+        media_class = MEDIA_CLASS_DIRECTORY
+        media_content_type = item["type"]
+        media_content_id = ""
+        can_play = False
+        can_expand = True
+
+    if media_class is None:
+        try:
+            media_class = CHILD_TYPE_MEDIA_CLASS[media_content_type]
+        except KeyError as err:
+            _LOGGER.debug("Unknown media type received: %s", media_content_type)
+            raise UnknownMediaType from err
+
+    thumbnail = item.get("thumbnail")
+    if thumbnail is not None and get_thumbnail_url is not None:
+        thumbnail = await get_thumbnail_url(
+            media_content_type, media_content_id, thumbnail_url=thumbnail
+        )
+
+    return BrowseMedia(
+        title=title,
+        media_class=media_class,
+        media_content_type=media_content_type,
+        media_content_id=media_content_id,
+        can_play=can_play,
+        can_expand=can_expand,
+        thumbnail=thumbnail,
+    )
+
+
+async def library_payload():
+    """
+    Create response payload to describe contents of a specific library.
+
+    Used by async_browse_media.
+    """
+    library_info = BrowseMedia(
+        media_class=MEDIA_CLASS_DIRECTORY,
+        media_content_id="library",
+        media_content_type="library",
+        title="Media Library",
+        can_play=False,
+        can_expand=True,
+        children=[],
+    )
+
+    library = {
+        MEDIA_TYPE_CHANNEL: "Channels",
+        "preset": "Favorites",
+    }
+
+    library_info.children = await asyncio.gather(
+        *(
+            item_payload(
+                {
+                    "label": item["label"],
+                    "type": item["type"],
+                    "uri": item["type"],
+                },
+            )
+            for item in [
+                {"label": name, "type": type_} for type_, name in library.items()
+            ]
+        )
+    )
+
+    return library_info
+
+
+async def get_media_info(media_library, search_id, search_type):
+    """Fetch media/channels."""
+    thumbnail = None
+    title = None
+    media = None
+
+    if search_type == "preset":
+        nav = await media_library.handle_set("netRemote.nav.state", 1)
+        if not nav:
+            _LOGGER.error("Failed to enter nav state")
+            return thumbnail, title, media
+        presets = await media_library.handle_list("netRemote.nav.presets")
+        await media_library.handle_set("netRemote.nav.state", 0)
+        media = []
+        for preset in presets:
+            if "band" in preset and "name" in preset and preset["name"].text:
+                entry = {
+                    **preset,
+                    **{
+                        "label": preset["name"].text.strip(),
+                        "type": "preset",
+                    },
+                }
+                if (
+                    not search_id
+                    or (search_id.isnumeric() and entry["band"] == int(search_id))
+                    or (search_id.lower() in entry["label"].lower())
+                ):
+                    media.append(entry)
+        title = "Favorites"
+    if search_type == MEDIA_TYPE_CHANNEL:
+        nav = await media_library.handle_set("netRemote.nav.state", 1)
+        if not nav:
+            _LOGGER.error("Failed to enter nav state")
+            return thumbnail, title, media
+
+        channels = await media_library.call(
+            "LIST_GET_NEXT/netRemote.nav.list/-1", {"maxItems": 100}
+        )
+        nav = media_library.handle_set("netRemote.nav.state", 0)
+
+        media = []
+        for item in channels.findall("item"):
+            if "key" not in item.attrib or not item.attrib["key"]:
+                continue
+
+            channel = {"band": int(item.attrib["key"])}
+            for field in item.findall("field"):
+                if "name" not in field.attrib:
+                    continue
+                value = []
+                for text in field.itertext():
+                    value.append(text.strip())
+                if not value:
+                    continue
+                channel[field.attrib["name"]] = "\n".join(value)
+
+            if "name" in channel and channel["name"]:
+                entry = {
+                    **channel,
+                    **{
+                        "label": channel["name"],
+                        "type": MEDIA_TYPE_CHANNEL,
+                    },
+                }
+                if (
+                    not search_id
+                    or (search_id.isnumeric() and entry["band"] == int(search_id))
+                    or (search_id.lower() in entry["label"].lower())
+                ):
+                    media.append(entry)
+        title = "Channels"
+        await nav
+
+    return thumbnail, title, media

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -5,7 +5,11 @@ from afsapi import AFSAPI
 import requests
 import voluptuous as vol
 
-from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerEntity
+from homeassistant.components.media_player import (
+    PLATFORM_SCHEMA,
+    MediaPlayerEntity,
+    BrowseError,
+)
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     MEDIA_TYPE_CHANNEL,
@@ -346,7 +350,7 @@ class AFSAPIDevice(MediaPlayerEntity):
         ):
             _, _, media = await get_media_info(fs_device, media_id, media_type)
             if media:
-                media_id = media[0]["band"]
+                media_id = media[0]["key"]
             else:
                 _LOGGER.error("No entry found for %s %s", media_type, media_id)
                 return
@@ -357,11 +361,11 @@ class AFSAPIDevice(MediaPlayerEntity):
             return False
 
         if media_type == "preset":
-            ok = await fs_device.handle_set(
+            result = await fs_device.handle_set(
                 "netRemote.nav.action.selectPreset", media_id
             )
         if media_type == MEDIA_TYPE_CHANNEL:
-            ok = await fs_device.handle_set("netRemote.nav.action.selectItem", media_id)
+            result = await fs_device.handle_set("netRemote.nav.action.selectItem", media_id)
 
         await fs_device.handle_set("netRemote.nav.state", 0)
-        return ok
+        return result

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -365,7 +365,9 @@ class AFSAPIDevice(MediaPlayerEntity):
                 "netRemote.nav.action.selectPreset", media_id
             )
         if media_type == MEDIA_TYPE_CHANNEL:
-            result = await fs_device.handle_set("netRemote.nav.action.selectItem", media_id)
+            result = await fs_device.handle_set(
+                "netRemote.nav.action.selectItem", media_id
+            )
 
         await fs_device.handle_set("netRemote.nav.state", 0)
         return result


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for switching channels through the media browser and the `media_player.play_media` service for the Frontier Silicon integration.
The media browser for supported devices will show entries for Channels and Favorites. These entries correspond to the current playback mode (e.g. "Internet Radio" will not show "DAB" favorites).
The meida browser triggers the media_player.play_media service with the numeric entry ID, but a user could also invoke the service through the automation interface. In this case content types "channel" and "preset" are supported. Both accept the numeric ID or a substring of the station name (on multiple matches the first one as returned by the device will be played).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://community.home-assistant.io/t/frontier-silicon-device-change-radio-station-in-internet-radio-mode-by-use-of-presets/262456
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
