### PR TITLE
Prometheus to support input_number

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -285,9 +285,7 @@ class PrometheusMetrics:
         metric.labels(**self._labels(state)).set(value)
 
     def _handle_input_number(self, state):
-        unit = self._unit_string(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT))
-
-        if unit:
+        if unit := self._unit_string(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
             metric = self._metric(
                 f"input_number_state_{unit}",
                 self.prometheus_cli.Gauge,
@@ -300,13 +298,11 @@ class PrometheusMetrics:
                 "State of the input number",
             )
 
-        try:
+        with suppress(ValueError):
             value = self.state_as_number(state)
             if state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_FAHRENHEIT:
                 value = fahrenheit_to_celsius(value)
             metric.labels(**self._labels(state)).set(value)
-        except ValueError:
-            pass
 
     def _handle_device_tracker(self, state):
         metric = self._metric(

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -1,11 +1,11 @@
 """Support for Prometheus metrics export."""
+from contextlib import suppress
 import logging
 import string
 
 from aiohttp import web
 import prometheus_client
 import voluptuous as vol
-from contextlib import suppress
 
 from homeassistant import core as hacore
 from homeassistant.components.climate.const import (

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -5,6 +5,7 @@ import string
 from aiohttp import web
 import prometheus_client
 import voluptuous as vol
+from contextlib import suppress
 
 from homeassistant import core as hacore
 from homeassistant.components.climate.const import (

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     DEGREE,
     ENERGY_KILO_WATT_HOUR,
     EVENT_STATE_CHANGED,
+    TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import split_entity_id
@@ -201,6 +202,13 @@ async def test_sensor_unit(hass, hass_client):
     sensor5.entity_id = "sensor.sps30_pm_1um_weight_concentration"
     await sensor5.async_update_ha_state()
 
+    sensor6 = DemoSensor(
+        None, "Target temperature", 22.7, None, None, TEMP_CELSIUS, None
+    )
+    sensor6.hass = hass
+    sensor6.entity_id = "input_number.target_temperature"
+    await sensor6.async_update_ha_state()
+
     await hass.async_block_till_done()
     body = await generate_latest_metrics(client)
 
@@ -226,6 +234,12 @@ async def test_sensor_unit(hass, hass_client):
         'sensor_unit_u0xb5g_per_mu0xb3{domain="sensor",'
         'entity="sensor.sps30_pm_1um_weight_concentration",'
         'friendly_name="SPS30 PM <1µm Weight concentration"} 3.7069' in body
+    )
+
+    assert (
+        'input_number_state_celsius{domain="input_number",'
+        'entity="input_number.target_temperature",'
+        'friendly_name="Target temperature"} 22.7' in body
     )
 
 
@@ -355,6 +369,11 @@ async def test_input_number(hass, hass_client):
     number2._attr_name = None
     await number2.async_update_ha_state()
 
+    number3 = DemoSensor(None, "Retry count", 5, None, None, None, None)
+    number3.hass = hass
+    number3.entity_id = "input_number.retry_count"
+    await number3.async_update_ha_state()
+
     await hass.async_block_till_done()
     body = await generate_latest_metrics(client)
 
@@ -368,6 +387,12 @@ async def test_input_number(hass, hass_client):
         'input_number_state{domain="input_number",'
         'entity="input_number.brightness",'
         'friendly_name="None"} 60.0' in body
+    )
+
+    assert (
+        'input_number_state{domain="input_number",'
+        'entity="input_number.retry_count",'
+        'friendly_name="Retry count"} 5.0' in body
     )
 
 


### PR DESCRIPTION
## Proposed change
Adding support of input_number domain to Prometheus


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
No documentation update required

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
