### PR TITLE
Improve Shelly color mode switch for dual mode bulbs

### DIFF
--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -369,8 +369,13 @@ class BlockShellyLight(ShellyBlockEntity, LightEntity):
                     self.wrapper.model,
                 )
 
-        if await self.set_light_mode(set_mode):
-            self.control_result = await self.set_state(**params)
+        # Shelly Color Bulb (SHCB-1) has mode parameter in ".../light/0/..."
+        if self.wrapper.model == "SHCB-1" and set_mode and self.mode != set_mode:
+            params["mode"] = set_mode
+            self.mode_result = self.control_result = await self.set_state(**params)
+        else:
+            if await self.set_light_mode(set_mode):
+                self.control_result = await self.set_state(**params)
 
         self.async_write_ha_state()
 

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -367,16 +367,10 @@ class BlockShellyLight(ShellyBlockEntity, LightEntity):
                     self.wrapper.model,
                 )
 
-        if (
-            set_mode
-            and self.mode != set_mode
-            and self.wrapper.model in DUAL_MODE_LIGHT_MODELS
-        ):
+        if set_mode and self.wrapper.model in DUAL_MODE_LIGHT_MODELS:
             params["mode"] = set_mode
-            self.mode_result = self.control_result = await self.set_state(**params)
-        else:
-            self.control_result = await self.set_state(**params)
 
+        self.control_result = await self.set_state(**params)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -1,12 +1,10 @@
 """Light for Shelly."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any, Final, cast
 
 from aioshelly.block_device import Block
-import async_timeout
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -35,7 +33,6 @@ from homeassistant.util.color import (
 
 from . import BlockDeviceWrapper, RpcDeviceWrapper
 from .const import (
-    AIOSHELLY_DEVICE_TIMEOUT_SEC,
     BLOCK,
     DATA_CONFIG_ENTRY,
     DOMAIN,
@@ -370,7 +367,11 @@ class BlockShellyLight(ShellyBlockEntity, LightEntity):
                     self.wrapper.model,
                 )
 
-        if set_mode and self.mode != set_mode and self.wrapper.model in DUAL_MODE_LIGHT_MODELS:
+        if (
+            set_mode
+            and self.mode != set_mode
+            and self.wrapper.model in DUAL_MODE_LIGHT_MODELS
+        ):
             params["mode"] = set_mode
             self.mode_result = self.control_result = await self.set_state(**params)
         else:

--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -134,7 +134,6 @@ class BlockShellyLight(ShellyBlockEntity, LightEntity):
         """Initialize light."""
         super().__init__(wrapper, block)
         self.control_result: dict[str, Any] | None = None
-        self.mode_result: dict[str, Any] | None = None
         self._supported_color_modes: set[str] = set()
         self._supported_features: int = 0
         self._min_kelvin: int = KELVIN_MIN_VALUE_WHITE
@@ -183,8 +182,8 @@ class BlockShellyLight(ShellyBlockEntity, LightEntity):
     @property
     def mode(self) -> str:
         """Return the color mode of the light."""
-        if self.mode_result:
-            return cast(str, self.mode_result["mode"])
+        if self.control_result and self.control_result.get("mode"):
+            return cast(str, self.control_result["mode"])
 
         if hasattr(self.block, "mode"):
             return cast(str, self.block.mode)
@@ -390,7 +389,6 @@ class BlockShellyLight(ShellyBlockEntity, LightEntity):
     def _update_callback(self) -> None:
         """When device updates, clear control & mode result that overrides state."""
         self.control_result = None
-        self.mode_result = None
         super()._update_callback()
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Shelly Color Bulb (SHCB-1) has mode parameter in ".../light/0/" command, so the mode change and color settings can be sent in 1 HTTP command.  In this case there are no flickering and only one record is created in the HA database.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
