### PR TITLE
Environment Canada config_flow fix

### DIFF
--- a/homeassistant/components/environment_canada/config_flow.py
+++ b/homeassistant/components/environment_canada/config_flow.py
@@ -17,9 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 
 async def validate_input(data):
     """Validate the user input allows us to connect."""
-    lat = data.get(CONF_LATITUDE)
-    lon = data.get(CONF_LONGITUDE)
-    station = data.get(CONF_STATION)
+    lat = data.get(CONF_LATITUDE, 0)
+    lon = data.get(CONF_LONGITUDE, 0)
+    station = data.get(CONF_STATION, "")
     lang = data.get(CONF_LANGUAGE)
 
     weather_data = ECWeather(

--- a/homeassistant/components/environment_canada/config_flow.py
+++ b/homeassistant/components/environment_canada/config_flow.py
@@ -17,16 +17,15 @@ _LOGGER = logging.getLogger(__name__)
 
 async def validate_input(data):
     """Validate the user input allows us to connect."""
-    lat = data.get(CONF_LATITUDE, 0)
-    lon = data.get(CONF_LONGITUDE, 0)
-    station = data.get(CONF_STATION, "")
-    lang = data.get(CONF_LANGUAGE)
+    lat = data.get(CONF_LATITUDE)
+    lon = data.get(CONF_LONGITUDE)
+    station = data.get(CONF_STATION)
+    lang = data.get(CONF_LANGUAGE).lower()
 
-    weather_data = ECWeather(
-        station_id=station,
-        coordinates=(lat, lon),
-        language=lang.lower(),
-    )
+    if station:
+        weather_data = ECWeather(station_id=station, language=lang)
+    else:
+        weather_data = ECWeather(coordinates=(lat, lon), language=lang)
     await weather_data.update()
 
     if lat is None or lon is None:

--- a/tests/components/environment_canada/test_config_flow.py
+++ b/tests/components/environment_canada/test_config_flow.py
@@ -123,7 +123,24 @@ async def test_exception_handling(hass, error):
         assert result["errors"] == {"base": base_error}
 
 
-async def test_lat_or_lon_not_specified(hass):
+async def test_import_station_not_specified(hass):
+    """Test that the import step works."""
+    with mocked_ec(), patch(
+        "homeassistant.components.environment_canada.async_setup_entry",
+        return_value=True,
+    ):
+        fake_config = dict(FAKE_CONFIG)
+        del fake_config[CONF_STATION]
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=fake_config
+        )
+        await hass.async_block_till_done()
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["data"] == FAKE_CONFIG
+        assert result["title"] == FAKE_TITLE
+
+
+async def test_import_lat_lon_not_specified(hass):
     """Test that the import step works."""
     with mocked_ec(), patch(
         "homeassistant.components.environment_canada.async_setup_entry",
@@ -131,6 +148,7 @@ async def test_lat_or_lon_not_specified(hass):
     ):
         fake_config = dict(FAKE_CONFIG)
         del fake_config[CONF_LATITUDE]
+        del fake_config[CONF_LONGITUDE]
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_IMPORT}, data=fake_config
         )


### PR DESCRIPTION


## Proposed change
Fix for https://github.com/home-assistant/core/issues/58907.

When moving to the async version of the library stricter parameter checking was put in place. This cause an exception on init of the library which caused the import flow to fail.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/58907
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
