### PR TITLE
Add SmartStart provisioning support to zwave_js WS API

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -208,8 +208,8 @@ QR_PROVISIONING_INFORMATION_SCHEMA = vol.All(
             vol.Required(PRODUCT_TYPE): int,
             vol.Required(PRODUCT_ID): int,
             vol.Required(APPLICATION_VERSION): str,
-            vol.Optional(MAX_INCLUSION_REQUEST_INTERVAL): int,
-            vol.Optional(UUID): str,
+            vol.Optional(MAX_INCLUSION_REQUEST_INTERVAL): vol.Any(int, None),
+            vol.Optional(UUID): vol.Any(str, None),
             vol.Optional(SUPPORTED_PROTOCOLS): vol.All(
                 cv.ensure_list,
                 [vol.Coerce(Protocols)],

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -143,8 +143,8 @@ UNPROVISION = "unprovision"
 MINIMUM_QR_STRING_LENGTH = 52
 
 
-def handle_planned_provisioning_entry(info: dict) -> ProvisioningEntry:
-    """Handle provisioning entry as provisioning input."""
+def convert_planned_provisioning_entry(info: dict) -> ProvisioningEntry:
+    """Handle provisioning entry dict to ProvisioningEntry."""
     info = ProvisioningEntry(
         dsk=info[DSK],
         security_classes=[SecurityClass(sec_cls) for sec_cls in info[SECURITY_CLASSES]],
@@ -155,8 +155,8 @@ def handle_planned_provisioning_entry(info: dict) -> ProvisioningEntry:
     return info
 
 
-def handle_qr_provisioning_information(info: dict) -> QRProvisioningInformation:
-    """Handle QR provisioning information as provisioning input."""
+def convert_qr_provisioning_information(info: dict) -> QRProvisioningInformation:
+    """Convert QR provisioning information dict to QRProvisioningInformation."""
     protocols = [Protocols(proto) for proto in info.get(SUPPORTED_PROTOCOLS, [])]
     info = QRProvisioningInformation(
         version=QRCodeVersion(info[VERSION]),
@@ -193,7 +193,7 @@ PLANNED_PROVISIONING_ENTRY_SCHEMA = vol.All(
         # Provisioning entries can have extra keys for SmartStart
         extra=vol.ALLOW_EXTRA,
     ),
-    handle_planned_provisioning_entry,
+    convert_planned_provisioning_entry,
 )
 
 QR_PROVISIONING_INFORMATION_SCHEMA = vol.All(
@@ -226,7 +226,7 @@ QR_PROVISIONING_INFORMATION_SCHEMA = vol.All(
             ),
         }
     ),
-    handle_qr_provisioning_information,
+    convert_qr_provisioning_information,
 )
 
 QR_CODE_STRING_SCHEMA = vol.All(str, vol.Length(min=MINIMUM_QR_STRING_LENGTH))

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -918,7 +918,7 @@ async def websocket_parse_qr_code_string(
         vol.Required(TYPE): "zwave_js/supports_feature",
         vol.Required(ENTRY_ID): str,
         vol.Required(FEATURE): vol.All(
-            vol.Coerce(int), vol.In(val.value for val in ZwaveFeature)
+            vol.Coerce(int), vol.In([val.value for val in ZwaveFeature])
         ),
     }
 )

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -124,15 +124,6 @@ QR_CODE_STRING = "qr_code_string"
 
 DSK = "dsk"
 
-PLANNED_PROVISIONING_ENTRY_SCHEMA = vol.Schema(
-    {
-        vol.Required(DSK): str,
-        vol.Required(SECURITY_CLASSES): vol.All(cv.ensure_list, [int]),
-    },
-    # Provisioning entries can have extra keys for SmartStart
-    extra=vol.ALLOW_EXTRA,
-)
-
 VERSION = "version"
 GENERIC_DEVICE_CLASS = "generic_device_class"
 SPECIFIC_DEVICE_CLASS = "specific_device_class"
@@ -144,6 +135,18 @@ APPLICATION_VERSION = "application_version"
 MAX_INCLUSION_REQUEST_INTERVAL = "max_inclusion_request_interval"
 UUID = "uuid"
 SUPPORTED_PROTOCOLS = "supported_protocols"
+
+UNPROVISION = "unprovision"
+
+# Helper schemas
+PLANNED_PROVISIONING_ENTRY_SCHEMA = vol.Schema(
+    {
+        vol.Required(DSK): str,
+        vol.Required(SECURITY_CLASSES): vol.All(cv.ensure_list, [int]),
+    },
+    # Provisioning entries can have extra keys for SmartStart
+    extra=vol.ALLOW_EXTRA,
+)
 
 QR_PROVISIONING_INFORMATION_SCHEMA = vol.Schema(
     {
@@ -914,6 +917,7 @@ async def websocket_stop_exclusion(
     {
         vol.Required(TYPE): "zwave_js/remove_node",
         vol.Required(ENTRY_ID): str,
+        vol.Optional(UNPROVISION): bool,
     }
 )
 @websocket_api.async_response
@@ -962,7 +966,7 @@ async def websocket_remove_node(
         controller.on("node removed", node_removed),
     ]
 
-    result = await controller.async_begin_exclusion()
+    result = await controller.async_begin_exclusion(msg.get(UNPROVISION))
     connection.send_result(
         msg[ID],
         result,

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -851,7 +851,7 @@ async def websocket_unprovision_smart_start_node(
             err.args[0],
         )
         return
-    dsk_or_node_id = msg.get(DSK) or msg.get(NODE_ID)
+    dsk_or_node_id = msg.get(DSK) or msg[NODE_ID]
     await client.driver.controller.async_unprovision_smart_start_node(dsk_or_node_id)
     connection.send_result(msg[ID])
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -116,7 +116,6 @@ DRY_RUN = "dry_run"
 # constants for inclusion
 INCLUSION_STRATEGY = "inclusion_strategy"
 PIN = "pin"
-PROVISIONING = "provisioning"
 FORCE_SECURITY = "force_security"
 PLANNED_PROVISIONING_ENTRY = "planned_provisioning_entry"
 QR_PROVISIONING_INFORMATION = "qr_provisioning_information"

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -250,50 +250,37 @@ def async_handle_failed_command(orig_func: Callable) -> Callable:
     return async_handle_failed_command_func
 
 
-def handle_planned_provisioning_entry(planned_provisioning_entry: dict) -> dict:
+def handle_planned_provisioning_entry(info: dict) -> ProvisioningEntry:
     """Handle provisioning entry as provisioning input."""
-    planned_provisioning_entry = ProvisioningEntry(
-        dsk=planned_provisioning_entry[DSK],
-        security_classes=[
-            SecurityClass(sec_cls)
-            for sec_cls in planned_provisioning_entry[SECURITY_CLASSES]
-        ],
+    info = ProvisioningEntry(
+        dsk=info[DSK],
+        security_classes=[SecurityClass(sec_cls) for sec_cls in info[SECURITY_CLASSES]],
         additional_properties={
-            k: v
-            for k, v in planned_provisioning_entry.items()
-            if k not in (DSK, SECURITY_CLASSES)
+            k: v for k, v in info.items() if k not in (DSK, SECURITY_CLASSES)
         },
     )
-    return planned_provisioning_entry
+    return info
 
 
-def handle_qr_provisioning_information(qr_provisioning_information: dict) -> dict:
+def handle_qr_provisioning_information(info: dict) -> QRProvisioningInformation:
     """Handle QR provisioning information as provisioning input."""
-    protocols = [
-        Protocols(proto)
-        for proto in qr_provisioning_information.get(SUPPORTED_PROTOCOLS, [])
-    ]
-    qr_provisioning_information = QRProvisioningInformation(
-        version=QRCodeVersion(qr_provisioning_information[VERSION]),
-        security_classes=[
-            SecurityClass(sec_cls)
-            for sec_cls in qr_provisioning_information[SECURITY_CLASSES]
-        ],
-        dsk=qr_provisioning_information[DSK],
-        generic_device_class=qr_provisioning_information[GENERIC_DEVICE_CLASS],
-        specific_device_class=qr_provisioning_information[SPECIFIC_DEVICE_CLASS],
-        installer_icon_type=qr_provisioning_information[INSTALLER_ICON_TYPE],
-        manufacturer_id=qr_provisioning_information[MANUFACTURER_ID],
-        product_type=qr_provisioning_information[PRODUCT_TYPE],
-        product_id=qr_provisioning_information[PRODUCT_ID],
-        application_version=qr_provisioning_information[APPLICATION_VERSION],
-        max_inclusion_request_interval=qr_provisioning_information.get(
-            MAX_INCLUSION_REQUEST_INTERVAL
-        ),
-        uuid=qr_provisioning_information.get(UUID),
+    protocols = [Protocols(proto) for proto in info.get(SUPPORTED_PROTOCOLS, [])]
+    info = QRProvisioningInformation(
+        version=QRCodeVersion(info[VERSION]),
+        security_classes=[SecurityClass(sec_cls) for sec_cls in info[SECURITY_CLASSES]],
+        dsk=info[DSK],
+        generic_device_class=info[GENERIC_DEVICE_CLASS],
+        specific_device_class=info[SPECIFIC_DEVICE_CLASS],
+        installer_icon_type=info[INSTALLER_ICON_TYPE],
+        manufacturer_id=info[MANUFACTURER_ID],
+        product_type=info[PRODUCT_TYPE],
+        product_id=info[PRODUCT_ID],
+        application_version=info[APPLICATION_VERSION],
+        max_inclusion_request_interval=info.get(MAX_INCLUSION_REQUEST_INTERVAL),
+        uuid=info.get(UUID),
         supported_protocols=protocols if protocols else None,
     )
-    return qr_provisioning_information
+    return info
 
 
 def validate_provisioning_info_for_inclusion_strategy(msg: dict) -> None:
@@ -811,9 +798,8 @@ async def websocket_provision_smart_start_node(
     provisioning_info = (
         msg.get(PLANNED_PROVISIONING_ENTRY)
         or msg.get(QR_PROVISIONING_INFORMATION)
-        or msg.get(QR_CODE_STRING)
+        or msg[QR_CODE_STRING]
     )
-    assert provisioning_info
 
     if (
         QR_PROVISIONING_INFORMATION in msg

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -797,20 +797,24 @@ async def websocket_provision_smart_start_node(
     client: Client,
 ) -> None:
     """Pre-provision a smart start node."""
-    if not (
-        provisioning_info := msg.get(PLANNED_PROVISIONING_ENTRY)
-        or msg.get(QR_PROVISIONING_INFORMATION)
-        or msg.get(QR_CODE_STRING)
-    ):
-        expected = ", ".join(
-            (PLANNED_PROVISIONING_ENTRY, QR_PROVISIONING_INFORMATION, QR_CODE_STRING)
-        )
+    try:
+        cv.has_at_least_one_key(
+            PLANNED_PROVISIONING_ENTRY, QR_PROVISIONING_INFORMATION, QR_CODE_STRING
+        )(msg)
+    except vol.Invalid as err:
         connection.send_error(
             msg[ID],
             ERR_INVALID_FORMAT,
-            f"must contain at least one of {expected}.",
+            err.args[0],
         )
         return
+
+    provisioning_info = (
+        msg.get(PLANNED_PROVISIONING_ENTRY)
+        or msg.get(QR_PROVISIONING_INFORMATION)
+        or msg.get(QR_CODE_STRING)
+    )
+    assert provisioning_info
 
     if (
         QR_PROVISIONING_INFORMATION in msg

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -137,6 +137,9 @@ SUPPORTED_PROTOCOLS = "supported_protocols"
 
 UNPROVISION = "unprovision"
 
+# https://github.com/zwave-js/node-zwave-js/blob/master/packages/core/src/security/QR.ts#L41
+MINIMUM_QR_STRING_LENGTH = 52
+
 # Helper schemas
 PLANNED_PROVISIONING_ENTRY_SCHEMA = vol.Schema(
     {
@@ -569,7 +572,9 @@ async def websocket_ping_node(
         vol.Exclusive(QR_PROVISIONING_INFORMATION, "options"): vol.All(
             QR_PROVISIONING_INFORMATION_SCHEMA, handle_qr_provisioning_information
         ),
-        vol.Exclusive(QR_CODE_STRING, "options"): str,
+        vol.Exclusive(QR_CODE_STRING, "options"): vol.All(
+            str, vol.Length(min=MINIMUM_QR_STRING_LENGTH)
+        ),
     }
 )
 @websocket_api.async_response
@@ -769,7 +774,9 @@ async def websocket_validate_dsk_and_enter_pin(
         vol.Exclusive(QR_PROVISIONING_INFORMATION, "options"): vol.All(
             QR_PROVISIONING_INFORMATION_SCHEMA, handle_qr_provisioning_information
         ),
-        vol.Exclusive(QR_CODE_STRING, "options"): str,
+        vol.Exclusive(QR_CODE_STRING, "options"): vol.All(
+            str, vol.Length(min=MINIMUM_QR_STRING_LENGTH)
+        ),
     }
 )
 @websocket_api.async_response
@@ -880,7 +887,9 @@ async def websocket_get_provisioning_entries(
     {
         vol.Required(TYPE): "zwave_js/parse_qr_code_string",
         vol.Required(ENTRY_ID): str,
-        vol.Required(QR_CODE_STRING): str,
+        vol.Required(QR_CODE_STRING): vol.All(
+            str, vol.Length(min=MINIMUM_QR_STRING_LENGTH)
+        ),
     }
 )
 @websocket_api.async_response
@@ -1029,7 +1038,9 @@ async def websocket_remove_node(
         vol.Exclusive(QR_PROVISIONING_INFORMATION, "options"): vol.All(
             QR_PROVISIONING_INFORMATION_SCHEMA, handle_qr_provisioning_information
         ),
-        vol.Exclusive(QR_CODE_STRING, "options"): str,
+        vol.Exclusive(QR_CODE_STRING, "options"): vol.All(
+            str, vol.Length(min=MINIMUM_QR_STRING_LENGTH)
+        ),
     }
 )
 @websocket_api.async_response

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -183,11 +183,7 @@ PLANNED_PROVISIONING_ENTRY_SCHEMA = vol.All(
             vol.Required(DSK): str,
             vol.Required(SECURITY_CLASSES): vol.All(
                 cv.ensure_list,
-                [
-                    vol.All(
-                        vol.Coerce(int), vol.In([val.value for val in SecurityClass])
-                    )
-                ],
+                [vol.Coerce(SecurityClass)],
             ),
         },
         # Provisioning entries can have extra keys for SmartStart
@@ -199,16 +195,10 @@ PLANNED_PROVISIONING_ENTRY_SCHEMA = vol.All(
 QR_PROVISIONING_INFORMATION_SCHEMA = vol.All(
     vol.Schema(
         {
-            vol.Required(VERSION): vol.All(
-                vol.Coerce(int), vol.In([val.value for val in QRCodeVersion])
-            ),
+            vol.Required(VERSION): vol.Coerce(QRCodeVersion),
             vol.Required(SECURITY_CLASSES): vol.All(
                 cv.ensure_list,
-                [
-                    vol.All(
-                        vol.Coerce(int), vol.In([val.value for val in SecurityClass])
-                    )
-                ],
+                [vol.Coerce(SecurityClass)],
             ),
             vol.Required(DSK): str,
             vol.Required(GENERIC_DEVICE_CLASS): int,
@@ -222,7 +212,7 @@ QR_PROVISIONING_INFORMATION_SCHEMA = vol.All(
             vol.Optional(UUID): str,
             vol.Optional(SUPPORTED_PROTOCOLS): vol.All(
                 cv.ensure_list,
-                [vol.All(vol.Coerce(int), vol.In([val.value for val in Protocols]))],
+                [vol.Coerce(Protocols)],
             ),
         }
     ),
@@ -718,12 +708,7 @@ async def websocket_add_node(
         vol.Required(ENTRY_ID): str,
         vol.Required(SECURITY_CLASSES): vol.All(
             cv.ensure_list,
-            [
-                vol.All(
-                    vol.Coerce(int),
-                    vol.In([sec_cls.value for sec_cls in SecurityClass]),
-                )
-            ],
+            [vol.Coerce(SecurityClass)],
         ),
         vol.Optional(CLIENT_SIDE_AUTH, default=False): bool,
     }
@@ -917,9 +902,7 @@ async def websocket_parse_qr_code_string(
     {
         vol.Required(TYPE): "zwave_js/supports_feature",
         vol.Required(ENTRY_ID): str,
-        vol.Required(FEATURE): vol.All(
-            vol.Coerce(int), vol.In([val.value for val in ZwaveFeature])
-        ),
+        vol.Required(FEATURE): vol.Coerce(ZwaveFeature),
     }
 )
 @websocket_api.async_response
@@ -933,9 +916,7 @@ async def websocket_supports_feature(
     client: Client,
 ) -> None:
     """Check if controller supports a particular feature."""
-    supported = await client.driver.controller.async_supports_feature(
-        ZwaveFeature(msg[FEATURE])
-    )
+    supported = await client.driver.controller.async_supports_feature(msg[FEATURE])
     connection.send_result(
         msg[ID],
         {"supported": supported},
@@ -1687,8 +1668,7 @@ async def websocket_subscribe_log_updates(
                     vol.Optional(LEVEL): vol.All(
                         str,
                         vol.Lower,
-                        vol.In([log_level.value for log_level in LogLevel]),
-                        lambda val: LogLevel(val),  # pylint: disable=unnecessary-lambda
+                        vol.Coerce(LogLevel),
                     ),
                     vol.Optional(LOG_TO_FILE): cv.boolean,
                     vol.Optional(FILENAME): str,

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -50,7 +50,7 @@ from homeassistant.components.zwave_js.api import (
     NODE_ID,
     OPTED_IN,
     PIN,
-    PLANNED_PROVISIIONING_ENTRY,
+    PLANNED_PROVISIONING_ENTRY,
     PRODUCT_ID,
     PRODUCT_TYPE,
     PROPERTY,
@@ -572,7 +572,7 @@ async def test_add_node(
             TYPE: "zwave_js/add_node",
             ENTRY_ID: entry.entry_id,
             INCLUSION_STRATEGY: InclusionStrategy.SECURITY_S2.value,
-            PLANNED_PROVISIIONING_ENTRY: {
+            PLANNED_PROVISIONING_ENTRY: {
                 DSK: "test",
                 SECURITY_CLASSES: [0],
             },
@@ -670,10 +670,40 @@ async def test_add_node(
     client.async_send_command.reset_mock()
     client.async_send_command.return_value = {"success": True}
 
-    # Test ValueError is caught as failure
+    # Test Smart Start QR provisioning information with S2 inclusion strategy fails
     await ws_client.send_json(
         {
             ID: 5,
+            TYPE: "zwave_js/add_node",
+            ENTRY_ID: entry.entry_id,
+            INCLUSION_STRATEGY: InclusionStrategy.SECURITY_S2.value,
+            QR_PROVISIONING_INFORMATION: {
+                VERSION: 1,
+                SECURITY_CLASSES: [0],
+                DSK: "test",
+                GENERIC_DEVICE_CLASS: 1,
+                SPECIFIC_DEVICE_CLASS: 1,
+                INSTALLER_ICON_TYPE: 1,
+                MANUFACTURER_ID: 1,
+                PRODUCT_TYPE: 1,
+                PRODUCT_ID: 1,
+                APPLICATION_VERSION: "test",
+            },
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+
+    assert len(client.async_send_command.call_args_list) == 0
+
+    client.async_send_command.reset_mock()
+    client.async_send_command.return_value = {" success": True}
+
+    # Test ValueError is caught as failure
+    await ws_client.send_json(
+        {
+            ID: 6,
             TYPE: "zwave_js/add_node",
             ENTRY_ID: entry.entry_id,
             INCLUSION_STRATEGY: InclusionStrategy.DEFAULT.value,
@@ -693,7 +723,7 @@ async def test_add_node(
     ):
         await ws_client.send_json(
             {
-                ID: 6,
+                ID: 7,
                 TYPE: "zwave_js/add_node",
                 ENTRY_ID: entry.entry_id,
             }
@@ -709,7 +739,7 @@ async def test_add_node(
     await hass.async_block_till_done()
 
     await ws_client.send_json(
-        {ID: 7, TYPE: "zwave_js/add_node", ENTRY_ID: entry.entry_id}
+        {ID: 8, TYPE: "zwave_js/add_node", ENTRY_ID: entry.entry_id}
     )
     msg = await ws_client.receive_json()
 
@@ -818,7 +848,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
             ID: 2,
             TYPE: "zwave_js/provision_smart_start_node",
             ENTRY_ID: entry.entry_id,
-            PLANNED_PROVISIIONING_ENTRY: {
+            PLANNED_PROVISIONING_ENTRY: {
                 DSK: "test",
                 SECURITY_CLASSES: [0],
             },
@@ -1004,6 +1034,23 @@ async def test_unprovision_smart_start_node(hass, integration, client, hass_ws_c
         "command": "controller.unprovision_smart_start_node",
         "dskOrNodeId": "test",
     }
+
+    client.async_send_command.reset_mock()
+    client.async_send_command.return_value = {}
+
+    # Test not including DSK or node ID as input fails
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/unprovision_smart_start_node",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+
+    assert len(client.async_send_command.call_args_list) == 0
 
     # Test FailedZWaveCommand is caught
     with patch(
@@ -1573,7 +1620,7 @@ async def test_replace_failed_node(
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,
             INCLUSION_STRATEGY: InclusionStrategy.SECURITY_S2.value,
-            PLANNED_PROVISIIONING_ENTRY: {
+            PLANNED_PROVISIONING_ENTRY: {
                 DSK: "test",
                 SECURITY_CLASSES: [0],
             },
@@ -1676,10 +1723,39 @@ async def test_replace_failed_node(
     client.async_send_command.reset_mock()
     client.async_send_command.return_value = {"success": True}
 
-    # Test ValueError is caught as failure
+    # Test S2 QR provisioning information with Smart Start inclusion strategy fails
     await ws_client.send_json(
         {
             ID: 5,
+            TYPE: "zwave_js/replace_failed_node",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 67,
+            INCLUSION_STRATEGY: InclusionStrategy.SMART_START.value,
+            QR_PROVISIONING_INFORMATION: {
+                VERSION: 0,
+                SECURITY_CLASSES: [0],
+                DSK: "test",
+                GENERIC_DEVICE_CLASS: 1,
+                SPECIFIC_DEVICE_CLASS: 1,
+                INSTALLER_ICON_TYPE: 1,
+                MANUFACTURER_ID: 1,
+                PRODUCT_TYPE: 1,
+                PRODUCT_ID: 1,
+                APPLICATION_VERSION: "test",
+            },
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+
+    client.async_send_command.reset_mock()
+    client.async_send_command.return_value = {"success": True}
+
+    # Test ValueError is caught as failure
+    await ws_client.send_json(
+        {
+            ID: 6,
             TYPE: "zwave_js/replace_failed_node",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,
@@ -1700,7 +1776,7 @@ async def test_replace_failed_node(
     ):
         await ws_client.send_json(
             {
-                ID: 6,
+                ID: 7,
                 TYPE: "zwave_js/replace_failed_node",
                 ENTRY_ID: entry.entry_id,
                 NODE_ID: 67,
@@ -1718,7 +1794,7 @@ async def test_replace_failed_node(
 
     await ws_client.send_json(
         {
-            ID: 7,
+            ID: 8,
             TYPE: "zwave_js/replace_failed_node",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -701,11 +701,7 @@ async def test_add_node(
     assert not msg["success"]
 
     # Even though inclusion fails, provision_smart_start_node should be called
-    assert len(client.async_send_command.call_args_list) == 1
-    assert (
-        client.async_send_command.call_args[0][0]["command"]
-        == "controller.provision_smart_start_node"
-    )
+    assert len(client.async_send_command.call_args_list) == 0
 
     client.async_send_command.reset_mock()
     client.async_send_command.return_value = {"success": True}

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -3159,7 +3159,7 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
     )
     msg = await ws_client.receive_json()
     assert not msg["success"]
-    assert "error" in msg and "value must be one of" in msg["error"]["message"]
+    assert "error" in msg and msg["error"]["code"] == "invalid_format"
 
     # Test error without service data
     await ws_client.send_json(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -12,6 +12,7 @@ from zwave_js_server.const import (
     Protocols,
     QRCodeVersion,
     SecurityClass,
+    ZwaveFeature,
 )
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import (
@@ -38,6 +39,7 @@ from homeassistant.components.zwave_js.api import (
     ENABLED,
     ENTRY_ID,
     ERR_NOT_LOADED,
+    FEATURE,
     FILENAME,
     FORCE_CONSOLE,
     GENERIC_DEVICE_CLASS,
@@ -1309,6 +1311,27 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
 
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_LOADED
+
+
+async def test_supports_feature(hass, integration, client, hass_ws_client):
+    """Test supports_feature websocket command."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+
+    client.async_send_command.return_value = {"supported": True}
+
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "zwave_js/supports_feature",
+            ENTRY_ID: entry.entry_id,
+            FEATURE: ZwaveFeature.SMART_START,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {"supported": True}
 
 
 async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_client):

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -700,7 +700,6 @@ async def test_add_node(
     msg = await ws_client.receive_json()
     assert not msg["success"]
 
-    # Even though inclusion fails, provision_smart_start_node should be called
     assert len(client.async_send_command.call_args_list) == 0
 
     client.async_send_command.reset_mock()

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -654,7 +654,7 @@ async def test_add_node(
             TYPE: "zwave_js/add_node",
             ENTRY_ID: entry.entry_id,
             INCLUSION_STRATEGY: InclusionStrategy.SECURITY_S2.value,
-            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
+            QR_CODE_STRING: "90testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 
@@ -666,7 +666,7 @@ async def test_add_node(
         "command": "controller.begin_inclusion",
         "options": {
             "strategy": InclusionStrategy.SECURITY_S2,
-            "provisioning": "testtesttesttesttesttesttesttesttesttesttesttesttest",
+            "provisioning": "90testtesttesttesttesttesttesttesttesttesttesttesttest",
         },
     }
 
@@ -698,6 +698,41 @@ async def test_add_node(
     msg = await ws_client.receive_json()
     assert not msg["success"]
 
+    # Even though inclusion fails, provision_smart_start_node should be called
+    assert len(client.async_send_command.call_args_list) == 1
+    assert (
+        client.async_send_command.call_args[0][0]["command"]
+        == "controller.provision_smart_start_node"
+    )
+
+    client.async_send_command.reset_mock()
+    client.async_send_command.return_value = {"success": True}
+
+    # Test QR provisioning information with S0 inclusion strategy fails
+    await ws_client.send_json(
+        {
+            ID: 5,
+            TYPE: "zwave_js/add_node",
+            ENTRY_ID: entry.entry_id,
+            INCLUSION_STRATEGY: InclusionStrategy.SECURITY_S0,
+            QR_PROVISIONING_INFORMATION: {
+                VERSION: 1,
+                SECURITY_CLASSES: [0],
+                DSK: "test",
+                GENERIC_DEVICE_CLASS: 1,
+                SPECIFIC_DEVICE_CLASS: 1,
+                INSTALLER_ICON_TYPE: 1,
+                MANUFACTURER_ID: 1,
+                PRODUCT_TYPE: 1,
+                PRODUCT_ID: 1,
+                APPLICATION_VERSION: "test",
+            },
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+
     assert len(client.async_send_command.call_args_list) == 0
 
     client.async_send_command.reset_mock()
@@ -710,7 +745,7 @@ async def test_add_node(
             TYPE: "zwave_js/add_node",
             ENTRY_ID: entry.entry_id,
             INCLUSION_STRATEGY: InclusionStrategy.DEFAULT.value,
-            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
+            QR_CODE_STRING: "90testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 
@@ -925,7 +960,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
             ID: 4,
             TYPE: "zwave_js/provision_smart_start_node",
             ENTRY_ID: entry.entry_id,
-            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
+            QR_CODE_STRING: "90testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 
@@ -935,7 +970,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
     assert len(client.async_send_command.call_args_list) == 1
     assert client.async_send_command.call_args[0][0] == {
         "command": "controller.provision_smart_start_node",
-        "entry": "testtesttesttesttesttesttesttesttesttesttesttesttest",
+        "entry": "90testtesttesttesttesttesttesttesttesttesttesttesttest",
     }
 
     client.async_send_command.reset_mock()
@@ -991,7 +1026,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
                 ID: 7,
                 TYPE: "zwave_js/provision_smart_start_node",
                 ENTRY_ID: entry.entry_id,
-                QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
+                QR_CODE_STRING: "90testtesttesttesttesttesttesttesttesttesttesttesttest",
             }
         )
         msg = await ws_client.receive_json()
@@ -1009,7 +1044,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
             ID: 8,
             TYPE: "zwave_js/provision_smart_start_node",
             ENTRY_ID: entry.entry_id,
-            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
+            QR_CODE_STRING: "90testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
     msg = await ws_client.receive_json()
@@ -1211,7 +1246,7 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
             ID: 1,
             TYPE: "zwave_js/parse_qr_code_string",
             ENTRY_ID: entry.entry_id,
-            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
+            QR_CODE_STRING: "90testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 
@@ -1236,7 +1271,7 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
     assert len(client.async_send_command.call_args_list) == 1
     assert client.async_send_command.call_args[0][0] == {
         "command": "utils.parse_qr_code_string",
-        "qr": "testtesttesttesttesttesttesttesttesttesttesttesttest",
+        "qr": "90testtesttesttesttesttesttesttesttesttesttesttesttest",
     }
 
     # Test FailedZWaveCommand is caught
@@ -1249,7 +1284,7 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
                 ID: 6,
                 TYPE: "zwave_js/parse_qr_code_string",
                 ENTRY_ID: entry.entry_id,
-                QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
+                QR_CODE_STRING: "90testtesttesttesttesttesttesttesttesttesttesttesttest",
             }
         )
         msg = await ws_client.receive_json()
@@ -1267,7 +1302,7 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
             ID: 7,
             TYPE: "zwave_js/parse_qr_code_string",
             ENTRY_ID: entry.entry_id,
-            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
+            QR_CODE_STRING: "90testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
     msg = await ws_client.receive_json()
@@ -1737,7 +1772,7 @@ async def test_replace_failed_node(
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,
             INCLUSION_STRATEGY: InclusionStrategy.SECURITY_S2.value,
-            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
+            QR_CODE_STRING: "90testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 
@@ -1750,38 +1785,9 @@ async def test_replace_failed_node(
         "nodeId": 67,
         "options": {
             "strategy": InclusionStrategy.SECURITY_S2,
-            "provisioning": "testtesttesttesttesttesttesttesttesttesttesttesttest",
+            "provisioning": "90testtesttesttesttesttesttesttesttesttesttesttesttest",
         },
     }
-
-    client.async_send_command.reset_mock()
-    client.async_send_command.return_value = {"success": True}
-
-    # Test S2 QR provisioning information with Smart Start inclusion strategy fails
-    await ws_client.send_json(
-        {
-            ID: 5,
-            TYPE: "zwave_js/replace_failed_node",
-            ENTRY_ID: entry.entry_id,
-            NODE_ID: 67,
-            INCLUSION_STRATEGY: InclusionStrategy.SMART_START.value,
-            QR_PROVISIONING_INFORMATION: {
-                VERSION: 0,
-                SECURITY_CLASSES: [0],
-                DSK: "test",
-                GENERIC_DEVICE_CLASS: 1,
-                SPECIFIC_DEVICE_CLASS: 1,
-                INSTALLER_ICON_TYPE: 1,
-                MANUFACTURER_ID: 1,
-                PRODUCT_TYPE: 1,
-                PRODUCT_ID: 1,
-                APPLICATION_VERSION: "test",
-            },
-        }
-    )
-
-    msg = await ws_client.receive_json()
-    assert not msg["success"]
 
     client.async_send_command.reset_mock()
     client.async_send_command.return_value = {"success": True}
@@ -1794,7 +1800,7 @@ async def test_replace_failed_node(
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,
             INCLUSION_STRATEGY: InclusionStrategy.DEFAULT.value,
-            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
+            QR_CODE_STRING: "90testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -876,7 +876,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
             TYPE: "zwave_js/provision_smart_start_node",
             ENTRY_ID: entry.entry_id,
             QR_PROVISIONING_INFORMATION: {
-                VERSION: 0,
+                VERSION: 1,
                 SECURITY_CLASSES: [0],
                 DSK: "test",
                 GENERIC_DEVICE_CLASS: 1,
@@ -897,7 +897,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
     assert client.async_send_command.call_args[0][0] == {
         "command": "controller.provision_smart_start_node",
         "entry": QRProvisioningInformation(
-            QRCodeVersion.S2,
+            QRCodeVersion.SMART_START,
             [SecurityClass.S2_UNAUTHENTICATED],
             "test",
             1,
@@ -938,10 +938,38 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
     client.async_send_command.reset_mock()
     client.async_send_command.return_value = {"success": True}
 
-    # Test no provisioning parameter provided causes failure
+    # Test QR provisioning information with S2 version throws error
     await ws_client.send_json(
         {
             ID: 5,
+            TYPE: "zwave_js/provision_smart_start_node",
+            ENTRY_ID: entry.entry_id,
+            QR_PROVISIONING_INFORMATION: {
+                VERSION: 0,
+                SECURITY_CLASSES: [0],
+                DSK: "test",
+                GENERIC_DEVICE_CLASS: 1,
+                SPECIFIC_DEVICE_CLASS: 1,
+                INSTALLER_ICON_TYPE: 1,
+                MANUFACTURER_ID: 1,
+                PRODUCT_TYPE: 1,
+                PRODUCT_ID: 1,
+                APPLICATION_VERSION: "test",
+            },
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+
+    client.async_send_command.reset_mock()
+    client.async_send_command.return_value = {"success": True}
+    assert len(client.async_send_command.call_args_list) == 0
+
+    # Test no provisioning parameter provided causes failure
+    await ws_client.send_json(
+        {
+            ID: 6,
             TYPE: "zwave_js/provision_smart_start_node",
             ENTRY_ID: entry.entry_id,
         }
@@ -957,7 +985,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
     ):
         await ws_client.send_json(
             {
-                ID: 6,
+                ID: 7,
                 TYPE: "zwave_js/provision_smart_start_node",
                 ENTRY_ID: entry.entry_id,
                 QR_CODE_STRING: "test",
@@ -975,7 +1003,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
 
     await ws_client.send_json(
         {
-            ID: 7,
+            ID: 8,
             TYPE: "zwave_js/provision_smart_start_node",
             ENTRY_ID: entry.entry_id,
             QR_CODE_STRING: "test",

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -654,7 +654,7 @@ async def test_add_node(
             TYPE: "zwave_js/add_node",
             ENTRY_ID: entry.entry_id,
             INCLUSION_STRATEGY: InclusionStrategy.SECURITY_S2.value,
-            QR_CODE_STRING: "test",
+            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 
@@ -664,7 +664,10 @@ async def test_add_node(
     assert len(client.async_send_command.call_args_list) == 1
     assert client.async_send_command.call_args[0][0] == {
         "command": "controller.begin_inclusion",
-        "options": {"strategy": InclusionStrategy.SECURITY_S2, "provisioning": "test"},
+        "options": {
+            "strategy": InclusionStrategy.SECURITY_S2,
+            "provisioning": "testtesttesttesttesttesttesttesttesttesttesttesttest",
+        },
     }
 
     client.async_send_command.reset_mock()
@@ -707,7 +710,7 @@ async def test_add_node(
             TYPE: "zwave_js/add_node",
             ENTRY_ID: entry.entry_id,
             INCLUSION_STRATEGY: InclusionStrategy.DEFAULT.value,
-            QR_CODE_STRING: "test",
+            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 
@@ -922,7 +925,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
             ID: 4,
             TYPE: "zwave_js/provision_smart_start_node",
             ENTRY_ID: entry.entry_id,
-            QR_CODE_STRING: "test",
+            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 
@@ -932,7 +935,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
     assert len(client.async_send_command.call_args_list) == 1
     assert client.async_send_command.call_args[0][0] == {
         "command": "controller.provision_smart_start_node",
-        "entry": "test",
+        "entry": "testtesttesttesttesttesttesttesttesttesttesttesttest",
     }
 
     client.async_send_command.reset_mock()
@@ -988,7 +991,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
                 ID: 7,
                 TYPE: "zwave_js/provision_smart_start_node",
                 ENTRY_ID: entry.entry_id,
-                QR_CODE_STRING: "test",
+                QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
             }
         )
         msg = await ws_client.receive_json()
@@ -1006,7 +1009,7 @@ async def test_provision_smart_start_node(hass, integration, client, hass_ws_cli
             ID: 8,
             TYPE: "zwave_js/provision_smart_start_node",
             ENTRY_ID: entry.entry_id,
-            QR_CODE_STRING: "test",
+            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
     msg = await ws_client.receive_json()
@@ -1208,7 +1211,7 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
             ID: 1,
             TYPE: "zwave_js/parse_qr_code_string",
             ENTRY_ID: entry.entry_id,
-            QR_CODE_STRING: "test",
+            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 
@@ -1233,7 +1236,7 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
     assert len(client.async_send_command.call_args_list) == 1
     assert client.async_send_command.call_args[0][0] == {
         "command": "utils.parse_qr_code_string",
-        "qr": "test",
+        "qr": "testtesttesttesttesttesttesttesttesttesttesttesttest",
     }
 
     # Test FailedZWaveCommand is caught
@@ -1246,7 +1249,7 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
                 ID: 6,
                 TYPE: "zwave_js/parse_qr_code_string",
                 ENTRY_ID: entry.entry_id,
-                QR_CODE_STRING: "test",
+                QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
             }
         )
         msg = await ws_client.receive_json()
@@ -1264,7 +1267,7 @@ async def test_parse_qr_code_string(hass, integration, client, hass_ws_client):
             ID: 7,
             TYPE: "zwave_js/parse_qr_code_string",
             ENTRY_ID: entry.entry_id,
-            QR_CODE_STRING: "test",
+            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
     msg = await ws_client.receive_json()
@@ -1734,7 +1737,7 @@ async def test_replace_failed_node(
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,
             INCLUSION_STRATEGY: InclusionStrategy.SECURITY_S2.value,
-            QR_CODE_STRING: "test",
+            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 
@@ -1745,7 +1748,10 @@ async def test_replace_failed_node(
     assert client.async_send_command.call_args[0][0] == {
         "command": "controller.replace_failed_node",
         "nodeId": 67,
-        "options": {"strategy": InclusionStrategy.SECURITY_S2, "provisioning": "test"},
+        "options": {
+            "strategy": InclusionStrategy.SECURITY_S2,
+            "provisioning": "testtesttesttesttesttesttesttesttesttesttesttesttest",
+        },
     }
 
     client.async_send_command.reset_mock()
@@ -1788,7 +1794,7 @@ async def test_replace_failed_node(
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,
             INCLUSION_STRATEGY: InclusionStrategy.DEFAULT.value,
-            QR_CODE_STRING: "test",
+            QR_CODE_STRING: "testtesttesttesttesttesttesttesttesttesttesttesttest",
         }
     )
 


### PR DESCRIPTION
## Proposed change
In this PR we update `add_node` and `replace_failed_node` commands to accept the new inputs. We also add the following commands:
- `provision_smart_start_node` - Pre-provision smart start node
- `unprovision_smart_start_node` - Remove pre-provisioned smart start node from provisioning list
- `get_provisioning_entries`- gets all registered provisioning entries
- `parse_qr_code_string` - Parses string from a QR code into provisioning information
- `supports_feature` - Returns whether controller supports a feature (Smart Start is the only feature to check at the moment)

And update `remove_node` to accept the optional `unprovision` parameter (also new)

The lib also has `get_provisioning_entry` but I am not sure that it would serve a purpose here unless we want to do something with it on the device info page for a node that was already added but the entry remains.

Dependent on https://github.com/home-assistant-libs/zwave-js-server-python/pull/315 and https://github.com/zwave-js/zwave-js-server/pull/432

Will be in draft for a bit while things get reviewed and released upstream, but I wanted to share this so that we could discuss any required changes to the model and plan the frontend work.

CC @MartinHjelmare 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
