### PR TITLE
Use entity category and state class in devolo Home Network

### DIFF
--- a/homeassistant/components/devolo_home_network/sensor.py
+++ b/homeassistant/components/devolo_home_network/sensor.py
@@ -7,8 +7,13 @@ from typing import Any
 
 from devolo_plc_api.device import Device
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    STATE_CLASS_MEASUREMENT,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -39,6 +44,7 @@ class DevoloSensorEntityDescription(
 SENSOR_TYPES: dict[str, DevoloSensorEntityDescription] = {
     CONNECTED_PLC_DEVICES: DevoloSensorEntityDescription(
         key=CONNECTED_PLC_DEVICES,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         entity_registry_enabled_default=False,
         icon="mdi:lan",
         name="Connected PLC devices",
@@ -51,10 +57,12 @@ SENSOR_TYPES: dict[str, DevoloSensorEntityDescription] = {
         entity_registry_enabled_default=True,
         icon="mdi:wifi",
         name="Connected Wifi clients",
+        state_class=STATE_CLASS_MEASUREMENT,
         value_func=lambda data: len(data["connected_stations"]),
     ),
     NEIGHBORING_WIFI_NETWORKS: DevoloSensorEntityDescription(
         key=NEIGHBORING_WIFI_NETWORKS,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         entity_registry_enabled_default=False,
         icon="mdi:wifi-marker",
         name="Neighboring Wifi networks",

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -8,9 +8,10 @@ from homeassistant.components.devolo_home_network.const import (
     LONG_UPDATE_INTERVAL,
     SHORT_UPDATE_INTERVAL,
 )
-from homeassistant.components.sensor import DOMAIN
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.components.sensor import DOMAIN, STATE_CLASS_MEASUREMENT
+from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry
 from homeassistant.util import dt
 
 from . import configure_integration
@@ -46,6 +47,7 @@ async def test_update_connected_wifi_clients(hass: HomeAssistant):
     state = hass.states.get(state_key)
     assert state is not None
     assert state.state == "1"
+    assert state.attributes["state_class"] == STATE_CLASS_MEASUREMENT
 
     # Emulate device failure
     with patch(
@@ -86,6 +88,9 @@ async def test_update_neighboring_wifi_networks(hass: HomeAssistant):
         assert state is not None
         assert state.state == "1"
 
+        er = entity_registry.async_get(hass)
+        assert er.async_get(state_key).entity_category == ENTITY_CATEGORY_DIAGNOSTIC
+
         # Emulate device failure
         with patch(
             "devolo_plc_api.device_api.deviceapi.DeviceApi.async_get_wifi_neighbor_access_points",
@@ -124,6 +129,9 @@ async def test_update_connected_plc_devices(hass: HomeAssistant):
         state = hass.states.get(state_key)
         assert state is not None
         assert state.state == "1"
+
+        er = entity_registry.async_get(hass)
+        assert er.async_get(state_key).entity_category == ENTITY_CATEGORY_DIAGNOSTIC
 
         # Emulate device failure
         with patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make use of entity category and state class in the devolo Home Network sensor platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
