### PR TITLE
Use saner native measurement units for xiaomi_miio sensors

### DIFF
--- a/homeassistant/components/xiaomi_miio/device.py
+++ b/homeassistant/components/xiaomi_miio/device.py
@@ -156,17 +156,16 @@ class XiaomiCoordinatedMiioEntity(CoordinatorEntity):
 
             return False
 
-    @classmethod
-    def _extract_value_from_attribute(cls, state, attribute):
+    def _extract_value_from_attribute(self, state, attribute):
         value = getattr(state, attribute)
         if isinstance(value, Enum):
             return value.value
         if isinstance(value, datetime.timedelta):
-            return cls._parse_time_delta(value)
+            return self._parse_time_delta(value)
         if isinstance(value, datetime.time):
-            return cls._parse_datetime_time(value)
+            return self._parse_datetime_time(value)
         if isinstance(value, datetime.datetime):
-            return cls._parse_datetime_datetime(value)
+            return self._parse_datetime_datetime(value)
 
         if value is None:
             _LOGGER.debug("Attribute %s is None, this is unexpected", attribute)

--- a/homeassistant/components/xiaomi_miio/device.py
+++ b/homeassistant/components/xiaomi_miio/device.py
@@ -173,8 +173,8 @@ class XiaomiCoordinatedMiioEntity(CoordinatorEntity):
         return value
 
     @staticmethod
-    def _parse_time_delta(timedelta: datetime.timedelta) -> int:
-        return int(timedelta.total_seconds())
+    def _parse_time_delta(value: datetime.timedelta) -> float:
+        return float(value.total_seconds())
 
     @staticmethod
     def _parse_datetime_time(time: datetime.time) -> str:

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -661,7 +661,7 @@ class XiaomiGenericSensor(XiaomiCoordinatedMiioEntity, SensorEntity):
         self._attr_native_value = self._determine_native_value()
         self._attr_extra_state_attributes = self._extract_attributes(coordinator.data)
 
-    def _extract_value_from_attribute(self, state, attribute):
+    def _parse_time_delta(self, value: timedelta) -> float:
         """Overridden to handle different time units for timedelta.
 
         This ensures that the device reported native values are converted to the ones
@@ -670,10 +670,6 @@ class XiaomiGenericSensor(XiaomiCoordinatedMiioEntity, SensorEntity):
         This needs to be done here as the parent class does not have access
         to the entity description.
         """
-        value = getattr(state, attribute)
-        if not isinstance(value, timedelta):
-            return super()._extract_value_from_attribute(state, attribute)
-
         conversion_map = {
             TIME_SECONDS: timedelta(seconds=1),
             TIME_MINUTES: timedelta(minutes=1),
@@ -682,11 +678,8 @@ class XiaomiGenericSensor(XiaomiCoordinatedMiioEntity, SensorEntity):
         }
 
         native_unit = self.entity_description.native_unit_of_measurement
-        if native_unit in conversion_map:
-            return round((value / conversion_map[native_unit]), 2)
 
-        _LOGGER.debug("No known conversion for %s, returning seconds", native_unit)
-        return value.total_seconds()
+        return round((value / conversion_map[native_unit]), 2)
 
     @callback
     def _extract_attributes(self, data):

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -677,9 +677,9 @@ class XiaomiGenericSensor(XiaomiCoordinatedMiioEntity, SensorEntity):
             TIME_DAYS: timedelta(days=1),
         }
 
-        native_unit = self.entity_description.native_unit_of_measurement
+        wanted_unit = self.entity_description.native_unit_of_measurement
 
-        return round((value / conversion_map[native_unit]), 2)
+        return round((value / conversion_map[wanted_unit]), 2)
 
     @callback
     def _extract_attributes(self, data):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The sensor values are not reported anymore in the device's native measurement unit (seconds),
but using a more suitable, sensor-specific units:
* Use Time, Total duration, Main Brush Left, Side Brush Left, and Filter Left are now reported in hours
* Last Clean Duration is reported in minutes

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR converts the xiaomi_miio vacuum sensor units to more human-readable ones instead of using the device-given, second granularity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59027
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
