### PR TITLE
Minor tweak of cv.deprecated + cv.removed

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -710,10 +710,10 @@ class multi_select:
 
 def _deprecated_or_removed(
     key: str,
-    replacement_key: str | None = None,
-    default: Any | None = None,
-    raise_if_present: bool | None = False,
-    option_status: str | None = "is deprecated",
+    replacement_key: str | None,
+    default: Any | None,
+    raise_if_present: bool,
+    removed: bool,
 ) -> Callable[[dict], dict]:
     """
     Log key as deprecated and provide a replacement (if exists) or fail.
@@ -735,36 +735,34 @@ def _deprecated_or_removed(
         # will be missing information, so let's guard.
         # https://github.com/home-assistant/core/issues/24982
         module_name = __name__
-    if replacement_key:
-        warning = (
-            "The '{key}' option {option_status},"
-            " please replace it with '{replacement_key}'"
-        )
+    if removed:
+        logger_func = logging.getLogger(module_name).error
+        option_status = "has been removed"
     else:
-        warning = (
-            "The '{key}' option {option_status},"
-            " please remove it from your configuration"
-        )
+        logger_func = logging.getLogger(module_name).warning
+        option_status = "is deprecated"
 
     def validator(config: dict) -> dict:
         """Check if key is in config and log warning or error."""
         if key in config:
             try:
-                warning_local = warning.replace(
-                    "'{key}' option",
-                    f"'{key}' option near {config.__config_file__}:{config.__line__}",  # type: ignore
-                )
+                near = f"near {config.__config_file__}:{config.__line__} "  # type: ignore
             except AttributeError:
-                warning_local = warning
-            warning_local = warning_local.format(
-                key=key,
-                replacement_key=replacement_key,
-                option_status=option_status,
-            )
-            if raise_if_present:
-                raise vol.Invalid(warning_local)
+                near = ""
+            arguments: tuple[str, ...]
+            if replacement_key:
+                warning = "The '%s' option %s%s, please replace it with '%s'"
+                arguments = (key, near, option_status, replacement_key)
+            else:
+                warning = (
+                    "The '%s' option %s%s, please remove it from your configuration"
+                )
+                arguments = (key, near, option_status)
 
-            logging.getLogger(module_name).warning(warning_local)
+            if raise_if_present:
+                raise vol.Invalid(warning % arguments)
+
+            logger_func(warning, *arguments)
             value = config[key]
             if replacement_key:
                 config.pop(key)
@@ -805,8 +803,8 @@ def deprecated(
         key,
         replacement_key=replacement_key,
         default=default,
-        raise_if_present=raise_if_present,
-        option_status="is deprecated",
+        raise_if_present=raise_if_present or False,
+        removed=False,
     )
 
 
@@ -825,8 +823,8 @@ def removed(
         key,
         replacement_key=None,
         default=default,
-        raise_if_present=raise_if_present,
-        option_status="was removed",
+        raise_if_present=raise_if_present or False,
+        removed=True,
     )
 
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -713,7 +713,7 @@ def _deprecated_or_removed(
     replacement_key: str | None,
     default: Any | None,
     raise_if_present: bool,
-    removed: bool,
+    option_removed: bool,
 ) -> Callable[[dict], dict]:
     """
     Log key as deprecated and provide a replacement (if exists) or fail.
@@ -735,7 +735,7 @@ def _deprecated_or_removed(
         # will be missing information, so let's guard.
         # https://github.com/home-assistant/core/issues/24982
         module_name = __name__
-    if removed:
+    if option_removed:
         logger_func = logging.getLogger(module_name).error
         option_status = "has been removed"
     else:
@@ -804,7 +804,7 @@ def deprecated(
         replacement_key=replacement_key,
         default=default,
         raise_if_present=raise_if_present or False,
-        removed=False,
+        option_removed=False,
     )
 
 
@@ -824,7 +824,7 @@ def removed(
         replacement_key=None,
         default=default,
         raise_if_present=raise_if_present or False,
-        removed=True,
+        option_removed=True,
     )
 
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -741,7 +741,7 @@ def test_deprecated_or_removed_param_and_raise(caplog, schema):
     with pytest.raises(vol.Invalid) as excinfo:
         deprecated_schema(test_data)
     assert (
-        "The 'mars' option was removed, please remove it from your configuration"
+        "The 'mars' option has been removed, please remove it from your configuration"
         in str(excinfo.value)
     )
     assert len(caplog.records) == 0
@@ -916,7 +916,7 @@ def test_deprecated_or_removed_logger_with_config_attributes(caplog):
     assert len(caplog.records) == 0
 
     # test as removed option
-    option_status = "was removed"
+    option_status = "has been removed"
     replacement = f"'mars' option near {file}:{line} {option_status}, please remove it from your configuration"
     config = OrderedDict([("mars", "blah")])
     setattr(config, "__config_file__", file)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Minor tweak of cv.deprecated + cv.removed:
 - Defer formatting of messages
 - Increase log severity of cv.removed to error

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
