### PR TITLE
Use unknown state for octoprint temperature sensors with None value

### DIFF
--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -211,16 +211,23 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
 
         for temp in printer.temperatures:
             if temp.name == self._api_tool:
-                return round(
+                val = (
                     temp.actual_temp
                     if self._temp_type == "actual"
-                    else temp.target_temp,
-                    2,
+                    else temp.target_temp
                 )
+                if not val:
+                    return None
+
+                return round(val, 2)
 
         return None
 
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success and self.coordinator.data["printer"]
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data["printer"]
+            and self.native_value
+        )

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -226,8 +226,4 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return (
-            self.coordinator.last_update_success
-            and self.coordinator.data["printer"]
-            and self.native_value is not None
-        )
+        return self.coordinator.last_update_success and self.coordinator.data["printer"]

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -216,7 +216,7 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
                     if self._temp_type == "actual"
                     else temp.target_temp
                 )
-                if not val:
+                if val is None:
                     return None
 
                 return round(val, 2)
@@ -229,5 +229,5 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
         return (
             self.coordinator.last_update_success
             and self.coordinator.data["printer"]
-            and self.native_value
+            and self.native_value is not None
         )

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -2,6 +2,8 @@
 from datetime import datetime
 from unittest.mock import patch
 
+from homeassistant.helpers import entity_registry as er
+
 from . import init_integration
 
 
@@ -24,7 +26,7 @@ async def test_sensors(hass):
     ):
         await init_integration(hass, "sensor", printer=printer, job=job)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     state = hass.states.get("sensor.octoprint_job_percentage")
     assert state is not None
@@ -90,7 +92,7 @@ async def test_sensors_no_target_temp(hass):
     ):
         await init_integration(hass, "sensor", printer=printer)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     state = hass.states.get("sensor.octoprint_actual_tool1_temp")
     assert state is not None

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -101,7 +101,7 @@ async def test_sensors_no_target_temp(hass):
 
     state = hass.states.get("sensor.octoprint_target_tool1_temp")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == "unknown"
     assert state.name == "OctoPrint target tool1 temp"
     entry = entity_registry.async_get("sensor.octoprint_target_tool1_temp")
     assert entry.unique_id == "target tool1 temp-uuid"

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -74,3 +74,34 @@ async def test_sensors(hass):
     assert state.name == "OctoPrint Estimated Finish Time"
     entry = entity_registry.async_get("sensor.octoprint_estimated_finish_time")
     assert entry.unique_id == "Estimated Finish Time-uuid"
+
+
+async def test_sensors_no_target_temp(hass):
+    """Test the underlying sensors."""
+    printer = {
+        "state": {
+            "flags": {},
+            "text": "Operational",
+        },
+        "temperature": {"tool1": {"actual": 18.83136, "target": None}},
+    }
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=datetime(2020, 2, 20, 9, 10, 0)
+    ):
+        await init_integration(hass, "sensor", printer=printer)
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    state = hass.states.get("sensor.octoprint_actual_tool1_temp")
+    assert state is not None
+    assert state.state == "18.83"
+    assert state.name == "OctoPrint actual tool1 temp"
+    entry = entity_registry.async_get("sensor.octoprint_actual_tool1_temp")
+    assert entry.unique_id == "actual tool1 temp-uuid"
+
+    state = hass.states.get("sensor.octoprint_target_tool1_temp")
+    assert state is not None
+    assert state.state == "unavailable"
+    assert state.name == "OctoPrint target tool1 temp"
+    entry = entity_registry.async_get("sensor.octoprint_target_tool1_temp")
+    assert entry.unique_id == "target tool1 temp-uuid"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Marks the temperature sensor as unavailable when the temperate is None

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59106
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
