### PR TITLE
Adjust frag_duration setting in stream

### DIFF
--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -102,18 +102,18 @@ class SegmentBuffer:
                         # The LL-HLS spec allows for a fragment's duration to be within the range [0.85x,1.0x]
                         # of the part target duration. We use the frag_duration option to tell ffmpeg to try to
                         # cut the fragments when they reach frag_duration. However, the resulting fragments can
-                        # have variability in their durations and can end up being too short or too long. If
-                        # there are two tracks, as in the case of a video feed with audio, the fragment cut seems
-                        # to be done on the first track that crosses the desired threshold, and cutting on the
-                        # audio track may result in a shorter video fragment than desired. Conversely, with a
+                        # have variability in their durations and can end up being too short or too long. With a
                         # video track with no audio, the discrete nature of frames means that the frame at the
                         # end of a fragment will sometimes extend slightly beyond the desired frag_duration.
-                        # Given this, our approach is to use a frag_duration near the upper end of the range for
-                        # outputs with audio using a frag_duration at the lower end of the range for outputs with
-                        # only video.
+                        # If there are two tracks, as in the case of a video feed with audio, there is an added
+                        # wrinkle as the fragment cut seems to be done on the first track that crosses the desired
+                        # threshold, and cutting on the audio track may also result in a shorter video fragment
+                        # than desired.
+                        # Given this, our approach is to give ffmpeg a frag_duration somewhere in the middle
+                        # of the range, hoping that the parts stay pretty well bounded, and we adjust the part
+                        # durations a bit in the hls metadata so that everything "looks" ok.
                         "frag_duration": str(
-                            self._stream_settings.part_target_duration
-                            * (98e4 if add_audio else 9e5)
+                            self._stream_settings.part_target_duration * 9e5
                         ),
                     }
                     if self._stream_settings.ll_hls


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As I was doing more testing with LL-HLS I noticed a playback artifact when using hls.js with one of my cameras. The playback loader is consistently skipping the last part in a segment. This can be addressed somewhat in the frontend via playback options, but I think the cause is when the media fragments are consistently slightly too long and the metadata reported is slightly shorter. Near the end of the segment, the loader sees that the duration of the media it has already equals the total duration indicated in the metadata, so the last part is skipped. However, when actually concatenating the media itself, there is now a hole where the missing fragment should belong, which can cause playback problems.
Previously the fragmenting strategy was to use a higher `frag_duration` parameter when streams have audio to avoid having any parts which are too short, as having any of these seems to break the iOS native player. However, with the addition of a floor for part duration metadata in #58036, this may not be a problem as long as the average part duration is still ok. Assuming this is the case, risking a too short part duration is better than risking a too long part duration, as a too long part duration may cause more issues with the last part having an inaccurate duration.
This value seems to work better for my cameras, but we may need to tweak things further or perhaps make this `frag_duration` multiplier a tunable parameter depending on what other users experience.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
