### PR TITLE
Add support for Irrigator (ggq) in Tuya

### DIFF
--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -181,6 +181,8 @@ class DPCode(str, Enum):
     CONTROL_2 = "control_2"
     CONTROL_3 = "control_3"
     CRY_DETECTION_SWITCH = "cry_detection_switch"
+    COUNTDOWN = "countdown"
+    COUNTDOWN_LEFT = "countdown_left"
     CUP_NUMBER = "cup_number"  # NUmber of cups
     CUR_CURRENT = "cur_current"  # Actual current
     CUR_POWER = "cur_power"  # Actual power

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -55,6 +55,15 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
             entity_category=ENTITY_CATEGORY_CONFIG,
         ),
     ),
+    # Irrigator
+    # https://developer.tuya.com/en/docs/iot/categoryggq?id=Kaiuz1qib7z0k
+    "ggq": (
+        NumberEntityDescription(
+            key=DPCode.COUNTDOWN,
+            name="Countdown",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+    ),
     # Human Presence Sensor
     # https://developer.tuya.com/en/docs/iot/categoryhps?id=Kaiuz42yhn1hs
     "hps": (

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -142,11 +142,6 @@ SENSORS: dict[str, tuple[SensorEntityDescription, ...]] = {
     # https://developer.tuya.com/en/docs/iot/categoryggq?id=Kaiuz1qib7z0k
     "ggq": (
         SensorEntityDescription(
-            key=DPCode.COUNTDOWN,
-            name="Countdown",
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        SensorEntityDescription(
             key=DPCode.COUNTDOWN_LEFT,
             name="Countdown left",
             state_class=STATE_CLASS_MEASUREMENT,

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -138,6 +138,9 @@ SENSORS: dict[str, tuple[SensorEntityDescription, ...]] = {
         ),
         *BATTERY_SENSORS,
     ),
+    # Irrigator
+    # https://developer.tuya.com/en/docs/iot/categoryggq?id=Kaiuz1qib7z0k
+    "ggq": BATTERY_SENSORS,
     # Switch
     # https://developer.tuya.com/en/docs/iot/s?id=K9gf7o5prgf7s
     "kg": (

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -143,12 +143,12 @@ SENSORS: dict[str, tuple[SensorEntityDescription, ...]] = {
     "ggq": (
         SensorEntityDescription(
             key=DPCode.COUNTDOWN,
-            name="Countdown",            
+            name="Countdown",
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         SensorEntityDescription(
             key=DPCode.COUNTDOWN_LEFT,
-            name="Countdown left",            
+            name="Countdown left",
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         *BATTERY_SENSORS,

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -140,7 +140,19 @@ SENSORS: dict[str, tuple[SensorEntityDescription, ...]] = {
     ),
     # Irrigator
     # https://developer.tuya.com/en/docs/iot/categoryggq?id=Kaiuz1qib7z0k
-    "ggq": BATTERY_SENSORS,
+    "ggq": (
+        SensorEntityDescription(
+            key=DPCode.COUNTDOWN,
+            name="Countdown",            
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        SensorEntityDescription(
+            key=DPCode.COUNTDOWN_LEFT,
+            name="Countdown left",            
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        *BATTERY_SENSORS,
+    ),
     # Switch
     # https://developer.tuya.com/en/docs/iot/s?id=K9gf7o5prgf7s
     "kg": (

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -92,6 +92,10 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     # https://developer.tuya.com/en/docs/iot/categoryggq?id=Kaiuz1qib7z0k
     "ggq": (
         SwitchEntityDescription(
+            key=DPCode.START,
+            name="Start",            
+        ),
+        SwitchEntityDescription(
             key=DPCode.SWITCH,
             name="Switch",
         ),

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -93,7 +93,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "ggq": (
         SwitchEntityDescription(
             key=DPCode.START,
-            name="Start",            
+            name="Start",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH,

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -92,12 +92,6 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     # https://developer.tuya.com/en/docs/iot/categoryggq?id=Kaiuz1qib7z0k
     "ggq": (
         SwitchEntityDescription(
-            key=DPCode.CHILD_LOCK,
-            name="Child Lock",
-            icon="mdi:account-lock",
-            entity_category=ENTITY_CATEGORY_CONFIG,
-        ),
-        SwitchEntityDescription(
             key=DPCode.SWITCH,
             name="Switch",
         ),

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -88,6 +88,20 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
             name="Switch",
         ),
     ),
+    # Irrigator
+    # https://developer.tuya.com/en/docs/iot/categoryggq?id=Kaiuz1qib7z0k
+    "ggq": (
+        SwitchEntityDescription(
+            key=DPCode.CHILD_LOCK,
+            name="Child Lock",
+            icon="mdi:account-lock",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            name="Switch",
+        ),
+    ),
     # Switch
     # https://developer.tuya.com/en/docs/iot/s?id=K9gf7o5prgf7s
     "kg": (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the support for Irrigation systems (Water Computer) with category ggq. 

https://developer.tuya.com/en/docs/iot/categoryggq?id=Kaiuz1qib7z0k

The following entities will be added:

- Switch
- Battery [%]
- Countdown [min]
- Countdown Left [min]

Source:
```json
{
   "biz_type":0,
   "category":"ggq",
   "icon":"smart/icon/ay1559701439060fw6BY/252620ee7b379e21c75db0d36b0aa39d.png",
   "model":"AOK6036",
   "name":"Water Computer",
   "product_id":"htnnfasr",
   "product_name":"Water Computer",
   "status":[
      {
         "code":"switch",
         "value":false
      },
      {
         "code":"countdown",
         "value":1
      },
      {
         "code":"countdown_left",
         "value":0
      },
      {
         "code":"battery_percentage",
         "value":90
      }
   ],
   "sub":true
}
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
