### PR TITLE
Add zwave_js select entity category

### DIFF
--- a/homeassistant/components/zwave_js/select.py
+++ b/homeassistant/components/zwave_js/select.py
@@ -9,6 +9,7 @@ from zwave_js_server.const.command_class.sound_switch import ToneID
 
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN, SelectEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -52,6 +53,8 @@ async def async_setup_entry(
 class ZwaveSelectEntity(ZWaveBaseEntity, SelectEntity):
     """Representation of a Z-Wave select entity."""
 
+    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+
     def __init__(
         self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
     ) -> None:
@@ -85,6 +88,8 @@ class ZwaveSelectEntity(ZWaveBaseEntity, SelectEntity):
 
 class ZwaveDefaultToneSelectEntity(ZWaveBaseEntity, SelectEntity):
     """Representation of a Z-Wave default tone select entity."""
+
+    _attr_entity_category = ENTITY_CATEGORY_CONFIG
 
     def __init__(
         self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo

--- a/tests/components/zwave_js/test_select.py
+++ b/tests/components/zwave_js/test_select.py
@@ -1,14 +1,25 @@
 """Test the Z-Wave JS number platform."""
-from zwave_js_server.event import Event
+from unittest.mock import MagicMock
 
-from homeassistant.const import STATE_UNKNOWN
+from zwave_js_server.event import Event
+from zwave_js_server.model.node import Node
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_CONFIG, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.entity_registry as er
 
 DEFAULT_TONE_SELECT_ENTITY = "select.indoor_siren_6_default_tone_2"
 PROTECTION_SELECT_ENTITY = "select.family_room_combo_local_protection_state"
 MULTILEVEL_SWITCH_SELECT_ENTITY = "select.front_door_siren"
 
 
-async def test_default_tone_select(hass, client, aeotec_zw164_siren, integration):
+async def test_default_tone_select(
+    hass: HomeAssistant,
+    client: MagicMock,
+    aeotec_zw164_siren: Node,
+    integration: ConfigEntry,
+) -> None:
     """Test the default tone select entity."""
     node = aeotec_zw164_siren
     state = hass.states.get(DEFAULT_TONE_SELECT_ENTITY)
@@ -47,6 +58,12 @@ async def test_default_tone_select(hass, client, aeotec_zw164_siren, integration
         "29UPWA~1 (2 sec)",
         "30DOOR~1 (27 sec)",
     ]
+
+    entity_registry = er.async_get(hass)
+    entity_entry = entity_registry.async_get(DEFAULT_TONE_SELECT_ENTITY)
+
+    assert entity_entry
+    assert entity_entry.entity_category == ENTITY_CATEGORY_CONFIG
 
     # Test select option with string value
     await hass.services.async_call(
@@ -102,10 +119,16 @@ async def test_default_tone_select(hass, client, aeotec_zw164_siren, integration
     node.receive_event(event)
 
     state = hass.states.get(DEFAULT_TONE_SELECT_ENTITY)
+    assert state
     assert state.state == "30DOOR~1 (27 sec)"
 
 
-async def test_protection_select(hass, client, inovelli_lzw36, integration):
+async def test_protection_select(
+    hass: HomeAssistant,
+    client: MagicMock,
+    inovelli_lzw36: Node,
+    integration: ConfigEntry,
+) -> None:
     """Test the default tone select entity."""
     node = inovelli_lzw36
     state = hass.states.get(PROTECTION_SELECT_ENTITY)
@@ -118,6 +141,12 @@ async def test_protection_select(hass, client, inovelli_lzw36, integration):
         "ProtectedBySequence",
         "NoOperationPossible",
     ]
+
+    entity_registry = er.async_get(hass)
+    entity_entry = entity_registry.async_get(PROTECTION_SELECT_ENTITY)
+
+    assert entity_entry
+    assert entity_entry.entity_category == ENTITY_CATEGORY_CONFIG
 
     # Test select option with string value
     await hass.services.async_call(
@@ -176,6 +205,7 @@ async def test_protection_select(hass, client, inovelli_lzw36, integration):
     node.receive_event(event)
 
     state = hass.states.get(PROTECTION_SELECT_ENTITY)
+    assert state
     assert state.state == "ProtectedBySequence"
 
     # Test null value
@@ -199,6 +229,7 @@ async def test_protection_select(hass, client, inovelli_lzw36, integration):
     node.receive_event(event)
 
     state = hass.states.get(PROTECTION_SELECT_ENTITY)
+    assert state
     assert state.state == STATE_UNKNOWN
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- Some select entities have been marked as config, eg default tone of siren devices and protection mode of smart plugs. Config entities:
  - Are not included in a service call targeting a whole device or area.
  - Are, by default, not exposed to Google Assistant or Alexa.
  - Are shown on a separate card on the device configuration page.
  - Do not show up on the automatically generated Lovelace Dashboards.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Categorize some select entities as config.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
