### PR TITLE
Add system health to devolo Home Network

### DIFF
--- a/homeassistant/components/devolo_home_network/strings.json
+++ b/homeassistant/components/devolo_home_network/strings.json
@@ -21,5 +21,10 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "home_control": "The devolo Home Control Central Unit does not work with this integration."
     }
+  },
+  "system_health": {
+    "info": {
+      "firmware_updates_available": "Firmware updates available"
+    }
   }
 }

--- a/homeassistant/components/devolo_home_network/system_health.py
+++ b/homeassistant/components/devolo_home_network/system_health.py
@@ -1,0 +1,34 @@
+"""Provide info to system health."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from homeassistant.components import system_health
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN
+
+
+@callback
+def async_register(
+    hass: HomeAssistant, register: system_health.SystemHealthRegistration
+) -> None:
+    """Register system health callbacks."""
+    register.async_register_info(system_health_info)
+
+
+async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
+    """Get info for the info page."""
+    states: list[bool] = []
+    firmware_updates_available = await asyncio.gather(
+        *[
+            entity["device"].device.async_check_firmware_available()
+            for entity in hass.data[DOMAIN].values()
+        ]
+    )
+
+    for result in firmware_updates_available:
+        states.append(result["result"] == "UPDATE_AVAILABLE")
+
+    return {"firmware_updates_available": any(states)}

--- a/tests/components/devolo_home_network/conftest.py
+++ b/tests/components/devolo_home_network/conftest.py
@@ -5,7 +5,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from . import async_connect
-from .const import CONNECTED_STATIONS, DISCOVERY_INFO, NEIGHBOR_ACCESS_POINTS, PLCNET
+from .const import (
+    CONNECTED_STATIONS,
+    DISCOVERY_INFO,
+    FIRMWARE_UPDATE_AVAILABLE,
+    NEIGHBOR_ACCESS_POINTS,
+    PLCNET,
+)
 
 
 @pytest.fixture()
@@ -13,6 +19,9 @@ def mock_device():
     """Mock connecting to a devolo home network device."""
     with patch("devolo_plc_api.device.Device.async_connect", async_connect), patch(
         "devolo_plc_api.device.Device.async_disconnect"
+    ), patch(
+        "devolo_plc_api.device_api.deviceapi.DeviceApi.async_check_firmware_available",
+        new=AsyncMock(return_value=FIRMWARE_UPDATE_AVAILABLE),
     ), patch(
         "devolo_plc_api.device_api.deviceapi.DeviceApi.async_get_wifi_connected_station",
         new=AsyncMock(return_value=CONNECTED_STATIONS),

--- a/tests/components/devolo_home_network/const.py
+++ b/tests/components/devolo_home_network/const.py
@@ -39,8 +39,8 @@ DISCOVERY_INFO = zeroconf.HaServiceInfo(
 DISCOVERY_INFO_WRONG_DEVICE = zeroconf.HaServiceInfo(properties={"MT": "2600"})
 
 FIRMWARE_UPDATE_AVAILABLE = {
-    "result": "UPDATE_NOT_AVAILABLE",
-    "new_firmware_version": "",
+    "result": "UPDATE_AVAILABLE",
+    "new_firmware_version": "5.4.3",
 }
 
 NEIGHBOR_ACCESS_POINTS = {

--- a/tests/components/devolo_home_network/const.py
+++ b/tests/components/devolo_home_network/const.py
@@ -38,6 +38,11 @@ DISCOVERY_INFO = zeroconf.HaServiceInfo(
 
 DISCOVERY_INFO_WRONG_DEVICE = zeroconf.HaServiceInfo(properties={"MT": "2600"})
 
+FIRMWARE_UPDATE_AVAILABLE = {
+    "result": "UPDATE_NOT_AVAILABLE",
+    "new_firmware_version": "",
+}
+
 NEIGHBOR_ACCESS_POINTS = {
     "neighbor_aps": [
         {

--- a/tests/components/devolo_home_network/test_system_health.py
+++ b/tests/components/devolo_home_network/test_system_health.py
@@ -1,4 +1,7 @@
 """Tests for the devolo Home Network system health."""
+from unittest.mock import patch
+
+from devolo_plc_api.exceptions.device import DeviceUnavailable
 import pytest
 
 from homeassistant.components.devolo_home_network.const import DOMAIN
@@ -21,5 +24,11 @@ async def test_system_health(hass: HomeAssistant):
     await hass.async_block_till_done()
 
     info = await get_system_health_info(hass, DOMAIN)
+    assert info["firmware_updates_available"] is True
 
-    assert info["firmware_updates_available"] is False
+    with patch(
+        "devolo_plc_api.device_api.deviceapi.DeviceApi.async_check_firmware_available",
+        side_effect=DeviceUnavailable,
+    ):
+        info = await get_system_health_info(hass, DOMAIN)
+        assert info["firmware_updates_available"] is False

--- a/tests/components/devolo_home_network/test_system_health.py
+++ b/tests/components/devolo_home_network/test_system_health.py
@@ -1,0 +1,24 @@
+"""Tests for the devolo Home Network system health."""
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import configure_integration
+
+from tests.common import get_system_health_info
+
+
+@pytest.mark.usefixtures("mock_device")
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_system_health(hass: HomeAssistant):
+    """Test system health."""
+    await async_setup_component(hass, "system_health", {})
+
+    entry = configure_integration(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    info = await get_system_health_info(hass, "devolo_home_network")
+
+    assert info["firmware_updates_available"] is False

--- a/tests/components/devolo_home_network/test_system_health.py
+++ b/tests/components/devolo_home_network/test_system_health.py
@@ -1,6 +1,7 @@
 """Tests for the devolo Home Network system health."""
 import pytest
 
+from homeassistant.components.devolo_home_network.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -19,6 +20,6 @@ async def test_system_health(hass: HomeAssistant):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    info = await get_system_health_info(hass, "devolo_home_network")
+    info = await get_system_health_info(hass, DOMAIN)
 
     assert info["firmware_updates_available"] is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add system health to devolo Home Network currently showing, if there is a firmware update available for any device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
