### PR TITLE
Fix totalconnect config flow

### DIFF
--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -38,7 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         TotalConnectClient, username, password, usercodes
     )
 
-    if not client.is_valid_credentials():
+    if not client.is_logged_in():
         raise ConfigEntryAuthFailed("TotalConnect authentication failed")
 
     coordinator = TotalConnectDataUpdateCoordinator(hass, client)

--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -88,5 +88,3 @@ class TotalConnectDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(exception) from exception
         except ValueError as exception:
             raise UpdateFailed("Unknown state from TotalConnect") from exception
-
-        return True

--- a/homeassistant/components/totalconnect/config_flow.py
+++ b/homeassistant/components/totalconnect/config_flow.py
@@ -40,7 +40,7 @@ class TotalConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 TotalConnectClient, username, password, None
             )
 
-            if client.is_valid_credentials():
+            if client.is_logged_in():
                 # username/password valid so show user locations
                 self.username = username
                 self.password = password
@@ -136,7 +136,7 @@ class TotalConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.usercodes,
         )
 
-        if not client.is_valid_credentials():
+        if not client.is_logged_in():
             errors["base"] = "invalid_auth"
             return self.async_show_form(
                 step_id="reauth_confirm",

--- a/homeassistant/components/totalconnect/config_flow.py
+++ b/homeassistant/components/totalconnect/config_flow.py
@@ -4,6 +4,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import CONF_USERCODES, DOMAIN
 
@@ -88,6 +89,14 @@ class TotalConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
         else:
+            # Force the loading of locations using I/O
+            number_locations = await self.hass.async_add_executor_job(
+                self.client.get_number_locations,
+            )
+            if number_locations < 1:
+                raise HomeAssistantError(
+                    "There are no locations enabled or available for this TotalConnect user."
+                )
             for location_id in self.client.locations:
                 self.usercodes[location_id] = None
 

--- a/homeassistant/components/totalconnect/manifest.json
+++ b/homeassistant/components/totalconnect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "totalconnect",
   "name": "Total Connect",
   "documentation": "https://www.home-assistant.io/integrations/totalconnect",
-  "requirements": ["total_connect_client==2021.10"],
+  "requirements": ["total_connect_client==2021.11.1"],
   "dependencies": [],
   "codeowners": ["@austinmroczek"],
   "config_flow": true,

--- a/homeassistant/components/totalconnect/manifest.json
+++ b/homeassistant/components/totalconnect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "totalconnect",
   "name": "Total Connect",
   "documentation": "https://www.home-assistant.io/integrations/totalconnect",
-  "requirements": ["total_connect_client==2021.8.3"],
+  "requirements": ["total_connect_client==2021.10"],
   "dependencies": [],
   "codeowners": ["@austinmroczek"],
   "config_flow": true,

--- a/homeassistant/components/totalconnect/manifest.json
+++ b/homeassistant/components/totalconnect/manifest.json
@@ -2,7 +2,7 @@
   "domain": "totalconnect",
   "name": "Total Connect",
   "documentation": "https://www.home-assistant.io/integrations/totalconnect",
-  "requirements": ["total_connect_client==2021.11.1"],
+  "requirements": ["total_connect_client==2021.11.2"],
   "dependencies": [],
   "codeowners": ["@austinmroczek"],
   "config_flow": true,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2320,7 +2320,7 @@ todoist-python==8.0.0
 toonapi==0.2.1
 
 # homeassistant.components.totalconnect
-total_connect_client==2021.10
+total_connect_client==2021.11.1
 
 # homeassistant.components.tplink_lte
 tp-connected==0.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2320,7 +2320,7 @@ todoist-python==8.0.0
 toonapi==0.2.1
 
 # homeassistant.components.totalconnect
-total_connect_client==2021.8.3
+total_connect_client==2021.10
 
 # homeassistant.components.tplink_lte
 tp-connected==0.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2320,7 +2320,7 @@ todoist-python==8.0.0
 toonapi==0.2.1
 
 # homeassistant.components.totalconnect
-total_connect_client==2021.11.1
+total_connect_client==2021.11.2
 
 # homeassistant.components.tplink_lte
 tp-connected==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1339,7 +1339,7 @@ tesla-powerwall==0.3.12
 toonapi==0.2.1
 
 # homeassistant.components.totalconnect
-total_connect_client==2021.8.3
+total_connect_client==2021.10
 
 # homeassistant.components.transmission
 transmissionrpc==0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1339,7 +1339,7 @@ tesla-powerwall==0.3.12
 toonapi==0.2.1
 
 # homeassistant.components.totalconnect
-total_connect_client==2021.10
+total_connect_client==2021.11.1
 
 # homeassistant.components.transmission
 transmissionrpc==0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1339,7 +1339,7 @@ tesla-powerwall==0.3.12
 toonapi==0.2.1
 
 # homeassistant.components.totalconnect
-total_connect_client==2021.11.1
+total_connect_client==2021.11.2
 
 # homeassistant.components.transmission
 transmissionrpc==0.11

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -1,8 +1,7 @@
 """Common methods used across tests for TotalConnect."""
 from unittest.mock import patch
 
-from total_connect_client.const import ArmingState, _ResultCode
-from total_connect_client.zone import ZoneStatus, ZoneType
+from total_connect_client import ArmingState, ResultCode, ZoneStatus, ZoneType
 
 from homeassistant.components.totalconnect.const import CONF_USERCODES, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -43,7 +42,7 @@ USER = {
 }
 
 RESPONSE_AUTHENTICATE = {
-    "ResultCode": _ResultCode.SUCCESS.value,
+    "ResultCode": ResultCode.SUCCESS.value,
     "SessionID": 1,
     "Locations": LOCATIONS,
     "ModuleFlags": MODULE_FLAGS,
@@ -51,7 +50,7 @@ RESPONSE_AUTHENTICATE = {
 }
 
 RESPONSE_AUTHENTICATE_FAILED = {
-    "ResultCode": _ResultCode.BAD_USER_OR_PASSWORD.value,
+    "ResultCode": ResultCode.BAD_USER_OR_PASSWORD.value,
     "ResultData": "test bad authentication",
 }
 
@@ -254,18 +253,18 @@ RESPONSE_UNKNOWN = {
     "ArmingState": ArmingState.DISARMED,
 }
 
-RESPONSE_ARM_SUCCESS = {"ResultCode": _ResultCode.ARM_SUCCESS.value}
-RESPONSE_ARM_FAILURE = {"ResultCode": _ResultCode.COMMAND_FAILED.value}
-RESPONSE_DISARM_SUCCESS = {"ResultCode": _ResultCode.DISARM_SUCCESS.value}
+RESPONSE_ARM_SUCCESS = {"ResultCode": ResultCode.ARM_SUCCESS.value}
+RESPONSE_ARM_FAILURE = {"ResultCode": ResultCode.COMMAND_FAILED.value}
+RESPONSE_DISARM_SUCCESS = {"ResultCode": ResultCode.DISARM_SUCCESS.value}
 RESPONSE_DISARM_FAILURE = {
-    "ResultCode": _ResultCode.COMMAND_FAILED.value,
+    "ResultCode": ResultCode.COMMAND_FAILED.value,
     "ResultData": "Command Failed",
 }
 RESPONSE_USER_CODE_INVALID = {
-    "ResultCode": _ResultCode.USER_CODE_INVALID.value,
+    "ResultCode": ResultCode.USER_CODE_INVALID.value,
     "ResultData": "testing user code invalid",
 }
-RESPONSE_SUCCESS = {"ResultCode": _ResultCode.SUCCESS.value}
+RESPONSE_SUCCESS = {"ResultCode": ResultCode.SUCCESS.value}
 
 USERNAME = "username@me.com"
 PASSWORD = "password"
@@ -291,7 +290,7 @@ PARTITION_DETAILS_2 = {
 
 PARTITION_DETAILS = {"PartitionDetails": [PARTITION_DETAILS_1, PARTITION_DETAILS_2]}
 RESPONSE_PARTITION_DETAILS = {
-    "ResultCode": _ResultCode.SUCCESS.value,
+    "ResultCode": ResultCode.SUCCESS.value,
     "ResultData": "testing partition details",
     "PartitionsInfoList": PARTITION_DETAILS,
 }

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -1,8 +1,7 @@
 """Common methods used across tests for TotalConnect."""
 from unittest.mock import patch
 
-from total_connect_client.client import TotalConnectClient
-from total_connect_client.const import ArmingState
+from total_connect_client.const import ArmingState, _ResultCode
 from total_connect_client.zone import ZoneStatus, ZoneType
 
 from homeassistant.components.totalconnect.const import CONF_USERCODES, DOMAIN
@@ -44,7 +43,7 @@ USER = {
 }
 
 RESPONSE_AUTHENTICATE = {
-    "ResultCode": TotalConnectClient.SUCCESS,
+    "ResultCode": _ResultCode.SUCCESS.value,
     "SessionID": 1,
     "Locations": LOCATIONS,
     "ModuleFlags": MODULE_FLAGS,
@@ -52,7 +51,7 @@ RESPONSE_AUTHENTICATE = {
 }
 
 RESPONSE_AUTHENTICATE_FAILED = {
-    "ResultCode": TotalConnectClient.BAD_USER_OR_PASSWORD,
+    "ResultCode": _ResultCode.BAD_USER_OR_PASSWORD.value,
     "ResultData": "test bad authentication",
 }
 
@@ -255,18 +254,18 @@ RESPONSE_UNKNOWN = {
     "ArmingState": ArmingState.DISARMED,
 }
 
-RESPONSE_ARM_SUCCESS = {"ResultCode": TotalConnectClient.ARM_SUCCESS}
-RESPONSE_ARM_FAILURE = {"ResultCode": TotalConnectClient.COMMAND_FAILED}
-RESPONSE_DISARM_SUCCESS = {"ResultCode": TotalConnectClient.DISARM_SUCCESS}
+RESPONSE_ARM_SUCCESS = {"ResultCode": _ResultCode.ARM_SUCCESS.value}
+RESPONSE_ARM_FAILURE = {"ResultCode": _ResultCode.COMMAND_FAILED.value}
+RESPONSE_DISARM_SUCCESS = {"ResultCode": _ResultCode.DISARM_SUCCESS.value}
 RESPONSE_DISARM_FAILURE = {
-    "ResultCode": TotalConnectClient.COMMAND_FAILED,
+    "ResultCode": _ResultCode.COMMAND_FAILED.value,
     "ResultData": "Command Failed",
 }
 RESPONSE_USER_CODE_INVALID = {
-    "ResultCode": TotalConnectClient.USER_CODE_INVALID,
+    "ResultCode": _ResultCode.USER_CODE_INVALID.value,
     "ResultData": "testing user code invalid",
 }
-RESPONSE_SUCCESS = {"ResultCode": TotalConnectClient.SUCCESS}
+RESPONSE_SUCCESS = {"ResultCode": _ResultCode.SUCCESS.value}
 
 USERNAME = "username@me.com"
 PASSWORD = "password"
@@ -292,7 +291,7 @@ PARTITION_DETAILS_2 = {
 
 PARTITION_DETAILS = {"PartitionDetails": [PARTITION_DETAILS_1, PARTITION_DETAILS_2]}
 RESPONSE_PARTITION_DETAILS = {
-    "ResultCode": TotalConnectClient.SUCCESS,
+    "ResultCode": _ResultCode.SUCCESS.value,
     "ResultData": "testing partition details",
     "PartitionsInfoList": PARTITION_DETAILS,
 }

--- a/tests/components/totalconnect/test_config_flow.py
+++ b/tests/components/totalconnect/test_config_flow.py
@@ -95,7 +95,7 @@ async def test_abort_if_already_setup(hass):
     with patch(
         "homeassistant.components.totalconnect.config_flow.TotalConnectClient"
     ) as client_mock:
-        client_mock.return_value.is_valid_credentials.return_value = True
+        client_mock.return_value.is_logged_in.return_value = True
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
@@ -111,7 +111,7 @@ async def test_login_failed(hass):
     with patch(
         "homeassistant.components.totalconnect.config_flow.TotalConnectClient"
     ) as client_mock:
-        client_mock.return_value.is_valid_credentials.return_value = False
+        client_mock.return_value.is_logged_in.return_value = False
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
@@ -143,7 +143,7 @@ async def test_reauth(hass):
         "homeassistant.components.totalconnect.async_setup_entry", return_value=True
     ):
         # first test with an invalid password
-        client_mock.return_value.is_valid_credentials.return_value = False
+        client_mock.return_value.is_logged_in.return_value = False
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PASSWORD: "password"}
@@ -153,7 +153,7 @@ async def test_reauth(hass):
         assert result["errors"] == {"base": "invalid_auth"}
 
         # now test with the password valid
-        client_mock.return_value.is_valid_credentials.return_value = True
+        client_mock.return_value.is_logged_in.return_value = True
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PASSWORD: "password"}

--- a/tests/components/totalconnect/test_config_flow.py
+++ b/tests/components/totalconnect/test_config_flow.py
@@ -1,10 +1,13 @@
 """Tests for the TotalConnect config flow."""
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import data_entry_flow
 from homeassistant.components.totalconnect.const import CONF_USERCODES, DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_PASSWORD
+from homeassistant.exceptions import HomeAssistantError
 
 from .common import (
     CONFIG_DATA,
@@ -163,3 +166,34 @@ async def test_reauth(hass):
         await hass.async_block_till_done()
 
     assert len(hass.config_entries.async_entries()) == 1
+
+
+async def test_no_locations(hass):
+    """Test with no user locations."""
+    # user/pass provided, so check if valid then ask for usercodes on locations form
+    responses = [
+        RESPONSE_AUTHENTICATE,
+        RESPONSE_PARTITION_DETAILS,
+        RESPONSE_GET_ZONE_DETAILS_SUCCESS,
+        RESPONSE_DISARMED,
+    ]
+
+    with patch(TOTALCONNECT_REQUEST, side_effect=responses,) as mock_request, patch(
+        "homeassistant.components.totalconnect.async_setup_entry", return_value=True
+    ), patch(
+        "homeassistant.components.totalconnect.TotalConnectClient.get_number_locations",
+        return_value=0,
+    ):
+
+        with pytest.raises(HomeAssistantError) as err:
+            await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_USER},
+                data=CONFIG_DATA_NO_USERCODES,
+            )
+
+        assert (
+            f"{err.value}"
+            == "There are no locations enabled or available for this TotalConnect user."
+        )
+        assert mock_request.call_count == 1

--- a/tests/components/totalconnect/test_init.py
+++ b/tests/components/totalconnect/test_init.py
@@ -22,7 +22,7 @@ async def test_reauth_started(hass):
         "homeassistant.components.totalconnect.TotalConnectClient",
         autospec=True,
     ) as mock_client:
-        mock_client.return_value.is_valid_credentials.return_value = False
+        mock_client.return_value.is_logged_in.return_value = False
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This fixes the bug preventing new TotalConnect integrations being created from the configuration flow.  

I forgot to account for an upstream change that used synchronous IO in a new spot, and it was hidden by the way I'm using Mock in tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/59263
- This PR is related to issue: https://github.com/home-assistant/core/pull/58818
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [n/a] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
