### PR TITLE
Support generic xiaomi_miio vacuums

### DIFF
--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -313,16 +313,6 @@ async def async_create_miio_device_and_coordinator(
         or model.startswith(ROBOROCK_GENERIC)
         or model.startswith(ROCKROBO_GENERIC)
     ):
-        if model not in MODELS_VACUUM and (
-            model.startswith(ROBOROCK_GENERIC) or model.startswith(ROCKROBO_GENERIC)
-        ):
-            _LOGGER.warning(
-                "Vacuum model %s is not officially supported, please create an issue at "
-                "https://github.com/rytilahti/python-miio/issues and provide the model name if it works as "
-                "expected",
-                model,
-            )
-
         device = Vacuum(host, token)
         update_method = _async_update_data_vacuum
         coordinator_class = DataUpdateCoordinator[VacuumCoordinatorData]

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -66,6 +66,8 @@ from .const import (
     MODELS_PURIFIER_MIOT,
     MODELS_SWITCH,
     MODELS_VACUUM,
+    ROBOROCK_GENERIC,
+    ROCKROBO_GENERIC,
     AuthException,
     SetupException,
 )
@@ -267,7 +269,7 @@ async def async_create_miio_device_and_coordinator(
     hass: core.HomeAssistant, entry: config_entries.ConfigEntry
 ):
     """Set up a data coordinator and one miio device to service multiple entities."""
-    model = entry.data[CONF_MODEL]
+    model: str = entry.data[CONF_MODEL]
     host = entry.data[CONF_HOST]
     token = entry.data[CONF_TOKEN]
     name = entry.title
@@ -280,6 +282,8 @@ async def async_create_miio_device_and_coordinator(
         model not in MODELS_HUMIDIFIER
         and model not in MODELS_FAN
         and model not in MODELS_VACUUM
+        and not model.startswith(ROBOROCK_GENERIC)
+        and not model.startswith(ROCKROBO_GENERIC)
     ):
         return
 
@@ -304,7 +308,21 @@ async def async_create_miio_device_and_coordinator(
         device = AirPurifier(host, token)
     elif model.startswith("zhimi.airfresh."):
         device = AirFresh(host, token)
-    elif model in MODELS_VACUUM:
+    elif (
+        model in MODELS_VACUUM
+        or model.startswith(ROBOROCK_GENERIC)
+        or model.startswith(ROCKROBO_GENERIC)
+    ):
+        if model not in MODELS_VACUUM and (
+            model.startswith(ROBOROCK_GENERIC) or model.startswith(ROCKROBO_GENERIC)
+        ):
+            _LOGGER.warning(
+                "Vacuum model %s is not officially supported, please create an issue at "
+                "https://github.com/rytilahti/python-miio/issues and provide the model name if it works as "
+                "expected.",
+                model,
+            )
+
         device = Vacuum(host, token)
         update_method = _async_update_data_vacuum
         coordinator_class = DataUpdateCoordinator[VacuumCoordinatorData]

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -319,7 +319,7 @@ async def async_create_miio_device_and_coordinator(
             _LOGGER.warning(
                 "Vacuum model %s is not officially supported, please create an issue at "
                 "https://github.com/rytilahti/python-miio/issues and provide the model name if it works as "
-                "expected.",
+                "expected",
                 model,
             )
 

--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -202,7 +202,8 @@ ROCKROBO_S4_MAX = "roborock.vacuum.a19"
 ROCKROBO_S5_MAX = "roborock.vacuum.s5e"
 ROCKROBO_S6_PURE = "roborock.vacuum.a08"
 ROCKROBO_E2 = "roborock.vacuum.e2"
-ROCKROBO_GENERIC = "roborock.vacuum"
+ROBOROCK_GENERIC = "roborock.vacuum"
+ROCKROBO_GENERIC = "rockrobo.vacuum"
 MODELS_VACUUM = [
     ROCKROBO_V1,
     ROCKROBO_E2,
@@ -214,6 +215,7 @@ MODELS_VACUUM = [
     ROCKROBO_S6_MAXV,
     ROCKROBO_S6_PURE,
     ROCKROBO_S7,
+    ROBOROCK_GENERIC,
     ROCKROBO_GENERIC,
 ]
 MODELS_VACUUM_WITH_MOP = [

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -81,6 +81,8 @@ from .const import (
     MODELS_PURIFIER_MIIO,
     MODELS_PURIFIER_MIOT,
     MODELS_VACUUM,
+    ROBOROCK_GENERIC,
+    ROCKROBO_GENERIC,
 )
 from .device import XiaomiCoordinatedMiioEntity, XiaomiMiioEntity
 from .gateway import XiaomiGatewayDevice
@@ -593,7 +595,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     elif config_entry.data[CONF_FLOW_TYPE] == CONF_DEVICE:
         host = config_entry.data[CONF_HOST]
         token = config_entry.data[CONF_TOKEN]
-        model = config_entry.data[CONF_MODEL]
+        model: str = config_entry.data[CONF_MODEL]
 
         if model in (MODEL_FAN_ZA1, MODEL_FAN_ZA3, MODEL_FAN_ZA4, MODEL_FAN_P5):
             return
@@ -625,7 +627,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 sensors = PURIFIER_MIIO_SENSORS
             elif model in MODELS_PURIFIER_MIOT:
                 sensors = PURIFIER_MIOT_SENSORS
-            elif model in MODELS_VACUUM:
+            elif (
+                model in MODELS_VACUUM
+                or model.startswith(ROBOROCK_GENERIC)
+                or model.startswith(ROCKROBO_GENERIC)
+            ):
                 return _setup_vacuum_sensors(hass, config_entry, async_add_entities)
 
             for sensor, description in SENSOR_TYPES.items():


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

It seems that by making the vacuum model support check, we've dropped a lot of supported vacuum models that have never been reported as working correctly.

This PR re-enables these models and emits a warning asking folks to report the model as working. With these reports we can then build a proper map of model and features and continue to improve from there.

Unsupported sensors are already no longer created due to https://github.com/home-assistant/core/pull/58880 so this already ensures that only supported sensors are created nevertheless.

The mop sensors won't be created for these generic vacuums, however.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59183
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
