### PR TITLE
Improve support for flux_led pixel/RBM controllers

### DIFF
--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -3,7 +3,7 @@
   "name": "Flux LED/MagicHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "requirements": ["flux_led==0.24.17"],
+  "requirements": ["flux_led==0.24.18"],
   "quality_scale": "platinum",
   "codeowners": ["@icemanch"],
   "iot_class": "local_push",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -658,7 +658,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.24.17
+flux_led==0.24.18
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -393,7 +393,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.24.17
+flux_led==0.24.18
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -46,8 +46,10 @@ def _mocked_bulb() -> AIOWifiLedBulb:
 
     bulb.device_type = DeviceType.Bulb
     bulb.async_setup = AsyncMock(side_effect=_save_setup_callback)
+    bulb.effect_list = ["some_effect"]
     bulb.async_set_custom_pattern = AsyncMock()
     bulb.async_set_preset_pattern = AsyncMock()
+    bulb.async_set_effect = AsyncMock()
     bulb.async_set_white_temp = AsyncMock()
     bulb.async_stop = AsyncMock()
     bulb.async_update = AsyncMock()
@@ -68,6 +70,7 @@ def _mocked_bulb() -> AIOWifiLedBulb:
     bulb.getWhiteTemperature = MagicMock(return_value=(2700, 128))
     bulb.brightness = 128
     bulb.model_num = 0x35
+    bulb.effect = None
     bulb.model = "Smart Bulb (0x35)"
     bulb.version_num = 8
     bulb.rgbwcapable = True

--- a/tests/components/flux_led/conftest.py
+++ b/tests/components/flux_led/conftest.py
@@ -1,0 +1,11 @@
+"""Tests for the flux_led integration."""
+
+import pytest
+
+from tests.common import mock_device_registry
+
+
+@pytest.fixture(name="device_reg")
+def device_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -27,7 +27,6 @@ from homeassistant.components.flux_led.const import (
     MODE_AUTO,
     TRANSITION_JUMP,
 )
-from homeassistant.components.flux_led.light import EFFECT_CUSTOM_CODE, FLUX_EFFECT_LIST
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
@@ -41,6 +40,7 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
     ATTR_WHITE,
     DOMAIN as LIGHT_DOMAIN,
+    EFFECT_RANDOM,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -202,7 +202,7 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
     assert attributes[ATTR_COLOR_MODE] == "rgb"
-    assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
+    assert attributes[ATTR_EFFECT_LIST] == [*bulb.effect_list, EFFECT_RANDOM]
     assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
@@ -253,16 +253,8 @@ async def test_rgb_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
         blocking=True,
     )
-    bulb.async_set_preset_pattern.assert_called_with(43, 50)
-    bulb.async_set_preset_pattern.reset_mock()
-
-    with pytest.raises(ValueError):
-        await hass.services.async_call(
-            LIGHT_DOMAIN,
-            "turn_on",
-            {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "does not exist"},
-            blocking=True,
-        )
+    bulb.async_set_effect.assert_called_with("purple_fade", 50)
+    bulb.async_set_effect.reset_mock()
 
 
 async def test_rgb_cct_light(hass: HomeAssistant) -> None:
@@ -288,7 +280,7 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
     assert attributes[ATTR_COLOR_MODE] == "rgb"
-    assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
+    assert attributes[ATTR_EFFECT_LIST] == [*bulb.effect_list, EFFECT_RANDOM]
     assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "rgb"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
@@ -339,8 +331,8 @@ async def test_rgb_cct_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
         blocking=True,
     )
-    bulb.async_set_preset_pattern.assert_called_with(43, 50)
-    bulb.async_set_preset_pattern.reset_mock()
+    bulb.async_set_effect.assert_called_with("purple_fade", 50)
+    bulb.async_set_effect.reset_mock()
     bulb.color_mode = FLUX_COLOR_MODE_CCT
     bulb.getWhiteTemperature = Mock(return_value=(5000, 128))
     bulb.color_temp = 5000
@@ -407,7 +399,7 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
     assert attributes[ATTR_COLOR_MODE] == "rgbw"
-    assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
+    assert attributes[ATTR_EFFECT_LIST] == [*bulb.effect_list, EFFECT_RANDOM]
     assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgbw"]
     assert attributes[ATTR_RGB_COLOR] == (255, 42, 42)
 
@@ -483,8 +475,8 @@ async def test_rgbw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
         blocking=True,
     )
-    bulb.async_set_preset_pattern.assert_called_with(43, 50)
-    bulb.async_set_preset_pattern.reset_mock()
+    bulb.async_set_effect.assert_called_with("purple_fade", 50)
+    bulb.async_set_effect.reset_mock()
 
 
 async def test_rgb_or_w_light(hass: HomeAssistant) -> None:
@@ -509,7 +501,7 @@ async def test_rgb_or_w_light(hass: HomeAssistant) -> None:
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
     assert attributes[ATTR_COLOR_MODE] == "rgb"
-    assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
+    assert attributes[ATTR_EFFECT_LIST] == [*bulb.effect_list, EFFECT_RANDOM]
     assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb", "white"]
     assert attributes[ATTR_RGB_COLOR] == (255, 0, 0)
 
@@ -567,8 +559,8 @@ async def test_rgb_or_w_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
         blocking=True,
     )
-    bulb.async_set_preset_pattern.assert_called_with(43, 50)
-    bulb.async_set_preset_pattern.reset_mock()
+    bulb.async_set_effect.assert_called_with("purple_fade", 50)
+    bulb.async_set_effect.reset_mock()
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -620,7 +612,7 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
     assert attributes[ATTR_COLOR_MODE] == "rgbww"
-    assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
+    assert attributes[ATTR_EFFECT_LIST] == [*bulb.effect_list, EFFECT_RANDOM]
     assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "rgbww"]
     assert attributes[ATTR_HS_COLOR] == (3.237, 94.51)
 
@@ -721,8 +713,8 @@ async def test_rgbcw_light(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "purple_fade"},
         blocking=True,
     )
-    bulb.async_set_preset_pattern.assert_called_with(43, 50)
-    bulb.async_set_preset_pattern.reset_mock()
+    bulb.async_set_effect.assert_called_with("purple_fade", 50)
+    bulb.async_set_effect.reset_mock()
 
 
 async def test_white_light(hass: HomeAssistant) -> None:
@@ -804,7 +796,7 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
     assert attributes[ATTR_COLOR_MODE] == "rgb"
-    assert attributes[ATTR_EFFECT_LIST] == [*FLUX_EFFECT_LIST, "custom"]
+    assert attributes[ATTR_EFFECT_LIST] == [*bulb.effect_list, EFFECT_RANDOM, "custom"]
     assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
@@ -822,11 +814,11 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "custom"},
         blocking=True,
     )
+    bulb.effect = "custom"
     bulb.async_set_custom_pattern.assert_called_with(
         [[0, 0, 255], [255, 0, 0]], 88, "jump"
     )
     bulb.async_set_custom_pattern.reset_mock()
-    bulb.preset_pattern_num = EFFECT_CUSTOM_CODE
     await async_mock_device_turn_on(hass, bulb)
 
     state = hass.states.get(entity_id)
@@ -840,11 +832,11 @@ async def test_rgb_light_custom_effects(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 55, ATTR_EFFECT: "custom"},
         blocking=True,
     )
+    bulb.effect = "custom"
     bulb.async_set_custom_pattern.assert_called_with(
         [[0, 0, 255], [255, 0, 0]], 88, "jump"
     )
     bulb.async_set_custom_pattern.reset_mock()
-    bulb.preset_pattern_num = EFFECT_CUSTOM_CODE
     await async_mock_device_turn_on(hass, bulb)
 
     state = hass.states.get(entity_id)
@@ -886,7 +878,7 @@ async def test_rgb_light_custom_effects_invalid_colors(
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
     assert attributes[ATTR_COLOR_MODE] == "rgb"
-    assert attributes[ATTR_EFFECT_LIST] == FLUX_EFFECT_LIST
+    assert attributes[ATTR_EFFECT_LIST] == [*bulb.effect_list, EFFECT_RANDOM]
     assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 
@@ -915,7 +907,7 @@ async def test_rgb_light_custom_effect_via_service(
     attributes = state.attributes
     assert attributes[ATTR_BRIGHTNESS] == 128
     assert attributes[ATTR_COLOR_MODE] == "rgb"
-    assert attributes[ATTR_EFFECT_LIST] == [*FLUX_EFFECT_LIST]
+    assert attributes[ATTR_EFFECT_LIST] == [*bulb.effect_list, EFFECT_RANDOM]
     assert attributes[ATTR_SUPPORTED_COLOR_MODES] == ["rgb"]
     assert attributes[ATTR_HS_COLOR] == (0, 100)
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve support for flux_led pixel/RBM controllers

- RBM effects 1-100 are now available

- Fetch flux_led effects from library (each model can have different effects)

- Changelog: https://github.com/Danielhiversen/flux_led/compare/0.24.17...0.24.18

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
