### PR TITLE
Add current version to updater attributes

### DIFF
--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_RELEASE_NOTES = "release_notes"
 ATTR_NEWEST_VERSION = "newest_version"
+ATTR_CURRENT_VERSION = "current_version"
 
 CONF_REPORTING = "reporting"
 CONF_COMPONENT_REPORTING = "include_used_components"
@@ -51,6 +52,7 @@ class Updater:
         self.update_available = update_available
         self.release_notes = release_notes
         self.newest_version = newest_version
+        self.current_version = current_version
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/updater/binary_sensor.py
+++ b/homeassistant/components/updater/binary_sensor.py
@@ -7,7 +7,12 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import ATTR_NEWEST_VERSION, ATTR_RELEASE_NOTES, DOMAIN as UPDATER_DOMAIN
+from . import (
+    ATTR_CURRENT_VERSION,
+    ATTR_NEWEST_VERSION,
+    ATTR_RELEASE_NOTES,
+    DOMAIN as UPDATER_DOMAIN,
+)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -45,4 +50,6 @@ class UpdaterBinary(CoordinatorEntity, BinarySensorEntity):
             data[ATTR_RELEASE_NOTES] = self.coordinator.data.release_notes
         if self.coordinator.data.newest_version:
             data[ATTR_NEWEST_VERSION] = self.coordinator.data.newest_version
+        if self.coordinator.data.current_version:
+            data[ATTR_CURRENT_VERSION] = self.coordinator.data.current_version
         return data

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -51,6 +51,10 @@ async def test_new_version_shows_entity_true(hass, mock_get_newest_version):
         hass.states.get("binary_sensor.updater").attributes["release_notes"]
         == RELEASE_NOTES
     )
+    assert (
+        hass.states.get("binary_sensor.updater").attributes["current_version"]
+        == MOCK_VERSION
+    )
 
 
 async def test_same_version_shows_entity_false(hass, mock_get_newest_version):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the current version to the updater attributes. When I notice an update is available, I would have to navigate into the config/info section to see the current version so I know how far back I need to read in the release notes. This change adds the current version to the updater attributes so it can be viewed easily along with the newest available version and the link to the release notes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20213

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
