### PR TITLE
Drop block on local proxies from HA Cloud

### DIFF
--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -63,13 +63,5 @@ MODE_PROD = "production"
 DISPATCHER_REMOTE_UPDATE = "cloud_remote_update"
 
 
-class InvalidTrustedNetworks(Exception):
-    """Raised when invalid trusted networks config."""
-
-
-class InvalidTrustedProxies(Exception):
-    """Raised when invalid trusted proxies config."""
-
-
 class RequireRelink(Exception):
     """The skill needs to be relinked."""

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -33,8 +33,6 @@ from .const import (
     PREF_GOOGLE_SECURE_DEVICES_PIN,
     PREF_TTS_DEFAULT_VOICE,
     REQUEST_TIMEOUT,
-    InvalidTrustedNetworks,
-    InvalidTrustedProxies,
     RequireRelink,
 )
 
@@ -42,14 +40,6 @@ _LOGGER = logging.getLogger(__name__)
 
 
 _CLOUD_ERRORS = {
-    InvalidTrustedNetworks: (
-        HTTPStatus.INTERNAL_SERVER_ERROR,
-        "Remote UI not compatible with 127.0.0.1/::1 as a trusted network.",
-    ),
-    InvalidTrustedProxies: (
-        HTTPStatus.INTERNAL_SERVER_ERROR,
-        "Remote UI not compatible with 127.0.0.1/::1 as trusted proxies.",
-    ),
     asyncio.TimeoutError: (
         HTTPStatus.BAD_GATEWAY,
         "Unable to reach the Home Assistant cloud.",

--- a/homeassistant/components/cloud/prefs.py
+++ b/homeassistant/components/cloud/prefs.py
@@ -1,8 +1,6 @@
 """Preference management for cloud."""
 from __future__ import annotations
 
-from ipaddress import ip_address
-
 from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.auth.models import User
 from homeassistant.core import callback
@@ -34,8 +32,6 @@ from .const import (
     PREF_SHOULD_EXPOSE,
     PREF_TTS_DEFAULT_VOICE,
     PREF_USERNAME,
-    InvalidTrustedNetworks,
-    InvalidTrustedProxies,
 )
 
 STORAGE_KEY = DOMAIN
@@ -109,14 +105,6 @@ class CloudPreferences:
         ):
             if value is not UNDEFINED:
                 prefs[key] = value
-
-        if remote_enabled is True and self._has_local_trusted_network:
-            prefs[PREF_ENABLE_REMOTE] = False
-            raise InvalidTrustedNetworks
-
-        if remote_enabled is True and self._has_local_trusted_proxies:
-            prefs[PREF_ENABLE_REMOTE] = False
-            raise InvalidTrustedProxies
 
         await self._save_prefs(prefs)
 
@@ -217,9 +205,6 @@ class CloudPreferences:
         if not self._prefs.get(PREF_ENABLE_REMOTE, False):
             return False
 
-        if self._has_local_trusted_network or self._has_local_trusted_proxies:
-            return False
-
         return True
 
     @property
@@ -309,38 +294,6 @@ class CloudPreferences:
         # Fetch the user. It can happen that the user no longer exists if
         # an image was restored without restoring the cloud prefs.
         return await self._hass.auth.async_get_user(user_id)
-
-    @property
-    def _has_local_trusted_network(self) -> bool:
-        """Return if we allow localhost to bypass auth."""
-        local4 = ip_address("127.0.0.1")
-        local6 = ip_address("::1")
-
-        for prv in self._hass.auth.auth_providers:
-            if prv.type != "trusted_networks":
-                continue
-
-            for network in prv.trusted_networks:
-                if local4 in network or local6 in network:
-                    return True
-
-        return False
-
-    @property
-    def _has_local_trusted_proxies(self) -> bool:
-        """Return if we allow localhost to be a proxy and use its data."""
-        if not hasattr(self._hass, "http"):
-            return False
-
-        local4 = ip_address("127.0.0.1")
-        local6 = ip_address("::1")
-
-        if any(
-            local4 in nwk or local6 in nwk for nwk in self._hass.http.trusted_proxies
-        ):
-            return True
-
-        return False
 
     async def _save_prefs(self, prefs):
         """Save preferences to disk."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Requires https://github.com/home-assistant/core/pull/59333

Misconfigured trusted networks could allow unwanted access. This is blocked but with #59333 it will be blocked in another way.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
