### PR TITLE
Move onewire device compatibility checks

### DIFF
--- a/homeassistant/components/onewire/const.py
+++ b/homeassistant/components/onewire/const.py
@@ -20,6 +20,25 @@ DOMAIN = "onewire"
 DEVICE_KEYS_0_7 = range(8)
 DEVICE_KEYS_A_B = ("A", "B")
 
+DEVICE_SUPPORT_OWSERVER = {
+    "05": (),
+    "10": (),
+    "12": (),
+    "1D": (),
+    "1F": (),
+    "22": (),
+    "26": (),
+    "28": (),
+    "29": (),
+    "3A": (),
+    "3B": (),
+    "42": (),
+    "7E": ("EDS0066", "EDS0068"),
+    "EF": ("HB_MOISTURE_METER", "HobbyBoards_EF"),
+}
+DEVICE_SUPPORT_SYSBUS = ["10", "22", "28", "3B", "42"]
+
+
 MANUFACTURER_MAXIM = "Maxim Integrated"
 MANUFACTURER_HOBBYBOARDS = "Hobby Boards"
 MANUFACTURER_EDS = "Embedded Data Systems"

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -137,7 +137,7 @@ class OneWireHub:
             device_id = f"{device_family}-{interface.mac_address[2:]}"
             if device_family not in DEVICE_SUPPORT_SYSBUS:
                 _LOGGER.warning(
-                    "Ignoring unknown family (%s) of sensor found for device: %s",
+                    "Ignoring unknown device family (%s) found for device %s",
                     device_family,
                     device_id,
                 )

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -132,7 +132,14 @@ class OneWireHub:
         """Discover all sysbus devices."""
         devices: list[OWDeviceDescription] = []
         assert self.pi1proxy
-        for interface in self.pi1proxy.find_all_sensors():
+        all_sensors = self.pi1proxy.find_all_sensors()
+        if not all_sensors:
+            _LOGGER.error(
+                "No onewire sensor found. Check if dtoverlay=w1-gpio "
+                "is in your /boot/config.txt. "
+                "Check the mount_dir parameter if it's defined"
+            )
+        for interface in all_sensors:
             device_family = interface.mac_address[:2]
             device_id = f"{device_family}-{interface.mac_address[2:]}"
             if device_family not in DEVICE_SUPPORT_SYSBUS:
@@ -155,12 +162,6 @@ class OneWireHub:
                 interface=interface,
             )
             devices.append(device)
-        if not devices:
-            _LOGGER.error(
-                "No onewire sensor found. Check if dtoverlay=w1-gpio "
-                "is in your /boot/config.txt. "
-                "Check the mount_dir parameter if it's defined"
-            )
         return devices
 
     def _discover_devices_owserver(

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -49,6 +49,7 @@ ATTR_DEVICE_FILE = "device_file"
 ATTR_DEVICE_INFO = "device_info"
 ATTR_INJECT_READS = "inject_reads"
 ATTR_UNIQUE_ID = "unique_id"
+ATTR_UNKNOWN_DEVICE = "unknown_device"
 
 FIXED_ATTRIBUTES = (
     ATTR_DEVICE_CLASS,
@@ -62,7 +63,7 @@ MOCK_OWPROXY_DEVICES = {
         ATTR_INJECT_READS: [
             b"",  # read device type
         ],
-        SENSOR_DOMAIN: [],
+        ATTR_UNKNOWN_DEVICE: True,
     },
     "05.111111111111": {
         ATTR_INJECT_READS: [
@@ -879,7 +880,7 @@ MOCK_OWPROXY_DEVICES = {
 
 MOCK_SYSBUS_DEVICES = {
     "00-111111111111": {
-        SENSOR_DOMAIN: [],
+        ATTR_UNKNOWN_DEVICE: True,
     },
     "10-111111111111": {
         ATTR_DEVICE_INFO: {
@@ -900,12 +901,6 @@ MOCK_SYSBUS_DEVICES = {
             },
         ],
     },
-    "12-111111111111": {
-        SENSOR_DOMAIN: [],
-    },
-    "1D-111111111111": {
-        SENSOR_DOMAIN: [],
-    },
     "22-111111111111": {
         ATTR_DEVICE_INFO: {
             ATTR_IDENTIFIERS: {(DOMAIN, "22-111111111111")},
@@ -913,7 +908,7 @@ MOCK_SYSBUS_DEVICES = {
             ATTR_MODEL: "22",
             ATTR_NAME: "22-111111111111",
         },
-        "sensor": [
+        SENSOR_DOMAIN: [
             {
                 ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
                 ATTR_ENTITY_ID: "sensor.22_111111111111_temperature",
@@ -924,9 +919,6 @@ MOCK_SYSBUS_DEVICES = {
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
             },
         ],
-    },
-    "26-111111111111": {
-        SENSOR_DOMAIN: [],
     },
     "28-111111111111": {
         ATTR_DEVICE_INFO: {
@@ -946,12 +938,6 @@ MOCK_SYSBUS_DEVICES = {
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
             },
         ],
-    },
-    "29-111111111111": {
-        SENSOR_DOMAIN: [],
-    },
-    "3A-111111111111": {
-        SENSOR_DOMAIN: [],
     },
     "3B-111111111111": {
         ATTR_DEVICE_INFO: {
@@ -1028,11 +1014,5 @@ MOCK_SYSBUS_DEVICES = {
                 ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
             },
         ],
-    },
-    "EF-111111111111": {
-        SENSOR_DOMAIN: [],
-    },
-    "EF-111111111112": {
-        SENSOR_DOMAIN: [],
     },
 }

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -48,7 +48,7 @@ async def test_warning_no_devices(
     sysbus_config_entry: ConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Test being able to unload an entry."""
+    """Test warning is generated when no sysbus devices found."""
     with caplog.at_level(logging.WARNING, logger="homeassistant.components.onewire"):
         await hass.config_entries.async_setup(sysbus_config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -1,4 +1,5 @@
 """Tests for 1-Wire config flow."""
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -39,6 +40,19 @@ async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     assert config_entry.state is ConfigEntryState.NOT_LOADED
     assert not hass.data.get(DOMAIN)
+
+
+@pytest.mark.usefixtures("sysbus")
+async def test_warning_no_devices(
+    hass: HomeAssistant,
+    sysbus_config_entry: ConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test being able to unload an entry."""
+    with caplog.at_level(logging.WARNING, logger="homeassistant.components.onewire"):
+        await hass.config_entries.async_setup(sysbus_config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert "No onewire sensor found. Check if dtoverlay=w1-gpio" in caplog.text
 
 
 @pytest.mark.usefixtures("sysbus")

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for 1-Wire sensor platform."""
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,7 +16,12 @@ from . import (
     setup_owproxy_mock_devices,
     setup_sysbus_mock_devices,
 )
-from .const import ATTR_DEVICE_INFO, MOCK_OWPROXY_DEVICES, MOCK_SYSBUS_DEVICES
+from .const import (
+    ATTR_DEVICE_INFO,
+    ATTR_UNKNOWN_DEVICE,
+    MOCK_OWPROXY_DEVICES,
+    MOCK_SYSBUS_DEVICES,
+)
 
 from tests.common import mock_device_registry, mock_registry
 
@@ -28,7 +34,11 @@ def override_platforms():
 
 
 async def test_owserver_sensor(
-    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock, device_id: str
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    owproxy: MagicMock,
+    device_id: str,
+    caplog: pytest.LogCaptureFixture,
 ):
     """Test for 1-Wire device.
 
@@ -46,8 +56,13 @@ async def test_owserver_sensor(
     expected_devices = ensure_list(mock_device.get(ATTR_DEVICE_INFO))
 
     setup_owproxy_mock_devices(owproxy, SENSOR_DOMAIN, [device_id])
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    with caplog.at_level(logging.WARNING, logger="homeassistant.components.onewire"):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        if mock_device.get(ATTR_UNKNOWN_DEVICE):
+            assert "Ignoring unknown device family/type" in caplog.text
+        else:
+            assert "Ignoring unknown device family/type" not in caplog.text
 
     check_device_registry(device_registry, expected_devices)
     assert len(entity_registry.entities) == len(expected_entities)
@@ -63,7 +78,10 @@ async def test_owserver_sensor(
 @pytest.mark.usefixtures("sysbus")
 @pytest.mark.parametrize("device_id", MOCK_SYSBUS_DEVICES.keys(), indirect=True)
 async def test_onewiredirect_setup_valid_device(
-    hass: HomeAssistant, sysbus_config_entry: ConfigEntry, device_id: str
+    hass: HomeAssistant,
+    sysbus_config_entry: ConfigEntry,
+    device_id: str,
+    caplog: pytest.LogCaptureFixture,
 ):
     """Test that sysbus config entry works correctly."""
     device_registry = mock_device_registry(hass)
@@ -80,9 +98,13 @@ async def test_onewiredirect_setup_valid_device(
     with patch("pi1wire._finder.glob.glob", return_value=glob_result,), patch(
         "pi1wire.OneWire.get_temperature",
         side_effect=read_side_effect,
-    ):
+    ), caplog.at_level(logging.WARNING, logger="homeassistant.components.onewire"):
         await hass.config_entries.async_setup(sysbus_config_entry.entry_id)
         await hass.async_block_till_done()
+        if mock_device.get(ATTR_UNKNOWN_DEVICE):
+            assert "Ignoring unknown device family" in caplog.text
+        else:
+            assert "Ignoring unknown device family" not in caplog.text
 
     check_device_registry(device_registry, expected_devices)
     assert len(entity_registry.entities) == len(expected_entities)

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -98,7 +98,11 @@ async def test_onewiredirect_setup_valid_device(
     with patch("pi1wire._finder.glob.glob", return_value=glob_result,), patch(
         "pi1wire.OneWire.get_temperature",
         side_effect=read_side_effect,
-    ), caplog.at_level(logging.WARNING, logger="homeassistant.components.onewire"):
+    ), caplog.at_level(
+        logging.WARNING, logger="homeassistant.components.onewire"
+    ), patch(
+        "homeassistant.components.onewire.sensor.asyncio.sleep"
+    ):
         await hass.config_entries.async_setup(sysbus_config_entry.entry_id)
         await hass.async_block_till_done()
         assert "No onewire sensor found. Check if dtoverlay=w1-gpio" not in caplog.text

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -101,6 +101,7 @@ async def test_onewiredirect_setup_valid_device(
     ), caplog.at_level(logging.WARNING, logger="homeassistant.components.onewire"):
         await hass.config_entries.async_setup(sysbus_config_entry.entry_id)
         await hass.async_block_till_done()
+        assert "No onewire sensor found. Check if dtoverlay=w1-gpio" not in caplog.text
         if mock_device.get(ATTR_UNKNOWN_DEVICE):
             assert "Ignoring unknown device family" in caplog.text
         else:

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -1,4 +1,5 @@
 """Tests for 1-Wire devices connected on OWServer."""
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,7 +22,7 @@ from . import (
     check_entities,
     setup_owproxy_mock_devices,
 )
-from .const import ATTR_DEVICE_INFO, MOCK_OWPROXY_DEVICES
+from .const import ATTR_DEVICE_INFO, ATTR_UNKNOWN_DEVICE, MOCK_OWPROXY_DEVICES
 
 from tests.common import mock_device_registry, mock_registry
 
@@ -34,7 +35,11 @@ def override_platforms():
 
 
 async def test_owserver_switch(
-    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock, device_id: str
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    owproxy: MagicMock,
+    device_id: str,
+    caplog: pytest.LogCaptureFixture,
 ):
     """Test for 1-Wire switch.
 
@@ -48,8 +53,13 @@ async def test_owserver_switch(
     expected_devices = ensure_list(mock_device.get(ATTR_DEVICE_INFO))
 
     setup_owproxy_mock_devices(owproxy, SWITCH_DOMAIN, [device_id])
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    with caplog.at_level(logging.WARNING, logger="homeassistant.components.onewire"):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        if mock_device.get(ATTR_UNKNOWN_DEVICE):
+            assert "Ignoring unknown device family/type" in caplog.text
+        else:
+            assert "Ignoring unknown device family/type" not in caplog.text
 
     check_device_registry(device_registry, expected_devices)
     assert len(entity_registry.entities) == len(expected_entities)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Historically, unknown devices raised a warning in the `sensor` platform, and it was not adjusted when `binary_sensor` and `switch` platforms were added.
This moves the warnings to initialization methods of `onewirehub`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
