### PR TITLE
Bump paho-mqtt to 1.6.1

### DIFF
--- a/homeassistant/components/mqtt/manifest.json
+++ b/homeassistant/components/mqtt/manifest.json
@@ -3,7 +3,7 @@
   "name": "MQTT",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/mqtt",
-  "requirements": ["paho-mqtt==1.5.1"],
+  "requirements": ["paho-mqtt==1.6.1"],
   "dependencies": ["http"],
   "codeowners": ["@emontnemery"],
   "iot_class": "local_push"

--- a/homeassistant/components/shiftr/manifest.json
+++ b/homeassistant/components/shiftr/manifest.json
@@ -2,7 +2,7 @@
   "domain": "shiftr",
   "name": "shiftr.io",
   "documentation": "https://www.home-assistant.io/integrations/shiftr",
-  "requirements": ["paho-mqtt==1.5.1"],
+  "requirements": ["paho-mqtt==1.6.1"],
   "codeowners": ["@fabaff"],
   "iot_class": "cloud_push"
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -19,7 +19,7 @@ home-assistant-frontend==20211103.0
 httpx==0.19.0
 ifaddr==0.1.7
 jinja2==3.0.2
-paho-mqtt==1.5.1
+paho-mqtt==1.6.1
 pillow==8.2.0
 pip>=8.0.3,<20.3
 pyserial==3.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1169,7 +1169,7 @@ p1monitor==1.0.0
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.5.1
+paho-mqtt==1.6.1
 
 # homeassistant.components.panasonic_bluray
 panacotta==0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -695,7 +695,7 @@ p1monitor==1.0.0
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.5.1
+paho-mqtt==1.6.1
 
 # homeassistant.components.panasonic_viera
 panasonic_viera==0.3.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upgrades `paho-mqtt` from 1.5.1 to 1.6.1.

### Changelog:

v1.6.1 - 2021-10-21
===================

- Fix Python 2.7 compatilibity.


v1.6.0 - 2021-10-20
===================

- Changed default TLS version to 1.2 instead of 1.0.
- Fix incoming MQTT v5 messages with overall property length > 127 bytes being
  incorrectly decoded. Closes https://github.com/eclipse/paho.mqtt.python/issues/541.
- MQTTMessageInfo.wait_for_publish() and MQTTMessageInfo.is_published() will
  now raise exceptions if called when the publish call produced an error.
  Closes https://github.com/eclipse/paho.mqtt.python/issues/550.
- Remove periodic retry checks for outgoing messages with QoS>0. This means
  that outgoing messages will only be retried on the client reconnecting to
  the server. They will *not* be retried when the client is still connected.
- The `rc` parameter in the `on_disconnect` callback now has meaningful values
  in the case of an error. Closes https://github.com/eclipse/paho.mqtt.python/issues/441.
- Callbacks can now be applied to client instances using decorators.
- PUBACK messages are now sent to the broker only after the on_message
  callback has returned.
- Raise exceptions when attempting to set MQTT v5 properties to forbidden
  values. Closes https://github.com/eclipse/paho.mqtt.python/issues/586.
- Callbacks can now be updated from within a callback.
- Remove _out_packet_mutex and _current_out_packet_mutex and convert the
  _out_packet queue use to thread safe.
- Add basic MQTT v5 support to the subscribe and publish helper functions.
  Closes https://github.com/eclipse/paho.mqtt.python/issues/575.
- Fix on_disconnect() sometimes calling the MQTT v3.x callback when it should
  call the MQTT v5 callback. Closes https://github.com/eclipse/paho.mqtt.python/issues/570.
- Big performance improvement when receiving large payloads, particularly for
  SSL. Closes https://github.com/eclipse/paho.mqtt.python/issues/571,
- Fix connecting with MQTT v5 to a broker that doesn't support MQTT v5.
  Closes https://github.com/eclipse/paho.mqtt.python/issues/566.
- Removed ancient Mosquitto compatibility class.
- Fix exception on calling Client(client_id="", clean_session=False).
  Closes https://github.com/eclipse/paho.mqtt.python/issues/520.
- Experimental support for Websockets continuation frames. Closes https://github.com/eclipse/paho.mqtt.python/issues/500.
  Closes https://github.com/eclipse/paho.mqtt.python/issues/89.
- `Properties.json()` now converts Correlation Data bytes() objects to hex.
  Closes https://github.com/eclipse/paho.mqtt.python/issues/555.
- Only use the internal sockpair wakeup when running with loop_start() or
  loop(). This removes problems when running with an external event loop.
- Drain all of sockpairR bytes to avoid unnecessary wakeups and possible
  timeouts. Closes https://github.com/eclipse/paho.mqtt.python/issues/563.
- Add timeout to MQTTMessageInfo:wait_for_publish().

(source: <https://github.com/eclipse/paho.mqtt.python/blob/v1.6.1/ChangeLog.txt>)
Full compare view: <https://github.com/eclipse/paho.mqtt.python/compare/v1.5.1...1.6.1>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/59257

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
