### PR TITLE
Add switch control GPIO from outside Home Assistant

### DIFF
--- a/homeassistant/components/rpi_gpio/switch.py
+++ b/homeassistant/components/rpi_gpio/switch.py
@@ -47,6 +47,7 @@ class RPiGPIOSwitch(ToggleEntity):
         self._name = name or DEVICE_DEFAULT_NAME
         self._port = port
         self._on_state = 0 if invert_logic else 1
+        self._is_on = None
         rpi_gpio.setup_output(self._port)
 
     @property
@@ -56,13 +57,13 @@ class RPiGPIOSwitch(ToggleEntity):
 
     @property
     def should_poll(self):
-        """No polling needed."""
+        """Polling needed."""
         return True
 
     @property
     def is_on(self):
         """Return true if device is on."""
-        return rpi_gpio.read_input(self._port) == self._on_state
+        return self._is_on
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
@@ -73,3 +74,7 @@ class RPiGPIOSwitch(ToggleEntity):
         """Turn the device off."""
         rpi_gpio.write_output(self._port, 1 - self._on_state)
         self.schedule_update_ha_state()
+
+    def update(self):
+        """Update the GPIO state."""
+        self._is_on = rpi_gpio.read_input(self._port) == self._on_state


### PR DESCRIPTION
enabling switch control GPIO from outside HomeAssistant and reading the current state of outputs

## Breaking change
None

## Proposed change
Enable/Disabled state of the switch can be control outside Home Assistant.
Change is to enable pooling of status and directly read state from GPIO.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- on documentation site : 
https://www.home-assistant.io/integrations/rpi_gpio/
this warning :
"Note that a pin managed by Home Assistant is expected to be exclusive to Home Assistant." 
should be removed from documentation

## Checklist
- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
