### PR TITLE
Add button entities to Renault

### DIFF
--- a/homeassistant/components/renault/binary_sensor.py
+++ b/homeassistant/components/renault/binary_sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .const import DOMAIN
-from .renault_entities import RenaultDataEntity, RenaultEntityDescription
+from .renault_entities import RenaultDataEntity, RenaultDataEntityDescription
 from .renault_hub import RenaultHub
 
 
@@ -33,7 +33,7 @@ class RenaultBinarySensorRequiredKeysMixin:
 @dataclass
 class RenaultBinarySensorEntityDescription(
     BinarySensorEntityDescription,
-    RenaultEntityDescription,
+    RenaultDataEntityDescription,
     RenaultBinarySensorRequiredKeysMixin,
 ):
     """Class describing Renault binary sensor entities."""

--- a/homeassistant/components/renault/button.py
+++ b/homeassistant/components/renault/button.py
@@ -1,0 +1,93 @@
+"""Support for Renault button entities."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .renault_entities import RenaultEntity
+from .renault_hub import RenaultHub
+
+
+@dataclass
+class RenaultButtonRequiredKeysMixin:
+    """Mixin for required keys."""
+
+    async_press: Callable[[RenaultButtonEntity], Awaitable]
+    cooldown: int
+
+
+@dataclass
+class RenaultButtonEntityDescription(
+    ButtonEntityDescription, RenaultButtonRequiredKeysMixin
+):
+    """Class describing Renault button entities."""
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Renault entities from config entry."""
+    proxy: RenaultHub = hass.data[DOMAIN][config_entry.entry_id]
+    entities: list[RenaultButtonEntity] = [
+        RenaultButtonEntity(vehicle, description)
+        for vehicle in proxy.vehicles.values()
+        for description in BUTTON_TYPES
+    ]
+    async_add_entities(entities)
+
+
+class RenaultButtonEntity(RenaultEntity, ButtonEntity):
+    """Mixin for sensor specific attributes."""
+
+    entity_description: RenaultButtonEntityDescription
+
+    async def async_press(self) -> None:
+        """Send out a persistent notification."""
+        await self.entity_description.async_press(self)
+        if self.entity_description.cooldown > 0:
+            self._attr_available = False
+            await asyncio.sleep(self.entity_description.cooldown)
+            self._attr_available = True
+
+
+async def _start_charge(entity: RenaultButtonEntity) -> None:
+    """Return the icon of this entity."""
+    entity.hass.components.persistent_notification.async_create(
+        "Button pressed", title="set_charge_start"
+    )
+    await entity.vehicle.vehicle.set_charge_start()
+
+
+async def _start_air_conditioner(entity: RenaultButtonEntity) -> None:
+    """Return the icon of this entity."""
+    entity.hass.components.persistent_notification.async_create(
+        "Button pressed", title="set_ac_start"
+    )
+    await entity.vehicle.vehicle.set_ac_start(21)
+
+
+BUTTON_TYPES: tuple[RenaultButtonEntityDescription, ...] = (
+    RenaultButtonEntityDescription(
+        async_press=_start_air_conditioner,
+        cooldown=30,
+        key="start_air_conditioner",
+        icon="mdi:air-conditioner",
+        name="Start Air Conditioner",
+    ),
+    RenaultButtonEntityDescription(
+        async_press=_start_charge,
+        cooldown=30,
+        key="start_charge",
+        icon="mdi:ev-station",
+        name="Start Charge",
+    ),
+)

--- a/homeassistant/components/renault/button.py
+++ b/homeassistant/components/renault/button.py
@@ -61,17 +61,11 @@ class RenaultButtonEntity(RenaultEntity, ButtonEntity):
 
 async def _start_charge(entity: RenaultButtonEntity) -> None:
     """Return the icon of this entity."""
-    entity.hass.components.persistent_notification.async_create(
-        "Button pressed", title="set_charge_start"
-    )
     await entity.vehicle.vehicle.set_charge_start()
 
 
 async def _start_air_conditioner(entity: RenaultButtonEntity) -> None:
     """Return the icon of this entity."""
-    entity.hass.components.persistent_notification.async_create(
-        "Button pressed", title="set_ac_start"
-    )
     await entity.vehicle.vehicle.set_ac_start(21)
 
 

--- a/homeassistant/components/renault/const.py
+++ b/homeassistant/components/renault/const.py
@@ -1,5 +1,6 @@
 """Constants for the Renault component."""
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -13,6 +14,7 @@ DEFAULT_SCAN_INTERVAL = 300  # 5 minutes
 
 PLATFORMS = [
     BINARY_SENSOR_DOMAIN,
+    BUTTON_DOMAIN,
     DEVICE_TRACKER_DOMAIN,
     SELECT_DOMAIN,
     SENSOR_DOMAIN,

--- a/homeassistant/components/renault/device_tracker.py
+++ b/homeassistant/components/renault/device_tracker.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .renault_entities import RenaultDataEntity, RenaultEntityDescription
+from .renault_entities import RenaultDataEntity, RenaultDataEntityDescription
 from .renault_hub import RenaultHub
 
 
@@ -51,8 +51,8 @@ class RenaultDeviceTracker(
         return SOURCE_TYPE_GPS
 
 
-DEVICE_TRACKER_TYPES: tuple[RenaultEntityDescription, ...] = (
-    RenaultEntityDescription(
+DEVICE_TRACKER_TYPES: tuple[RenaultDataEntityDescription, ...] = (
+    RenaultDataEntityDescription(
         key="location",
         coordinator="location",
         icon="mdi:car",

--- a/homeassistant/components/renault/select.py
+++ b/homeassistant/components/renault/select.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .const import DEVICE_CLASS_CHARGE_MODE, DOMAIN
-from .renault_entities import RenaultDataEntity, RenaultEntityDescription
+from .renault_entities import RenaultDataEntity, RenaultDataEntityDescription
 from .renault_hub import RenaultHub
 
 
@@ -29,7 +29,9 @@ class RenaultSelectRequiredKeysMixin:
 
 @dataclass
 class RenaultSelectEntityDescription(
-    SelectEntityDescription, RenaultEntityDescription, RenaultSelectRequiredKeysMixin
+    SelectEntityDescription,
+    RenaultDataEntityDescription,
+    RenaultSelectRequiredKeysMixin,
 ):
     """Class describing Renault select entities."""
 

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -43,7 +43,7 @@ from homeassistant.util.dt import as_utc, parse_datetime
 
 from .const import DEVICE_CLASS_CHARGE_STATE, DEVICE_CLASS_PLUG_STATE, DOMAIN
 from .renault_coordinator import T
-from .renault_entities import RenaultDataEntity, RenaultEntityDescription
+from .renault_entities import RenaultDataEntity, RenaultDataEntityDescription
 from .renault_hub import RenaultHub
 from .renault_vehicle import RenaultVehicleProxy
 
@@ -58,7 +58,9 @@ class RenaultSensorRequiredKeysMixin:
 
 @dataclass
 class RenaultSensorEntityDescription(
-    SensorEntityDescription, RenaultEntityDescription, RenaultSensorRequiredKeysMixin
+    SensorEntityDescription,
+    RenaultDataEntityDescription,
+    RenaultSensorRequiredKeysMixin,
 ):
     """Class describing Renault sensor entities."""
 

--- a/homeassistant/components/renault/services.py
+++ b/homeassistant/components/renault/services.py
@@ -112,6 +112,14 @@ def setup_services(hass: HomeAssistant) -> None:
 
     async def charge_start(service_call: ServiceCall) -> None:
         """Start charge."""
+        # The Renault start charge service has been replaced by a
+        # dedicated button entity and marked as deprecated
+        LOGGER.warning(
+            "The 'renault.charge_start' service is deprecated and "
+            "replaced by a dedicated start charge button entity; Please "
+            "use that entity to start the charge instead"
+        )
+
         proxy = get_vehicle_proxy(service_call.data)
 
         LOGGER.debug("Charge start attempt")

--- a/homeassistant/components/renault/services.py
+++ b/homeassistant/components/renault/services.py
@@ -116,7 +116,7 @@ def setup_services(hass: HomeAssistant) -> None:
         # dedicated button entity and marked as deprecated
         LOGGER.warning(
             "The 'renault.charge_start' service is deprecated and "
-            "replaced by a dedicated start charge button entity; Please "
+            "replaced by a dedicated start charge button entity; please "
             "use that entity to start the charge instead"
         )
 

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -4,6 +4,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_PLUG,
     DOMAIN as BINARY_SENSOR_DOMAIN,
 )
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.renault.const import (
     CONF_KAMEREON_ACCOUNT_ID,
@@ -115,6 +116,20 @@ MOCK_VEHICLES = {
                 ATTR_ENTITY_ID: "binary_sensor.reg_number_charging",
                 ATTR_STATE: STATE_ON,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_charging",
+            },
+        ],
+        BUTTON_DOMAIN: [
+            {
+                ATTR_ENTITY_ID: "button.reg_number_start_air_conditioner",
+                ATTR_ICON: "mdi:air-conditioner",
+                ATTR_STATE: STATE_UNKNOWN,
+                ATTR_UNIQUE_ID: "vf1aaaaa555777999_start_air_conditioner",
+            },
+            {
+                ATTR_ENTITY_ID: "button.reg_number_start_charge",
+                ATTR_ICON: "mdi:ev-station",
+                ATTR_STATE: STATE_UNKNOWN,
+                ATTR_UNIQUE_ID: "vf1aaaaa555777999_start_charge",
             },
         ],
         DEVICE_TRACKER_DOMAIN: [],
@@ -249,6 +264,20 @@ MOCK_VEHICLES = {
                 ATTR_ENTITY_ID: "binary_sensor.reg_number_charging",
                 ATTR_STATE: STATE_OFF,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777999_charging",
+            },
+        ],
+        BUTTON_DOMAIN: [
+            {
+                ATTR_ENTITY_ID: "button.reg_number_start_air_conditioner",
+                ATTR_ICON: "mdi:air-conditioner",
+                ATTR_STATE: STATE_UNKNOWN,
+                ATTR_UNIQUE_ID: "vf1aaaaa555777999_start_air_conditioner",
+            },
+            {
+                ATTR_ENTITY_ID: "button.reg_number_start_charge",
+                ATTR_ICON: "mdi:ev-station",
+                ATTR_STATE: STATE_UNKNOWN,
+                ATTR_UNIQUE_ID: "vf1aaaaa555777999_start_charge",
             },
         ],
         DEVICE_TRACKER_DOMAIN: [
@@ -389,6 +418,20 @@ MOCK_VEHICLES = {
                 ATTR_ENTITY_ID: "binary_sensor.reg_number_charging",
                 ATTR_STATE: STATE_ON,
                 ATTR_UNIQUE_ID: "vf1aaaaa555777123_charging",
+            },
+        ],
+        BUTTON_DOMAIN: [
+            {
+                ATTR_ENTITY_ID: "button.reg_number_start_air_conditioner",
+                ATTR_ICON: "mdi:air-conditioner",
+                ATTR_STATE: STATE_UNKNOWN,
+                ATTR_UNIQUE_ID: "vf1aaaaa555777123_start_air_conditioner",
+            },
+            {
+                ATTR_ENTITY_ID: "button.reg_number_start_charge",
+                ATTR_ICON: "mdi:ev-station",
+                ATTR_STATE: STATE_UNKNOWN,
+                ATTR_UNIQUE_ID: "vf1aaaaa555777123_start_charge",
             },
         ],
         DEVICE_TRACKER_DOMAIN: [
@@ -532,6 +575,14 @@ MOCK_VEHICLES = {
             "location": "location.json",
         },
         BINARY_SENSOR_DOMAIN: [],
+        BUTTON_DOMAIN: [
+            {
+                ATTR_ENTITY_ID: "button.reg_number_start_air_conditioner",
+                ATTR_ICON: "mdi:air-conditioner",
+                ATTR_STATE: STATE_UNKNOWN,
+                ATTR_UNIQUE_ID: "vf1aaaaa555777123_start_air_conditioner",
+            },
+        ],
         DEVICE_TRACKER_DOMAIN: [
             {
                 ATTR_ENTITY_ID: "device_tracker.reg_number_location",

--- a/tests/components/renault/test_button.py
+++ b/tests/components/renault/test_button.py
@@ -1,0 +1,185 @@
+"""Tests for Renault sensors."""
+from unittest.mock import patch
+
+import pytest
+from renault_api.kamereon import schemas
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.button.const import SERVICE_PRESS
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+from . import check_device_registry, check_entities_no_data
+from .const import ATTR_ENTITY_ID, MOCK_VEHICLES
+
+from tests.common import load_fixture, mock_device_registry, mock_registry
+
+pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicles")
+
+
+@pytest.fixture(autouse=True)
+def override_platforms():
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.renault.PLATFORMS", [BUTTON_DOMAIN]):
+        yield
+
+
+@pytest.mark.usefixtures("fixtures_with_data")
+async def test_buttons(
+    hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
+):
+    """Test for Renault device trackers."""
+
+    entity_registry = mock_registry(hass)
+    device_registry = mock_device_registry(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_vehicle = MOCK_VEHICLES[vehicle_type]
+    check_device_registry(device_registry, mock_vehicle["expected_device"])
+
+    expected_entities = mock_vehicle[BUTTON_DOMAIN]
+    assert len(entity_registry.entities) == len(expected_entities)
+
+    check_entities_no_data(hass, entity_registry, expected_entities, STATE_UNKNOWN)
+
+
+@pytest.mark.usefixtures("fixtures_with_no_data")
+async def test_button_empty(
+    hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
+):
+    """Test for Renault device trackers with empty data from Renault."""
+
+    entity_registry = mock_registry(hass)
+    device_registry = mock_device_registry(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_vehicle = MOCK_VEHICLES[vehicle_type]
+    check_device_registry(device_registry, mock_vehicle["expected_device"])
+
+    expected_entities = mock_vehicle[BUTTON_DOMAIN]
+    assert len(entity_registry.entities) == len(expected_entities)
+    check_entities_no_data(hass, entity_registry, expected_entities, STATE_UNKNOWN)
+
+
+@pytest.mark.usefixtures("fixtures_with_invalid_upstream_exception")
+async def test_button_errors(
+    hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
+):
+    """Test for Renault device trackers with temporary failure."""
+
+    entity_registry = mock_registry(hass)
+    device_registry = mock_device_registry(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_vehicle = MOCK_VEHICLES[vehicle_type]
+    check_device_registry(device_registry, mock_vehicle["expected_device"])
+
+    expected_entities = mock_vehicle[BUTTON_DOMAIN]
+    assert len(entity_registry.entities) == len(expected_entities)
+
+    check_entities_no_data(hass, entity_registry, expected_entities, STATE_UNKNOWN)
+
+
+@pytest.mark.usefixtures("fixtures_with_access_denied_exception")
+@pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
+async def test_button_access_denied(
+    hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
+):
+    """Test for Renault device trackers with access denied failure."""
+
+    entity_registry = mock_registry(hass)
+    device_registry = mock_device_registry(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_vehicle = MOCK_VEHICLES[vehicle_type]
+    check_device_registry(device_registry, mock_vehicle["expected_device"])
+
+    expected_entities = mock_vehicle[BUTTON_DOMAIN]
+    assert len(entity_registry.entities) == len(expected_entities)
+
+    check_entities_no_data(hass, entity_registry, expected_entities, STATE_UNKNOWN)
+
+
+@pytest.mark.usefixtures("fixtures_with_not_supported_exception")
+@pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
+async def test_button_not_supported(
+    hass: HomeAssistant, config_entry: ConfigEntry, vehicle_type: str
+):
+    """Test for Renault device trackers with not supported failure."""
+
+    entity_registry = mock_registry(hass)
+    device_registry = mock_device_registry(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_vehicle = MOCK_VEHICLES[vehicle_type]
+    check_device_registry(device_registry, mock_vehicle["expected_device"])
+
+    expected_entities = mock_vehicle[BUTTON_DOMAIN]
+    assert len(entity_registry.entities) == len(expected_entities)
+
+    check_entities_no_data(hass, entity_registry, expected_entities, STATE_UNKNOWN)
+
+
+@pytest.mark.usefixtures("fixtures_with_data")
+@pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
+async def test_button_start_charge(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Test that button invokes renault_api with correct data."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    data = {
+        ATTR_ENTITY_ID: "button.reg_number_start_charge",
+    }
+
+    with patch(
+        "renault_api.renault_vehicle.RenaultVehicle.set_charge_start",
+        return_value=(
+            schemas.KamereonVehicleHvacStartActionDataSchema.loads(
+                load_fixture("renault/action.set_charge_start.json")
+            )
+        ),
+    ) as mock_action:
+        await hass.services.async_call(
+            BUTTON_DOMAIN, SERVICE_PRESS, service_data=data, blocking=True
+        )
+    assert len(mock_action.mock_calls) == 1
+    assert mock_action.mock_calls[0][1] == ()
+
+
+@pytest.mark.usefixtures("fixtures_with_data")
+@pytest.mark.parametrize("vehicle_type", ["zoe_40"], indirect=True)
+async def test_button_start_air_conditioner(
+    hass: HomeAssistant, config_entry: ConfigEntry
+):
+    """Test that button invokes renault_api with correct data."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    data = {
+        ATTR_ENTITY_ID: "button.reg_number_start_air_conditioner",
+    }
+
+    with patch(
+        "renault_api.renault_vehicle.RenaultVehicle.set_ac_start",
+        return_value=(
+            schemas.KamereonVehicleHvacStartActionDataSchema.loads(
+                load_fixture("renault/action.set_ac_start.json")
+            )
+        ),
+    ) as mock_action:
+        await hass.services.async_call(
+            BUTTON_DOMAIN, SERVICE_PRESS, service_data=data, blocking=True
+        )
+    assert len(mock_action.mock_calls) == 1
+    assert mock_action.mock_calls[0][1] == (21, None)

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -236,7 +236,9 @@ async def test_service_set_charge_schedule_multi(
     assert mock_action.mock_calls[0][1] == (mock_call_data,)
 
 
-async def test_service_set_charge_start(hass: HomeAssistant, config_entry: ConfigEntry):
+async def test_service_set_charge_start(
+    hass: HomeAssistant, config_entry: ConfigEntry, caplog: pytest.LogCaptureFixture
+):
     """Test that service invokes renault_api with correct data."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -258,6 +260,7 @@ async def test_service_set_charge_start(hass: HomeAssistant, config_entry: Confi
         )
     assert len(mock_action.mock_calls) == 1
     assert mock_action.mock_calls[0][1] == ()
+    assert f"'{DOMAIN}.{SERVICE_CHARGE_START}' service is deprecated" in caplog.text
 
 
 async def test_service_invalid_device_id(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `renault.charge_start` service is deprecated and replaced by a dedicated start charge button entity; please use that entity to start the charge instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a button to `start charge` and a button to `start air-conditioning` (with Renault default target temperature of 21°C).
Mark old `start charge` service as deprecated as it has been replaced by new entity.
Note: keeping `start air conditioning` service as it has the added ability to choose a temperature and a timestamp.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
