### PR TITLE
Add options flow to handle inactive tiles in tile integration

### DIFF
--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -25,8 +25,6 @@ DEVICE_TYPES = ["PHONE", "TILE"]
 DEFAULT_INIT_TASK_LIMIT = 2
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=2)
 
-CONF_SHOW_INACTIVE = "show_inactive"
-
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Tile as config entry."""

--- a/homeassistant/components/tile/config_flow.py
+++ b/homeassistant/components/tile/config_flow.py
@@ -9,10 +9,11 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN
+from .const import CONF_SHOW_INACTIVE, DEFAULT_SHOW_INACTIVE, DOMAIN
 
 
 class TileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -56,3 +57,43 @@ class TileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._show_form({"base": "invalid_auth"})
 
         return self.async_create_entry(title=user_input[CONF_USERNAME], data=user_input)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> TileOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return TileOptionsFlowHandler(config_entry)
+
+
+class TileOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Tile options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry):
+        """Initialize Tile options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage Tile options."""
+        if user_input is not None:
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(self.config_entry.entry_id)
+            )
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SHOW_INACTIVE,
+                        default=self.config_entry.options.get(
+                            CONF_SHOW_INACTIVE, DEFAULT_SHOW_INACTIVE
+                        ),
+                    ): bool
+                }
+            ),
+        )

--- a/homeassistant/components/tile/config_flow.py
+++ b/homeassistant/components/tile/config_flow.py
@@ -70,7 +70,7 @@ class TileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 class TileOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle Tile options."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry):
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize Tile options flow."""
         self.config_entry = config_entry
 

--- a/homeassistant/components/tile/const.py
+++ b/homeassistant/components/tile/const.py
@@ -7,3 +7,6 @@ DATA_COORDINATOR = "coordinator"
 DATA_TILE = "tile"
 
 LOGGER = logging.getLogger(__package__)
+
+CONF_SHOW_INACTIVE = "show_inactive"
+DEFAULT_SHOW_INACTIVE = False

--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -19,7 +19,13 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from . import DATA_COORDINATOR, DATA_TILE, DOMAIN
+from .const import (
+    CONF_SHOW_INACTIVE,
+    DATA_COORDINATOR,
+    DATA_TILE,
+    DEFAULT_SHOW_INACTIVE,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,6 +45,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Tile device trackers."""
+    show_inactive = entry.options.get(CONF_SHOW_INACTIVE, DEFAULT_SHOW_INACTIVE)
     async_add_entities(
         [
             TileDeviceTracker(
@@ -47,6 +54,7 @@ async def async_setup_entry(
                 tile,
             )
             for tile_uuid, tile in hass.data[DOMAIN][entry.entry_id][DATA_TILE].items()
+            if tile.visible or show_inactive
         ]
     )
 

--- a/tests/components/tile/test_config_flow.py
+++ b/tests/components/tile/test_config_flow.py
@@ -5,77 +5,61 @@ from pytile.errors import TileError
 
 from homeassistant import data_entry_flow
 from homeassistant.components.tile import DOMAIN
+from homeassistant.components.tile.const import CONF_SHOW_INACTIVE
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
+CONF = {
+    CONF_USERNAME: "user@host.com",
+    CONF_PASSWORD: "123abc",
+}
 
-async def test_duplicate_error(hass):
+
+async def test_duplicate_error(hass: HomeAssistant):
     """Test that errors are shown when duplicates are added."""
-    conf = {
-        CONF_USERNAME: "user@host.com",
-        CONF_PASSWORD: "123abc",
-    }
-
-    MockConfigEntry(domain=DOMAIN, unique_id="user@host.com", data=conf).add_to_hass(
+    MockConfigEntry(domain=DOMAIN, unique_id="user@host.com", data=CONF).add_to_hass(
         hass
     )
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=conf
+        DOMAIN, context={"source": SOURCE_USER}, data=CONF
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
 
 
-async def test_invalid_credentials(hass):
+async def test_invalid_credentials(hass: HomeAssistant):
     """Test that invalid credentials key throws an error."""
-    conf = {
-        CONF_USERNAME: "user@host.com",
-        CONF_PASSWORD: "123abc",
-    }
-
     with patch(
         "homeassistant.components.tile.config_flow.async_login",
         side_effect=TileError,
     ):
         result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=conf
+            DOMAIN, context={"source": SOURCE_USER}, data=CONF
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_step_import(hass):
+async def test_step_import(hass: HomeAssistant):
     """Test that the import step works."""
-    conf = {
-        CONF_USERNAME: "user@host.com",
-        CONF_PASSWORD: "123abc",
-    }
-
     with patch(
         "homeassistant.components.tile.async_setup_entry", return_value=True
     ), patch("homeassistant.components.tile.config_flow.async_login"):
         result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=CONF
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == "user@host.com"
-        assert result["data"] == {
-            CONF_USERNAME: "user@host.com",
-            CONF_PASSWORD: "123abc",
-        }
+        assert result["data"] == CONF
 
 
-async def test_step_user(hass):
+async def test_step_user(hass: HomeAssistant):
     """Test that the user step works."""
-    conf = {
-        CONF_USERNAME: "user@host.com",
-        CONF_PASSWORD: "123abc",
-    }
-
     with patch(
         "homeassistant.components.tile.async_setup_entry", return_value=True
     ), patch("homeassistant.components.tile.config_flow.async_login"):
@@ -86,7 +70,7 @@ async def test_step_user(hass):
         assert result["step_id"] == "user"
 
         result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=conf
+            DOMAIN, context={"source": SOURCE_USER}, data=CONF
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == "user@host.com"
@@ -94,3 +78,22 @@ async def test_step_user(hass):
             CONF_USERNAME: "user@host.com",
             CONF_PASSWORD: "123abc",
         }
+
+
+async def test_options_flow(hass: HomeAssistant):
+    """Test config flow options."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="user@host.com", data=CONF)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result.get("type") == data_entry_flow.RESULT_TYPE_FORM
+    assert result.get("step_id") == "init"
+    assert "flow_id" in result
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SHOW_INACTIVE: True},
+    )
+
+    assert result.get("type") == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result.get("data") == {CONF_SHOW_INACTIVE: True}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Hidden/inactive tiles will not be added by default, but can be changed via the Configure option on the integration

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add options flow to handle inactive tiles in tile integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
