### PR TITLE
Fix zeroconf with sonos v1 firmware

### DIFF
--- a/homeassistant/components/sonos/config_flow.py
+++ b/homeassistant/components/sonos/config_flow.py
@@ -30,7 +30,7 @@ class SonosDiscoveryFlowHandler(DiscoveryFlowHandler):
     ) -> FlowResult:
         """Handle a flow initialized by zeroconf."""
         hostname = discovery_info["hostname"]
-        if hostname is None or not hostname.startswith("Sonos-"):
+        if hostname is None or not hostname.lower().startswith("sonos"):
             return self.async_abort(reason="not_sonos_device")
         await self.async_set_unique_id(self._domain, raise_on_progress=False)
         host = discovery_info[CONF_HOST]

--- a/homeassistant/components/sonos/helpers.py
+++ b/homeassistant/components/sonos/helpers.py
@@ -44,5 +44,10 @@ def soco_error(errorcodes: list[str] | None = None) -> Callable:
 
 def hostname_to_uid(hostname: str) -> str:
     """Convert a Sonos hostname to a uid."""
-    baseuid = hostname.split("-")[1].replace(".local.", "")
+    if hostname.startswith("Sonos-"):
+        baseuid = hostname.split("-")[1].replace(".local.", "")
+    elif hostname.startswith("sonos"):
+        baseuid = hostname[5:].replace(".local.", "")
+    else:
+        raise ValueError(f"{hostname} is not a sonos device.")
     return f"{UID_PREFIX}{baseuid}{UID_POSTFIX}"

--- a/tests/components/sonos/test_config_flow.py
+++ b/tests/components/sonos/test_config_flow.py
@@ -75,6 +75,56 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
     assert len(mock_manager.mock_calls) == 2
 
 
+async def test_zeroconf_sonos_v1(hass: core.HomeAssistant):
+    """Test we pass sonos devices to the discovery manager with v1 firmware devices."""
+
+    mock_manager = hass.data[DATA_SONOS_DISCOVERY_MANAGER] = MagicMock()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data={
+            "host": "192.168.1.107",
+            "port": 1443,
+            "hostname": "sonos5CAAFDE47AC8.local.",
+            "type": "_sonos._tcp.local.",
+            "name": "Sonos-5CAAFDE47AC8._sonos._tcp.local.",
+            "properties": {
+                "_raw": {
+                    "info": b"/api/v1/players/RINCON_5CAAFDE47AC801400/info",
+                    "vers": b"1",
+                    "protovers": b"1.18.9",
+                },
+                "info": "/api/v1/players/RINCON_5CAAFDE47AC801400/info",
+                "vers": "1",
+                "protovers": "1.18.9",
+            },
+        },
+    )
+    assert result["type"] == "form"
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.sonos.async_setup",
+        return_value=True,
+    ) as mock_setup, patch(
+        "homeassistant.components.sonos.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Sonos"
+    assert result2["data"] == {}
+
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_manager.mock_calls) == 2
+
+
 async def test_zeroconf_form_not_sonos(hass: core.HomeAssistant):
     """Test we abort on non-sonos devices."""
     mock_manager = hass.data[DATA_SONOS_DISCOVERY_MANAGER] = MagicMock()

--- a/tests/components/sonos/test_helpers.py
+++ b/tests/components/sonos/test_helpers.py
@@ -1,9 +1,15 @@
 """Test the sonos config flow."""
 from __future__ import annotations
 
+import pytest
+
 from homeassistant.components.sonos.helpers import hostname_to_uid
 
 
 async def test_uid_to_hostname():
     """Test we can convert a hostname to a uid."""
     assert hostname_to_uid("Sonos-347E5C0CF1E3.local.") == "RINCON_347E5C0CF1E301400"
+    assert hostname_to_uid("sonos5CAAFDE47AC8.local.") == "RINCON_5CAAFDE47AC801400"
+
+    with pytest.raises(ValueError):
+        assert hostname_to_uid("notsonos5CAAFDE47AC8.local.")


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sonos v1 firmware uses a different mdns hostname.

fixes #58002

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
