### PR TITLE
Rename zeroconf service info

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -61,7 +61,7 @@ MAX_PROPERTY_VALUE_LEN = 230
 # Dns label max length
 MAX_NAME_LEN = 63
 
-# Attributes for HaServiceInfo
+# Attributes for ZeroconfServiceInfo
 ATTR_HOST: Final = "host"
 ATTR_HOSTNAME: Final = "hostname"
 ATTR_NAME: Final = "name"
@@ -87,7 +87,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-class HaServiceInfo(TypedDict):
+class ZeroconfServiceInfo(TypedDict):
     """Prepared info from mDNS entries."""
 
     host: str
@@ -466,7 +466,7 @@ def async_get_homekit_discovery_domain(
     return None
 
 
-def info_from_service(service: AsyncServiceInfo) -> HaServiceInfo | None:
+def info_from_service(service: AsyncServiceInfo) -> ZeroconfServiceInfo | None:
     """Return prepared info from mDNS entries."""
     properties: dict[str, Any] = {"_raw": {}}
 
@@ -493,7 +493,7 @@ def info_from_service(service: AsyncServiceInfo) -> HaServiceInfo | None:
     if (host := _first_non_link_local_or_v6_address(addresses)) is None:
         return None
 
-    return HaServiceInfo(
+    return ZeroconfServiceInfo(
         host=str(host),
         port=service.port,
         hostname=service.server,

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.components.apple_tv.const import CONF_START_OFF, DOMAIN
 
 from tests.common import MockConfigEntry
 
-DMAP_SERVICE = zeroconf.HaServiceInfo(
+DMAP_SERVICE = zeroconf.ZeroconfServiceInfo(
     type="_touch-able._tcp.local.",
     name="dmapid.something",
     properties={"CtlN": "Apple TV"},
@@ -400,7 +400,7 @@ async def test_zeroconf_unsupported_service_aborts(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.HaServiceInfo(
+        data=zeroconf.ZeroconfServiceInfo(
             type="_dummy._tcp.local.",
             properties={},
         ),
@@ -414,7 +414,7 @@ async def test_zeroconf_add_mrp_device(hass, mrp_device, pairing):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.HaServiceInfo(
+        data=zeroconf.ZeroconfServiceInfo(
             type="_mediaremotetv._tcp.local.",
             properties={"UniqueIdentifier": "mrpid", "Name": "Kitchen"},
         ),

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -293,7 +293,7 @@ async def test_reauth_flow_update_configuration(hass):
         ),
         (
             SOURCE_ZEROCONF,
-            zeroconf.HaServiceInfo(
+            zeroconf.ZeroconfServiceInfo(
                 host=DEFAULT_HOST,
                 port=80,
                 hostname=f"axis-{MAC.lower()}.local.",
@@ -363,7 +363,7 @@ async def test_discovery_flow(hass, source: str, discovery_info: dict):
         ),
         (
             SOURCE_ZEROCONF,
-            zeroconf.HaServiceInfo(
+            zeroconf.ZeroconfServiceInfo(
                 host=DEFAULT_HOST,
                 port=80,
                 name=f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
@@ -411,7 +411,7 @@ async def test_discovered_device_already_configured(
         ),
         (
             SOURCE_ZEROCONF,
-            zeroconf.HaServiceInfo(
+            zeroconf.ZeroconfServiceInfo(
                 host="2.3.4.5",
                 port=8080,
                 name=f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",
@@ -479,7 +479,7 @@ async def test_discovery_flow_updated_configuration(
         ),
         (
             SOURCE_ZEROCONF,
-            zeroconf.HaServiceInfo(
+            zeroconf.ZeroconfServiceInfo(
                 host="",
                 port=0,
                 name="",
@@ -517,7 +517,7 @@ async def test_discovery_flow_ignore_non_axis_device(
         ),
         (
             SOURCE_ZEROCONF,
-            zeroconf.HaServiceInfo(
+            zeroconf.ZeroconfServiceInfo(
                 host="169.254.3.4",
                 port=80,
                 name=f"AXIS M1065-LW - {MAC}._axis-video._tcp.local.",

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -197,7 +197,7 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.HaServiceInfo(
+        data=zeroconf.ZeroconfServiceInfo(
             name="test-bond-id.some-other-tail-info", host="test-host"
         ),
     )
@@ -229,7 +229,7 @@ async def test_zeroconf_form_token_unavailable(hass: core.HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 name="test-bond-id.some-other-tail-info", host="test-host"
             ),
         )
@@ -264,7 +264,7 @@ async def test_zeroconf_form_with_token_available(hass: core.HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 name="test-bond-id.some-other-tail-info", host="test-host"
             ),
         )
@@ -302,7 +302,7 @@ async def test_zeroconf_already_configured(hass: core.HomeAssistant):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 name="already-registered-bond-id.some-other-tail-info",
                 host="updated-host",
             ),
@@ -343,7 +343,7 @@ async def test_zeroconf_already_configured_refresh_token(hass: core.HomeAssistan
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 name="already-registered-bond-id.some-other-tail-info",
                 host="updated-host",
             ),
@@ -376,7 +376,7 @@ async def test_zeroconf_already_configured_no_reload_same_host(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 name="already-registered-bond-id.some-other-tail-info",
                 host="stored-host",
             ),
@@ -393,7 +393,7 @@ async def test_zeroconf_form_unexpected_error(hass: core.HomeAssistant):
     await _help_test_form_unexpected_error(
         hass,
         source=config_entries.SOURCE_ZEROCONF,
-        initial_input=zeroconf.HaServiceInfo(
+        initial_input=zeroconf.ZeroconfServiceInfo(
             name="test-bond-id.some-other-tail-info",
             host="test-host",
         ),

--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -20,7 +20,7 @@ MOCK_SETTINGS = {
     "name": "Test name",
     "device": {"mac": "test-mac", "hostname": "test-host"},
 }
-DISCOVERY_INFO = zeroconf.HaServiceInfo(
+DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
     host=["169.1.1.1", "1.1.1.1"],
     port=0,
     hostname="shc012345.local.",
@@ -528,7 +528,7 @@ async def test_zeroconf_cannot_connect(hass, mock_zeroconf):
 
 async def test_zeroconf_link_local(hass, mock_zeroconf):
     """Test we get the form."""
-    DISCOVERY_INFO_LINK_LOCAL = zeroconf.HaServiceInfo(
+    DISCOVERY_INFO_LINK_LOCAL = zeroconf.ZeroconfServiceInfo(
         host=["169.1.1.1"],
         port=0,
         hostname="shc012345.local.",
@@ -552,7 +552,7 @@ async def test_zeroconf_not_bosch_shc(hass, mock_zeroconf):
     """Test we filter out non-bosch_shc devices."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data=zeroconf.HaServiceInfo(host="1.1.1.1", name="notboschshc"),
+        data=zeroconf.ZeroconfServiceInfo(host="1.1.1.1", name="notboschshc"),
         context={"source": config_entries.SOURCE_ZEROCONF},
     )
     assert result["type"] == "abort"

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -144,7 +144,7 @@ async def test_zeroconf_snmp_error(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 hostname="example.local.", name="Brother Printer"
             ),
         )
@@ -159,7 +159,7 @@ async def test_zeroconf_unsupported_model(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 hostname="example.local.",
                 name="Brother Printer",
                 properties={"product": "MFC-8660DN"},
@@ -184,7 +184,7 @@ async def test_zeroconf_device_exists_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 hostname="example.local.", name="Brother Printer"
             ),
         )
@@ -201,7 +201,9 @@ async def test_zeroconf_no_probe_existing_device(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(hostname="localhost", name="Brother Printer"),
+            data=zeroconf.ZeroconfServiceInfo(
+                hostname="localhost", name="Brother Printer"
+            ),
         )
         await hass.async_block_till_done()
 
@@ -220,7 +222,7 @@ async def test_zeroconf_confirm_create_entry(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 hostname="example.local.", name="Brother Printer"
             ),
         )

--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -120,7 +120,7 @@ async def test_api_password_abort(hass):
 @pytest.mark.parametrize(
     "source, data, unique_id",
     [
-        (SOURCE_ZEROCONF, zeroconf.HaServiceInfo(host=HOST), MAC),
+        (SOURCE_ZEROCONF, zeroconf.ZeroconfServiceInfo(host=HOST), MAC),
     ],
 )
 async def test_discovery_zeroconf(

--- a/tests/components/devolo_home_control/const.py
+++ b/tests/components/devolo_home_control/const.py
@@ -2,7 +2,7 @@
 
 from homeassistant.components import zeroconf
 
-DISCOVERY_INFO = zeroconf.HaServiceInfo(
+DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
     host="192.168.0.1",
     port=14791,
     hostname="test.local.",
@@ -19,6 +19,8 @@ DISCOVERY_INFO = zeroconf.HaServiceInfo(
     },
 )
 
-DISCOVERY_INFO_WRONG_DEVOLO_DEVICE = zeroconf.HaServiceInfo(properties={"MT": "2700"})
+DISCOVERY_INFO_WRONG_DEVOLO_DEVICE = zeroconf.ZeroconfServiceInfo(
+    properties={"MT": "2700"}
+)
 
-DISCOVERY_INFO_WRONG_DEVICE = zeroconf.HaServiceInfo(properties={"Features": ""})
+DISCOVERY_INFO_WRONG_DEVICE = zeroconf.ZeroconfServiceInfo(properties={"Features": ""})

--- a/tests/components/devolo_home_network/const.py
+++ b/tests/components/devolo_home_network/const.py
@@ -16,7 +16,7 @@ CONNECTED_STATIONS = {
     ],
 }
 
-DISCOVERY_INFO = zeroconf.HaServiceInfo(
+DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
     host=IP,
     port=14791,
     hostname="test.local.",
@@ -36,7 +36,7 @@ DISCOVERY_INFO = zeroconf.HaServiceInfo(
     },
 )
 
-DISCOVERY_INFO_WRONG_DEVICE = zeroconf.HaServiceInfo(properties={"MT": "2600"})
+DISCOVERY_INFO_WRONG_DEVICE = zeroconf.ZeroconfServiceInfo(properties={"MT": "2600"})
 
 NEIGHBOR_ACCESS_POINTS = {
     "neighbor_aps": [

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -82,7 +82,7 @@ async def test_form_zeroconf_wrong_oui(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.HaServiceInfo(
+        data=zeroconf.ZeroconfServiceInfo(
             properties={"macaddress": "notdoorbirdoui"},
             host="192.168.1.8",
             name="Doorstation - abc123._axis-video._tcp.local.",
@@ -98,7 +98,7 @@ async def test_form_zeroconf_link_local_ignored(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.HaServiceInfo(
+        data=zeroconf.ZeroconfServiceInfo(
             properties={"macaddress": "1CCAE3DOORBIRD"},
             host="169.254.103.61",
             name="Doorstation - abc123._axis-video._tcp.local.",
@@ -121,7 +121,7 @@ async def test_form_zeroconf_correct_oui(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 properties={"macaddress": "1CCAE3DOORBIRD"},
                 name="Doorstation - abc123._axis-video._tcp.local.",
                 host="192.168.1.5",
@@ -180,7 +180,7 @@ async def test_form_zeroconf_correct_oui_wrong_device(hass, doorbell_state_side_
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 properties={"macaddress": "1CCAE3DOORBIRD"},
                 name="Doorstation - abc123._axis-video._tcp.local.",
                 host="192.168.1.5",

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -158,7 +158,7 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.HaServiceInfo(
+        data=zeroconf.ZeroconfServiceInfo(
             properties={"serialnum": "1234"},
             host="1.1.1.1",
         ),
@@ -254,7 +254,7 @@ async def test_zeroconf_serial_already_exists(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.HaServiceInfo(
+        data=zeroconf.ZeroconfServiceInfo(
             properties={"serialnum": "1234"},
             host="1.1.1.1",
         ),
@@ -289,7 +289,7 @@ async def test_zeroconf_host_already_exists(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.HaServiceInfo(
+            data=zeroconf.ZeroconfServiceInfo(
                 properties={"serialnum": "1234"},
                 host="1.1.1.1",
             ),

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -18,7 +18,7 @@ from .const import MOCK_HOST, MOCK_PORT
 
 from tests.common import MockConfigEntry
 
-MOCK_ZEROCONF_DATA = zeroconf.HaServiceInfo(
+MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
     host="192.168.0.254",
     port=80,
     hostname="Freebox-Server.local.",

--- a/tests/components/lookin/__init__.py
+++ b/tests/components/lookin/__init__.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from aiolookin import Climate, Device, Remote
 
-from homeassistant.components.zeroconf import HaServiceInfo
+from homeassistant.components.zeroconf import ZeroconfServiceInfo
 
 DEVICE_ID = "98F33163"
 MODULE = "homeassistant.components.lookin"
@@ -17,7 +17,7 @@ DEFAULT_ENTRY_TITLE = DEVICE_NAME
 
 ZC_NAME = f"LOOKin_{DEVICE_ID}"
 ZC_TYPE = "_lookin._tcp."
-ZEROCONF_DATA: HaServiceInfo = {
+ZEROCONF_DATA: ZeroconfServiceInfo = {
     "host": IP_ADDRESS,
     "hostname": f"{ZC_NAME.lower()}.local.",
     "port": 80,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename HaServiceInfo to ZeroconfServiceInfo.
As discussed in https://github.com/home-assistant/core/pull/58958#discussion_r745915752
cc @frenck @bdraco @KapJI 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
