### PR TITLE
Fix issue with ranges in requirements with hassfest

### DIFF
--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -26,7 +26,7 @@ PACKAGE_REGEX = re.compile(
     r"^(?:--.+\s)?([-_\.\w\d\[\]]+)(==|>=|<=|~=|!=|<|>|===)*(.*)$"
 )
 PIP_REGEX = re.compile(r"^(--.+\s)?([-_\.\w\d]+.*(?:==|>=|<=|~=|!=|<|>|===)?.*$)")
-PIP_VERSION_RANGE_SEPERATOR = re.compile(r"^(==|>=|<=|~=|!=|<|>|===)?(.*)$")
+PIP_VERSION_RANGE_SEPARATOR = re.compile(r"^(==|>=|<=|~=|!=|<|>|===)?(.*)$")
 SUPPORTED_PYTHON_TUPLES = [
     REQUIRED_PYTHON_VER[:2],
     tuple(map(operator.add, REQUIRED_PYTHON_VER, (0, 1, 0)))[:2],
@@ -100,7 +100,7 @@ def validate_requirements_format(integration: Integration) -> bool:
             continue
 
         for part in version.split(","):
-            version_part = PIP_VERSION_RANGE_SEPERATOR.match(part)
+            version_part = PIP_VERSION_RANGE_SEPARATOR.match(part)
             if (
                 version_part
                 and AwesomeVersion(version_part.group(2)).strategy

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -26,6 +26,7 @@ PACKAGE_REGEX = re.compile(
     r"^(?:--.+\s)?([-_\.\w\d\[\]]+)(==|>=|<=|~=|!=|<|>|===)*(.*)$"
 )
 PIP_REGEX = re.compile(r"^(--.+\s)?([-_\.\w\d]+.*(?:==|>=|<=|~=|!=|<|>|===)?.*$)")
+PIP_VERSION_RANGE_SEPERATOR = re.compile(r"^(==|>=|<=|~=|!=|<|>|===)?(.*)$")
 SUPPORTED_PYTHON_TUPLES = [
     REQUIRED_PYTHON_VER[:2],
     tuple(map(operator.add, REQUIRED_PYTHON_VER, (0, 1, 0)))[:2],
@@ -95,15 +96,21 @@ def validate_requirements_format(integration: Integration) -> bool:
             )
             continue
 
-        if (
-            version
-            and AwesomeVersion(version).strategy == AwesomeVersionStrategy.UNKNOWN
-        ):
-            integration.add_error(
-                "requirements",
-                f"Unable to parse package version ({version}) for {pkg}.",
-            )
+        if not version:
             continue
+
+        for part in version.split(","):
+            version_part = PIP_VERSION_RANGE_SEPERATOR.match(part)
+            if (
+                version_part
+                and AwesomeVersion(version_part.group(2)).strategy
+                == AwesomeVersionStrategy.UNKNOWN
+            ):
+                integration.add_error(
+                    "requirements",
+                    f"Unable to parse package version ({version}) for {pkg}.",
+                )
+                continue
 
     return len(integration.errors) == start_errors
 

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -45,7 +45,14 @@ def test_validate_requirements_format_wrongly_pinned(integration: Integration):
 
 def test_validate_requirements_format_ignore_pin_for_custom(integration: Integration):
     """Test requirement ignore pinning for custom."""
-    integration.manifest["requirements"] = ["test_package>=1", "test_package"]
+    integration.manifest["requirements"] = [
+        "test_package>=1",
+        "test_package",
+        "test_package>=1.2.3,<3.2.1",
+        "test_package~=0.5.0",
+        "test_package>=1.4.2,<1.4.99,>=1.7,<1.8.99",
+        "test_package>=1.4.2,<1.9,!=1.5",
+    ]
     integration.path = Path("")
     assert validate_requirements_format(integration)
     assert len(integration.errors) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes issues with hassfest in custom integrations where they used ranges in the version part of the requirement definition.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
