### PR TITLE
Add timeout to all tradfri API calls

### DIFF
--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -143,12 +143,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         gw_status = True
         try:
             await api(gateway.get_gateway_info(), timeout=TIMEOUT_API)
-        except RequestError:
+        except (RequestError, PytradfriError):
             _LOGGER.error("Keep-alive failed")
-            gw_status = False
-        except PytradfriError as exc:
-            msg = f"keep-alive {exc}"
-            _LOGGER.error(msg)
             gw_status = False
 
         async_dispatcher_send(hass, SIGNAL_GW, gw_status)

--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -142,9 +142,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         gw_status = True
         try:
-            await api(gateway.get_gateway_info())
+            await api(gateway.get_gateway_info(), timeout=TIMEOUT_API)
         except RequestError:
             _LOGGER.error("Keep-alive failed")
+            gw_status = False
+        except PytradfriError as exc:
+            msg = f"keep-alive {exc}"
+            _LOGGER.error(msg)
             gw_status = False
 
         async_dispatcher_send(hass, SIGNAL_GW, gw_status)

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 import logging
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
 from pytradfri.command import Command
 from pytradfri.device import Device
@@ -28,10 +28,7 @@ from .const import DOMAIN, SIGNAL_GW, TIMEOUT_API
 _LOGGER = logging.getLogger(__name__)
 
 
-FuncArg = TypeVar("FuncArg", bound=Callable[..., Any])
-
-
-def handle_error(func: FuncArg) -> FuncArg:
+def handle_error(func: Callable[..., Any]) -> Callable[..., Any]:
     """Handle tradfri api call error."""
 
     @wraps(func)
@@ -42,7 +39,7 @@ def handle_error(func: FuncArg) -> FuncArg:
         except PytradfriError as err:
             _LOGGER.error("Unable to execute command %s: %s", command, err)
 
-    return cast(FuncArg, wrapper)
+    return cast(Callable[..., Any], wrapper)
 
 
 class TradfriBaseClass(Entity):

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 import logging
-from typing import Any, TypeVar, cast
+from typing import Any
 
 from pytradfri.command import Command
 from pytradfri.device import Device
@@ -28,10 +28,7 @@ from .const import DOMAIN, SIGNAL_GW, TIMEOUT_API
 _LOGGER = logging.getLogger(__name__)
 
 
-Func = TypeVar("Func", bound=Callable[..., Any])
-
-
-def handle_error(func: Func) -> Func:
+def handle_error(func: Callable[..., Any]) -> Callable[..., Any]:
     """Handle tradfri api call error."""
 
     @wraps(func)
@@ -42,7 +39,7 @@ def handle_error(func: Func) -> Func:
         except PytradfriError as err:
             _LOGGER.error("Unable to execute command %s: %s", command, err)
 
-    return cast(Func, wrapper)
+    return wrapper
 
 
 class TradfriBaseClass(Entity):

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 import logging
-from typing import Any, cast
+from typing import Any
 
 from pytradfri.command import Command
 from pytradfri.device import Device
@@ -39,7 +39,7 @@ def handle_error(func: Callable[..., Any]) -> Callable[..., Any]:
         except PytradfriError as err:
             _LOGGER.error("Unable to execute command %s: %s", command, err)
 
-    return cast(Callable[..., Any], wrapper)
+    return wrapper
 
 
 class TradfriBaseClass(Entity):

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -28,10 +28,10 @@ from .const import DOMAIN, SIGNAL_GW, TIMEOUT_API
 _LOGGER = logging.getLogger(__name__)
 
 
-F = TypeVar("F", bound=Callable[..., Any])
+FuncArg = TypeVar("FuncArg", bound=Callable[..., Any])
 
 
-def handle_error(func: F) -> F:
+def handle_error(func: FuncArg) -> FuncArg:
     """Handle tradfri api call error."""
 
     @wraps(func)
@@ -42,7 +42,7 @@ def handle_error(func: F) -> F:
         except PytradfriError as err:
             _LOGGER.error("Unable to execute command %s: %s", command, err)
 
-    return cast(F, wrapper)
+    return cast(FuncArg, wrapper)
 
 
 class TradfriBaseClass(Entity):

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 import logging
-from typing import Any
+from typing import Any, TypeVar, cast
 
 from pytradfri.command import Command
 from pytradfri.device import Device
@@ -28,7 +28,10 @@ from .const import DOMAIN, SIGNAL_GW, TIMEOUT_API
 _LOGGER = logging.getLogger(__name__)
 
 
-def handle_error(func: Callable[..., Any]) -> Callable[[str], Any]:
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def handle_error(func: F) -> F:
     """Handle tradfri api call error."""
 
     @wraps(func)
@@ -39,7 +42,7 @@ def handle_error(func: Callable[..., Any]) -> Callable[[str], Any]:
         except PytradfriError as err:
             _LOGGER.error("Unable to execute command %s: %s", command, err)
 
-    return wrapper
+    return cast(F, wrapper)
 
 
 class TradfriBaseClass(Entity):

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -23,21 +23,19 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
-from .const import DOMAIN, SIGNAL_GW
+from .const import DOMAIN, SIGNAL_GW, TIMEOUT_API
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def handle_error(
-    func: Callable[[Command | list[Command]], Any]
-) -> Callable[[str], Any]:
+def handle_error(func: Callable[..., Any]) -> Callable[[str], Any]:
     """Handle tradfri api call error."""
 
     @wraps(func)
     async def wrapper(command: Command | list[Command]) -> None:
         """Decorate api call."""
         try:
-            await func(command)
+            await func(command, timeout=TIMEOUT_API)
         except PytradfriError as err:
             _LOGGER.error("Unable to execute command %s: %s", command, err)
 

--- a/homeassistant/components/tradfri/base_class.py
+++ b/homeassistant/components/tradfri/base_class.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 import logging
-from typing import Any
+from typing import Any, TypeVar, cast
 
 from pytradfri.command import Command
 from pytradfri.device import Device
@@ -28,7 +28,10 @@ from .const import DOMAIN, SIGNAL_GW, TIMEOUT_API
 _LOGGER = logging.getLogger(__name__)
 
 
-def handle_error(func: Callable[..., Any]) -> Callable[..., Any]:
+Func = TypeVar("Func", bound=Callable[..., Any])
+
+
+def handle_error(func: Func) -> Func:
     """Handle tradfri api call error."""
 
     @wraps(func)
@@ -39,7 +42,7 @@ def handle_error(func: Callable[..., Any]) -> Callable[..., Any]:
         except PytradfriError as err:
             _LOGGER.error("Unable to execute command %s: %s", command, err)
 
-    return wrapper
+    return cast(Func, wrapper)
 
 
 class TradfriBaseClass(Entity):

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_KEY,
     DOMAIN,
     KEY_SECURITY_CODE,
+    TIMEOUT_API,
 )
 
 
@@ -197,7 +198,7 @@ async def get_gateway_info(
 
         api = factory.request
         gateway = Gateway()
-        gateway_info_result = await api(gateway.get_gateway_info())
+        gateway_info_result = await api(gateway.get_gateway_info(), timeout=TIMEOUT_API)
 
         await factory.shutdown()
     except (OSError, RequestError) as err:

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 from uuid import uuid4
 
 import async_timeout
-from pytradfri import Gateway, RequestError
+from pytradfri import Gateway, PytradfriError, RequestError
 from pytradfri.api.aiocoap_api import APIFactory
 import voluptuous as vol
 
@@ -201,7 +201,7 @@ async def get_gateway_info(
         gateway_info_result = await api(gateway.get_gateway_info(), timeout=TIMEOUT_API)
 
         await factory.shutdown()
-    except (OSError, RequestError) as err:
+    except (OSError, RequestError, PytradfriError) as err:
         # We're also catching OSError as PyTradfri doesn't catch that one yet
         # Upstream PR: https://github.com/ggravlingen/pytradfri/pull/189
         raise AuthError("cannot_connect") from err


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add timeout=TIMEOUT_API to all api calls in tradfri.

Remark the typing of handle_error (with …) was needed because we call func(command, timeout=TIMEOUT_API) and mypy do not like this modification, however it is not a problem as the wrapper limits the legal arguments.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
