### PR TITLE
Home plus control covers

### DIFF
--- a/homeassistant/components/home_plus_control/__init__.py
+++ b/homeassistant/components/home_plus_control/__init__.py
@@ -45,8 +45,8 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-# The Legrand Home+ Control platform is currently limited to "switch" entities
-PLATFORMS = ["switch"]
+# The Legrand Home+ Control platform is currently limited to "cover" and "switch" entities
+PLATFORMS = ["cover", "switch"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/home_plus_control/const.py
+++ b/homeassistant/components/home_plus_control/const.py
@@ -12,6 +12,7 @@ DISPATCHER_REMOVERS = "dispatcher_removers"
 
 # Legrand Model Identifiers - https://developer.legrand.com/documentation/product-cluster-list/#
 HW_TYPE = {
+    "NBR": "NBR - Bubendorff Roller Shutter",
     "NLC": "NLC - Cable Outlet",
     "NLF": "NLF - On-Off Dimmer Switch w/o Neutral",
     "NLP": "NLP - Socket (Connected) Outlet",

--- a/homeassistant/components/home_plus_control/cover.py
+++ b/homeassistant/components/home_plus_control/cover.py
@@ -1,10 +1,14 @@
-"""Legrand Home+ Control Switch Entity Module that uses the HomeAssistant DataUpdateCoordinator."""
+"""Legrand Home+ Control Cover Entity Module that uses the HomeAssistant DataUpdateCoordinator."""
 from functools import partial
 
-from homeassistant.components.switch import (
-    DEVICE_CLASS_OUTLET,
-    DEVICE_CLASS_SWITCH,
-    SwitchEntity,
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    DEVICE_CLASS_SHUTTER,
+    SUPPORT_CLOSE,
+    SUPPORT_OPEN,
+    SUPPORT_SET_POSITION,
+    SUPPORT_STOP,
+    CoverEntity,
 )
 from homeassistant.core import callback
 from homeassistant.helpers import dispatcher
@@ -15,8 +19,8 @@ from .const import DISPATCHER_REMOVERS, DOMAIN, HW_TYPE, SIGNAL_ADD_ENTITIES
 
 
 @callback
-def add_switch_entities(new_unique_ids, coordinator, add_entities):
-    """Add switch entities to the platform.
+def add_cover_entities(new_unique_ids, coordinator, add_entities):
+    """Add cover entities to the platform.
 
     Args:
         new_unique_ids (set): Unique identifiers of entities to be added to Home Assistant.
@@ -24,44 +28,43 @@ def add_switch_entities(new_unique_ids, coordinator, add_entities):
         add_entities (function): Method called to add entities to Home Assistant.
     """
     new_entities = [
-        HomeControlSwitchEntity(coordinator, uid)
+        HomeControlCoverEntity(coordinator, uid)
         for uid in new_unique_ids
-        if coordinator.data[uid].device != "automation"
+        if coordinator.data[uid].device == "automation"
     ]
     add_entities(new_entities)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Legrand Home+ Control Switch platform in HomeAssistant.
+    """Set up the Legrand Home+ Control Cover platform in HomeAssistant.
 
     Args:
         hass (HomeAssistant): HomeAssistant core object.
         config_entry (ConfigEntry): ConfigEntry object that configures this platform.
         async_add_entities (function): Function called to add entities of this platform.
     """
-    partial_add_switch_entities = partial(
-        add_switch_entities, add_entities=async_add_entities
+    partial_add_cover_entities = partial(
+        add_cover_entities, add_entities=async_add_entities
     )
-    # Connect the dispatcher for the switch platform
+    # Connect the dispatcher for the cover platform
     hass.data[DOMAIN][config_entry.entry_id][DISPATCHER_REMOVERS].append(
         dispatcher.async_dispatcher_connect(
-            hass, SIGNAL_ADD_ENTITIES, partial_add_switch_entities
+            hass, SIGNAL_ADD_ENTITIES, partial_add_cover_entities
         )
     )
 
 
-class HomeControlSwitchEntity(CoordinatorEntity, SwitchEntity):
-    """Entity that represents a Legrand Home+ Control switch.
+class HomeControlCoverEntity(CoordinatorEntity, CoverEntity):
+    """Entity that represents a Legrand Home+ Control Cover.
 
-    It extends the HomeAssistant-provided classes of the CoordinatorEntity and the SwitchEntity.
+    It extends the HomeAssistant-provided classes of the CoordinatorEntity and the CoverEntity.
 
     The CoordinatorEntity class provides:
       should_poll
       async_update
       async_added_to_hass
 
-    The SwitchEntity class provides the functionality of a ToggleEntity and additional power
-    consumption methods and state attributes.
+    The CoverEntity class provides all functionalities expected in a cover.
     """
 
     def __init__(self, coordinator, idx):
@@ -97,35 +100,50 @@ class HomeControlSwitchEntity(CoordinatorEntity, SwitchEntity):
     @property
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
-        if self.module.device == "plug":
-            return DEVICE_CLASS_OUTLET
-        return DEVICE_CLASS_SWITCH
+        return DEVICE_CLASS_SHUTTER
 
     @property
     def available(self) -> bool:
         """Return if entity is available.
 
         This is the case when the coordinator is able to update the data successfully
-        AND the switch entity is reachable.
+        AND the cover entity is reachable.
 
         This method overrides the one of the CoordinatorEntity
         """
         return self.coordinator.last_update_success and self.module.reachable
 
     @property
-    def is_on(self):
-        """Return entity state."""
-        return self.module.status == "on"
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION
 
-    async def async_turn_on(self, **kwargs):
-        """Turn the light on."""
-        # Do the turning on.
-        await self.module.turn_on()
-        # Update the data
+    async def async_close_cover(self, **kwargs):
+        """Close the cover."""
+        await self.module.close()
         await self.coordinator.async_request_refresh()
 
-    async def async_turn_off(self, **kwargs):
-        """Turn the entity off."""
-        await self.module.turn_off()
-        # Update the data
+    async def async_open_cover(self, **kwargs):
+        """Close the cover."""
+        await self.module.open()
         await self.coordinator.async_request_refresh()
+
+    async def async_stop_cover(self, **kwargs):
+        """Stop the cover."""
+        await self.module.stop()
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_cover_position(self, **kwargs):
+        """Move the cover shutter to a specific position."""
+        await self.module.set_level(kwargs[ATTR_POSITION])
+        await self.coordinator.async_request_refresh()
+
+    @property
+    def current_cover_position(self):
+        """Return the current position of cover shutter."""
+        return self.module.level
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return self.module.level == self.module.CLOSED_FULL

--- a/homeassistant/components/home_plus_control/manifest.json
+++ b/homeassistant/components/home_plus_control/manifest.json
@@ -3,7 +3,7 @@
   "name": "Legrand Home+ Control",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/home_plus_control",
-  "requirements": ["homepluscontrol==0.0.5"],
+  "requirements": ["homepluscontrol==0.1"],
   "dependencies": ["http"],
   "codeowners": ["@chemaaa"],
   "iot_class": "cloud_polling"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -831,7 +831,7 @@ homeconnect==0.6.3
 homematicip==1.0.1
 
 # homeassistant.components.home_plus_control
-homepluscontrol==0.0.5
+homepluscontrol==0.1
 
 # homeassistant.components.horizon
 horimote==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -518,7 +518,7 @@ homeconnect==0.6.3
 homematicip==1.0.1
 
 # homeassistant.components.home_plus_control
-homepluscontrol==0.0.5
+homepluscontrol==0.1
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk

--- a/tests/components/home_plus_control/conftest.py
+++ b/tests/components/home_plus_control/conftest.py
@@ -1,4 +1,5 @@
 """Test setup and fixtures for component Home+ Control by Legrand."""
+from homepluscontrol.homeplusautomation import HomePlusAutomation
 from homepluscontrol.homeplusinteractivemodule import HomePlusInteractiveModule
 from homepluscontrol.homeplusplant import HomePlusPlant
 import pytest
@@ -92,12 +93,23 @@ def mock_modules():
             fw="42",
             reachable=True,
         ),
+        "0000000487654321fedcba": HomePlusAutomation(
+            plant,
+            id="0000000487654321fedcba",
+            name="Dining Room Cover",
+            hw_type="NBR",
+            device="automation",
+            fw="42",
+            reachable=True,
+        ),
     }
 
     # Set lights off and plugs on
     for mod_stat in modules.values():
         mod_stat.status = "on"
-        if mod_stat.device == "light":
+        if mod_stat.device == "automation":
+            mod_stat.status = "open"
+        elif mod_stat.device == "light":
             mod_stat.status = "off"
 
     return modules


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for cover platform to Legrand Home + Control integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20246

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
