### PR TITLE
Add tilt support to bond covers

### DIFF
--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -54,10 +54,6 @@ class BondCover(BondEntity, CoverEntity):
     ) -> None:
         """Create HA entity representing Bond cover."""
         super().__init__(hub, device, bpup_subs)
-
-    @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
         supported_features = 0
         if self._device.supports_open():
             supported_features |= SUPPORT_OPEN
@@ -72,7 +68,7 @@ class BondCover(BondEntity, CoverEntity):
                 supported_features |= SUPPORT_STOP
             if self._device.supports_tilt_open() or self._device.supports_tilt_close():
                 supported_features |= SUPPORT_STOP_TILT
-        return supported_features
+        self._attr_supported_features = supported_features
 
     def _apply_state(self, state: dict) -> None:
         cover_open = state.get("open")

--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -80,11 +80,6 @@ class BondCover(BondEntity, CoverEntity):
             True if cover_open == 0 else False if cover_open == 1 else None
         )
 
-    @property
-    def current_cover_tilt_position(self) -> None:
-        """Tilt position is always assumed state."""
-        return None
-
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self._hub.bond.action(self._device.device_id, Action.open())

--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -5,7 +5,16 @@ from typing import Any
 
 from bond_api import Action, BPUPSubscriptions, DeviceType
 
-from homeassistant.components.cover import DEVICE_CLASS_SHADE, CoverEntity
+from homeassistant.components.cover import (
+    DEVICE_CLASS_SHADE,
+    SUPPORT_CLOSE,
+    SUPPORT_CLOSE_TILT,
+    SUPPORT_OPEN,
+    SUPPORT_OPEN_TILT,
+    SUPPORT_STOP,
+    SUPPORT_STOP_TILT,
+    CoverEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
@@ -46,11 +55,35 @@ class BondCover(BondEntity, CoverEntity):
         """Create HA entity representing Bond cover."""
         super().__init__(hub, device, bpup_subs)
 
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        supported_features = 0
+        if self._device.supports_open():
+            supported_features |= SUPPORT_OPEN
+        if self._device.supports_close():
+            supported_features |= SUPPORT_CLOSE
+        if self._device.supports_tilt_open():
+            supported_features |= SUPPORT_OPEN_TILT
+        if self._device.supports_tilt_close():
+            supported_features |= SUPPORT_CLOSE_TILT
+        if self._device.supports_hold():
+            if self._device.supports_open() or self._device.supports_close():
+                supported_features |= SUPPORT_STOP
+            if self._device.supports_tilt_open() or self._device.supports_tilt_close():
+                supported_features |= SUPPORT_STOP_TILT
+        return supported_features
+
     def _apply_state(self, state: dict) -> None:
         cover_open = state.get("open")
         self._attr_is_closed = (
             True if cover_open == 0 else False if cover_open == 1 else None
         )
+
+    @property
+    def current_cover_tilt_position(self) -> None:
+        """Tilt position is always assumed state."""
+        return None
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
@@ -63,3 +96,15 @@ class BondCover(BondEntity, CoverEntity):
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Hold cover."""
         await self._hub.bond.action(self._device.device_id, Action.hold())
+
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+        """Open the cover tilt."""
+        await self._hub.bond.action(self._device.device_id, Action.open_tilt())
+
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+        """Close the cover tilt."""
+        await self._hub.bond.action(self._device.device_id, Action.close_tilt())
+
+    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+        """Stop the cover."""
+        await self.async_stop_cover()

--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -99,12 +99,12 @@ class BondCover(BondEntity, CoverEntity):
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
-        await self._hub.bond.action(self._device.device_id, Action.open_tilt())
+        await self._hub.bond.action(self._device.device_id, Action.tilt_open())
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
-        await self._hub.bond.action(self._device.device_id, Action.close_tilt())
+        await self._hub.bond.action(self._device.device_id, Action.tilt_close())
 
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self.async_stop_cover()
+        await self._hub.bond.action(self._device.device_id, Action.hold())

--- a/homeassistant/components/bond/manifest.json
+++ b/homeassistant/components/bond/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bond",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/bond",
-  "requirements": ["bond-api==0.1.14"],
+  "requirements": ["bond-api==0.1.15"],
   "zeroconf": ["_bond._tcp.local."],
   "codeowners": ["@bdraco", "@prystupa", "@joshs85"],
   "quality_scale": "platinum",

--- a/homeassistant/components/bond/utils.py
+++ b/homeassistant/components/bond/utils.py
@@ -82,6 +82,26 @@ class BondDevice:
         """Return True if this device supports any of the direction related commands."""
         return self._has_any_action({Action.SET_DIRECTION})
 
+    def supports_open(self) -> bool:
+        """Return True if this device supports opening."""
+        return self._has_any_action({Action.OPEN})
+
+    def supports_close(self) -> bool:
+        """Return True if this device supports closing."""
+        return self._has_any_action({Action.CLOSE})
+
+    def supports_tilt_open(self) -> bool:
+        """Return True if this device supports tilt opening."""
+        return self._has_any_action({Action.TILT_OPEN})
+
+    def supports_tilt_close(self) -> bool:
+        """Return True if this device supports tilt closing."""
+        return self._has_any_action({Action.TILT_CLOSE})
+
+    def supports_hold(self) -> bool:
+        """Return True if this device supports hold aka stop."""
+        return self._has_any_action({Action.HOLD})
+
     def supports_light(self) -> bool:
         """Return True if this device supports any of the light related commands."""
         return self._has_any_action({Action.TURN_LIGHT_ON, Action.TURN_LIGHT_OFF})

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -418,7 +418,7 @@ blockchain==1.4.4
 # bme680==1.0.5
 
 # homeassistant.components.bond
-bond-api==0.1.14
+bond-api==0.1.15
 
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.19

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -263,7 +263,7 @@ blebox_uniapi==1.3.3
 blinkpy==0.17.0
 
 # homeassistant.components.bond
-bond-api==0.1.14
+bond-api==0.1.15
 
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.19

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -136,7 +136,7 @@ async def test_tilt_open_cover(hass: core.HomeAssistant):
 async def test_tilt_close_cover(hass: core.HomeAssistant):
     """Tests that tilt close cover command delegates to API."""
     await setup_platform(
-        hass, COVER_DOMAIN, shades("name-1"), bond_device_id="test-device-id"
+        hass, COVER_DOMAIN, tilt_only_shades("name-1"), bond_device_id="test-device-id"
     )
 
     with patch_bond_action() as mock_close, patch_bond_device_state():
@@ -154,7 +154,7 @@ async def test_tilt_close_cover(hass: core.HomeAssistant):
 async def test_tilt_stop_cover(hass: core.HomeAssistant):
     """Tests that tilt stop cover command delegates to API."""
     await setup_platform(
-        hass, COVER_DOMAIN, shades("name-1"), bond_device_id="test-device-id"
+        hass, COVER_DOMAIN, tilt_only_shades("name-1"), bond_device_id="test-device-id"
     )
 
     with patch_bond_action() as mock_hold, patch_bond_device_state():

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -8,8 +8,11 @@ from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_CLOSE_COVER,
+    SERVICE_CLOSE_COVER_TILT,
     SERVICE_OPEN_COVER,
+    SERVICE_OPEN_COVER_TILT,
     SERVICE_STOP_COVER,
+    SERVICE_STOP_COVER_TILT,
 )
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -27,7 +30,20 @@ from tests.common import async_fire_time_changed
 
 def shades(name: str):
     """Create motorized shades with given name."""
-    return {"name": name, "type": DeviceType.MOTORIZED_SHADES}
+    return {
+        "name": name,
+        "type": DeviceType.MOTORIZED_SHADES,
+        "actions": ["Open", "Close", "Hold"],
+    }
+
+
+def tilt_only_shades(name: str):
+    """Create motorized shades with given name."""
+    return {
+        "name": name,
+        "type": DeviceType.MOTORIZED_SHADES,
+        "actions": ["TiltOpen", "TiltClose", "Hold"],
+    }
 
 
 async def test_entity_registry(hass: core.HomeAssistant):
@@ -91,6 +107,60 @@ async def test_stop_cover(hass: core.HomeAssistant):
         await hass.services.async_call(
             COVER_DOMAIN,
             SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: "cover.name_1"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_hold.assert_called_once_with("test-device-id", Action.hold())
+
+
+async def test_tilt_open_cover(hass: core.HomeAssistant):
+    """Tests that tilt open cover command delegates to API."""
+    await setup_platform(
+        hass, COVER_DOMAIN, tilt_only_shades("name-1"), bond_device_id="test-device-id"
+    )
+
+    with patch_bond_action() as mock_open, patch_bond_device_state():
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER_TILT,
+            {ATTR_ENTITY_ID: "cover.name_1"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_open.assert_called_once_with("test-device-id", Action.tilt_open())
+
+
+async def test_tilt_close_cover(hass: core.HomeAssistant):
+    """Tests that tilt close cover command delegates to API."""
+    await setup_platform(
+        hass, COVER_DOMAIN, shades("name-1"), bond_device_id="test-device-id"
+    )
+
+    with patch_bond_action() as mock_close, patch_bond_device_state():
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER_TILT,
+            {ATTR_ENTITY_ID: "cover.name_1"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_close.assert_called_once_with("test-device-id", Action.tilt_close())
+
+
+async def test_tilt_stop_cover(hass: core.HomeAssistant):
+    """Tests that tilt stop cover command delegates to API."""
+    await setup_platform(
+        hass, COVER_DOMAIN, shades("name-1"), bond_device_id="test-device-id"
+    )
+
+    with patch_bond_action() as mock_hold, patch_bond_device_state():
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER_TILT,
             {ATTR_ENTITY_ID: "cover.name_1"},
             blocking=True,
         )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tilt support to bond covers

dep changelog: https://github.com/prystupa/bond-api/compare/v0.1.14...v0.1.15

closes #59396

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
