### PR TITLE
Remove yaml config from modem_callerid

### DIFF
--- a/homeassistant/components/modem_callerid/config_flow.py
+++ b/homeassistant/components/modem_callerid/config_flow.py
@@ -1,10 +1,9 @@
 """Config flow for Modem Caller ID integration."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
-from phone_modem import DEFAULT_PORT, PhoneModem
+from phone_modem import PhoneModem
 import serial.tools.list_ports
 from serial.tools.list_ports_common import ListPortInfo
 import voluptuous as vol
@@ -15,8 +14,6 @@ from homeassistant.const import CONF_DEVICE, CONF_NAME
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DEFAULT_NAME, DOMAIN, EXCEPTIONS
-
-_LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema({"name": str, "device": str})
 
@@ -101,30 +98,6 @@ class PhoneModemFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         user_input = user_input or {}
         schema = vol.Schema({vol.Required(CONF_DEVICE): vol.In(unused_ports)})
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
-
-    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
-        """Import a config entry from configuration.yaml."""
-        if self._async_current_entries():
-            _LOGGER.warning(
-                "Loading Modem_callerid via platform setup is deprecated; Please remove it from your configuration"
-            )
-        if CONF_DEVICE not in config:
-            config[CONF_DEVICE] = DEFAULT_PORT
-        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
-        for port in ports:
-            if port.device == config[CONF_DEVICE]:
-                if (
-                    await self.validate_device_errors(
-                        dev_path=port.device,
-                        unique_id=_generate_unique_id(port),
-                    )
-                    is None
-                ):
-                    return self.async_create_entry(
-                        title=config.get(CONF_NAME, DEFAULT_NAME),
-                        data={CONF_DEVICE: port.device},
-                    )
-        return self.async_abort(reason="cannot_connect")
 
     async def validate_device_errors(
         self, dev_path: str, unique_id: str

--- a/homeassistant/components/modem_callerid/const.py
+++ b/homeassistant/components/modem_callerid/const.py
@@ -5,7 +5,6 @@ from phone_modem import exceptions
 from serial import SerialException
 
 DATA_KEY_API = "api"
-DATA_KEY_COORDINATOR = "coordinator"
 DEFAULT_NAME = "Phone Modem"
 DOMAIN = "modem_callerid"
 ICON = "mdi:phone-classic"

--- a/homeassistant/components/modem_callerid/sensor.py
+++ b/homeassistant/components/modem_callerid/sensor.py
@@ -1,48 +1,15 @@
 """A sensor for incoming calls using a USB modem that supports caller ID."""
 from __future__ import annotations
 
-from phone_modem import DEFAULT_PORT, PhoneModem
-import voluptuous as vol
+from phone_modem import PhoneModem
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_DEVICE,
-    CONF_NAME,
-    EVENT_HOMEASSISTANT_STOP,
-    STATE_IDLE,
-)
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_DEVICE, EVENT_HOMEASSISTANT_STOP, STATE_IDLE
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, entity_platform
-from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.helpers import entity_platform
 
-from .const import CID, DATA_KEY_API, DEFAULT_NAME, DOMAIN, ICON, SERVICE_REJECT_CALL
-
-# Deprecated in Home Assistant 2021.10
-PLATFORM_SCHEMA = cv.deprecated(
-    vol.All(
-        PLATFORM_SCHEMA.extend(
-            {
-                vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-                vol.Optional(CONF_DEVICE, default=DEFAULT_PORT): cv.string,
-            }
-        )
-    )
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigEntry,
-    async_add_entities: entity_platform.AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the Modem Caller ID component."""
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
-    )
+from .const import CID, DATA_KEY_API, DOMAIN, ICON, SERVICE_REJECT_CALL
 
 
 async def async_setup_entry(

--- a/tests/components/modem_callerid/test_config_flow.py
+++ b/tests/components/modem_callerid/test_config_flow.py
@@ -5,8 +5,8 @@ import phone_modem
 import serial.tools.list_ports
 
 from homeassistant.components import usb
-from homeassistant.components.modem_callerid.const import DEFAULT_NAME, DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USB, SOURCE_USER
+from homeassistant.components.modem_callerid.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USB, SOURCE_USER
 from homeassistant.const import CONF_DEVICE, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
@@ -15,7 +15,7 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
-from . import CONF_DATA, IMPORT_DATA, _patch_config_flow_modem
+from . import _patch_config_flow_modem
 
 DISCOVERY_INFO = {
     "device": phone_modem.DEFAULT_PORT,
@@ -171,34 +171,3 @@ async def test_abort_user_with_existing_flow(hass: HomeAssistant):
 
         assert result2["type"] == RESULT_TYPE_ABORT
         assert result2["reason"] == "already_in_progress"
-
-
-@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
-async def test_flow_import(hass: HomeAssistant):
-    """Test import step."""
-    with _patch_config_flow_modem(AsyncMock()):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={CONF_SOURCE: SOURCE_IMPORT}, data=IMPORT_DATA
-        )
-
-        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == DEFAULT_NAME
-        assert result["data"] == CONF_DATA
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={CONF_SOURCE: SOURCE_IMPORT}, data=IMPORT_DATA
-        )
-
-        assert result["type"] == RESULT_TYPE_ABORT
-        assert result["reason"] == "already_configured"
-
-
-async def test_flow_import_cannot_connect(hass: HomeAssistant):
-    """Test import connection error."""
-    with _patch_config_flow_modem(AsyncMock()) as modemmock:
-        modemmock.side_effect = phone_modem.exceptions.SerialError
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={CONF_SOURCE: SOURCE_IMPORT}, data=IMPORT_DATA
-        )
-        assert result["type"] == RESULT_TYPE_ABORT
-        assert result["reason"] == "cannot_connect"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The previously deprecated YAML configuration of the Phone Modem integration has been removed.

Phone Modem is now configured via the UI, any existing YAML configuration has been imported in previous releases and can now be safely removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove yaml config from modem_callerid #46677

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
