### PR TITLE
Revert "Bump async_timeout to 4.0.1"

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ aiohttp==3.8.0
 aiohttp_cors==0.7.0
 astral==2.2
 async-upnp-client==0.22.12
-async_timeout==4.0.1
+async_timeout==4.0.0
 attrs==21.2.0
 awesomeversion==21.10.1
 backports.zoneinfo;python_version<"3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # Home Assistant Core
 aiohttp==3.8.0
 astral==2.2
-async_timeout==4.0.1
+async_timeout==4.0.0
 attrs==21.2.0
 awesomeversion==21.10.1
 backports.zoneinfo;python_version<"3.9"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ PACKAGES = find_packages(exclude=["tests", "tests.*"])
 REQUIRES = [
     "aiohttp==3.8.0",
     "astral==2.2",
-    "async_timeout==4.0.1",
+    "async_timeout==4.0.0",
     "attrs==21.2.0",
     "awesomeversion==21.10.1",
     'backports.zoneinfo;python_version<"3.9"',


### PR DESCRIPTION
Reverts home-assistant/core#59565

We likely need to wait on this one until aiohttp bumps it since its hard pinned per https://github.com/home-assistant/core/pull/59565#issuecomment-966869445