### PR TITLE
Add type hints to Siren and Switch deCONZ platforms

### DIFF
--- a/homeassistant/components/deconz/siren.py
+++ b/homeassistant/components/deconz/siren.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import ValuesView
+from typing import Any
 
 from pydeconz.light import Siren
 

--- a/homeassistant/components/deconz/siren.py
+++ b/homeassistant/components/deconz/siren.py
@@ -79,7 +79,7 @@ class DeconzSiren(DeconzDevice, SirenEntity):
     @property
     def is_on(self) -> bool:
         """Return true if siren is on."""
-        return bool(self._device.is_on)
+        return self._device.is_on  # type: ignore[no-any-return]
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on siren."""

--- a/homeassistant/components/deconz/siren.py
+++ b/homeassistant/components/deconz/siren.py
@@ -80,7 +80,7 @@ class DeconzSiren(DeconzDevice, SirenEntity):
         """Return true if siren is on."""
         return bool(self._device.is_on)
 
-    async def async_turn_on(self, **kwargs: int) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on siren."""
         data = {}
         if (duration := kwargs.get(ATTR_DURATION)) is not None:

--- a/homeassistant/components/deconz/siren.py
+++ b/homeassistant/components/deconz/siren.py
@@ -1,5 +1,9 @@
 """Support for deCONZ siren."""
 
+from __future__ import annotations
+
+from collections.abc import ValuesView
+
 from pydeconz.light import Siren
 
 from homeassistant.components.siren import (
@@ -10,20 +14,28 @@ from homeassistant.components.siren import (
     SUPPORT_TURN_ON,
     SirenEntity,
 )
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .deconz_device import DeconzDevice
-from .gateway import get_gateway_from_config_entry
+from .gateway import DeconzGateway, get_gateway_from_config_entry
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up sirens for deCONZ component."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_siren(lights=gateway.api.lights.values()):
+    def async_add_siren(
+        lights: list[Siren] | ValuesView[Siren] = gateway.api.lights.values(),
+    ) -> None:
         """Add siren from deCONZ."""
         entities = []
 
@@ -53,8 +65,9 @@ class DeconzSiren(DeconzDevice, SirenEntity):
     """Representation of a deCONZ siren."""
 
     TYPE = DOMAIN
+    _device: Siren
 
-    def __init__(self, device, gateway) -> None:
+    def __init__(self, device: Siren, gateway: DeconzGateway) -> None:
         """Set up siren."""
         super().__init__(device, gateway)
 
@@ -63,17 +76,17 @@ class DeconzSiren(DeconzDevice, SirenEntity):
         )
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if siren is on."""
-        return self._device.is_on
+        return bool(self._device.is_on)
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs: int) -> None:
         """Turn on siren."""
         data = {}
         if (duration := kwargs.get(ATTR_DURATION)) is not None:
             data["duration"] = duration * 10
         await self._device.turn_on(**data)
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs: None) -> None:
         """Turn off siren."""
         await self._device.turn_off()

--- a/homeassistant/components/deconz/siren.py
+++ b/homeassistant/components/deconz/siren.py
@@ -87,6 +87,6 @@ class DeconzSiren(DeconzDevice, SirenEntity):
             data["duration"] = duration * 10
         await self._device.turn_on(**data)
 
-    async def async_turn_off(self, **kwargs: None) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off siren."""
         await self._device.turn_off()

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import ValuesView
+from typing import Any
 
 from pydeconz.light import Light, Siren
 

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -85,6 +85,6 @@ class DeconzPowerPlug(DeconzDevice, SwitchEntity):
         """Turn on switch."""
         await self._device.set_state(on=True)
 
-    async def async_turn_off(self, **kwargs: None) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off switch."""
         await self._device.set_state(on=False)

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -1,18 +1,28 @@
 """Support for deCONZ switches."""
 
-from pydeconz.light import Siren
+from __future__ import annotations
+
+from collections.abc import ValuesView
+
+from pydeconz.light import Light, Siren
 
 from homeassistant.components.switch import DOMAIN, SwitchEntity
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN as DECONZ_DOMAIN, POWER_PLUGS
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up switches for deCONZ component.
 
     Switches are based on the same device class as lights in deCONZ.
@@ -32,7 +42,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             entity_registry.async_remove(entity_id)
 
     @callback
-    def async_add_switch(lights=gateway.api.lights.values()):
+    def async_add_switch(
+        lights: list[Light] | ValuesView[Light] = gateway.api.lights.values(),
+    ) -> None:
         """Add switch from deCONZ."""
         entities = []
 
@@ -62,16 +74,17 @@ class DeconzPowerPlug(DeconzDevice, SwitchEntity):
     """Representation of a deCONZ power plug."""
 
     TYPE = DOMAIN
+    _device: Light
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if switch is on."""
-        return self._device.state
+        return bool(self._device.state)
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs: None) -> None:
         """Turn on switch."""
         await self._device.set_state(on=True)
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs: None) -> None:
         """Turn off switch."""
         await self._device.set_state(on=False)

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -81,7 +81,7 @@ class DeconzPowerPlug(DeconzDevice, SwitchEntity):
         """Return true if switch is on."""
         return self._device.state  # type: ignore[no-any-return]
 
-    async def async_turn_on(self, **kwargs: None) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on switch."""
         await self._device.set_state(on=True)
 

--- a/homeassistant/components/deconz/switch.py
+++ b/homeassistant/components/deconz/switch.py
@@ -79,7 +79,7 @@ class DeconzPowerPlug(DeconzDevice, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
-        return bool(self._device.state)
+        return self._device.state  # type: ignore[no-any-return]
 
     async def async_turn_on(self, **kwargs: None) -> None:
         """Turn on switch."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Start improving type hints to deCONZ integration. Does not depend on library for type hint, that's something for later.

Split from https://github.com/home-assistant/core/pull/58968

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
