### PR TITLE
Add typing to deCONZ Lock and Logbook platforms

### DIFF
--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -1,4 +1,7 @@
 """Provides device automations for deconz events."""
+
+from __future__ import annotations
+
 import voluptuous as vol
 
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
@@ -14,10 +17,11 @@ from homeassistant.const import (
     CONF_TYPE,
     CONF_UNIQUE_ID,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from . import DOMAIN
-from .deconz_event import CONF_DECONZ_EVENT, CONF_GESTURE
+from .deconz_event import CONF_DECONZ_EVENT, CONF_GESTURE, DeconzAlarmEvent, DeconzEvent
 
 CONF_SUBTYPE = "subtype"
 
@@ -613,16 +617,20 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 )
 
 
-def _get_deconz_event_from_device_id(hass, device_id):
-    """Resolve deconz event from device id."""
+def _get_deconz_event_from_device(
+    hass: HomeAssistant,
+    device: dr.DeviceEntry,
+) -> DeconzAlarmEvent | DeconzEvent:
+    """Resolve deconz event from device."""
     for gateway in hass.data.get(DOMAIN, {}).values():
-
         for deconz_event in gateway.events:
-
-            if device_id == deconz_event.device_id:
+            if device.id == deconz_event.device_id:
+                assert isinstance(deconz_event, (DeconzAlarmEvent, DeconzEvent))
                 return deconz_event
 
-    return None
+    raise InvalidDeviceAutomationConfig(
+        f'No deconz_event tied to device "{device.name}" found'
+    )
 
 
 async def async_validate_trigger_config(hass, config):
@@ -658,11 +666,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
 
     trigger = REMOTES[device.model][trigger]
 
-    deconz_event = _get_deconz_event_from_device_id(hass, device.id)
-    if deconz_event is None:
-        raise InvalidDeviceAutomationConfig(
-            f'No deconz_event tied to device "{device.name}" found'
-        )
+    deconz_event = _get_deconz_event_from_device(hass, device)
 
     event_id = deconz_event.serial
 

--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -625,7 +625,6 @@ def _get_deconz_event_from_device(
     for gateway in hass.data.get(DOMAIN, {}).values():
         for deconz_event in gateway.events:
             if device.id == deconz_event.device_id:
-                assert isinstance(deconz_event, (DeconzAlarmEvent, DeconzEvent))
                 return deconz_event
 
     raise InvalidDeviceAutomationConfig(

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import ValuesView
+from typing import Any
 
 from pydeconz.light import Lock
 from pydeconz.sensor import DoorLock
@@ -91,13 +92,12 @@ class DeconzLock(DeconzDevice, LockEntity):
     @property
     def is_locked(self) -> bool:
         """Return true if lock is on."""
-        assert isinstance(self._device.is_locked, bool)
-        return self._device.is_locked
+        return self._device.is_locked  # type: ignore[no-any-return]
 
-    async def async_lock(self, **kwargs: None) -> None:
+    async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
         await self._device.lock()
 
-    async def async_unlock(self, **kwargs: None) -> None:
+    async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
         await self._device.unlock()

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -1,23 +1,35 @@
 """Support for deCONZ locks."""
 
+from __future__ import annotations
+
+from collections.abc import ValuesView
+
 from pydeconz.light import Lock
 from pydeconz.sensor import DoorLock
 
 from homeassistant.components.lock import DOMAIN, LockEntity
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up locks for deCONZ component."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_lock_from_light(lights=gateway.api.lights.values()):
+    def async_add_lock_from_light(
+        lights: list[Lock] | ValuesView[Lock] = gateway.api.lights.values(),
+    ) -> None:
         """Add lock from deCONZ."""
         entities = []
 
@@ -41,7 +53,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
     @callback
-    def async_add_lock_from_sensor(sensors=gateway.api.sensors.values()):
+    def async_add_lock_from_sensor(
+        sensors: list[DoorLock] | ValuesView[DoorLock] = gateway.api.sensors.values(),
+    ) -> None:
         """Add lock from deCONZ."""
         entities = []
 
@@ -72,16 +86,18 @@ class DeconzLock(DeconzDevice, LockEntity):
     """Representation of a deCONZ lock."""
 
     TYPE = DOMAIN
+    _device: DoorLock | Lock
 
     @property
-    def is_locked(self):
+    def is_locked(self) -> bool:
         """Return true if lock is on."""
+        assert isinstance(self._device.is_locked, bool)
         return self._device.is_locked
 
-    async def async_lock(self, **kwargs):
+    async def async_lock(self, **kwargs: None) -> None:
         """Lock the lock."""
         await self._device.lock()
 
-    async def async_unlock(self, **kwargs):
+    async def async_unlock(self, **kwargs: None) -> None:
         """Unlock the lock."""
         await self._device.unlock()

--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -5,15 +5,11 @@ from collections.abc import Callable
 
 from homeassistant.const import ATTR_DEVICE_ID, CONF_EVENT
 from homeassistant.core import HomeAssistant, callback
+import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.event import Event
 
 from .const import CONF_GESTURE, DOMAIN as DECONZ_DOMAIN
-from .deconz_event import (
-    CONF_DECONZ_ALARM_EVENT,
-    CONF_DECONZ_EVENT,
-    DeconzAlarmEvent,
-    DeconzEvent,
-)
+from .deconz_event import CONF_DECONZ_ALARM_EVENT, CONF_DECONZ_EVENT
 from .device_trigger import (
     CONF_BOTH_BUTTONS,
     CONF_BOTTOM_BUTTONS,
@@ -57,7 +53,7 @@ from .device_trigger import (
     CONF_TURN_OFF,
     CONF_TURN_ON,
     REMOTES,
-    _get_deconz_event_from_device_id,
+    _get_deconz_event_from_device,
 )
 
 ACTIONS = {
@@ -108,7 +104,9 @@ INTERFACES = {
 }
 
 
-def _get_device_event_description(modelid: str, event: int) -> tuple:
+def _get_device_event_description(
+    modelid: str, event: int
+) -> tuple[str | None, str | None]:
     """Get device event description."""
     device_event_descriptions = REMOTES[modelid]
 
@@ -124,17 +122,16 @@ def _get_device_event_description(modelid: str, event: int) -> tuple:
 @callback
 def async_describe_events(
     hass: HomeAssistant,
-    async_describe_event: Callable[[str, str, Callable[[Event], dict]], None],
+    async_describe_event: Callable[[str, str, Callable[[Event], dict[str, str]]], None],
 ) -> None:
     """Describe logbook events."""
+    device_registry = dr.async_get(hass)
 
     @callback
-    def async_describe_deconz_alarm_event(event: Event) -> dict:
+    def async_describe_deconz_alarm_event(event: Event) -> dict[str, str]:
         """Describe deCONZ logbook alarm event."""
-        deconz_alarm_event: DeconzAlarmEvent | DeconzEvent | None = (
-            _get_deconz_event_from_device_id(hass, event.data[ATTR_DEVICE_ID])
-        )
-        assert deconz_alarm_event
+        device = device_registry.devices[event.data[ATTR_DEVICE_ID]]
+        deconz_alarm_event = _get_deconz_event_from_device(hass, device)
 
         data = event.data[CONF_EVENT]
 
@@ -144,12 +141,10 @@ def async_describe_events(
         }
 
     @callback
-    def async_describe_deconz_event(event: Event) -> dict:
+    def async_describe_deconz_event(event: Event) -> dict[str, str]:
         """Describe deCONZ logbook event."""
-        deconz_event: DeconzEvent | None = _get_deconz_event_from_device_id(
-            hass, event.data[ATTR_DEVICE_ID]
-        )
-        assert deconz_event
+        device = device_registry.devices[event.data[ATTR_DEVICE_ID]]
+        deconz_event = _get_deconz_event_from_device(hass, device)
 
         action = None
         interface = None

--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -108,9 +108,9 @@ INTERFACES = {
 }
 
 
-def _get_device_event_description(modelid: str, event: str) -> tuple:
+def _get_device_event_description(modelid: str, event: int) -> tuple:
     """Get device event description."""
-    device_event_descriptions: dict = REMOTES[modelid]
+    device_event_descriptions = REMOTES[modelid]
 
     for event_type_tuple, event_dict in device_event_descriptions.items():
         if event == event_dict.get(CONF_EVENT):
@@ -131,9 +131,10 @@ def async_describe_events(
     @callback
     def async_describe_deconz_alarm_event(event: Event) -> dict:
         """Describe deCONZ logbook alarm event."""
-        deconz_alarm_event: DeconzAlarmEvent | None = _get_deconz_event_from_device_id(
-            hass, event.data[ATTR_DEVICE_ID]
+        deconz_alarm_event: DeconzAlarmEvent | DeconzEvent | None = (
+            _get_deconz_event_from_device_id(hass, event.data[ATTR_DEVICE_ID])
         )
+        assert deconz_alarm_event
 
         data = event.data[CONF_EVENT]
 
@@ -148,6 +149,7 @@ def async_describe_events(
         deconz_event: DeconzEvent | None = _get_deconz_event_from_device_id(
             hass, event.data[ATTR_DEVICE_ID]
         )
+        assert deconz_event
 
         action = None
         interface = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Start improving type hints to deCONZ integration. Does not depend on library for type hint, that's something for later.

Split from https://github.com/home-assistant/core/pull/58968

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
