### PR TITLE
Use atomicwrites for mission critical core files

### DIFF
--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -42,7 +42,7 @@ class AuthStore:
         self._groups: dict[str, models.Group] | None = None
         self._perm_lookup: PermissionLookup | None = None
         self._store = hass.helpers.storage.Store(
-            STORAGE_VERSION, STORAGE_KEY, private=True
+            STORAGE_VERSION, STORAGE_KEY, private=True, atomic_writes=True
         )
         self._lock = asyncio.Lock()
 

--- a/homeassistant/auth/mfa_modules/notify.py
+++ b/homeassistant/auth/mfa_modules/notify.py
@@ -100,7 +100,7 @@ class NotifyAuthModule(MultiFactorAuthModule):
         super().__init__(hass, config)
         self._user_settings: _UsersDict | None = None
         self._user_store = hass.helpers.storage.Store(
-            STORAGE_VERSION, STORAGE_KEY, private=True
+            STORAGE_VERSION, STORAGE_KEY, private=True, atomic_writes=True
         )
         self._include = config.get(CONF_INCLUDE, [])
         self._exclude = config.get(CONF_EXCLUDE, [])

--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -77,7 +77,7 @@ class TotpAuthModule(MultiFactorAuthModule):
         super().__init__(hass, config)
         self._users: dict[str, str] | None = None
         self._user_store = hass.helpers.storage.Store(
-            STORAGE_VERSION, STORAGE_KEY, private=True
+            STORAGE_VERSION, STORAGE_KEY, private=True, atomic_writes=True
         )
         self._init_lock = asyncio.Lock()
 

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -63,7 +63,7 @@ class Data:
         """Initialize the user data store."""
         self.hass = hass
         self._store = hass.helpers.storage.Store(
-            STORAGE_VERSION, STORAGE_KEY, private=True
+            STORAGE_VERSION, STORAGE_KEY, private=True, atomic_writes=True
         )
         self._data: dict[str, Any] | None = None
         # Legacy mode will allow usernames to start/end with whitespace

--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_ID, EVENT_COMPONENT_LOADED
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import ATTR_COMPONENT
-from homeassistant.util.file import write_utf8_file
+from homeassistant.util.file import write_utf8_file_atomic
 from homeassistant.util.yaml import dump, load_yaml
 
 DOMAIN = "config"
@@ -254,4 +254,4 @@ def _write(path, data):
     # Do it before opening file. If dump causes error it will now not
     # truncate the file.
     contents = dump(data)
-    write_utf8_file(path, contents)
+    write_utf8_file_atomic(path, contents)

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -25,7 +25,9 @@ class Network:
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the Network class."""
-        self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
+        self._store = hass.helpers.storage.Store(
+            STORAGE_VERSION, STORAGE_KEY, atomic_writes=True
+        )
         self._data: dict[str, Any] = {}
         self.adapters: list[Adapter] = []
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1715,7 +1715,7 @@ class Config:
     async def async_load(self) -> None:
         """Load [homeassistant] core config."""
         store = self.hass.helpers.storage.Store(
-            CORE_STORAGE_VERSION, CORE_STORAGE_KEY, private=True
+            CORE_STORAGE_VERSION, CORE_STORAGE_KEY, private=True, atomic_writes=True
         )
 
         if not (data := await store.async_load()):
@@ -1763,7 +1763,7 @@ class Config:
         }
 
         store = self.hass.helpers.storage.Store(
-            CORE_STORAGE_VERSION, CORE_STORAGE_KEY, private=True
+            CORE_STORAGE_VERSION, CORE_STORAGE_KEY, private=True, atomic_writes=True
         )
         await store.async_save(data)
 

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -49,7 +49,9 @@ class AreaRegistry:
         """Initialize the area registry."""
         self.hass = hass
         self.areas: MutableMapping[str, AreaEntry] = {}
-        self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
+        self._store = hass.helpers.storage.Store(
+            STORAGE_VERSION, STORAGE_KEY, atomic_writes=True
+        )
         self._normalized_name_area_idx: dict[str, str] = {}
 
     @callback

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -162,7 +162,9 @@ class DeviceRegistry:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the device registry."""
         self.hass = hass
-        self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
+        self._store = hass.helpers.storage.Store(
+            STORAGE_VERSION, STORAGE_KEY, atomic_writes=True
+        )
         self._clear_index()
 
     @callback

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -155,7 +155,9 @@ class EntityRegistry:
         self.hass = hass
         self.entities: dict[str, RegistryEntry]
         self._index: dict[tuple[str, str, str], str] = {}
-        self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
+        self._store = hass.helpers.storage.Store(
+            STORAGE_VERSION, STORAGE_KEY, atomic_writes=True
+        )
         self.hass.bus.async_listen(
             EVENT_DEVICE_REGISTRY_UPDATED, self.async_device_modified
         )

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -76,6 +76,7 @@ class Store:
         private: bool = False,
         *,
         encoder: type[JSONEncoder] | None = None,
+        atomic_writes: bool = False,
     ) -> None:
         """Initialize storage class."""
         self.version = version
@@ -88,6 +89,7 @@ class Store:
         self._write_lock = asyncio.Lock()
         self._load_task: asyncio.Future | None = None
         self._encoder = encoder
+        self._atomic_writes = atomic_writes
 
     @property
     def path(self):
@@ -238,7 +240,13 @@ class Store:
             os.makedirs(os.path.dirname(path))
 
         _LOGGER.debug("Writing data for %s to %s", self.key, path)
-        json_util.save_json(path, data, self._private, encoder=self._encoder)
+        json_util.save_json(
+            path,
+            data,
+            self._private,
+            encoder=self._encoder,
+            atomic_writes=self._atomic_writes,
+        )
 
     async def _async_migrate_func(self, old_version, old_data):
         """Migrate to the new version."""

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -7,6 +7,7 @@ astral==2.2
 async-upnp-client==0.22.12
 async_timeout==4.0.0
 attrs==21.2.0
+atomicwrites==1.4.0
 awesomeversion==21.10.1
 backports.zoneinfo;python_version<"3.9"
 bcrypt==3.1.7

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,8 +6,8 @@ aiohttp_cors==0.7.0
 astral==2.2
 async-upnp-client==0.22.12
 async_timeout==4.0.0
-attrs==21.2.0
 atomicwrites==1.4.0
+attrs==21.2.0
 awesomeversion==21.10.1
 backports.zoneinfo;python_version<"3.9"
 bcrypt==3.1.7

--- a/homeassistant/util/file.py
+++ b/homeassistant/util/file.py
@@ -34,10 +34,10 @@ def write_utf8_file_atomic(
     negatively impact performance.
     """
     try:
-        with AtomicWriter(filename, overwrite=True).open() as fh:
+        with AtomicWriter(filename, overwrite=True).open() as fdesc:
             if not private:
-                os.fchmod(fh.fileno(), 0o644)
-            fh.write(utf8_data)
+                os.fchmod(fdesc.fileno(), 0o644)
+            fdesc.write(utf8_data)
     except OSError as error:
         _LOGGER.exception("Saving file failed: %s", filename)
         raise WriteError(error) from error

--- a/homeassistant/util/file.py
+++ b/homeassistant/util/file.py
@@ -5,6 +5,8 @@ import logging
 import os
 import tempfile
 
+from atomicwrites import AtomicWriter
+
 from homeassistant.exceptions import HomeAssistantError
 
 _LOGGER = logging.getLogger(__name__)
@@ -12,6 +14,33 @@ _LOGGER = logging.getLogger(__name__)
 
 class WriteError(HomeAssistantError):
     """Error writing the data."""
+
+
+def write_utf8_file_atomic(
+    filename: str,
+    utf8_data: str,
+    private: bool = False,
+) -> None:
+    """Write a file and rename it into place using atomicwrites.
+
+    Writes all or nothing.
+
+    This function uses fsync under the hood. It should
+    only be used to write mission critical files as
+    fsync can block for a few seconds or longer is the
+    disk is busy.
+
+    Using this function frequently will significantly
+    negatively impact performance.
+    """
+    try:
+        with AtomicWriter(filename, overwrite=True).open() as fh:
+            if not private:
+                os.fchmod(fh.fileno(), 0o644)
+            fh.write(utf8_data)
+    except OSError as error:
+        _LOGGER.exception("Saving file failed: %s", filename)
+        raise WriteError(error) from error
 
 
 def write_utf8_file(
@@ -33,8 +62,8 @@ def write_utf8_file(
         ) as fdesc:
             fdesc.write(utf8_data)
             tmp_filename = fdesc.name
-        if not private:
-            os.chmod(tmp_filename, 0o644)
+            if not private:
+                os.fchmod(fdesc.fileno(), 0o644)
         os.replace(tmp_filename, filename)
     except OSError as error:
         _LOGGER.exception("Saving file failed: %s", filename)

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -10,7 +10,7 @@ from typing import Any
 from homeassistant.core import Event, State
 from homeassistant.exceptions import HomeAssistantError
 
-from .file import write_utf8_file
+from .file import write_utf8_file, write_utf8_file_atomic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,6 +49,7 @@ def save_json(
     private: bool = False,
     *,
     encoder: type[json.JSONEncoder] | None = None,
+    atomic_writes: bool = False,
 ) -> None:
     """Save JSON data to a file.
 
@@ -61,7 +62,10 @@ def save_json(
         _LOGGER.error(msg)
         raise SerializationError(msg) from error
 
-    write_utf8_file(filename, json_data, private)
+    if atomic_writes:
+        write_utf8_file_atomic(filename, json_data, private)
+    else:
+        write_utf8_file(filename, json_data, private)
 
 
 def format_unserializable_data(data: dict[str, Any]) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ aiohttp==3.8.0
 astral==2.2
 async_timeout==4.0.0
 attrs==21.2.0
+atomicwrites==1.4.0
 awesomeversion==21.10.1
 backports.zoneinfo;python_version<"3.9"
 bcrypt==3.1.7

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -31,6 +31,7 @@ responses==0.12.0
 respx==0.17.0
 stdlib-list==0.7.0
 tqdm==4.49.0
+types-atomicwrites==1.4.1
 types-croniter==1.0.0
 types-backports==0.1.3
 types-certifi==0.1.4

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ REQUIRES = [
     "astral==2.2",
     "async_timeout==4.0.0",
     "attrs==21.2.0",
+    "atomicwrites==1.4.0",
     "awesomeversion==21.10.1",
     'backports.zoneinfo;python_version<"3.9"',
     "bcrypt==3.1.7",

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -67,11 +67,12 @@ def test_save_and_load_private():
     assert stats.st_mode & 0o77 == 0
 
 
-def test_overwrite_and_reload():
+@pytest.mark.parametrize("atomic_writes", [True, False])
+def test_overwrite_and_reload(atomic_writes):
     """Test that we can overwrite an existing file and read back."""
     fname = _path_for("test3")
-    save_json(fname, TEST_JSON_A)
-    save_json(fname, TEST_JSON_B)
+    save_json(fname, TEST_JSON_A, atomic_writes=atomic_writes)
+    save_json(fname, TEST_JSON_B, atomic_writes=atomic_writes)
     data = load_json(fname)
     assert data == TEST_JSON_B
 


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Followup for #59384
https://github.com/home-assistant/core/pull/59384#issuecomment-963639370

Implements #43332 for mission critical files in order to ensure
reliability without sacrificing performance


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
