### PR TITLE
Add typing to deCONZ Climate and Cover platforms

### DIFF
--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import ValuesView
+from typing import Any
 
 from pydeconz.sensor import (
     THERMOSTAT_FAN_MODE_AUTO,
@@ -244,23 +245,20 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
     @property
     def current_temperature(self) -> float:
         """Return the current temperature."""
-        assert isinstance(self._device.temperature, float)
-        return self._device.temperature
+        return self._device.temperature  # type: ignore[no-any-return]
 
     @property
     def target_temperature(self) -> float | None:
         """Return the target temperature."""
         if self._device.mode == THERMOSTAT_MODE_COOL and self._device.cooling_setpoint:
-            assert isinstance(self._device.cooling_setpoint, float)
-            return self._device.cooling_setpoint
+            return self._device.cooling_setpoint  # type: ignore[no-any-return]
 
         if self._device.heating_setpoint:
-            assert isinstance(self._device.heating_setpoint, float)
-            return self._device.heating_setpoint
+            return self._device.heating_setpoint  # type: ignore[no-any-return]
 
         return None
 
-    async def async_set_temperature(self, **kwargs: float | int) -> None:
+    async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if ATTR_TEMPERATURE not in kwargs:
             raise ValueError(f"Expected attribute {ATTR_TEMPERATURE}")

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -181,7 +181,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         )
 
     @property
-    def fan_modes(self) -> list:
+    def fan_modes(self) -> list[str]:
         """Return the list of available fan operation modes."""
         return list(FAN_MODE_TO_DECONZ)
 
@@ -206,7 +206,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         )
 
     @property
-    def hvac_modes(self) -> list:
+    def hvac_modes(self) -> list[str]:
         """Return the list of available hvac operation modes."""
         return list(self._hvac_mode_to_deconz)
 
@@ -270,7 +270,7 @@ class DeconzThermostat(DeconzDevice, ClimateEntity):
         await self._device.set_config(**data)
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, bool | int]:
         """Return the state attributes of the thermostat."""
         attr = {}
 

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -113,15 +113,15 @@ class DeconzCover(DeconzDevice, CoverEntity):
         position = 100 - kwargs[ATTR_POSITION]
         await self._device.set_position(lift=position)
 
-    async def async_open_cover(self, **kwargs: None) -> None:
+    async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""
         await self._device.open()
 
-    async def async_close_cover(self, **kwargs: None) -> None:
+    async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         await self._device.close()
 
-    async def async_stop_cover(self, **kwargs: None) -> None:
+    async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover."""
         await self._device.stop()
 

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import ValuesView
+from typing import Any
 
 from pydeconz.light import Cover
 
@@ -100,8 +101,7 @@ class DeconzCover(DeconzDevice, CoverEntity):
     @property
     def current_cover_position(self) -> int:
         """Return the current position of the cover."""
-        assert isinstance(self._device.lift, int)
-        return 100 - self._device.lift
+        return 100 - self._device.lift  # type: ignore[no-any-return]
 
     @property
     def is_closed(self) -> bool:
@@ -129,8 +129,7 @@ class DeconzCover(DeconzDevice, CoverEntity):
     def current_cover_tilt_position(self) -> int | None:
         """Return the current tilt position of the cover."""
         if self._device.tilt is not None:
-            assert isinstance(self._device.tilt, int)
-            return 100 - self._device.tilt
+            return 100 - self._device.tilt  # type: ignore[no-any-return]
         return None
 
     async def async_set_cover_tilt_position(self, **kwargs: int) -> None:
@@ -138,14 +137,14 @@ class DeconzCover(DeconzDevice, CoverEntity):
         position = 100 - kwargs[ATTR_TILT_POSITION]
         await self._device.set_position(tilt=position)
 
-    async def async_open_cover_tilt(self, **kwargs: None) -> None:
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open cover tilt."""
         await self._device.set_position(tilt=0)
 
-    async def async_close_cover_tilt(self, **kwargs: None) -> None:
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close cover tilt."""
         await self._device.set_position(tilt=100)
 
-    async def async_stop_cover_tilt(self, **kwargs: None) -> None:
+    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop cover tilt."""
         await self._device.stop()

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -1,5 +1,9 @@
 """Support for deCONZ covers."""
 
+from __future__ import annotations
+
+from collections.abc import ValuesView
+
 from pydeconz.light import Cover
 
 from homeassistant.components.cover import (
@@ -18,11 +22,13 @@ from homeassistant.components.cover import (
     SUPPORT_STOP_TILT,
     CoverEntity,
 )
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .deconz_device import DeconzDevice
-from .gateway import get_gateway_from_config_entry
+from .gateway import DeconzGateway, get_gateway_from_config_entry
 
 DEVICE_CLASS = {
     "Level controllable output": DEVICE_CLASS_DAMPER,
@@ -31,13 +37,19 @@ DEVICE_CLASS = {
 }
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up covers for deCONZ component."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_cover(lights=gateway.api.lights.values()):
+    def async_add_cover(
+        lights: list[Cover] | ValuesView[Cover] = gateway.api.lights.values(),
+    ) -> None:
         """Add cover from deCONZ."""
         entities = []
 
@@ -66,8 +78,9 @@ class DeconzCover(DeconzDevice, CoverEntity):
     """Representation of a deCONZ cover."""
 
     TYPE = DOMAIN
+    _device: Cover
 
-    def __init__(self, device, gateway):
+    def __init__(self, device: Cover, gateway: DeconzGateway) -> None:
         """Set up cover device."""
         super().__init__(device, gateway)
 
@@ -85,52 +98,54 @@ class DeconzCover(DeconzDevice, CoverEntity):
         self._attr_device_class = DEVICE_CLASS.get(self._device.type)
 
     @property
-    def current_cover_position(self):
+    def current_cover_position(self) -> int:
         """Return the current position of the cover."""
+        assert isinstance(self._device.lift, int)
         return 100 - self._device.lift
 
     @property
-    def is_closed(self):
+    def is_closed(self) -> bool:
         """Return if the cover is closed."""
         return not self._device.is_open
 
-    async def async_set_cover_position(self, **kwargs):
+    async def async_set_cover_position(self, **kwargs: int) -> None:
         """Move the cover to a specific position."""
         position = 100 - kwargs[ATTR_POSITION]
         await self._device.set_position(lift=position)
 
-    async def async_open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs: None) -> None:
         """Open cover."""
         await self._device.open()
 
-    async def async_close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs: None) -> None:
         """Close cover."""
         await self._device.close()
 
-    async def async_stop_cover(self, **kwargs):
+    async def async_stop_cover(self, **kwargs: None) -> None:
         """Stop cover."""
         await self._device.stop()
 
     @property
-    def current_cover_tilt_position(self):
+    def current_cover_tilt_position(self) -> int | None:
         """Return the current tilt position of the cover."""
         if self._device.tilt is not None:
+            assert isinstance(self._device.tilt, int)
             return 100 - self._device.tilt
         return None
 
-    async def async_set_cover_tilt_position(self, **kwargs):
+    async def async_set_cover_tilt_position(self, **kwargs: int) -> None:
         """Tilt the cover to a specific position."""
         position = 100 - kwargs[ATTR_TILT_POSITION]
         await self._device.set_position(tilt=position)
 
-    async def async_open_cover_tilt(self, **kwargs):
+    async def async_open_cover_tilt(self, **kwargs: None) -> None:
         """Open cover tilt."""
         await self._device.set_position(tilt=0)
 
-    async def async_close_cover_tilt(self, **kwargs):
+    async def async_close_cover_tilt(self, **kwargs: None) -> None:
         """Close cover tilt."""
         await self._device.set_position(tilt=100)
 
-    async def async_stop_cover_tilt(self, **kwargs):
+    async def async_stop_cover_tilt(self, **kwargs: None) -> None:
         """Stop cover tilt."""
         await self._device.stop()

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -347,7 +347,7 @@ async def test_climate_device_with_cooling_support(
             "0": {
                 "config": {
                     "battery": 25,
-                    "coolsetpoint": None,
+                    "coolsetpoint": 1111,
                     "fanmode": None,
                     "heatsetpoint": 2222,
                     "mode": "heat",
@@ -398,8 +398,10 @@ async def test_climate_device_with_cooling_support(
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get("climate.zen_01").state == HVAC_MODE_COOL
+    assert hass.states.get("climate.zen_01").attributes["temperature"] == 11.1
 
     # Verify service calls
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Start improving type hints to deCONZ integration. Does not depend on library for type hint, that's something for later.

Split from https://github.com/home-assistant/core/pull/58968

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
