### PR TITLE
Add typing to deCONZ Alarm Control Panel and Binary Sensor platforms

### DIFF
--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -151,8 +151,7 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     @property
     def state(self) -> str | None:
         """Return the state of the control panel."""
-        assert self._device.panel
-        return DECONZ_TO_ALARM_STATE.get(self._device.panel)
+        return DECONZ_TO_ALARM_STATE[self._device.panel]
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -1,6 +1,9 @@
 """Support for deCONZ alarm control panel devices."""
 from __future__ import annotations
 
+from collections.abc import ValuesView
+
+from pydeconz.alarm_system import AlarmSystem
 from pydeconz.sensor import (
     ANCILLARY_CONTROL_ARMED_AWAY,
     ANCILLARY_CONTROL_ARMED_NIGHT,
@@ -23,6 +26,7 @@ from homeassistant.components.alarm_control_panel import (
     SUPPORT_ALARM_ARM_NIGHT,
     AlarmControlPanelEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
@@ -32,11 +36,12 @@ from homeassistant.const import (
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .deconz_device import DeconzDevice
-from .gateway import get_gateway_from_config_entry
+from .gateway import DeconzGateway, get_gateway_from_config_entry
 
 DECONZ_TO_ALARM_STATE = {
     ANCILLARY_CONTROL_ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
@@ -52,14 +57,22 @@ DECONZ_TO_ALARM_STATE = {
 }
 
 
-def get_alarm_system_for_unique_id(gateway, unique_id: str):
+def get_alarm_system_for_unique_id(
+    gateway: DeconzGateway, unique_id: str
+) -> AlarmSystem | None:
     """Retrieve alarm system unique ID is registered to."""
     for alarm_system in gateway.api.alarmsystems.values():
         if unique_id in alarm_system.devices:
+            assert isinstance(alarm_system, AlarmSystem)
             return alarm_system
+    return None
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up the deCONZ alarm control panel devices.
 
     Alarm control panels are based on the same device class as sensors in deCONZ.
@@ -68,7 +81,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_alarm_control_panel(sensors=gateway.api.sensors.values()) -> None:
+    def async_add_alarm_control_panel(
+        sensors: list[AncillaryControl]
+        | ValuesView[AncillaryControl] = gateway.api.sensors.values(),
+    ) -> None:
         """Add alarm control panel devices from deCONZ."""
         entities = []
 
@@ -77,10 +93,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
             if (
                 isinstance(sensor, AncillaryControl)
                 and sensor.unique_id not in gateway.entities[DOMAIN]
-                and get_alarm_system_for_unique_id(gateway, sensor.unique_id)
+                and (
+                    alarm_system := get_alarm_system_for_unique_id(
+                        gateway, sensor.unique_id
+                    )
+                )
+                is not None
             ):
 
-                entities.append(DeconzAlarmControlPanel(sensor, gateway))
+                entities.append(DeconzAlarmControlPanel(sensor, gateway, alarm_system))
 
         if entities:
             async_add_entities(entities)
@@ -100,16 +121,22 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     """Representation of a deCONZ alarm control panel."""
 
     TYPE = DOMAIN
+    _device: AncillaryControl
 
     _attr_code_format = FORMAT_NUMBER
     _attr_supported_features = (
         SUPPORT_ALARM_ARM_AWAY | SUPPORT_ALARM_ARM_HOME | SUPPORT_ALARM_ARM_NIGHT
     )
 
-    def __init__(self, device, gateway) -> None:
+    def __init__(
+        self,
+        device: AncillaryControl,
+        gateway: DeconzGateway,
+        alarm_system: AlarmSystem,
+    ) -> None:
         """Set up alarm control panel device."""
         super().__init__(device, gateway)
-        self.alarm_system = get_alarm_system_for_unique_id(gateway, device.unique_id)
+        self.alarm_system = alarm_system
 
     @callback
     def async_update_callback(self) -> None:
@@ -124,20 +151,21 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     @property
     def state(self) -> str | None:
         """Return the state of the control panel."""
-        return DECONZ_TO_ALARM_STATE.get(self._device.state)
+        assert self._device.panel
+        return DECONZ_TO_ALARM_STATE.get(self._device.panel)
 
-    async def async_alarm_arm_away(self, code: None = None) -> None:
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self.alarm_system.arm_away(code)
 
-    async def async_alarm_arm_home(self, code: None = None) -> None:
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         await self.alarm_system.arm_stay(code)
 
-    async def async_alarm_arm_night(self, code: None = None) -> None:
+    async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
         await self.alarm_system.arm_night(code)
 
-    async def async_alarm_disarm(self, code: None = None) -> None:
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         await self.alarm_system.disarm(code)

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -63,7 +63,6 @@ def get_alarm_system_for_unique_id(
     """Retrieve alarm system unique ID is registered to."""
     for alarm_system in gateway.api.alarmsystems.values():
         if unique_id in alarm_system.devices:
-            assert isinstance(alarm_system, AlarmSystem)
             return alarm_system
     return None
 
@@ -151,7 +150,7 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     @property
     def state(self) -> str | None:
         """Return the state of the control panel."""
-        return DECONZ_TO_ALARM_STATE[self._device.panel]
+        return DECONZ_TO_ALARM_STATE.get(self._device.panel)
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -154,8 +154,7 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if sensor is on."""
-        assert isinstance(self._device.state, bool)
-        return self._device.state
+        return self._device.state  # type: ignore[no-any-return]
 
     @property
     def extra_state_attributes(self) -> dict:
@@ -211,5 +210,4 @@ class DeconzTampering(DeconzDevice, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        assert isinstance(self._device.tampered, bool)
-        return self._device.tampered
+        return self._device.tampered  # type: ignore[no-any-return]

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -157,7 +157,7 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
         return self._device.state  # type: ignore[no-any-return]
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, bool | float | int | list | None]:
         """Return the state attributes of the sensor."""
         attr: dict[str, bool | float | int | list | None] = {}
 

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -1,7 +1,13 @@
 """Support for deCONZ binary sensors."""
+from __future__ import annotations
+
+from collections.abc import ValuesView
+
 from pydeconz.sensor import (
     Alarm,
     CarbonMonoxide,
+    DeconzBinarySensor as PydeconzBinarySensor,
+    DeconzSensor as PydeconzSensor,
     Fire,
     GenericFlag,
     OpenClose,
@@ -22,13 +28,15 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, ENTITY_CATEGORY_DIAGNOSTIC
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import ATTR_DARK, ATTR_ON
 from .deconz_device import DeconzDevice
-from .gateway import get_gateway_from_config_entry
+from .gateway import DeconzGateway, get_gateway_from_config_entry
 
 DECONZ_BINARY_SENSORS = (
     Alarm,
@@ -73,15 +81,22 @@ ENTITY_DESCRIPTIONS = {
 }
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up the deCONZ binary sensor."""
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_sensor(sensors=gateway.api.sensors.values()):
+    def async_add_sensor(
+        sensors: list[PydeconzSensor]
+        | ValuesView[PydeconzSensor] = gateway.api.sensors.values(),
+    ) -> None:
         """Add binary sensor from deCONZ."""
-        entities = []
+        entities: list[DeconzBinarySensor | DeconzTampering] = []
 
         for sensor in sensors:
 
@@ -120,8 +135,9 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     """Representation of a deCONZ binary sensor."""
 
     TYPE = DOMAIN
+    _device: PydeconzBinarySensor
 
-    def __init__(self, device, gateway):
+    def __init__(self, device: PydeconzBinarySensor, gateway: DeconzGateway) -> None:
         """Initialize deCONZ binary sensor."""
         super().__init__(device, gateway)
 
@@ -129,21 +145,22 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
             self.entity_description = entity_description
 
     @callback
-    def async_update_callback(self):
+    def async_update_callback(self) -> None:
         """Update the sensor's state."""
         keys = {"on", "reachable", "state"}
         if self._device.changed_keys.intersection(keys):
             super().async_update_callback()
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if sensor is on."""
+        assert isinstance(self._device.state, bool)
         return self._device.state
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict:
         """Return the state attributes of the sensor."""
-        attr = {}
+        attr: dict[str, bool | float | int | str | list | None] = {}
 
         if self._device.on is not None:
             attr[ATTR_ON] = self._device.on
@@ -168,11 +185,12 @@ class DeconzTampering(DeconzDevice, BinarySensorEntity):
     """Representation of a deCONZ tampering sensor."""
 
     TYPE = DOMAIN
+    _device: PydeconzSensor
 
     _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
     _attr_device_class = DEVICE_CLASS_TAMPER
 
-    def __init__(self, device, gateway):
+    def __init__(self, device: PydeconzSensor, gateway: DeconzGateway) -> None:
         """Initialize deCONZ binary sensor."""
         super().__init__(device, gateway)
 
@@ -193,4 +211,5 @@ class DeconzTampering(DeconzDevice, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
+        assert isinstance(self._device.tampered, bool)
         return self._device.tampered

--- a/homeassistant/components/deconz/binary_sensor.py
+++ b/homeassistant/components/deconz/binary_sensor.py
@@ -160,7 +160,7 @@ class DeconzBinarySensor(DeconzDevice, BinarySensorEntity):
     @property
     def extra_state_attributes(self) -> dict:
         """Return the state attributes of the sensor."""
-        attr: dict[str, bool | float | int | str | list | None] = {}
+        attr: dict[str, bool | float | int | list | None] = {}
 
         if self._device.on is not None:
             attr[ATTR_ON] = self._device.on


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Start improving type hints to deCONZ integration. Does not depend on library for type hint, that's something for later.

Split from https://github.com/home-assistant/core/pull/58968

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
