### PR TITLE
Alter RainMachine to enable/disable program/zones via separate switches

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -405,4 +405,4 @@ class RainMachineEntity(CoordinatorEntity):
     @callback
     def update_from_latest_data(self) -> None:
         """Update the state."""
-        raise NotImplementedError
+        pass

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -405,4 +405,4 @@ class RainMachineEntity(CoordinatorEntity):
     @callback
     def update_from_latest_data(self) -> None:
         """Update the state."""
-        pass
+        raise NotImplementedError

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -21,8 +21,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import aiohttp_client, config_validation as cv
-import homeassistant.helpers.device_registry as dr
+from homeassistant.helpers import (
+    aiohttp_client,
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -323,6 +327,34 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate an old config entry."""
+    version = entry.version
+
+    LOGGER.debug("Migrating from version %s", version)
+
+    # 1 -> 2: Removing old, unnecessary change to MAC address in unique ID:
+    if version == 1:
+        version = entry.version = 2
+
+        ent_reg = er.async_get(hass)
+        for entity_entry in [
+            e for e in ent_reg.entities.values() if e.config_entry_id == entry.entry_id
+        ]:
+            unique_id_pieces = entity_entry.unique_id.split("_")
+            mac = unique_id_pieces[0]
+            unique_id_pieces[0] = ":".join(
+                mac[i : i + 2] for i in range(0, len(mac), 2)
+            )
+            ent_reg.async_update_entity(
+                entity_entry.entity_id, new_unique_id="_".join(unique_id_pieces)
+            )
+
+    LOGGER.info("Migration to version %s successful", version)
+
+    return True
+
+
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle an options update."""
     await hass.config_entries.async_reload(entry.entry_id)
@@ -355,10 +387,7 @@ class RainMachineEntity(CoordinatorEntity):
         )
         self._attr_extra_state_attributes = {}
         self._attr_name = f"{controller.name} {description.name}"
-        # The colons are removed from the device MAC simply because that value
-        # (unnecessarily) makes up the existing unique ID formula and we want to avoid
-        # a breaking change:
-        self._attr_unique_id = f"{controller.mac.replace(':', '')}_{description.key}"
+        self._attr_unique_id = f"{controller.mac}_{description.key}"
         self._controller = controller
         self.entity_description = description
 

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -42,7 +42,7 @@ async def async_get_controller(
 class RainMachineFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a RainMachine config flow."""
 
-    VERSION = 1
+    VERSION = 2
 
     discovered_ip_address: str | None = None
 

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -151,10 +151,10 @@ async def async_setup_entry(
 
     entities: list[RainMachineActivitySwitch | RainMachineEnabledSwitch] = []
 
-    for kind, coordinator, switch_class, switch_enabled_class in [
+    for kind, coordinator, switch_class, switch_enabled_class in (
         ("program", program_coordinator, RainMachineProgram, RainMachineProgramEnabled),
         ("zone", zone_coordinator, RainMachineZone, RainMachineZoneEnabled),
-    ]:
+    ):
         for uid, data in coordinator.data.items():
             # Add a switch to start/stop the program or zone:
             entities.append(
@@ -263,7 +263,7 @@ class RainMachineActivitySwitch(RainMachineBaseSwitch):
         off right after turning it on.
         """
         if not self.coordinator.data[self.entity_description.uid]["active"]:
-            self._attr_is_off = False
+            self._attr_is_on = False
             self.async_write_ha_state()
             return
 

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ID
+from homeassistant.const import ATTR_ID, ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -50,8 +50,6 @@ ATTR_SUN_EXPOSURE = "sun_exposure"
 ATTR_TIME_REMAINING = "time_remaining"
 ATTR_VEGETATION_TYPE = "vegetation_type"
 ATTR_ZONES = "zones"
-
-DEFAULT_ICON = "mdi:water"
 
 DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 
@@ -130,10 +128,6 @@ async def async_setup_entry(
     platform = entity_platform.async_get_current_platform()
 
     for service_name, schema, method in (
-        ("disable_program", {}, "async_disable_program"),
-        ("disable_zone", {}, "async_disable_zone"),
-        ("enable_program", {}, "async_enable_program"),
-        ("enable_zone", {}, "async_enable_zone"),
         ("start_program", {}, "async_start_program"),
         (
             "start_zone",
@@ -149,44 +143,51 @@ async def async_setup_entry(
     ):
         platform.async_register_entity_service(service_name, schema, method)
 
-    controller = hass.data[DOMAIN][entry.entry_id][DATA_CONTROLLER]
-    programs_coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR][
-        DATA_PROGRAMS
-    ]
-    zones_coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR][DATA_ZONES]
+    data = hass.data[DOMAIN][entry.entry_id]
+    controller = data[DATA_CONTROLLER]
+    program_coordinator = data[DATA_COORDINATOR][DATA_PROGRAMS]
+    zone_coordinator = data[DATA_COORDINATOR][DATA_ZONES]
 
-    entities: list[RainMachineProgram | RainMachineZone] = [
-        RainMachineProgram(
-            entry,
-            programs_coordinator,
-            controller,
-            RainMachineSwitchDescription(
-                key=f"RainMachineProgram_{uid}", name=program["name"], uid=uid
-            ),
-        )
-        for uid, program in programs_coordinator.data.items()
-    ]
-    entities.extend(
-        [
-            RainMachineZone(
-                entry,
-                zones_coordinator,
-                controller,
-                RainMachineSwitchDescription(
-                    key=f"RainMachineZone_{uid}", name=zone["name"], uid=uid
-                ),
+    entities: list[RainMachineProgram | RainMachineZone] = []
+
+    for kind, coordinator, switch_class, switch_enabled_class in [
+        ("program", program_coordinator, RainMachineProgram, RainMachineProgramEnabled),
+        ("zone", zone_coordinator, RainMachineZone, RainMachineZoneEnabled),
+    ]:
+        for uid, data in coordinator.data.items():
+            entities.append(
+                switch_class(
+                    entry,
+                    coordinator,
+                    controller,
+                    RainMachineSwitchDescription(
+                        key=f"{controller.name}_{kind}_{uid}",
+                        name=data["name"],
+                        uid=uid,
+                    ),
+                )
             )
-            for uid, zone in zones_coordinator.data.items()
-        ]
-    )
+            entities.append(
+                switch_enabled_class(
+                    entry,
+                    coordinator,
+                    controller,
+                    RainMachineSwitchDescription(
+                        key=f"{controller.name}_{kind}_{uid}_enabled",
+                        name=f"{data['name']} Enabled",
+                        entity_category=ENTITY_CATEGORY_CONFIG,
+                        uid=uid,
+                    ),
+                )
+            )
 
     async_add_entities(entities)
 
 
 class RainMachineSwitch(RainMachineEntity, SwitchEntity):
-    """A class to represent a generic RainMachine switch."""
+    """Define a base RainMachine switch."""
 
-    _attr_icon = DEFAULT_ICON
+    _attr_icon = "mdi:water"
     entity_description: RainMachineSwitchDescription
 
     def __init__(
@@ -196,37 +197,31 @@ class RainMachineSwitch(RainMachineEntity, SwitchEntity):
         controller: Controller,
         description: RainMachineSwitchDescription,
     ) -> None:
-        """Initialize a generic RainMachine switch."""
+        """Initialize."""
         super().__init__(entry, coordinator, controller, description)
 
         self._attr_is_on = False
-        self._data = coordinator.data[self.entity_description.uid]
+        self._data = coordinator.data[description.uid]
         self._entry = entry
-        self._is_active = True
 
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return super().available and self._is_active
-
-    async def _async_run_switch_coroutine(self, api_coro: Coroutine) -> None:
-        """Run a coroutine to toggle the switch."""
+    async def _async_run_api_coroutine(self, api_coro: Coroutine) -> None:
+        """Await an API coroutine, handle any errors, and update as appropriate."""
         try:
             resp = await api_coro
         except RequestError as err:
             LOGGER.error(
-                'Error while toggling %s "%s": %s',
-                self.entity_description.key,
-                self.unique_id,
+                'Error while executing %s on "%s": %s',
+                api_coro.__name__,
+                self.name,
                 err,
             )
             return
 
         if resp["statusCode"] != 0:
             LOGGER.error(
-                'Error while toggling %s "%s": %s',
-                self.entity_description.key,
-                self.unique_id,
+                'Error while executing %s on "%s": %s',
+                api_coro.__name__,
+                self.name,
                 resp["message"],
             )
             return
@@ -237,92 +232,57 @@ class RainMachineSwitch(RainMachineEntity, SwitchEntity):
             async_update_programs_and_zones(self.hass, self._entry)
         )
 
-    async def async_disable_program(self) -> None:
-        """Disable a program."""
-        raise NotImplementedError("Service not implemented for this entity")
-
-    async def async_disable_zone(self) -> None:
-        """Disable a zone."""
-        raise NotImplementedError("Service not implemented for this entity")
-
-    async def async_enable_program(self) -> None:
-        """Enable a program."""
-        raise NotImplementedError("Service not implemented for this entity")
-
-    async def async_enable_zone(self) -> None:
-        """Enable a zone."""
-        raise NotImplementedError("Service not implemented for this entity")
-
     async def async_start_program(self) -> None:
-        """Start a program."""
+        """Start the program."""
         raise NotImplementedError("Service not implemented for this entity")
 
     async def async_start_zone(self, *, zone_run_time: int) -> None:
-        """Start a zone."""
+        """Start the zone."""
         raise NotImplementedError("Service not implemented for this entity")
 
     async def async_stop_program(self) -> None:
-        """Stop a program."""
+        """Stop the program."""
         raise NotImplementedError("Service not implemented for this entity")
 
     async def async_stop_zone(self) -> None:
-        """Stop a zone."""
+        """Stop the zone."""
         raise NotImplementedError("Service not implemented for this entity")
-
-    @callback
-    def update_from_latest_data(self) -> None:
-        """Update the state."""
-        self._data = self.coordinator.data[self.entity_description.uid]
-        self._is_active = self._data["active"]
 
 
 class RainMachineProgram(RainMachineSwitch):
-    """A RainMachine program."""
-
-    @property
-    def zones(self) -> list:
-        """Return a list of active zones associated with this program."""
-        return [z for z in self._data["wateringTimes"] if z["active"]]
-
-    async def async_disable_program(self) -> None:
-        """Disable a program."""
-        await self._controller.programs.disable(self.entity_description.uid)
-        await async_update_programs_and_zones(self.hass, self._entry)
-
-    async def async_enable_program(self) -> None:
-        """Enable a program."""
-        await self._controller.programs.enable(self.entity_description.uid)
-        await async_update_programs_and_zones(self.hass, self._entry)
+    """Define a RainMachine program."""
 
     async def async_start_program(self) -> None:
-        """Start a program."""
+        """Start the program."""
         await self.async_turn_on()
 
     async def async_stop_program(self) -> None:
-        """Stop a program."""
+        """Stop the program."""
         await self.async_turn_off()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the program off."""
-        await self._async_run_switch_coroutine(
+        """Turn the switch off."""
+        await self._async_run_api_coroutine(
             self._controller.programs.stop(self.entity_description.uid)
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the program on."""
-        await self._async_run_switch_coroutine(
+        """Turn the switch on."""
+        await self._async_run_api_coroutine(
             self._controller.programs.start(self.entity_description.uid)
         )
 
     @callback
     def update_from_latest_data(self) -> None:
         """Update the state."""
-        super().update_from_latest_data()
+        self._data = self.coordinator.data[self.entity_description.uid]
 
         self._attr_is_on = bool(self._data["status"])
 
-        next_run: str | None = None
-        if self._data.get("nextRun") is not None:
+        next_run: str | None
+        if self._data.get("nextRun") is None:
+            next_run = None
+        else:
             next_run = datetime.strptime(
                 f"{self._data['nextRun']} {self._data['startTime']}",
                 "%Y-%m-%d %H:%M",
@@ -332,34 +292,37 @@ class RainMachineProgram(RainMachineSwitch):
             {
                 ATTR_ID: self.entity_description.uid,
                 ATTR_NEXT_RUN: next_run,
-                ATTR_SOAK: self.coordinator.data[self.entity_description.uid].get(
-                    "soak"
-                ),
-                ATTR_STATUS: RUN_STATUS_MAP[
-                    self.coordinator.data[self.entity_description.uid]["status"]
-                ],
-                ATTR_ZONES: ", ".join(z["name"] for z in self.zones),
+                ATTR_SOAK: self._data.get("soak"),
+                ATTR_STATUS: RUN_STATUS_MAP[self._data["status"]],
+                ATTR_ZONES: [z for z in self._data["wateringTimes"] if z["active"]],
             }
         )
 
 
+class RainMachineProgramEnabled(RainMachineSwitch):
+    """Define a switch to enable/disable a RainMachine program."""
+
+    _attr_icon = "mdi:cog"
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the program."""
+        await self._async_run_api_coroutine(
+            self._controller.programs.disable(self.entity_description.uid)
+        )
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the program."""
+        await self._async_run_api_coroutine(
+            self._controller.programs.enable(self.entity_description.uid)
+        )
+
+
 class RainMachineZone(RainMachineSwitch):
-    """A RainMachine zone."""
-
-    async def async_disable_zone(self) -> None:
-        """Disable a zone."""
-        await self._controller.zones.disable(self.entity_description.uid)
-        await async_update_programs_and_zones(self.hass, self._entry)
-
-    async def async_enable_zone(self) -> None:
-        """Enable a zone."""
-        await self._controller.zones.enable(self.entity_description.uid)
-        await async_update_programs_and_zones(self.hass, self._entry)
+    """Define a RainMachine zone."""
 
     async def async_start_zone(self, *, zone_run_time: int) -> None:
         """Start a particular zone for a certain amount of time."""
-        await self._controller.zones.start(self.entity_description.uid, zone_run_time)
-        await async_update_programs_and_zones(self.hass, self._entry)
+        await self.async_turn_off(duration=zone_run_time)
 
     async def async_stop_zone(self) -> None:
         """Stop a zone."""
@@ -367,29 +330,28 @@ class RainMachineZone(RainMachineSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the zone off."""
-        await self._async_run_switch_coroutine(
+        await self._async_run_api_coroutine(
             self._controller.zones.stop(self.entity_description.uid)
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the zone on."""
-        await self._async_run_switch_coroutine(
+        await self._async_run_api_coroutine(
             self._controller.zones.start(
                 self.entity_description.uid,
-                self._entry.options[CONF_ZONE_RUN_TIME],
+                kwargs.get("duration", self._entry.options[CONF_ZONE_RUN_TIME]),
             )
         )
 
     @callback
     def update_from_latest_data(self) -> None:
         """Update the state."""
-        super().update_from_latest_data()
+        self._data = self.coordinator.data[self.entity_description.uid]
 
         self._attr_is_on = bool(self._data["state"])
 
         self._attr_extra_state_attributes.update(
             {
-                ATTR_STATUS: RUN_STATUS_MAP[self._data["state"]],
                 ATTR_AREA: self._data.get("waterSense").get("area"),
                 ATTR_CURRENT_CYCLE: self._data.get("cycle"),
                 ATTR_FIELD_CAPACITY: self._data.get("waterSense").get("fieldCapacity"),
@@ -400,8 +362,27 @@ class RainMachineZone(RainMachineSwitch):
                 ATTR_SLOPE: SLOPE_TYPE_MAP.get(self._data.get("slope")),
                 ATTR_SOIL_TYPE: SOIL_TYPE_MAP.get(self._data.get("soil")),
                 ATTR_SPRINKLER_TYPE: SPRINKLER_TYPE_MAP.get(self._data.get("group_id")),
+                ATTR_STATUS: RUN_STATUS_MAP[self._data["state"]],
                 ATTR_SUN_EXPOSURE: SUN_EXPOSURE_MAP.get(self._data.get("sun")),
                 ATTR_TIME_REMAINING: self._data.get("remaining"),
                 ATTR_VEGETATION_TYPE: VEGETATION_MAP.get(self._data.get("type")),
             }
+        )
+
+
+class RainMachineZoneEnabled(RainMachineSwitch):
+    """Define a switch to enable/disable a RainMachine zone."""
+
+    _attr_icon = "mdi:cog"
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the zone."""
+        await self._async_run_api_coroutine(
+            self._controller.zones.disable(self.entity_description.uid)
+        )
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the zone."""
+        await self._async_run_api_coroutine(
+            self._controller.zones.enable(self.entity_description.uid)
         )

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -149,7 +149,7 @@ async def async_setup_entry(
     program_coordinator = data[DATA_COORDINATOR][DATA_PROGRAMS]
     zone_coordinator = data[DATA_COORDINATOR][DATA_ZONES]
 
-    entities: list[RainMachineProgram | RainMachineZone] = []
+    entities: list[RainMachineActivitySwitch | RainMachineEnabledSwitch] = []
 
     for kind, coordinator, switch_class, switch_enabled_class in [
         ("program", program_coordinator, RainMachineProgram, RainMachineProgramEnabled),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `rainmachine.disable_program`, `rainmachine.enable_program`, `rainmachine.disable_zone`, and `rainmachine.enable_zone` services have been removed. Instead, new configuration switches related to each entity can be used to enable/disable the program/zone.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With https://github.com/home-assistant/core/pull/57145, I altered RainMachine entity services to utilize targets instead of internal RainMachine IDs for programs and zones. Combined with the fact that enabling/disabling a program/zone currently marks the entity as `unavailable`, this created a situation where a user could call, say, `rainmachine.disable_program` and be unable to re-enable the program.

This PR alters things to move enabling/disabling a program/zone to a separate switch; this decouples the program/zone's "activity availability" from the HASS concept of `available` (which is more appropriate when talking about whether the device is online, the API can be reached, etc.).

![CleanShot 2021-11-12 at 16 48 18](https://user-images.githubusercontent.com/47216/141596268-38bff936-7c2f-4a43-acfe-16791a42eb12.png)

![CleanShot 2021-11-12 at 16 48 25](https://user-images.githubusercontent.com/47216/141596264-c6852aa6-4bf3-4f53-a7ea-9d2611caa601.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/59262
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20287

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
