### PR TITLE
Add TP-Link LED control for Kasa plugs and strips

### DIFF
--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -38,12 +38,8 @@ class CoordinatedTPLinkEntity(CoordinatorEntity):
         """Initialize the switch."""
         super().__init__(coordinator)
         self.device: SmartDevice = device
+        self._attr_name = self.device.alias
         self._attr_unique_id = self.device.device_id
-
-    @property
-    def name(self) -> str:
-        """Return the name of the Smart Plug."""
-        return cast(str, self.device.alias)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -8,6 +8,7 @@ from kasa import SmartDevice
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -29,7 +30,7 @@ async def async_setup_entry(
     device = coordinator.device
     if not device.is_plug and not device.is_strip:
         return
-    entities = []
+    entities: list = []
     if device.is_strip:
         # Historically we only add the children if the device is a strip
         _LOGGER.debug("Initializing strip with %s sockets", len(device.children))
@@ -38,7 +39,45 @@ async def async_setup_entry(
     else:
         entities.append(SmartPlugSwitch(device, coordinator))
 
+    entities.append(SmartPlugLedSwitch(device, coordinator))
+
     async_add_entities(entities)
+
+
+class SmartPlugLedSwitch(CoordinatedTPLinkEntity, SwitchEntity):
+    """Representation of switch for the LED of a TPLink Smart Plug."""
+
+    coordinator: TPLinkDataUpdateCoordinator
+
+    def __init__(
+        self, device: SmartDevice, coordinator: TPLinkDataUpdateCoordinator
+    ) -> None:
+        """Initialize the LED switch."""
+        super().__init__(device, coordinator)
+
+        self._attr_entity_category = ENTITY_CATEGORY_CONFIG
+        self._attr_name = f"{device.alias} LED"
+        self._attr_unique_id = f"{self.device.mac}_led"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the LED."""
+        return "mdi:led-on" if self.is_on else "mdi:led-off"
+
+    @async_refresh_after
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the LED switch on."""
+        await self.device.set_led(True)
+
+    @async_refresh_after
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the LED switch off."""
+        await self.device.set_led(False)
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if LED switch is on."""
+        return bool(self.device.led)
 
 
 class SmartPlugSwitch(CoordinatedTPLinkEntity, SwitchEntity):

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -49,13 +49,14 @@ class SmartPlugLedSwitch(CoordinatedTPLinkEntity, SwitchEntity):
 
     coordinator: TPLinkDataUpdateCoordinator
 
+    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+
     def __init__(
         self, device: SmartDevice, coordinator: TPLinkDataUpdateCoordinator
     ) -> None:
         """Initialize the LED switch."""
         super().__init__(device, coordinator)
 
-        self._attr_entity_category = ENTITY_CATEGORY_CONFIG
         self._attr_name = f"{device.alias} LED"
         self._attr_unique_id = f"{self.device.mac}_led"
 

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -91,6 +91,7 @@ def _mocked_plug() -> SmartPlug:
     plug.hw_info = {"sw_ver": "1.0.0"}
     plug.turn_off = AsyncMock()
     plug.turn_on = AsyncMock()
+    plug.set_led = AsyncMock()
     plug.protocol = _mock_protocol()
     return plug
 
@@ -111,6 +112,7 @@ def _mocked_strip() -> SmartStrip:
     strip.hw_info = {"sw_ver": "1.0.0"}
     strip.turn_off = AsyncMock()
     strip.turn_on = AsyncMock()
+    strip.set_led = AsyncMock()
     strip.protocol = _mock_protocol()
     plug0 = _mocked_plug()
     plug0.alias = "Plug0"

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -40,12 +40,6 @@ async def test_plug(hass: HomeAssistant) -> None:
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
 
-    # We should have a LED entity for the strip
-    led_entity_id = f"{entity_id}_led"
-    led_state = hass.states.get(led_entity_id)
-    assert led_state.state == STATE_ON
-    assert led_state.name == f"{state.name} LED"
-
     await hass.services.async_call(
         SWITCH_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
@@ -57,6 +51,26 @@ async def test_plug(hass: HomeAssistant) -> None:
     )
     plug.turn_on.assert_called_once()
     plug.turn_on.reset_mock()
+
+
+async def test_plug_led(hass: HomeAssistant) -> None:
+    """Test a smart plug LED."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    plug = _mocked_plug()
+    with _patch_discovery(device=plug), _patch_single_discovery(device=plug):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "switch.my_plug"
+    state = hass.states.get(entity_id)
+
+    led_entity_id = f"{entity_id}_led"
+    led_state = hass.states.get(led_entity_id)
+    assert led_state.state == STATE_ON
+    assert led_state.name == f"{state.name} LED"
 
     await hass.services.async_call(
         SWITCH_DOMAIN, "turn_off", {ATTR_ENTITY_ID: led_entity_id}, blocking=True
@@ -122,25 +136,7 @@ async def test_strip(hass: HomeAssistant) -> None:
 
     # Verify we only create entities for the children
     # since this is what the previous version did
-    strip_entity_id = "switch.my_strip"
-    assert hass.states.get(strip_entity_id) is None
-
-    # We should have a LED entity for the strip
-    led_entity_id = f"{strip_entity_id}_led"
-    led_state = hass.states.get(led_entity_id)
-    assert led_state.state == STATE_ON
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN, "turn_off", {ATTR_ENTITY_ID: led_entity_id}, blocking=True
-    )
-    strip.set_led.assert_called_once_with(False)
-    strip.set_led.reset_mock()
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN, "turn_on", {ATTR_ENTITY_ID: led_entity_id}, blocking=True
-    )
-    strip.set_led.assert_called_once_with(True)
-    strip.set_led.reset_mock()
+    assert hass.states.get("switch.my_strip") is None
 
     for plug_id in range(2):
         entity_id = f"switch.plug{plug_id}"
@@ -158,6 +154,35 @@ async def test_strip(hass: HomeAssistant) -> None:
         )
         strip.children[plug_id].turn_on.assert_called_once()
         strip.children[plug_id].turn_on.reset_mock()
+
+
+async def test_strip_led(hass: HomeAssistant) -> None:
+    """Test a smart strip LED."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    strip = _mocked_strip()
+    with _patch_discovery(device=strip), _patch_single_discovery(device=strip):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    # We should have a LED entity for the strip
+    led_entity_id = "switch.my_strip_led"
+    led_state = hass.states.get(led_entity_id)
+    assert led_state.state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_off", {ATTR_ENTITY_ID: led_entity_id}, blocking=True
+    )
+    strip.set_led.assert_called_once_with(False)
+    strip.set_led.reset_mock()
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {ATTR_ENTITY_ID: led_entity_id}, blocking=True
+    )
+    strip.set_led.assert_called_once_with(True)
+    strip.set_led.reset_mock()
 
 
 async def test_strip_unique_ids(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Kasa Switches have LED control through python-kasa, but this is not
available in home assistant at the moment. This creates a new switch
allowing for LED control of the kasa smart switches.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

<!--
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
-->
None at the moment.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
