### PR TITLE
Add support for property attribute shorthand in Fan entity

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -235,6 +235,13 @@ class FanEntity(ToggleEntity):
     """Base class for fan entities."""
 
     entity_description: FanEntityDescription
+    _attr_current_direction: str | None = None
+    _attr_oscillating: bool | None = None
+    _attr_percentage: int | None = None
+    _attr_preset_mode: str | None = None
+    _attr_preset_modes: list[str] | None = None
+    _attr_speed_count: int | None = None
+    _attr_supported_features = 0
 
     @_fan_native
     def set_speed(self, speed: str) -> None:
@@ -469,6 +476,9 @@ class FanEntity(ToggleEntity):
     @property
     def percentage(self) -> int | None:
         """Return the current speed as a percentage."""
+        if self._attr_percentage is not None:
+            return self._attr_percentage
+
         if (
             not self._implemented_preset_mode
             and self.preset_modes
@@ -482,6 +492,9 @@ class FanEntity(ToggleEntity):
     @property
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
+        if self._attr_speed_count is not None:
+            return self._attr_speed_count
+
         speed_list = speed_list_without_preset_modes(self.speed_list)
         if speed_list:
             return len(speed_list)
@@ -505,12 +518,12 @@ class FanEntity(ToggleEntity):
     @property
     def current_direction(self) -> str | None:
         """Return the current direction of the fan."""
-        return None
+        return self._attr_current_direction
 
     @property
-    def oscillating(self):
+    def oscillating(self) -> bool | None:
         """Return whether or not the fan is currently oscillating."""
-        return None
+        return self._attr_oscillating
 
     @property
     def capability_attributes(self):
@@ -607,6 +620,9 @@ class FanEntity(ToggleEntity):
         data: dict[str, float | str | None] = {}
         supported_features = self.supported_features
 
+        if supported_features is None:
+            return data
+
         if supported_features & SUPPORT_DIRECTION:
             data[ATTR_DIRECTION] = self.current_direction
 
@@ -627,16 +643,14 @@ class FanEntity(ToggleEntity):
         return data
 
     @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
-        return 0
-
-    @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., auto, smart, interval, favorite.
 
         Requires SUPPORT_SET_SPEED.
         """
+        if self._attr_preset_mode is not None:
+            return self._attr_preset_mode
+
         speed = self.speed
         if self.preset_modes and speed in self.preset_modes:
             return speed
@@ -648,6 +662,9 @@ class FanEntity(ToggleEntity):
 
         Requires SUPPORT_SET_SPEED.
         """
+        if self._attr_preset_modes is not None:
+            return self._attr_preset_modes
+
         return preset_modes_from_speed_list(self.speed_list)
 
 

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -237,11 +237,11 @@ class FanEntity(ToggleEntity):
     entity_description: FanEntityDescription
     _attr_current_direction: str | None = None
     _attr_oscillating: bool | None = None
-    _attr_percentage: int | None = None
-    _attr_preset_mode: str | None = None
-    _attr_preset_modes: list[str] | None = None
+    _attr_percentage: int | None
+    _attr_preset_mode: str | None
+    _attr_preset_modes: list[str] | None
     _attr_speed_count: int | None = None
-    _attr_supported_features = 0
+    _attr_supported_features: int = 0
 
     @_fan_native
     def set_speed(self, speed: str) -> None:
@@ -476,7 +476,7 @@ class FanEntity(ToggleEntity):
     @property
     def percentage(self) -> int | None:
         """Return the current speed as a percentage."""
-        if self._attr_percentage is not None:
+        if hasattr(self, "_attr_percentage"):
             return self._attr_percentage
 
         if (
@@ -620,9 +620,6 @@ class FanEntity(ToggleEntity):
         data: dict[str, float | str | None] = {}
         supported_features = self.supported_features
 
-        if supported_features is None:
-            return data
-
         if supported_features & SUPPORT_DIRECTION:
             data[ATTR_DIRECTION] = self.current_direction
 
@@ -643,12 +640,17 @@ class FanEntity(ToggleEntity):
         return data
 
     @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return self._attr_supported_features
+
+    @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., auto, smart, interval, favorite.
 
         Requires SUPPORT_SET_SPEED.
         """
-        if self._attr_preset_mode is not None:
+        if hasattr(self, "_attr_preset_mode"):
             return self._attr_preset_mode
 
         speed = self.speed
@@ -662,7 +664,7 @@ class FanEntity(ToggleEntity):
 
         Requires SUPPORT_SET_SPEED.
         """
-        if self._attr_preset_modes is not None:
+        if hasattr(self, "_attr_preset_modes"):
             return self._attr_preset_modes
 
         return preset_modes_from_speed_list(self.speed_list)

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -240,7 +240,7 @@ class FanEntity(ToggleEntity):
     _attr_percentage: int | None
     _attr_preset_mode: str | None
     _attr_preset_modes: list[str] | None
-    _attr_speed_count: int | None = None
+    _attr_speed_count: int
     _attr_supported_features: int = 0
 
     @_fan_native
@@ -492,7 +492,7 @@ class FanEntity(ToggleEntity):
     @property
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
-        if self._attr_speed_count is not None:
+        if hasattr(self, "_attr_speed_count"):
             return self._attr_speed_count
 
         speed_list = speed_list_without_preset_modes(self.speed_list)

--- a/tests/components/fan/test_init.py
+++ b/tests/components/fan/test_init.py
@@ -65,3 +65,22 @@ async def test_async_fanentity(hass):
         await fan.async_increase_speed()
     with pytest.raises(NotImplementedError):
         await fan.async_decrease_speed()
+
+
+@pytest.mark.parametrize(
+    "attribute_name, attribute_value",
+    [
+        ("current_direction", "forward"),
+        ("oscillating", True),
+        ("percentage", 50),
+        ("preset_mode", "medium"),
+        ("preset_modes", ["low", "medium", "high"]),
+        ("speed_count", 50),
+        ("supported_features", 1),
+    ],
+)
+def test_fanentity_attributes(attribute_name, attribute_value):
+    """Test fan entity attribute shorthand."""
+    fan = BaseFan()
+    setattr(fan, f"_attr_{attribute_name}", attribute_value)
+    assert getattr(fan, attribute_name) == attribute_value


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will add support for attribute shorthand for [property implementation](https://developers.home-assistant.io/docs/core/entity/#entity-class-or-instance-attributes)
follow up of #59615

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/developers.home-assistant/pull/1136

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
