### PR TITLE
Bump Nettigo Air Monitor backend library

### DIFF
--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -9,7 +9,7 @@ from aiohttp.client_exceptions import ClientConnectorError, ClientError
 import async_timeout
 from nettigo_air_monitor import (
     ApiError,
-    AuthRequired,
+    AuthFailed,
     ConnectionOptions,
     InvalidSensorData,
     NAMSensors,
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     options = ConnectionOptions(host=host, username=username, password=password)
     try:
         nam = await NettigoAirMonitor.create(websession, options)
-    except AuthRequired as err:
+    except AuthFailed as err:
         raise ConfigEntryAuthFailed from err
     except (ClientError, ClientConnectorError, asyncio.TimeoutError) as err:
         raise ConfigEntryNotReady from err

--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -1,14 +1,16 @@
 """The Nettigo Air Monitor component."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import cast
 
-from aiohttp import ClientSession
-from aiohttp.client_exceptions import ClientConnectorError
+from aiohttp.client_exceptions import ClientConnectorError, ClientError
 import async_timeout
 from nettigo_air_monitor import (
     ApiError,
+    AuthRequired,
+    ConnectionOptions,
     InvalidSensorData,
     NAMSensors,
     NettigoAirMonitor,
@@ -16,13 +18,18 @@ from nettigo_air_monitor import (
 
 from homeassistant.components.air_quality import DOMAIN as AIR_QUALITY_PLATFORM
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
 
 from .const import (
     ATTR_SDS011,
@@ -41,10 +48,20 @@ PLATFORMS = ["sensor"]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Nettigo as config entry."""
     host: str = entry.data[CONF_HOST]
+    username: str | None = entry.data.get(CONF_USERNAME)
+    password: str | None = entry.data.get(CONF_PASSWORD)
 
     websession = async_get_clientsession(hass)
 
-    coordinator = NAMDataUpdateCoordinator(hass, websession, host, entry.unique_id)
+    options = ConnectionOptions(host=host, username=username, password=password)
+    try:
+        nam = await NettigoAirMonitor.create(websession, options)
+    except AuthRequired as err:
+        raise ConfigEntryAuthFailed from err
+    except (ClientError, ClientConnectorError, asyncio.TimeoutError) as err:
+        raise ConfigEntryNotReady from err
+
+    coordinator = NAMDataUpdateCoordinator(hass, nam, entry.unique_id)
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})
@@ -81,14 +98,12 @@ class NAMDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(
         self,
         hass: HomeAssistant,
-        session: ClientSession,
-        host: str,
+        nam: NettigoAirMonitor,
         unique_id: str | None,
     ) -> None:
         """Initialize."""
-        self.host = host
-        self.nam = NettigoAirMonitor(session, host)
         self._unique_id = unique_id
+        self.nam = nam
 
         super().__init__(
             hass, _LOGGER, name=DOMAIN, update_interval=DEFAULT_UPDATE_INTERVAL
@@ -120,5 +135,5 @@ class NAMDataUpdateCoordinator(DataUpdateCoordinator):
             name=DEFAULT_NAME,
             sw_version=self.nam.software_version,
             manufacturer=MANUFACTURER,
-            configuration_url=f"http://{self.host}/",
+            configuration_url=f"http://{self.nam.host}/",
         )

--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -117,6 +117,8 @@ class NAMDataUpdateCoordinator(DataUpdateCoordinator):
             # get the data 4 times, so we use a longer than usual timeout here.
             async with async_timeout.timeout(30):
                 data = await self.nam.async_update()
+        # We do not need to catch AuthFailed exception here because sensor data is
+        # always available without authorization.
         except (ApiError, ClientConnectorError, InvalidSensorData) as error:
             raise UpdateFailed(error) from error
 

--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -58,7 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         nam = await NettigoAirMonitor.create(websession, options)
     except AuthFailed as err:
         raise ConfigEntryAuthFailed from err
-    except (ClientError, ClientConnectorError, asyncio.TimeoutError) as err:
+    except (ApiError, ClientError, ClientConnectorError, asyncio.TimeoutError) as err:
         raise ConfigEntryNotReady from err
 
     coordinator = NAMDataUpdateCoordinator(hass, nam, entry.unique_id)

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -53,7 +53,8 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize flow."""
-        self.host: str = ""
+        self.host: str
+        self.entry: config_entries.ConfigEntry
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -169,7 +170,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reauth(self, data: dict[str, Any]) -> FlowResult:
         """Handle configuration by re-auth."""
         if entry := self.hass.config_entries.async_get_entry(self.context["entry_id"]):
-            self.config_entry = entry
+            self.entry = entry
         self.host = data[CONF_HOST]
         self.context["title_placeholders"] = {"host": self.host}
         return await self.async_step_reauth_confirm()
@@ -189,9 +190,9 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="reauth_unsuccessful")
             else:
                 self.hass.config_entries.async_update_entry(
-                    self.config_entry, data={**user_input, CONF_HOST: self.host}
+                    self.entry, data={**user_input, CONF_HOST: self.host}
                 )
-                await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+                await self.hass.config_entries.async_reload(self.entry.entry_id)
                 return self.async_abort(reason="reauth_successful")
 
         return self.async_show_form(

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -183,9 +183,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await async_get_mac(self.hass, self.host, user_input)
-            except AuthFailed:
-                errors["base"] = "invalid_auth"
-            except (ApiError, ClientConnectorError, asyncio.TimeoutError):
+            except (ApiError, AuthFailed, ClientConnectorError, asyncio.TimeoutError):
                 return self.async_abort(reason="reauth_unsuccessful")
             else:
                 self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -9,7 +9,7 @@ from aiohttp.client_exceptions import ClientConnectorError
 import async_timeout
 from nettigo_air_monitor import (
     ApiError,
-    AuthRequired,
+    AuthFailed,
     CannotGetMac,
     ConnectionOptions,
     NettigoAirMonitor,
@@ -66,7 +66,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 mac = await async_get_mac(self.hass, self.host, {})
-            except AuthRequired:
+            except AuthFailed:
                 return await self.async_step_credentials()
             except (ApiError, ClientConnectorError, asyncio.TimeoutError):
                 errors["base"] = "cannot_connect"
@@ -99,7 +99,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 mac = await async_get_mac(self.hass, self.host, user_input)
-            except AuthRequired:
+            except AuthFailed:
                 errors["base"] = "invalid_auth"
             except (ApiError, ClientConnectorError, asyncio.TimeoutError):
                 errors["base"] = "cannot_connect"
@@ -132,7 +132,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             mac = await async_get_mac(self.hass, self.host, {})
-        except AuthRequired:
+        except AuthFailed:
             return await self.async_step_credentials()
         except (ApiError, ClientConnectorError, asyncio.TimeoutError):
             return self.async_abort(reason="cannot_connect")
@@ -189,7 +189,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 await async_get_mac(self.hass, host, user_input)
-            except AuthRequired:
+            except AuthFailed:
                 errors["base"] = "invalid_auth"
             except (ApiError, ClientConnectorError, asyncio.TimeoutError):
                 errors["base"] = "cannot_connect"

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -3,16 +3,23 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, cast
+from typing import Any
 
 from aiohttp.client_exceptions import ClientConnectorError
 import async_timeout
-from nettigo_air_monitor import ApiError, CannotGetMac, NettigoAirMonitor
+from nettigo_air_monitor import (
+    ApiError,
+    AuthRequired,
+    CannotGetMac,
+    ConnectionOptions,
+    NettigoAirMonitor,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
-from homeassistant.const import ATTR_NAME, CONF_HOST
+from homeassistant.const import ATTR_NAME, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
@@ -22,6 +29,19 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+async def async_get_mac(hass: HomeAssistant, host: str, data: dict[str, Any]) -> str:
+    """Get device MAC address."""
+    websession = async_get_clientsession(hass)
+
+    options = ConnectionOptions(host, data.get(CONF_USERNAME), data.get(CONF_PASSWORD))
+    nam = await NettigoAirMonitor.create(websession, options)
+    # Device firmware uses synchronous code and doesn't respond to http queries
+    # when reading data from sensors. The nettigo-air-monitor library tries to get
+    # the data 4 times, so we use a longer than usual timeout here.
+    async with async_timeout.timeout(30):
+        return await nam.async_get_mac_address()
+
+
 class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Nettigo Air Monitor."""
 
@@ -29,18 +49,21 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize flow."""
-        self.host: str | None = None
+        self.host: str = ""
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a flow initialized by the user."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             self.host = user_input[CONF_HOST]
+
             try:
-                mac = await self._async_get_mac(cast(str, self.host))
+                mac = await async_get_mac(self.hass, self.host, {})
+            except AuthRequired:
+                return await self.async_step_credentials()
             except (ApiError, ClientConnectorError, asyncio.TimeoutError):
                 errors["base"] = "cannot_connect"
             except CannotGetMac:
@@ -49,23 +72,57 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-
                 await self.async_set_unique_id(format_mac(mac))
                 self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
                 return self.async_create_entry(
-                    title=cast(str, self.host),
+                    title=self.host,
                     data=user_input,
                 )
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_HOST, default=""): str,
-                }
-            ),
+            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
             errors=errors,
+        )
+
+    async def async_step_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the credentials step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                mac = await async_get_mac(self.hass, self.host, user_input)
+            except AuthRequired:
+                errors["base"] = "invalid_auth"
+            except (ApiError, ClientConnectorError, asyncio.TimeoutError):
+                errors["base"] = "cannot_connect"
+            except CannotGetMac:
+                return self.async_abort(reason="device_unsupported")
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(format_mac(mac))
+                self._abort_if_unique_id_configured({CONF_HOST: self.host})
+
+                return self.async_create_entry(
+                    title=self.host,
+                    data={**user_input, CONF_HOST: self.host},
+                )
+        else:
+            user_input = {}
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_USERNAME, default=user_input.get(CONF_USERNAME)): str,
+                vol.Required(CONF_PASSWORD, default=user_input.get(CONF_PASSWORD)): str,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="credentials", data_schema=schema, errors=errors
         )
 
     async def async_step_zeroconf(
@@ -78,7 +135,9 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_HOST: self.host})
 
         try:
-            mac = await self._async_get_mac(self.host)
+            mac = await async_get_mac(self.hass, self.host, {})
+        except AuthRequired:
+            return await self.async_step_credentials()
         except (ApiError, ClientConnectorError, asyncio.TimeoutError):
             return self.async_abort(reason="cannot_connect")
         except CannotGetMac:
@@ -101,7 +160,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             return self.async_create_entry(
-                title=cast(str, self.host),
+                title=self.host,
                 data={CONF_HOST: self.host},
             )
 
@@ -112,13 +171,3 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders={CONF_HOST: self.host},
             errors=errors,
         )
-
-    async def _async_get_mac(self, host: str) -> str:
-        """Get device MAC address."""
-        websession = async_get_clientsession(self.hass)
-        nam = NettigoAirMonitor(websession, host)
-        # Device firmware uses synchronous code and doesn't respond to http queries
-        # when reading data from sensors. The nettigo-air-monitor library tries to get
-        # the data 4 times, so we use a longer than usual timeout here.
-        async with async_timeout.timeout(30):
-            return await nam.async_get_mac_address()

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -190,10 +190,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except AuthFailed:
                 errors["base"] = "invalid_auth"
             except (ApiError, ClientConnectorError, asyncio.TimeoutError):
-                errors["base"] = "cannot_connect"
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
+                return self.async_abort(reason="reauth_unsuccessful")
             else:
                 self.hass.config_entries.async_update_entry(
                     self.config_entry, data={**user_input, CONF_HOST: host}

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -127,6 +127,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle zeroconf discovery."""
         self.host = discovery_info[CONF_HOST]
+        self.context["title_placeholders"] = {"host": self.host}
 
         # Do not probe the device if the host is already configured
         self._async_abort_entries_match({CONF_HOST: self.host})
@@ -142,8 +143,6 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         await self.async_set_unique_id(format_mac(mac))
         self._abort_if_unique_id_configured({CONF_HOST: self.host})
-
-        self.context["title_placeholders"] = {"host": self.host}
 
         return await self.async_step_confirm_discovery()
 

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -156,7 +156,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle discovery confirm."""
-        errors: dict = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             return self.async_create_entry(

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -171,9 +171,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.config_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
-        if not self.config_entry:
-            return self.async_abort(reason="reauth_failed_existing")
-
+        assert self.config_entry is not None
         self.context["title_placeholders"] = {"host": self.config_entry.data[CONF_HOST]}
         return await self.async_step_reauth_confirm()
 

--- a/homeassistant/components/nam/manifest.json
+++ b/homeassistant/components/nam/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nettigo Air Monitor",
   "documentation": "https://www.home-assistant.io/integrations/nam",
   "codeowners": ["@bieniu"],
-  "requirements": ["nettigo-air-monitor==1.1.1"],
+  "requirements": ["nettigo-air-monitor==1.2.0"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/homeassistant/components/nam/manifest.json
+++ b/homeassistant/components/nam/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nettigo Air Monitor",
   "documentation": "https://www.home-assistant.io/integrations/nam",
   "codeowners": ["@bieniu"],
-  "requirements": ["nettigo-air-monitor==1.2.0"],
+  "requirements": ["nettigo-air-monitor==1.2.1"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/homeassistant/components/nam/strings.json
+++ b/homeassistant/components/nam/strings.json
@@ -9,6 +9,7 @@
         }
       },
       "credentials": {
+        "description": "Please enter the correct username and password.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/homeassistant/components/nam/strings.json
+++ b/homeassistant/components/nam/strings.json
@@ -33,8 +33,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "device_unsupported": "The device is unsupported.",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reauth_failed_existing": "Could not update the config entry, please remove the integration and set it up again."
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   }
 }

--- a/homeassistant/components/nam/strings.json
+++ b/homeassistant/components/nam/strings.json
@@ -8,6 +8,12 @@
           "host": "[%key:common::config_flow::data::host%]"
         }
       },
+      "credentials": {
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
       "confirm_discovery": {
         "description": "Do you want to set up Nettigo Air Monitor at {host}?"
       }

--- a/homeassistant/components/nam/strings.json
+++ b/homeassistant/components/nam/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "{name}",
+    "flow_title": "{host}",
     "step": {
       "user": {
         "description": "Set up Nettigo Air Monitor integration.",
@@ -14,17 +14,27 @@
           "password": "[%key:common::config_flow::data::password%]"
         }
       },
+      "reauth_confirm": {
+        "description": "Please enter the correct username and password for host: {host}",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
       "confirm_discovery": {
         "description": "Do you want to set up Nettigo Air Monitor at {host}?"
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "device_unsupported": "The device is unsupported."
+      "device_unsupported": "The device is unsupported.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reauth_failed_existing": "Could not update the config entry, please remove the integration and set it up again."
     }
   }
 }

--- a/homeassistant/components/nam/strings.json
+++ b/homeassistant/components/nam/strings.json
@@ -33,7 +33,8 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "device_unsupported": "The device is unsupported.",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again."
     }
   }
 }

--- a/homeassistant/components/nam/strings.json
+++ b/homeassistant/components/nam/strings.json
@@ -9,7 +9,7 @@
         }
       },
       "credentials": {
-        "description": "Please enter the correct username and password.",
+        "description": "Please enter the username and password.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1056,7 +1056,7 @@ netdisco==3.0.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==1.2.0
+nettigo-air-monitor==1.2.1
 
 # homeassistant.components.neurio_energy
 neurio==0.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1056,7 +1056,7 @@ netdisco==3.0.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==1.1.1
+nettigo-air-monitor==1.2.0
 
 # homeassistant.components.neurio_energy
 neurio==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -642,7 +642,7 @@ netdisco==3.0.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==1.2.0
+nettigo-air-monitor==1.2.1
 
 # homeassistant.components.nexia
 nexia==0.9.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -642,7 +642,7 @@ netdisco==3.0.0
 netmap==0.7.0.2
 
 # homeassistant.components.nam
-nettigo-air-monitor==1.1.1
+nettigo-air-monitor==1.2.0
 
 # homeassistant.components.nexia
 nexia==0.9.11

--- a/tests/components/nam/__init__.py
+++ b/tests/components/nam/__init__.py
@@ -1,5 +1,5 @@
 """Tests for the Nettigo Air Monitor integration."""
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from homeassistant.components.nam.const import DOMAIN
 
@@ -52,9 +52,11 @@ async def init_integration(hass, co2_sensor=True) -> MockConfigEntry:
         # Remove conc_co2_ppm value
         nam_data["sensordatavalues"].pop(6)
 
-    with patch(
-        "homeassistant.components.nam.NettigoAirMonitor._async_get_data",
-        return_value=nam_data,
+    update_response = Mock(json=AsyncMock(return_value=nam_data))
+
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+        "homeassistant.components.nam.NettigoAirMonitor._async_http_request",
+        return_value=update_response,
     ):
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -362,10 +362,16 @@ async def test_zeroconf_with_auth(hass):
             data=DISCOVERY_INFO,
             context={"source": SOURCE_ZEROCONF},
         )
+        context = next(
+            flow["context"]
+            for flow in hass.config_entries.flow.async_progress()
+            if flow["flow_id"] == result["flow_id"]
+        )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "credentials"
     assert result["errors"] == {}
+    assert context["title_placeholders"]["host"] == "10.10.2.3"
 
     with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -149,37 +149,6 @@ async def test_reauth_unsuccessful(hass):
         assert result["reason"] == "reauth_unsuccessful"
 
 
-async def test_reauth_with_error(hass):
-    """Test starting a reauthentication flow."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="10.10.2.3",
-        unique_id="aa:bb:cc:dd:ee:ff",
-        data={"host": "10.10.2.3"},
-    )
-    entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.initialize",
-        side_effect=AuthFailed("Auth Error"),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
-            data=entry.data,
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["step_id"] == "reauth_confirm"
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input=VALID_AUTH,
-        )
-
-        assert result["errors"] == {"base": "invalid_auth"}
-
-
 @pytest.mark.parametrize(
     "error",
     [

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -2,21 +2,22 @@
 import asyncio
 from unittest.mock import patch
 
-from nettigo_air_monitor import ApiError, CannotGetMac
+from nettigo_air_monitor import ApiError, AuthFailed, CannotGetMac
 import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.nam.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER, SOURCE_ZEROCONF
 
 from tests.common import MockConfigEntry
 
-DISCOVERY_INFO = {"host": "10.10.2.3", "name": "NAM-12345"}
+DISCOVERY_INFO = {"host": "10.10.2.3"}
 VALID_CONFIG = {"host": "10.10.2.3"}
+VALID_AUTH = {"username": "fake_username", "password": "fake_password"}
 
 
-async def test_form_create_entry(hass):
-    """Test that the user step works."""
+async def test_form_create_entry_without_auth(hass):
+    """Test that the user step without auth works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -30,7 +31,6 @@ async def test_form_create_entry(hass):
     ), patch(
         "homeassistant.components.nam.async_setup_entry", return_value=True
     ) as mock_setup_entry:
-
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             VALID_CONFIG,
@@ -41,6 +41,117 @@ async def test_form_create_entry(hass):
     assert result["title"] == "10.10.2.3"
     assert result["data"]["host"] == "10.10.2.3"
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_create_entry_with_auth(hass):
+    """Test that the user step with auth works."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == SOURCE_USER
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.initialize",
+        side_effect=AuthFailed("Authorization has failed"),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_CONFIG,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "credentials"
+
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="aa:bb:cc:dd:ee:ff",
+    ), patch(
+        "homeassistant.components.nam.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_AUTH,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "10.10.2.3"
+    assert result["data"]["host"] == "10.10.2.3"
+    assert result["data"]["username"] == "fake_username"
+    assert result["data"]["password"] == "fake_password"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_reauth_successful(hass):
+    """Test starting a reauthentication flow."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="10.10.2.3",
+        unique_id="aa:bb:cc:dd:ee:ff",
+        data={"host": "10.10.2.3"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="aa:bb:cc:dd:ee:ff",
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+            data=entry.data,
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "reauth_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=VALID_AUTH,
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "reauth_successful"
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        (ApiError("Invalid response from device 10.10.2.3: 404"), "cannot_connect"),
+        (AuthFailed("Authorization has failed"), "invalid_auth"),
+        (asyncio.TimeoutError, "cannot_connect"),
+        (ValueError, "unknown"),
+    ],
+)
+async def test_form_with_auth_errors(hass, error):
+    """Test we handle errors when auth is required."""
+    exc, base_error = error
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.initialize",
+        side_effect=AuthFailed("Authorization has failed"),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=VALID_CONFIG,
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "credentials"
+
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.initialize",
+        side_effect=exc,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_AUTH,
+        )
+
+    assert result["errors"] == {"base": base_error}
 
 
 @pytest.mark.parametrize(
@@ -74,7 +185,6 @@ async def test_form_abort(hass):
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         side_effect=CannotGetMac("Cannot get MAC address from device"),
     ):
-
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
@@ -150,6 +260,42 @@ async def test_zeroconf(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_zeroconf_with_auth(hass):
+    """Test that the zeroconf step with auth works."""
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.initialize",
+        side_effect=AuthFailed("Authorization has failed"),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=DISCOVERY_INFO,
+            context={"source": SOURCE_ZEROCONF},
+        )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "credentials"
+    assert result["errors"] == {}
+
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        return_value="aa:bb:cc:dd:ee:ff",
+    ), patch(
+        "homeassistant.components.nam.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_AUTH,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "10.10.2.3"
+    assert result["data"]["host"] == "10.10.2.3"
+    assert result["data"]["username"] == "fake_username"
+    assert result["data"]["password"] == "fake_password"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
 async def test_zeroconf_host_already_configured(hass):
     """Test that errors are shown when host is already configured."""
     entry = MockConfigEntry(
@@ -181,7 +327,6 @@ async def test_zeroconf_errors(hass, error):
         "homeassistant.components.nam.NettigoAirMonitor.initialize",
         side_effect=exc,
     ):
-
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             data=DISCOVERY_INFO,

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -24,7 +24,7 @@ async def test_form_create_entry(hass):
     assert result["step_id"] == SOURCE_USER
     assert result["errors"] == {}
 
-    with patch(
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
     ), patch(
@@ -55,7 +55,7 @@ async def test_form_errors(hass, error):
     """Test we handle errors."""
     exc, base_error = error
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        "homeassistant.components.nam.NettigoAirMonitor.initialize",
         side_effect=exc,
     ):
 
@@ -70,7 +70,7 @@ async def test_form_errors(hass, error):
 
 async def test_form_abort(hass):
     """Test we handle abort after error."""
-    with patch(
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         side_effect=CannotGetMac("Cannot get MAC address from device"),
     ):
@@ -96,7 +96,7 @@ async def test_form_already_configured(hass):
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with patch(
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
     ):
@@ -114,7 +114,7 @@ async def test_form_already_configured(hass):
 
 async def test_zeroconf(hass):
     """Test we get the form."""
-    with patch(
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
         return_value="aa:bb:cc:dd:ee:ff",
     ):
@@ -131,7 +131,7 @@ async def test_zeroconf(hass):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {}
-    assert context["title_placeholders"]["name"] == "NAM-12345"
+    assert context["title_placeholders"]["host"] == "10.10.2.3"
     assert context["confirm_only"] is True
 
     with patch(
@@ -178,7 +178,7 @@ async def test_zeroconf_errors(hass, error):
     """Test we handle errors."""
     exc, reason = error
     with patch(
-        "homeassistant.components.nam.NettigoAirMonitor.async_get_mac_address",
+        "homeassistant.components.nam.NettigoAirMonitor.initialize",
         side_effect=exc,
     ):
 

--- a/tests/components/nam/test_init.py
+++ b/tests/components/nam/test_init.py
@@ -1,7 +1,7 @@
 """Test init of Nettigo Air Monitor integration."""
 from unittest.mock import patch
 
-from nettigo_air_monitor import ApiError
+from nettigo_air_monitor import ApiError, AuthFailed
 
 from homeassistant.components.air_quality import DOMAIN as AIR_QUALITY_PLATFORM
 from homeassistant.components.nam.const import DOMAIN
@@ -32,13 +32,31 @@ async def test_config_not_ready(hass):
         data={"host": "10.10.2.3"},
     )
 
-    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
-        "homeassistant.components.nam.NettigoAirMonitor._async_http_request",
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.initialize",
         side_effect=ApiError("API Error"),
     ):
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_config_auth_failed(hass):
+    """Test for setup failure if the auth fails."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="10.10.2.3",
+        unique_id="aa:bb:cc:dd:ee:ff",
+        data={"host": "10.10.2.3"},
+    )
+
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.initialize",
+        side_effect=AuthFailed("Authorization has failed"),
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_unload_entry(hass):

--- a/tests/components/nam/test_init.py
+++ b/tests/components/nam/test_init.py
@@ -32,8 +32,8 @@ async def test_config_not_ready(hass):
         data={"host": "10.10.2.3"},
     )
 
-    with patch(
-        "homeassistant.components.nam.NettigoAirMonitor._async_get_data",
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+        "homeassistant.components.nam.NettigoAirMonitor._async_http_request",
         side_effect=ApiError("API Error"),
     ):
         entry.add_to_hass(hass)

--- a/tests/components/nam/test_sensor.py
+++ b/tests/components/nam/test_sensor.py
@@ -1,6 +1,6 @@
 """Test sensor of Nettigo Air Monitor integration."""
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from nettigo_air_monitor import ApiError
 
@@ -373,9 +373,10 @@ async def test_incompleta_data_after_device_restart(hass):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
 
     future = utcnow() + timedelta(minutes=6)
-    with patch(
-        "homeassistant.components.nam.NettigoAirMonitor._async_get_data",
-        return_value=INCOMPLETE_NAM_DATA,
+    update_response = Mock(json=AsyncMock(return_value=INCOMPLETE_NAM_DATA))
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+        "homeassistant.components.nam.NettigoAirMonitor._async_http_request",
+        return_value=update_response,
     ):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
@@ -395,8 +396,8 @@ async def test_availability(hass):
     assert state.state == "7.6"
 
     future = utcnow() + timedelta(minutes=6)
-    with patch(
-        "homeassistant.components.nam.NettigoAirMonitor._async_get_data",
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+        "homeassistant.components.nam.NettigoAirMonitor._async_http_request",
         side_effect=ApiError("API Error"),
     ):
         async_fire_time_changed(hass, future)
@@ -407,9 +408,10 @@ async def test_availability(hass):
     assert state.state == STATE_UNAVAILABLE
 
     future = utcnow() + timedelta(minutes=12)
-    with patch(
-        "homeassistant.components.nam.NettigoAirMonitor._async_get_data",
-        return_value=nam_data,
+    update_response = Mock(json=AsyncMock(return_value=nam_data))
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+        "homeassistant.components.nam.NettigoAirMonitor._async_http_request",
+        return_value=update_response,
     ):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
@@ -426,9 +428,10 @@ async def test_manual_update_entity(hass):
 
     await async_setup_component(hass, "homeassistant", {})
 
-    with patch(
-        "homeassistant.components.nam.NettigoAirMonitor._async_get_data",
-        return_value=nam_data,
+    update_response = Mock(json=AsyncMock(return_value=nam_data))
+    with patch("homeassistant.components.nam.NettigoAirMonitor.initialize"), patch(
+        "homeassistant.components.nam.NettigoAirMonitor._async_http_request",
+        return_value=update_response,
     ) as mock_get_data:
         await hass.services.async_call(
             "homeassistant",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is the first step to add new features for integration. These features require devcice authentication, so the config flow had to be reworked.
With this change, the device will work with integration regardless of whether the user enables authentication or not.

Changelog: https://github.com/bieniu/nettigo-air-monitor/compare/1.1.1...1.2.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
