### PR TITLE
Only store not None fan state attributes

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -614,14 +614,16 @@ class FanEntity(ToggleEntity):
             data[ATTR_OSCILLATING] = self.oscillating
 
         if supported_features & SUPPORT_SET_SPEED:
-            data[ATTR_SPEED] = self.speed
-            data[ATTR_PERCENTAGE] = self.percentage
+            if self.speed is not None:
+                data[ATTR_SPEED] = self.speed
+            if self.percentage is not None:
+                data[ATTR_PERCENTAGE] = self.percentage
             data[ATTR_PERCENTAGE_STEP] = self.percentage_step
 
         if (
             supported_features & SUPPORT_PRESET_MODE
             or supported_features & SUPPORT_SET_SPEED
-        ):
+        ) and self.preset_mode is not None:
             data[ATTR_PRESET_MODE] = self.preset_mode
 
         return data

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -227,7 +227,7 @@ async def test_fans(hass, aioclient_mock, mock_deconz_websocket):
     await hass.async_block_till_done()
 
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
-    assert not hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE]
+    assert ATTR_PERCENTAGE not in hass.states.get("fan.ceiling_fan").attributes
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 

--- a/tests/components/demo/test_fan.py
+++ b/tests/components/demo/test_fan.py
@@ -169,7 +169,7 @@ async def test_turn_on_with_preset_mode_only(hass, fan_entity_id):
     )
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
-    assert state.attributes[fan.ATTR_PRESET_MODE] is None
+    assert fan.ATTR_PRESET_MODE not in state.attributes
 
     with pytest.raises(ValueError):
         await hass.services.async_call(
@@ -182,7 +182,7 @@ async def test_turn_on_with_preset_mode_only(hass, fan_entity_id):
 
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_OFF
-    assert state.attributes[fan.ATTR_PRESET_MODE] is None
+    assert fan.ATTR_PRESET_MODE not in state.attributes
 
 
 @pytest.mark.parametrize("fan_entity_id", FANS_WITH_PRESET_MODES)
@@ -199,7 +199,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_ON
     assert state.attributes[fan.ATTR_SPEED] == PRESET_MODE_AUTO
-    assert state.attributes[fan.ATTR_PERCENTAGE] is None
+    assert fan.ATTR_PERCENTAGE not in state.attributes
     assert state.attributes[fan.ATTR_PRESET_MODE] == PRESET_MODE_AUTO
     assert state.attributes[fan.ATTR_SPEED_LIST] == [
         fan.SPEED_OFF,
@@ -228,7 +228,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
     assert state.state == STATE_ON
     assert state.attributes[fan.ATTR_SPEED] == fan.SPEED_HIGH
     assert state.attributes[fan.ATTR_PERCENTAGE] == 100
-    assert state.attributes[fan.ATTR_PRESET_MODE] is None
+    assert fan.ATTR_PRESET_MODE not in state.attributes
 
     await hass.services.async_call(
         fan.DOMAIN,
@@ -239,7 +239,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_ON
     assert state.attributes[fan.ATTR_SPEED] == PRESET_MODE_SMART
-    assert state.attributes[fan.ATTR_PERCENTAGE] is None
+    assert fan.ATTR_PERCENTAGE not in state.attributes
     assert state.attributes[fan.ATTR_PRESET_MODE] == PRESET_MODE_SMART
 
     await hass.services.async_call(
@@ -249,7 +249,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
     assert state.state == STATE_OFF
     assert state.attributes[fan.ATTR_SPEED] == fan.SPEED_OFF
     assert state.attributes[fan.ATTR_PERCENTAGE] == 0
-    assert state.attributes[fan.ATTR_PRESET_MODE] is None
+    assert fan.ATTR_PRESET_MODE not in state.attributes
 
     with pytest.raises(ValueError):
         await hass.services.async_call(
@@ -264,7 +264,7 @@ async def test_turn_on_with_preset_mode_and_speed(hass, fan_entity_id):
     assert state.state == STATE_OFF
     assert state.attributes[fan.ATTR_SPEED] == fan.SPEED_OFF
     assert state.attributes[fan.ATTR_PERCENTAGE] == 0
-    assert state.attributes[fan.ATTR_PRESET_MODE] is None
+    assert fan.ATTR_PRESET_MODE not in state.attributes
 
 
 @pytest.mark.parametrize("fan_entity_id", LIMITED_AND_FULL_FAN_ENTITY_IDS)
@@ -352,7 +352,7 @@ async def test_set_preset_mode(hass, fan_entity_id):
     state = hass.states.get(fan_entity_id)
     assert state.state == STATE_ON
     assert state.attributes[fan.ATTR_SPEED] == PRESET_MODE_AUTO
-    assert state.attributes[fan.ATTR_PERCENTAGE] is None
+    assert fan.ATTR_PERCENTAGE not in state.attributes
     assert state.attributes[fan.ATTR_PRESET_MODE] == PRESET_MODE_AUTO
 
 

--- a/tests/components/tasmota/test_fan.py
+++ b/tests/components/tasmota/test_fan.py
@@ -53,7 +53,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     await hass.async_block_till_done()
     state = hass.states.get("fan.tasmota")
     assert state.state == STATE_OFF
-    assert state.attributes["percentage"] is None
+    assert "percentage" not in state.attributes
     assert state.attributes["supported_features"] == fan.SUPPORT_SET_SPEED
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -453,9 +453,21 @@ async def test_fan_init(
     entity_id = await find_entity_id(DOMAIN, zha_device, hass)
     assert entity_id is not None
     assert hass.states.get(entity_id).state == expected_state
-    assert hass.states.get(entity_id).attributes[ATTR_SPEED] == expected_speed
-    assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == expected_percentage
-    assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is None
+
+    if expected_speed is None:
+        assert ATTR_SPEED not in hass.states.get(entity_id).attributes
+    else:
+        assert hass.states.get(entity_id).attributes[ATTR_SPEED] == expected_speed
+
+    if expected_percentage is None:
+        assert ATTR_PERCENTAGE not in hass.states.get(entity_id).attributes
+    else:
+        assert (
+            hass.states.get(entity_id).attributes[ATTR_PERCENTAGE]
+            == expected_percentage
+        )
+
+    assert ATTR_PRESET_MODE not in hass.states.get(entity_id).attributes
 
 
 async def test_fan_update_entity(
@@ -474,7 +486,7 @@ async def test_fan_update_entity(
     assert hass.states.get(entity_id).state == STATE_OFF
     assert hass.states.get(entity_id).attributes[ATTR_SPEED] == SPEED_OFF
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == 0
-    assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is None
+    assert ATTR_PRESET_MODE not in hass.states.get(entity_id).attributes
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE_STEP] == 100 / 3
     assert cluster.read_attributes.await_count == 2
 
@@ -495,6 +507,6 @@ async def test_fan_update_entity(
     assert hass.states.get(entity_id).state == STATE_ON
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == 33
     assert hass.states.get(entity_id).attributes[ATTR_SPEED] == SPEED_LOW
-    assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is None
+    assert ATTR_PRESET_MODE not in hass.states.get(entity_id).attributes
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE_STEP] == 100 / 3
     assert cluster.read_attributes.await_count == 4


### PR DESCRIPTION
## Proposed change

Make the `FanEntity` state save/restore more resilient to match the recent changes around speed_list.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
