### PR TITLE
Refactor tests for modem_callerid

### DIFF
--- a/tests/components/modem_callerid/__init__.py
+++ b/tests/components/modem_callerid/__init__.py
@@ -3,24 +3,32 @@
 from unittest.mock import patch
 
 from phone_modem import DEFAULT_PORT
-
-from homeassistant.const import CONF_DEVICE
-
-CONF_DATA = {CONF_DEVICE: DEFAULT_PORT}
-
-IMPORT_DATA = {"sensor": {"platform": "modem_callerid"}}
+import serial.tools.list_ports_common
 
 
-def _patch_init_modem():
+def patch_init_modem():
+    """Mock modem."""
     return patch(
-        "homeassistant.components.modem_callerid.PhoneModem",
+        "homeassistant.components.modem_callerid.PhoneModem.initialize",
         autospec=True,
     )
 
 
-def _patch_config_flow_modem(mocked_modem):
+def patch_config_flow_modem(mocked_modem):
+    """Mock modem config flow."""
     return patch(
-        "homeassistant.components.modem_callerid.config_flow.PhoneModem",
+        "homeassistant.components.modem_callerid.config_flow.PhoneModem.test",
         autospec=True,
         return_value=mocked_modem,
     )
+
+
+def com_port():
+    """Mock of a serial port."""
+    port = serial.tools.list_ports_common.ListPortInfo(DEFAULT_PORT)
+    port.serial_number = "1234"
+    port.manufacturer = "Virtual serial port"
+    port.device = DEFAULT_PORT
+    port.description = "Some serial port"
+
+    return port

--- a/tests/components/modem_callerid/__init__.py
+++ b/tests/components/modem_callerid/__init__.py
@@ -3,29 +3,26 @@
 from unittest.mock import patch
 
 from phone_modem import DEFAULT_PORT
-import serial.tools.list_ports_common
+from serial.tools.list_ports_common import ListPortInfo
 
 
 def patch_init_modem():
     """Mock modem."""
     return patch(
         "homeassistant.components.modem_callerid.PhoneModem.initialize",
-        autospec=True,
     )
 
 
-def patch_config_flow_modem(mocked_modem):
+def patch_config_flow_modem():
     """Mock modem config flow."""
     return patch(
         "homeassistant.components.modem_callerid.config_flow.PhoneModem.test",
-        autospec=True,
-        return_value=mocked_modem,
     )
 
 
 def com_port():
     """Mock of a serial port."""
-    port = serial.tools.list_ports_common.ListPortInfo(DEFAULT_PORT)
+    port = ListPortInfo(DEFAULT_PORT)
     port.serial_number = "1234"
     port.manufacturer = "Virtual serial port"
     port.device = DEFAULT_PORT

--- a/tests/components/modem_callerid/test_config_flow.py
+++ b/tests/components/modem_callerid/test_config_flow.py
@@ -2,20 +2,15 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import phone_modem
-import serial.tools.list_ports
 
+from homeassistant import data_entry_flow
 from homeassistant.components import usb
 from homeassistant.components.modem_callerid.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USB, SOURCE_USER
 from homeassistant.const import CONF_DEVICE, CONF_SOURCE
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import (
-    RESULT_TYPE_ABORT,
-    RESULT_TYPE_CREATE_ENTRY,
-    RESULT_TYPE_FORM,
-)
 
-from . import _patch_config_flow_modem
+from . import com_port, patch_config_flow_modem
 
 DISCOVERY_INFO = {
     "device": phone_modem.DEFAULT_PORT,
@@ -34,47 +29,35 @@ def _patch_setup():
     )
 
 
-def com_port():
-    """Mock of a serial port."""
-    port = serial.tools.list_ports_common.ListPortInfo(phone_modem.DEFAULT_PORT)
-    port.serial_number = "1234"
-    port.manufacturer = "Virtual serial port"
-    port.device = phone_modem.DEFAULT_PORT
-    port.description = "Some serial port"
-
-    return port
-
-
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 async def test_flow_usb(hass: HomeAssistant):
     """Test usb discovery flow."""
-    port = com_port()
-    with _patch_config_flow_modem(AsyncMock()), _patch_setup():
+    with patch_config_flow_modem(AsyncMock()), _patch_setup():
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_USB},
             data=DISCOVERY_INFO,
         )
-        assert result["type"] == RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "usb_confirm"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={CONF_DEVICE: phone_modem.DEFAULT_PORT},
         )
-        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-        assert result["data"] == {CONF_DEVICE: port.device}
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["data"] == {CONF_DEVICE: com_port().device}
 
 
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 async def test_flow_usb_cannot_connect(hass: HomeAssistant):
     """Test usb flow connection error."""
-    with _patch_config_flow_modem(AsyncMock()) as modemmock:
+    with patch_config_flow_modem(AsyncMock()) as modemmock:
         modemmock.side_effect = phone_modem.exceptions.SerialError
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_USB}, data=DISCOVERY_INFO
         )
-        assert result["type"] == RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "cannot_connect"
 
 
@@ -91,13 +74,13 @@ async def test_flow_user(hass: HomeAssistant):
         port.pid,
     )
     mocked_modem = AsyncMock()
-    with _patch_config_flow_modem(mocked_modem), _patch_setup():
+    with patch_config_flow_modem(mocked_modem), _patch_setup():
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_USER},
             data={CONF_DEVICE: port_select},
         )
-        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"] == {CONF_DEVICE: port.device}
 
         result = await hass.config_entries.flow.async_init(
@@ -105,7 +88,7 @@ async def test_flow_user(hass: HomeAssistant):
             context={CONF_SOURCE: SOURCE_USER},
             data={CONF_DEVICE: port_select},
         )
-        assert result["type"] == RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "no_devices_found"
 
 
@@ -121,12 +104,12 @@ async def test_flow_user_error(hass: HomeAssistant):
         port.vid,
         port.pid,
     )
-    with _patch_config_flow_modem(AsyncMock()) as modemmock:
+    with patch_config_flow_modem(AsyncMock()) as modemmock:
         modemmock.side_effect = phone_modem.exceptions.SerialError
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={CONF_DEVICE: port_select}
         )
-        assert result["type"] == RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {"base": "cannot_connect"}
 
@@ -135,32 +118,32 @@ async def test_flow_user_error(hass: HomeAssistant):
             result["flow_id"],
             user_input={CONF_DEVICE: port_select},
         )
-        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"] == {CONF_DEVICE: port.device}
 
 
 @patch("serial.tools.list_ports.comports", MagicMock())
 async def test_flow_user_no_port_list(hass: HomeAssistant):
     """Test user with no list of ports."""
-    with _patch_config_flow_modem(AsyncMock()):
+    with patch_config_flow_modem(AsyncMock()):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_USER},
             data={CONF_DEVICE: phone_modem.DEFAULT_PORT},
         )
-        assert result["type"] == RESULT_TYPE_ABORT
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "no_devices_found"
 
 
 async def test_abort_user_with_existing_flow(hass: HomeAssistant):
     """Test user flow is aborted when another discovery has happened."""
-    with _patch_config_flow_modem(AsyncMock()):
+    with patch_config_flow_modem(AsyncMock()):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_USB},
             data=DISCOVERY_INFO,
         )
-        assert result["type"] == RESULT_TYPE_FORM
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "usb_confirm"
 
         result2 = await hass.config_entries.flow.async_init(
@@ -169,5 +152,5 @@ async def test_abort_user_with_existing_flow(hass: HomeAssistant):
             data={},
         )
 
-        assert result2["type"] == RESULT_TYPE_ABORT
+        assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result2["reason"] == "already_in_progress"

--- a/tests/components/modem_callerid/test_config_flow.py
+++ b/tests/components/modem_callerid/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test Modem Caller ID config flow."""
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import phone_modem
 
@@ -25,14 +25,13 @@ DISCOVERY_INFO = {
 def _patch_setup():
     return patch(
         "homeassistant.components.modem_callerid.async_setup_entry",
-        return_value=True,
     )
 
 
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 async def test_flow_usb(hass: HomeAssistant):
     """Test usb discovery flow."""
-    with patch_config_flow_modem(AsyncMock()), _patch_setup():
+    with patch_config_flow_modem(), _patch_setup():
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_USB},
@@ -52,7 +51,7 @@ async def test_flow_usb(hass: HomeAssistant):
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
 async def test_flow_usb_cannot_connect(hass: HomeAssistant):
     """Test usb flow connection error."""
-    with patch_config_flow_modem(AsyncMock()) as modemmock:
+    with patch_config_flow_modem() as modemmock:
         modemmock.side_effect = phone_modem.exceptions.SerialError
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_USB}, data=DISCOVERY_INFO
@@ -73,8 +72,7 @@ async def test_flow_user(hass: HomeAssistant):
         port.vid,
         port.pid,
     )
-    mocked_modem = AsyncMock()
-    with patch_config_flow_modem(mocked_modem), _patch_setup():
+    with patch_config_flow_modem(), _patch_setup():
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_USER},
@@ -104,7 +102,7 @@ async def test_flow_user_error(hass: HomeAssistant):
         port.vid,
         port.pid,
     )
-    with patch_config_flow_modem(AsyncMock()) as modemmock:
+    with patch_config_flow_modem() as modemmock:
         modemmock.side_effect = phone_modem.exceptions.SerialError
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={CONF_DEVICE: port_select}
@@ -125,7 +123,7 @@ async def test_flow_user_error(hass: HomeAssistant):
 @patch("serial.tools.list_ports.comports", MagicMock())
 async def test_flow_user_no_port_list(hass: HomeAssistant):
     """Test user with no list of ports."""
-    with patch_config_flow_modem(AsyncMock()):
+    with patch_config_flow_modem():
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_USER},
@@ -137,7 +135,7 @@ async def test_flow_user_no_port_list(hass: HomeAssistant):
 
 async def test_abort_user_with_existing_flow(hass: HomeAssistant):
     """Test user flow is aborted when another discovery has happened."""
-    with patch_config_flow_modem(AsyncMock()):
+    with patch_config_flow_modem():
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={CONF_SOURCE: SOURCE_USB},

--- a/tests/components/modem_callerid/test_init.py
+++ b/tests/components/modem_callerid/test_init.py
@@ -1,4 +1,6 @@
 """Test Modem Caller ID integration."""
+from unittest.mock import AsyncMock, patch
+
 from phone_modem import exceptions
 
 from homeassistant.components.modem_callerid.const import DOMAIN
@@ -18,7 +20,10 @@ async def test_setup_entry(hass: HomeAssistant):
         data={CONF_DEVICE: com_port().device},
     )
     entry.add_to_hass(hass)
-    with patch_init_modem():
+    with patch("aioserial.AioSerial", return_value=AsyncMock()), patch(
+        "homeassistant.components.modem_callerid.PhoneModem._get_response",
+        return_value="OK",
+    ), patch("phone_modem.PhoneModem._modem_sm"):
         await hass.config_entries.async_setup(entry.entry_id)
     assert entry.state == ConfigEntryState.LOADED
 

--- a/tests/components/modem_callerid/test_init.py
+++ b/tests/components/modem_callerid/test_init.py
@@ -1,13 +1,12 @@
 """Test Modem Caller ID integration."""
-from unittest.mock import patch
-
 from phone_modem import exceptions
 
 from homeassistant.components.modem_callerid.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_DEVICE
 from homeassistant.core import HomeAssistant
 
-from . import CONF_DATA, _patch_init_modem
+from . import com_port, patch_init_modem
 
 from tests.common import MockConfigEntry
 
@@ -16,10 +15,10 @@ async def test_setup_config(hass: HomeAssistant):
     """Test Modem Caller ID setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=CONF_DATA,
+        data={CONF_DEVICE: com_port().device},
     )
     entry.add_to_hass(hass)
-    with _patch_init_modem():
+    with patch_init_modem():
         await hass.config_entries.async_setup(entry.entry_id)
     assert entry.state == ConfigEntryState.LOADED
 
@@ -28,17 +27,15 @@ async def test_async_setup_entry_not_ready(hass: HomeAssistant):
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=CONF_DATA,
+        data={CONF_DEVICE: com_port().device},
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.modem_callerid.PhoneModem",
-        side_effect=exceptions.SerialError(),
-    ):
+    with patch_init_modem() as modemmock:
+        modemmock.side_effect = exceptions.SerialError
         await hass.config_entries.async_setup(entry.entry_id)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state == ConfigEntryState.SETUP_RETRY
     assert not hass.data.get(DOMAIN)
 
 
@@ -46,10 +43,10 @@ async def test_unload_config_entry(hass: HomeAssistant):
     """Test unload."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=CONF_DATA,
+        data={CONF_DEVICE: com_port().device},
     )
     entry.add_to_hass(hass)
-    with _patch_init_modem():
+    with patch_init_modem():
         await hass.config_entries.async_setup(entry.entry_id)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.state is ConfigEntryState.LOADED

--- a/tests/components/modem_callerid/test_init.py
+++ b/tests/components/modem_callerid/test_init.py
@@ -11,8 +11,8 @@ from . import com_port, patch_init_modem
 from tests.common import MockConfigEntry
 
 
-async def test_setup_config(hass: HomeAssistant):
-    """Test Modem Caller ID setup."""
+async def test_setup_entry(hass: HomeAssistant):
+    """Test Modem Caller ID entry setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_DEVICE: com_port().device},
@@ -39,7 +39,7 @@ async def test_async_setup_entry_not_ready(hass: HomeAssistant):
     assert not hass.data.get(DOMAIN)
 
 
-async def test_unload_config_entry(hass: HomeAssistant):
+async def test_unload_entry(hass: HomeAssistant):
     """Test unload."""
     entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor tests for modem_callerid

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
