### PR TITLE
Add button platform to onewire

### DIFF
--- a/homeassistant/components/onewire/button.py
+++ b/homeassistant/components/onewire/button.py
@@ -1,0 +1,88 @@
+"""Support for 1-Wire buttons."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .onewirehub import OneWireHub
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class OneWireButtonEntityDescription(ButtonEntityDescription):
+    """Class describing 1-Wire button entities."""
+
+
+ENTRY_BUTTON_TYPES = {
+    "cleanup_registry": OneWireButtonEntityDescription(
+        key="cleanup_registry",
+        icon="mdi:broom",
+        name="Cleanup 1-Wire devices on {}",
+    )
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Renault entities from config entry."""
+    onewirehub: OneWireHub = hass.data[DOMAIN][config_entry.entry_id]
+
+    async def _cleanup_registry(entity: OneWireConfigEntryButtonEntity) -> None:
+        # Get registries
+        device_registry = dr.async_get(entity.hass)
+        # Generate list of all device entries
+        registry_devices = list(
+            dr.async_entries_for_config_entry(device_registry, config_entry.entry_id)
+        )
+        # Remove devices that don't belong to any entity
+        for device in registry_devices:
+            if not onewirehub.has_device_in_cache(device):
+                _LOGGER.debug(
+                    "Removing device `%s` because it is no longer available",
+                    device.id,
+                )
+                device_registry.async_remove_device(device.id)
+
+    async_add_entities(
+        [
+            OneWireConfigEntryButtonEntity(
+                ENTRY_BUTTON_TYPES["cleanup_registry"],
+                config_entry,
+                _cleanup_registry,
+            ),
+        ]
+    )
+
+
+class OneWireConfigEntryButtonEntity(ButtonEntity):
+    """Implementation of a 1-Wire binary sensor."""
+
+    def __init__(
+        self,
+        description: OneWireButtonEntityDescription,
+        config_entry: ConfigEntry,
+        async_press: Callable[[OneWireConfigEntryButtonEntity], Awaitable],
+    ) -> None:
+        """Initialize the sensor."""
+        if TYPE_CHECKING:
+            assert description.name
+        self.entity_description = description
+        self._attr_name = description.name.format(config_entry.title)
+        self._async_press = async_press
+
+    async def async_press(self) -> None:
+        """Process the button press."""
+        await self._async_press(self)

--- a/homeassistant/components/onewire/button.py
+++ b/homeassistant/components/onewire/button.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_SYSTEM
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -26,6 +27,7 @@ class OneWireButtonEntityDescription(ButtonEntityDescription):
 ENTRY_BUTTON_TYPES = {
     "cleanup_registry": OneWireButtonEntityDescription(
         key="cleanup_registry",
+        entity_category=ENTITY_CATEGORY_SYSTEM,
         icon="mdi:broom",
         name="Cleanup 1-Wire devices on {}",
     )

--- a/homeassistant/components/onewire/const.py
+++ b/homeassistant/components/onewire/const.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 
@@ -49,6 +50,7 @@ READ_MODE_INT = "int"
 
 PLATFORMS = [
     BINARY_SENSOR_DOMAIN,
+    BUTTON_DOMAIN,
     SENSOR_DOMAIN,
     SWITCH_DOMAIN,
 ]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add "cleanup devices" button to onewire: one button per config entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59168
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
