### PR TITLE
Add service integration foundation

### DIFF
--- a/homeassistant/components/demo/__init__.py
+++ b/homeassistant/components/demo/__init__.py
@@ -31,6 +31,7 @@ COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM = [
     "light",
     "lock",
     "media_player",
+    "notify",
     "number",
     "select",
     "sensor",

--- a/homeassistant/components/demo/notify.py
+++ b/homeassistant/components/demo/notify.py
@@ -27,7 +27,7 @@ def get_service(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> BaseNotificationService:
     """Get the legacy demo notification service."""
-    return LegacyDemoNotificationService()
+    return DemoNotificationService()
 
 
 class DemoNotifyService(NotifyService):
@@ -39,7 +39,7 @@ class DemoNotifyService(NotifyService):
         self.hass.bus.fire(EVENT_NOTIFY, kwargs)
 
 
-class LegacyDemoNotificationService(BaseNotificationService):
+class DemoNotificationService(BaseNotificationService):
     """Represent the legacy demo notification service."""
 
     @property

--- a/homeassistant/components/demo/notify.py
+++ b/homeassistant/components/demo/notify.py
@@ -1,27 +1,53 @@
 """Demo notification service."""
-from homeassistant.components.notify import BaseNotificationService
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.notify import BaseNotificationService, NotifyService
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_platform import AddServicesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 EVENT_NOTIFY = "notify"
 
 
-def get_service(hass, config, discovery_info=None):
-    """Get the demo notification service."""
-    return DemoNotificationService(hass)
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_services: AddServicesCallback,
+) -> None:
+    """Set up the Demo config entry."""
+    async_add_services([DemoNotifyService()])
 
 
-class DemoNotificationService(BaseNotificationService):
-    """Implement demo notification service."""
+def get_service(
+    hass: HomeAssistant,
+    config: ConfigType,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> BaseNotificationService:
+    """Get the legacy demo notification service."""
+    return LegacyDemoNotificationService()
 
-    def __init__(self, hass):
-        """Initialize the service."""
-        self.hass = hass
+
+class DemoNotifyService(NotifyService):
+    """Represent a demo notification service."""
+
+    def send_message(self, message: str, **kwargs: Any) -> None:
+        """Send a message."""
+        kwargs["message"] = message
+        self.hass.bus.fire(EVENT_NOTIFY, kwargs)
+
+
+class LegacyDemoNotificationService(BaseNotificationService):
+    """Represent the legacy demo notification service."""
 
     @property
-    def targets(self):
+    def targets(self) -> dict[str, str]:
         """Return a dictionary of registered targets."""
         return {"test target name": "test target id"}
 
-    def send_message(self, message="", **kwargs):
-        """Send a message to a user."""
+    def send_message(self, message: str, **kwargs: Any) -> None:
+        """Send a message."""
         kwargs["message"] = message
         self.hass.bus.fire(EVENT_NOTIFY, kwargs)

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -1,20 +1,27 @@
 """Provides functionality to notify people."""
 from __future__ import annotations
 
+from functools import partial
+from typing import Any
+
 import voluptuous as vol
 
 import homeassistant.components.persistent_notification as pn
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_PLATFORM
 from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.service_integration import ServiceIntegration
+from homeassistant.helpers.service_platform import PlatformService, ServiceDescription
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (  # noqa: F401
+from .const import (
     ATTR_DATA,
     ATTR_MESSAGE,
     ATTR_TARGET,
     ATTR_TITLE,
     DOMAIN,
+    LOGGER,
     NOTIFY_SERVICE_SCHEMA,
     PERSISTENT_NOTIFICATION_SERVICE_SCHEMA,
     SERVICE_NOTIFY,
@@ -41,6 +48,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the notify services."""
     await async_setup_legacy(hass, config)
 
+    service_integration = hass.data[DOMAIN] = ServiceIntegration(
+        hass, LOGGER, DOMAIN, config
+    )
+    await service_integration.async_setup()
+
     async def persistent_notification(service: ServiceCall) -> None:
         """Send notification via the built-in persistsent_notify integration."""
         message = service.data[ATTR_MESSAGE]
@@ -63,3 +75,77 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
 
     return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry."""
+    service_integration: ServiceIntegration = hass.data[DOMAIN]
+    return await service_integration.async_setup_entry(entry)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    service_integration: ServiceIntegration = hass.data[DOMAIN]
+    return await service_integration.async_unload_entry(entry)
+
+
+class NotifyService(PlatformService):
+    """Represent a notify platform service."""
+
+    @property
+    def service_name(self) -> str:
+        """Return the name of the service, not including domain."""
+        return f"{self.platform.platform_name}_{SERVICE_NOTIFY}"
+
+    @property
+    def service_description(self) -> ServiceDescription:
+        """Return the service description."""
+        service_name = self.service_name
+        return ServiceDescription(
+            SERVICE_NOTIFY,
+            service_name,
+            f"Send a notification with {service_name}",
+            f"Sends a notification message using the {service_name} service.",
+        )
+
+    @property
+    def service_schema(self) -> vol.Schema:
+        """Return the service schema."""
+        return NOTIFY_SERVICE_SCHEMA
+
+    def send_message(self, message: str, **kwargs: Any) -> None:
+        """Send a message.
+
+        kwargs can contain ATTR_TITLE to specify a title.
+        """
+        raise NotImplementedError()
+
+    async def async_send_message(self, message: str, **kwargs: Any) -> None:
+        """Send a message.
+
+        kwargs can contain ATTR_TITLE to specify a title.
+        """
+        await self.hass.async_add_executor_job(
+            partial(self.send_message, message, **kwargs)
+        )
+
+    async def async_handle_service(self, service_call: ServiceCall) -> None:
+        """Handle the service call."""
+        kwargs = {}
+        message = service_call.data[ATTR_MESSAGE]
+        check_templates_warn(self.hass, message)
+        message.hass = self.hass
+        kwargs[ATTR_MESSAGE] = message.async_render(parse_result=False)
+
+        if title := service_call.data.get(ATTR_TITLE):
+            check_templates_warn(self.hass, title)
+            title.hass = self.hass
+            kwargs[ATTR_TITLE] = title.async_render(parse_result=False)
+
+        if (target := service_call.data.get(ATTR_TARGET)) is not None:
+            kwargs[ATTR_TARGET] = target
+
+        if data := service_call.data.get(ATTR_DATA):
+            kwargs[ATTR_DATA] = data
+
+        await self.async_send_message(**kwargs)

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -15,11 +15,12 @@ from homeassistant.helpers.service_integration import ServiceIntegration
 from homeassistant.helpers.service_platform import PlatformService, ServiceDescription
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
+from .const import (  # noqa: F401
     ATTR_DATA,
     ATTR_MESSAGE,
     ATTR_TARGET,
     ATTR_TITLE,
+    BASE_NOTIFY_SERVICE_SCHEMA,
     DOMAIN,
     LOGGER,
     NOTIFY_SERVICE_SCHEMA,
@@ -100,18 +101,12 @@ class NotifyService(PlatformService):
     @property
     def service_description(self) -> ServiceDescription:
         """Return the service description."""
-        service_name = self.service_name
-        return ServiceDescription(
-            SERVICE_NOTIFY,
-            service_name,
-            f"Send a notification with {service_name}",
-            f"Sends a notification message using the {service_name} service.",
-        )
+        return ServiceDescription(domain=DOMAIN, service_id="new_notify")
 
     @property
     def service_schema(self) -> vol.Schema:
         """Return the service schema."""
-        return NOTIFY_SERVICE_SCHEMA
+        return BASE_NOTIFY_SERVICE_SCHEMA
 
     def send_message(self, message: str, **kwargs: Any) -> None:
         """Send a message.
@@ -136,16 +131,5 @@ class NotifyService(PlatformService):
         check_templates_warn(self.hass, message)
         message.hass = self.hass
         kwargs[ATTR_MESSAGE] = message.async_render(parse_result=False)
-
-        if title := service_call.data.get(ATTR_TITLE):
-            check_templates_warn(self.hass, title)
-            title.hass = self.hass
-            kwargs[ATTR_TITLE] = title.async_render(parse_result=False)
-
-        if (target := service_call.data.get(ATTR_TARGET)) is not None:
-            kwargs[ATTR_TARGET] = target
-
-        if data := service_call.data.get(ATTR_DATA):
-            kwargs[ATTR_DATA] = data
 
         await self.async_send_message(**kwargs)

--- a/homeassistant/components/notify/const.py
+++ b/homeassistant/components/notify/const.py
@@ -23,18 +23,18 @@ LOGGER = logging.getLogger(__package__)
 SERVICE_NOTIFY = "notify"
 SERVICE_PERSISTENT_NOTIFICATION = "persistent_notification"
 
-NOTIFY_SERVICE_SCHEMA = vol.Schema(
+BASE_NOTIFY_SERVICE_SCHEMA = vol.Schema({vol.Required(ATTR_MESSAGE): cv.template})
+
+NOTIFY_SERVICE_SCHEMA = BASE_NOTIFY_SERVICE_SCHEMA.extend(
     {
-        vol.Required(ATTR_MESSAGE): cv.template,
         vol.Optional(ATTR_TITLE): cv.template,
         vol.Optional(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(ATTR_DATA): dict,
     }
 )
 
-PERSISTENT_NOTIFICATION_SERVICE_SCHEMA = vol.Schema(
+PERSISTENT_NOTIFICATION_SERVICE_SCHEMA = BASE_NOTIFY_SERVICE_SCHEMA.extend(
     {
-        vol.Required(ATTR_MESSAGE): cv.template,
         vol.Optional(ATTR_TITLE): cv.template,
     }
 )

--- a/homeassistant/components/notify/services.yaml
+++ b/homeassistant/components/notify/services.yaml
@@ -1,5 +1,17 @@
 # Describes the format for available notification services
 
+new_notify:
+  name: Send a notification
+  description: Sends a notification message to selected notify platforms.
+  fields:
+    message:
+      name: Message
+      description: Message body of the notification.
+      required: true
+      example: The garage door has been open for 10 minutes.
+      selector:
+        text:
+
 notify:
   name: Send a notification
   description: Sends a notification message to selected notify platforms.

--- a/homeassistant/helpers/service_integration.py
+++ b/homeassistant/helpers/service_integration.py
@@ -1,7 +1,6 @@
 """Helpers for integrations that manage services."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Iterable
 from itertools import chain
 import logging
@@ -9,7 +8,7 @@ from typing import cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.setup import async_prepare_setup_platform
 
 from .service_platform import PlatformService, ServicePlatform, ServicePlatformModule
@@ -86,11 +85,11 @@ class ServiceIntegration:
         if platform is None:
             raise ValueError("Config entry was never loaded!")
 
-        await platform.async_destroy()
+        platform.async_destroy()
         return True
 
-    async def _async_shutdown(self, event: Event) -> None:
+    @callback
+    def _async_shutdown(self, event: Event) -> None:
         """Call when Home Assistant is stopping."""
-        await asyncio.gather(
-            *(platform.async_shutdown() for platform in chain(self._platforms.values()))
-        )
+        for platform in self._platforms.values():
+            platform.async_shutdown()

--- a/homeassistant/helpers/service_integration.py
+++ b/homeassistant/helpers/service_integration.py
@@ -1,0 +1,96 @@
+"""Helpers for integrations that manage services."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from itertools import chain
+import logging
+from typing import cast
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.setup import async_prepare_setup_platform
+
+from .service_platform import PlatformService, ServicePlatform, ServicePlatformModule
+from .typing import ConfigType
+
+DATA_INSTANCES = "service_integrations"
+
+
+class ServiceIntegration:
+    """The ServiceIntegration manages platforms and their services."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: logging.Logger,
+        domain: str,
+        config: ConfigType,
+    ) -> None:
+        """Initialize a service integration."""
+        self.hass = hass
+        self.config: ConfigType = config
+        self.domain = domain
+        self.logger = logger
+
+        self._platforms: dict[str, ServicePlatform] = {}
+
+        hass.data.setdefault(DATA_INSTANCES, {})[domain] = self
+
+    @property
+    def services(self) -> Iterable[PlatformService]:
+        """Return an iterable that returns all services."""
+        return chain.from_iterable(
+            platform.services.values() for platform in self._platforms.values()
+        )
+
+    async def async_setup(self) -> None:
+        """Set up a full service integration."""
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_shutdown)
+
+    async def async_setup_entry(self, config_entry: ConfigEntry) -> bool:
+        """Set up a config entry."""
+        platform_type = config_entry.domain
+        platform = await async_prepare_setup_platform(
+            self.hass,
+            self.config,
+            self.domain,
+            platform_type,
+        )
+
+        if platform is None:
+            return False
+
+        key = config_entry.entry_id
+
+        if key in self._platforms:
+            raise ValueError("Config entry has already been setup!")
+
+        self._platforms[key] = ServicePlatform(
+            hass=self.hass,
+            logger=self.logger,
+            domain=self.domain,
+            platform_name=platform_type,
+            platform=cast(ServicePlatformModule, platform),
+        )
+
+        return await self._platforms[key].async_setup_entry(config_entry)
+
+    async def async_unload_entry(self, config_entry: ConfigEntry) -> bool:
+        """Unload a config entry."""
+        key = config_entry.entry_id
+
+        platform = self._platforms.pop(key, None)
+
+        if platform is None:
+            raise ValueError("Config entry was never loaded!")
+
+        await platform.async_reset()
+        return True
+
+    async def _async_shutdown(self, event: Event) -> None:
+        """Call when Home Assistant is stopping."""
+        await asyncio.gather(
+            *(platform.async_shutdown() for platform in chain(self._platforms.values()))
+        )

--- a/homeassistant/helpers/service_integration.py
+++ b/homeassistant/helpers/service_integration.py
@@ -86,7 +86,7 @@ class ServiceIntegration:
         if platform is None:
             raise ValueError("Config entry was never loaded!")
 
-        await platform.async_reset()
+        await platform.async_destroy()
         return True
 
     async def _async_shutdown(self, event: Event) -> None:

--- a/homeassistant/helpers/service_platform.py
+++ b/homeassistant/helpers/service_platform.py
@@ -420,14 +420,14 @@ class ServicePlatform:
         """Remove all services and data."""
         self.async_cancel_retry_setup()
 
-        if not self.services:
-            return
-
         tasks = [service.async_remove() for service in self.services.values()]
 
-        await asyncio.gather(*tasks)
+        if tasks:
+            await asyncio.gather(*tasks)
 
         self._setup_complete = False
+        if self not in self.hass.data[DATA_SERVICE_PLATFORM][self.platform_name]:
+            raise ValueError(f"{self} was already destroyed")
         self.hass.data[DATA_SERVICE_PLATFORM][self.platform_name].remove(self)
 
     async def _async_register_service(

--- a/homeassistant/helpers/service_platform.py
+++ b/homeassistant/helpers/service_platform.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Awaitable, Callable, Coroutine, Iterable
 from dataclasses import dataclass
 from logging import Logger
-from typing import Any, Protocol, cast
+from typing import Any, Dict, Protocol, cast
 
 import voluptuous as vol
 
@@ -479,7 +479,7 @@ class ServicePlatform:
         service_description = service.service_description
         integration = await async_get_integration(self.hass, service_description.domain)
         services_dict = cast(
-            dict[str, dict[str, Any]],
+            Dict[str, Dict[str, Any]],
             await self.hass.async_add_executor_job(
                 load_services_file, self.hass, integration
             ),

--- a/homeassistant/helpers/service_platform.py
+++ b/homeassistant/helpers/service_platform.py
@@ -476,6 +476,7 @@ class ServicePlatform:
     async def _set_service_description(self, service: PlatformService) -> None:
         """Set service description for a service and domain."""
         service_description = service.service_description
+        # TODO: Allow platform integrations to load service dicts from their domain.
         integration = await async_get_integration(self.hass, self.domain)
         services_dict = cast(
             dict,

--- a/homeassistant/helpers/service_platform.py
+++ b/homeassistant/helpers/service_platform.py
@@ -416,8 +416,8 @@ class ServicePlatform:
 
         service.async_on_remove(remove_service_cb)
 
-    async def async_reset(self) -> None:
-        """Remove all services and reset data."""
+    async def async_destroy(self) -> None:
+        """Remove all services and data."""
         self.async_cancel_retry_setup()
 
         if not self.services:
@@ -428,8 +428,7 @@ class ServicePlatform:
         await asyncio.gather(*tasks)
 
         self._setup_complete = False
-
-        # FIXME: Should we remove the platform instance from hass.data[DATA_SERVICE_PLATFORM]?
+        self.hass.data[DATA_SERVICE_PLATFORM][self.platform_name].remove(self)
 
     async def _async_register_service(
         self,

--- a/homeassistant/helpers/service_platform.py
+++ b/homeassistant/helpers/service_platform.py
@@ -1,0 +1,527 @@
+"""Manage the services for a single platform."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import asyncio
+from collections.abc import Awaitable, Callable, Coroutine, Iterable
+from dataclasses import dataclass
+from logging import Logger
+from typing import Any, Protocol, cast
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry, current_entry
+from homeassistant.const import CONF_DESCRIPTION, CONF_NAME, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    CoreState,
+    HomeAssistant,
+    ServiceCall,
+    callback,
+)
+from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
+from homeassistant.loader import async_get_integration
+from homeassistant.setup import async_start_setup
+
+from .event import async_call_later
+from .service import (
+    async_set_service_schema,
+    integration_service_call,
+    load_services_file,
+)
+
+CONF_FIELDS = "fields"
+
+SLOW_SETUP_WARNING = 10
+SLOW_SETUP_MAX_WAIT = 60
+SLOW_ADD_SERVICE_MAX_WAIT = 15  # Per PlatformService
+SLOW_ADD_MIN_TIMEOUT = 500
+
+DATA_SERVICE_PLATFORM = "service_platform"
+DATA_SERVICE_PLATFORM_LOCKS = "service_platform_locks"
+PLATFORM_NOT_READY_BASE_WAIT_TIME = 30  # seconds
+
+
+class ServicePlatformModule(Protocol):
+    """Protocol type for a platform using the ServicePlatform helper."""
+
+    async def async_setup_entry(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_services: AddServicesCallback,
+    ) -> None:
+        """Set up the config entry for the service platform."""
+
+
+class AddServicesCallback(Protocol):
+    """Protocol type for ServicePlatform.async_add_services callback."""
+
+    def __call__(self, new_services: Iterable[PlatformService]) -> None:
+        """Define async_add_services type."""
+
+
+class PlatformService(ABC):
+    """Represent the service of a service integration platform."""
+
+    # While not purely typed, it makes typehinting more useful for us
+    # and removes the need for constant None checks or asserts.
+    hass: HomeAssistant = None  # type: ignore
+    platform: ServicePlatform = None  # type: ignore
+
+    is_async: bool = False
+    parallel_updates: asyncio.Semaphore | None = None
+    _added: bool = False
+    # Hold list for functions to call on remove.
+    _on_remove: list[CALLBACK_TYPE] | None = None
+
+    @property
+    @abstractmethod
+    def service_name(self) -> str:
+        """Return the name of the service, not including domain."""
+
+    @property
+    @abstractmethod
+    def service_description(self) -> ServiceDescription:
+        """Return the service description."""
+
+    @property
+    @abstractmethod
+    def service_schema(self) -> vol.Schema:
+        """Return the service schema."""
+
+    @callback
+    def add_to_platform_start(
+        self,
+        hass: HomeAssistant,
+        platform: ServicePlatform,
+        parallel_updates: asyncio.Semaphore | None,
+    ) -> None:
+        """Start adding a service to a platform."""
+        self.hass = hass
+        self.platform = platform
+        self.parallel_updates = parallel_updates
+
+        if self._added:
+            raise HomeAssistantError(
+                f"Service {self.service_name} cannot be added a second time to a service platform"
+            )
+
+        self._added = True
+
+    @callback
+    def add_to_platform_abort(self) -> None:
+        """Abort adding a service to a platform."""
+        self.hass = None  # type: ignore
+        self.platform = None  # type: ignore
+        self.parallel_updates = None
+        self._added = False
+
+    async def async_remove(self) -> None:
+        """Remove service from Home Assistant."""
+        if self.platform and not self._added:
+            raise HomeAssistantError(
+                f"Service {self.service_name} async_remove called twice"
+            )
+
+        self._added = False
+
+        if self._on_remove is not None:
+            while self._on_remove:
+                self._on_remove.pop()()
+
+    @callback
+    def async_on_remove(self, func: CALLBACK_TYPE) -> None:
+        """Add a function to call when service removed."""
+        if self._on_remove is None:
+            self._on_remove = []
+        self._on_remove.append(func)
+
+    async def async_request_call(self, coro: Awaitable) -> None:
+        """Process request batched."""
+        if self.parallel_updates:
+            await self.parallel_updates.acquire()
+
+        try:
+            await coro
+        finally:
+            if self.parallel_updates:
+                self.parallel_updates.release()
+
+    @abstractmethod
+    async def async_handle_service(self, service_call: ServiceCall) -> None:
+        """Handle the service call."""
+
+
+class ServicePlatform:
+    """Manage the services for a single platform."""
+
+    def __init__(
+        self,
+        *,
+        hass: HomeAssistant,
+        logger: Logger,
+        domain: str,
+        platform_name: str,
+        platform: ServicePlatformModule,
+    ) -> None:
+        """Initialize the service platform."""
+        self.hass = hass
+        self.logger = logger
+        self.domain = domain
+        self.platform_name = platform_name
+        self.platform = platform
+        self.config_entry: ConfigEntry | None = None
+        self.services: dict[str, PlatformService] = {}
+        self._tasks: list[asyncio.Task] = []
+        # Stop tracking tasks after setup is completed
+        self._setup_complete = False
+        # Method to cancel the retry of setup
+        self._async_cancel_retry_setup: CALLBACK_TYPE | None = None
+
+        self.parallel_updates: asyncio.Semaphore | None = None
+        self.parallel_updates_created = False
+
+        hass.data.setdefault(DATA_SERVICE_PLATFORM, {}).setdefault(
+            self.platform_name, []
+        ).append(self)
+        hass.data.setdefault(DATA_SERVICE_PLATFORM_LOCKS, {})
+
+    def __repr__(self) -> str:
+        """Represent a ServicePlatform."""
+        return f"<ServicePlatform domain={self.domain} platform_name={self.platform_name} config_entry={self.config_entry}>"
+
+    @callback
+    def _get_parallel_updates_semaphore(
+        self, service_is_async: bool
+    ) -> asyncio.Semaphore | None:
+        """Get or create a semaphore for parallel updates.
+
+        Semaphore will be created on demand because we base it off if update method is async or not.
+
+        If parallel updates is set to 0, we skip the semaphore.
+        If parallel updates is set to a number, we initialize the semaphore to that number.
+        The default value for parallel requests is decided based on the first service that is added to Home Assistant.
+        It's 1 by default.
+        """
+        if self.parallel_updates_created:
+            return self.parallel_updates
+
+        self.parallel_updates_created = True
+
+        parallel_updates = getattr(self.platform, "PARALLEL_UPDATES", None)
+
+        if parallel_updates is None and not service_is_async:
+            parallel_updates = 1
+
+        if parallel_updates == 0:
+            parallel_updates = None
+
+        if parallel_updates is not None:
+            self.parallel_updates = asyncio.Semaphore(parallel_updates)
+
+        return self.parallel_updates
+
+    async def async_shutdown(self) -> None:
+        """Call when Home Assistant is stopping."""
+        self.async_cancel_retry_setup()
+
+    @callback
+    def async_cancel_retry_setup(self) -> None:
+        """Cancel retry setup."""
+        if self._async_cancel_retry_setup is not None:
+            self._async_cancel_retry_setup()
+            self._async_cancel_retry_setup = None
+
+    async def async_setup_entry(self, config_entry: ConfigEntry) -> bool:
+        """Set up the platform from a config entry."""
+        self.config_entry = config_entry
+        platform = self.platform
+
+        @callback
+        def async_create_setup_task() -> Coroutine:
+            """Get task to set up platform."""
+            current_entry.set(config_entry)
+            return platform.async_setup_entry(
+                self.hass, config_entry, self._async_schedule_add_services
+            )
+
+        return await self._async_setup_platform(async_create_setup_task)
+
+    async def _async_setup_platform(
+        self, async_create_setup_task: Callable[[], Coroutine], tries: int = 0
+    ) -> bool:
+        """Set up a platform via config file or config entry.
+
+        async_create_setup_task creates a coroutine that sets up platform.
+        """
+        logger = self.logger
+        hass = self.hass
+        full_name = f"{self.domain}.{self.platform_name}"
+
+        logger.info("Setting up %s", full_name)
+        warn_task = hass.loop.call_later(
+            SLOW_SETUP_WARNING,
+            logger.warning,
+            "Setup of %s platform %s is taking over %s seconds.",
+            self.domain,
+            self.platform_name,
+            SLOW_SETUP_WARNING,
+        )
+        with async_start_setup(hass, [full_name]):
+            try:
+                task = async_create_setup_task()
+
+                async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, self.domain):
+                    await asyncio.shield(task)
+
+                # Block till all services are added
+                while self._tasks:
+                    pending = [task for task in self._tasks if not task.done()]
+                    self._tasks.clear()
+
+                    if pending:
+                        await asyncio.gather(*pending)
+
+                hass.config.components.add(full_name)
+                self._setup_complete = True
+                return True
+            except PlatformNotReady as ex:
+                tries += 1
+                wait_time = min(tries, 6) * PLATFORM_NOT_READY_BASE_WAIT_TIME
+                message = str(ex)
+                ready_message = f"ready yet: {message}" if message else "ready yet"
+                if tries == 1:
+                    logger.warning(
+                        "Platform %s not %s; Retrying in background in %d seconds",
+                        self.platform_name,
+                        ready_message,
+                        wait_time,
+                    )
+                else:
+                    logger.debug(
+                        "Platform %s not %s; Retrying in %d seconds",
+                        self.platform_name,
+                        ready_message,
+                        wait_time,
+                    )
+
+                async def setup_again(*_args: Any) -> None:
+                    """Run setup again."""
+                    self._async_cancel_retry_setup = None
+                    await self._async_setup_platform(async_create_setup_task, tries)
+
+                if hass.state == CoreState.running:
+                    self._async_cancel_retry_setup = async_call_later(
+                        hass, wait_time, setup_again
+                    )
+                else:
+                    self._async_cancel_retry_setup = hass.bus.async_listen_once(
+                        EVENT_HOMEASSISTANT_STARTED, setup_again
+                    )
+                return False
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Setup of platform %s is taking longer than %s seconds."
+                    " Startup will proceed without waiting any longer.",
+                    self.platform_name,
+                    SLOW_SETUP_MAX_WAIT,
+                )
+                return False
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "Error while setting up %s platform for %s",
+                    self.platform_name,
+                    self.domain,
+                )
+                return False
+            finally:
+                warn_task.cancel()
+
+    @callback
+    def _async_schedule_add_services(
+        self, new_services: Iterable[PlatformService]
+    ) -> None:
+        """Schedule adding service for a single platform async."""
+        task = self.hass.async_create_task(
+            self.async_add_services(new_services),
+        )
+
+        if not self._setup_complete:
+            self._tasks.append(task)
+
+    async def async_add_services(self, new_services: Iterable[PlatformService]) -> None:
+        """Add service for a single platform async."""
+        if not new_services:
+            return
+
+        tasks = [self._async_add_service(service) for service in new_services]
+        timeout = max(SLOW_ADD_SERVICE_MAX_WAIT * len(tasks), SLOW_ADD_MIN_TIMEOUT)
+
+        try:
+            async with self.hass.timeout.async_timeout(timeout, self.domain):
+                await asyncio.gather(*tasks)
+        except asyncio.TimeoutError:
+            self.logger.warning(
+                "Timed out adding service for domain %s with platform %s after %ds",
+                self.domain,
+                self.platform_name,
+                timeout,
+            )
+        except Exception:
+            self.logger.exception(
+                "Error adding service for domain %s with platform %s",
+                self.domain,
+                self.platform_name,
+            )
+            raise
+
+    async def _async_add_service(
+        self,
+        service: PlatformService,
+    ) -> None:
+        """Add a service to the platform."""
+        service.add_to_platform_start(
+            self.hass,
+            self,
+            self._get_parallel_updates_semaphore(service.is_async),
+        )
+
+        await self._async_register_service(service, service.service_schema)
+
+        self.services[service.service_name] = service
+
+        @callback
+        def remove_service_cb() -> None:
+            """Remove service from services list."""
+            self.services.pop(service.service_name)
+
+            domain_platform_services = [
+                domain_service
+                for platform in self.hass.data[DATA_SERVICE_PLATFORM][
+                    self.platform_name
+                ]
+                for domain_service in platform.services
+                if platform.domain == self.domain
+                and domain_service == service.service_name
+            ]
+
+            # Only remove service from core
+            # if this is the last domain platform service
+            # for platform_name and service name.
+            if len(domain_platform_services) >= 1:
+                return
+
+            self.hass.services.async_remove(self.domain, service.service_name)
+
+        service.async_on_remove(remove_service_cb)
+
+    async def async_reset(self) -> None:
+        """Remove all services and reset data."""
+        self.async_cancel_retry_setup()
+
+        if not self.services:
+            return
+
+        tasks = [service.async_remove() for service in self.services.values()]
+
+        await asyncio.gather(*tasks)
+
+        self._setup_complete = False
+
+        # FIXME: Should we remove the platform instance from hass.data[DATA_SERVICE_PLATFORM]?
+
+    async def _async_register_service(
+        self,
+        service: PlatformService,
+        schema: vol.Schema,
+    ) -> None:
+        """Register a platform service.
+
+        Services will automatically be shared by all platforms of the same domain.
+        """
+        # We need to hold the lock since we yield to the loop
+        # before we can finish registering the service.
+        if self.domain not in self.hass.data[DATA_SERVICE_PLATFORM_LOCKS]:
+            self.hass.data[DATA_SERVICE_PLATFORM_LOCKS][self.domain] = asyncio.Lock()
+
+        async with self.hass.data[DATA_SERVICE_PLATFORM_LOCKS][self.domain]:
+            if self.hass.services.has_service(self.domain, service.service_name):
+                return
+
+            # Setting the service description can raise errors
+            # when getting the integration and loading the services.yaml.
+            try:
+                await self._set_service_description(service)
+            except Exception:
+                service.add_to_platform_abort()
+                raise
+
+        async def handle_service(call: ServiceCall) -> None:
+            """Handle the service."""
+            await integration_service_call(
+                self.hass,
+                [
+                    plf
+                    for plf in self.hass.data[DATA_SERVICE_PLATFORM][self.platform_name]
+                    if plf.domain == self.domain
+                ],
+                call,
+            )
+
+        self.hass.services.async_register(
+            self.domain, service.service_name, handle_service, schema
+        )
+
+    async def _set_service_description(self, service: PlatformService) -> None:
+        """Set service description for a service and domain."""
+        service_description = service.service_description
+        integration = await async_get_integration(self.hass, self.domain)
+        services_dict = cast(
+            dict,
+            await self.hass.async_add_executor_job(
+                load_services_file, self.hass, integration
+            ),
+        )
+        if not services_dict:
+            raise HomeAssistantError(f"Invalid services.yaml file for {self.domain}")
+
+        # Register the service description
+        service_desc = {
+            CONF_NAME: service_description.name,
+            CONF_DESCRIPTION: service_description.description,
+            CONF_FIELDS: services_dict[service_description.service_base_name][
+                CONF_FIELDS
+            ],
+        }
+        async_set_service_schema(
+            self.hass, self.domain, service_description.service_name, service_desc
+        )
+
+
+@dataclass
+class ServiceDescription:
+    """Represent a service description."""
+
+    service_base_name: str
+    service_name: str
+    name: str
+    description: str
+
+
+@callback
+def async_get_platforms(
+    hass: HomeAssistant, integration_name: str
+) -> list[ServicePlatform]:
+    """Find existing platforms."""
+    if (
+        DATA_SERVICE_PLATFORM not in hass.data
+        or integration_name not in hass.data[DATA_SERVICE_PLATFORM]
+    ):
+        return []
+
+    platforms: list[ServicePlatform] = hass.data[DATA_SERVICE_PLATFORM][
+        integration_name
+    ]
+
+    return platforms

--- a/tests/common.py
+++ b/tests/common.py
@@ -1178,7 +1178,8 @@ def mock_platform(hass, platform_path, module=None):
         mock_integration(hass, MockModule(domain))
 
     _LOGGER.info("Adding mock integration platform: %s", platform_path)
-    module_cache[platform_path] = module or Mock()
+    platform = module_cache[platform_path] = module or Mock()
+    return platform
 
 
 def async_capture_events(hass, event_name):

--- a/tests/components/demo/test_notify.py
+++ b/tests/components/demo/test_notify.py
@@ -8,13 +8,7 @@ import voluptuous as vol
 
 import homeassistant.components.demo.notify as demo
 import homeassistant.components.notify as notify
-from homeassistant.components.notify.const import (
-    ATTR_DATA,
-    ATTR_MESSAGE,
-    ATTR_TARGET,
-    ATTR_TITLE,
-    SERVICE_NOTIFY,
-)
+from homeassistant.components.notify.const import ATTR_MESSAGE, SERVICE_NOTIFY
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
@@ -222,12 +216,7 @@ async def test_notify_config_entry(hass: HomeAssistant, events) -> None:
     service_name = f"demo_{SERVICE_NOTIFY}"
     assert hass.services.has_service("notify", service_name)
 
-    service_data = {
-        ATTR_MESSAGE: "World",
-        ATTR_TITLE: "Hello",
-        ATTR_TARGET: ["target_one", "target_two"],
-        ATTR_DATA: {"data_one": 1},
-    }
+    service_data = {ATTR_MESSAGE: "World"}
 
     await hass.services.async_call("notify", service_name, service_data, blocking=True)
     await hass.async_block_till_done()

--- a/tests/components/group/test_notify.py
+++ b/tests/components/group/test_notify.py
@@ -13,8 +13,8 @@ from tests.common import get_fixture_path
 
 async def test_send_message_with_data(hass):
     """Test sending a message with to a notify group."""
-    service1 = demo.DemoNotificationService(hass)
-    service2 = demo.DemoNotificationService(hass)
+    service1 = demo.DemoNotificationService()
+    service2 = demo.DemoNotificationService()
 
     service1.send_message = MagicMock(autospec=True)
     service2.send_message = MagicMock(autospec=True)

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -20,7 +20,7 @@ from tests.common import MockConfigEntry
 
 async def test_same_targets(hass: HomeAssistant):
     """Test not changing the targets in a notify service."""
-    test = LegacyNotificationService(hass)
+    test = NotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -35,7 +35,7 @@ async def test_same_targets(hass: HomeAssistant):
 
 async def test_change_targets(hass: HomeAssistant):
     """Test changing the targets in a notify service."""
-    test = LegacyNotificationService(hass)
+    test = NotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -52,7 +52,7 @@ async def test_change_targets(hass: HomeAssistant):
 
 async def test_add_targets(hass: HomeAssistant):
     """Test adding the targets in a notify service."""
-    test = LegacyNotificationService(hass)
+    test = NotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -69,7 +69,7 @@ async def test_add_targets(hass: HomeAssistant):
 
 async def test_remove_targets(hass: HomeAssistant):
     """Test removing targets from the targets in a notify service."""
-    test = LegacyNotificationService(hass)
+    test = NotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -84,7 +84,7 @@ async def test_remove_targets(hass: HomeAssistant):
     assert test.registered_targets == {"test_c": 1}
 
 
-class LegacyNotificationService(notify.BaseNotificationService):
+class NotificationService(notify.BaseNotificationService):
     """A test class for legacy notification services."""
 
     def __init__(self, hass):
@@ -111,10 +111,6 @@ async def test_warn_template(hass, caplog):
     # We should only log it once
     assert caplog.text.count("Passing templates to notify service is deprecated") == 1
     assert hass.states.get("persistent_notification.notification") is not None
-
-
-class NotificationService(notify.NotifyService):
-    """A test class for notification services."""
 
 
 async def test_notify_service(

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -1,12 +1,26 @@
 """The tests for notify services that change targets."""
+from typing import cast
+from unittest.mock import Mock, call
+
 from homeassistant.components import notify
+from homeassistant.components.notify.const import (
+    ATTR_DATA,
+    ATTR_MESSAGE,
+    ATTR_TARGET,
+    ATTR_TITLE,
+    DOMAIN,
+    SERVICE_NOTIFY,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_platform import async_get_platforms
 from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
 
 
 async def test_same_targets(hass: HomeAssistant):
     """Test not changing the targets in a notify service."""
-    test = NotificationService(hass)
+    test = LegacyNotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -21,7 +35,7 @@ async def test_same_targets(hass: HomeAssistant):
 
 async def test_change_targets(hass: HomeAssistant):
     """Test changing the targets in a notify service."""
-    test = NotificationService(hass)
+    test = LegacyNotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -38,7 +52,7 @@ async def test_change_targets(hass: HomeAssistant):
 
 async def test_add_targets(hass: HomeAssistant):
     """Test adding the targets in a notify service."""
-    test = NotificationService(hass)
+    test = LegacyNotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -55,7 +69,7 @@ async def test_add_targets(hass: HomeAssistant):
 
 async def test_remove_targets(hass: HomeAssistant):
     """Test removing targets from the targets in a notify service."""
-    test = NotificationService(hass)
+    test = LegacyNotificationService(hass)
     await test.async_setup(hass, "notify", "test")
     await test.async_register_services()
     await hass.async_block_till_done()
@@ -70,8 +84,8 @@ async def test_remove_targets(hass: HomeAssistant):
     assert test.registered_targets == {"test_c": 1}
 
 
-class NotificationService(notify.BaseNotificationService):
-    """A test class for notification services."""
+class LegacyNotificationService(notify.BaseNotificationService):
+    """A test class for legacy notification services."""
 
     def __init__(self, hass):
         """Initialize the service."""
@@ -97,3 +111,73 @@ async def test_warn_template(hass, caplog):
     # We should only log it once
     assert caplog.text.count("Passing templates to notify service is deprecated") == 1
     assert hass.states.get("persistent_notification.notification") is not None
+
+
+class NotificationService(notify.NotifyService):
+    """A test class for notification services."""
+
+
+async def test_notify_service(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
+    """Test call notify send message."""
+    entry = MockConfigEntry()
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    service_platforms = async_get_platforms(hass, "test")
+    assert service_platforms
+    notify_platform = next(
+        platform for platform in service_platforms if platform.domain == "notify"
+    )
+    service_name = f"{notify_platform.platform_name}_{SERVICE_NOTIFY}"
+    assert notify_platform.services
+    notify_service = cast(notify.NotifyService, notify_platform.services[service_name])
+    notify_service.send_message = Mock()  # type: ignore[assignment]
+    service_data = {
+        ATTR_MESSAGE: "World",
+        ATTR_TITLE: "Hello",
+        ATTR_TARGET: ["target_one", "target_two"],
+        ATTR_DATA: {"data_one": 1},
+    }
+
+    await hass.services.async_call(
+        DOMAIN,
+        service_name,
+        service_data,
+        blocking=True,
+    )
+
+    assert notify_service.send_message.call_count == 1
+    assert notify_service.send_message.call_args == call(
+        "World",
+        title="Hello",
+        target=["target_one", "target_two"],
+        data={"data_one": 1},
+    )
+
+
+async def test_setup_unload_notify(
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
+    """Test set up and unload the notify integration."""
+    entry = MockConfigEntry()
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    service_platforms = async_get_platforms(hass, "test")
+    assert service_platforms
+    notify_platform = next(
+        platform for platform in service_platforms if platform.domain == "notify"
+    )
+    service_name = f"{notify_platform.platform_name}_{SERVICE_NOTIFY}"
+    assert service_name in notify_platform.services
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not notify_platform.services

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -3,14 +3,7 @@ from typing import cast
 from unittest.mock import Mock, call
 
 from homeassistant.components import notify
-from homeassistant.components.notify.const import (
-    ATTR_DATA,
-    ATTR_MESSAGE,
-    ATTR_TARGET,
-    ATTR_TITLE,
-    DOMAIN,
-    SERVICE_NOTIFY,
-)
+from homeassistant.components.notify.const import ATTR_MESSAGE, DOMAIN, SERVICE_NOTIFY
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_platform import async_get_platforms
 from homeassistant.setup import async_setup_component
@@ -132,12 +125,7 @@ async def test_notify_service(
     assert notify_platform.services
     notify_service = cast(notify.NotifyService, notify_platform.services[service_name])
     notify_service.send_message = Mock()  # type: ignore[assignment]
-    service_data = {
-        ATTR_MESSAGE: "World",
-        ATTR_TITLE: "Hello",
-        ATTR_TARGET: ["target_one", "target_two"],
-        ATTR_DATA: {"data_one": 1},
-    }
+    service_data = {ATTR_MESSAGE: "World"}
 
     await hass.services.async_call(
         DOMAIN,
@@ -147,12 +135,7 @@ async def test_notify_service(
     )
 
     assert notify_service.send_message.call_count == 1
-    assert notify_service.send_message.call_args == call(
-        "World",
-        title="Hello",
-        target=["target_one", "target_two"],
-        data={"data_one": 1},
-    )
+    assert notify_service.send_message.call_args == call("World")
 
 
 async def test_setup_unload_notify(

--- a/tests/helpers/test_service_integration.py
+++ b/tests/helpers/test_service_integration.py
@@ -168,10 +168,8 @@ async def test_unload_entry_resets_platform(hass):
                 MockPlatformService(
                     service_name="test_service_mock",
                     service_description=ServiceDescription(
-                        "mock",
-                        "test_service_mock",
-                        "Test a service",
-                        "Description for testing a service",
+                        domain="test_domain",
+                        service_id="mock",
                     ),
                     service_schema=vol.Schema({}),
                 )

--- a/tests/helpers/test_service_integration.py
+++ b/tests/helpers/test_service_integration.py
@@ -1,0 +1,197 @@
+"""Test the service integration helper."""
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.helpers.service_integration import ServiceIntegration
+from homeassistant.helpers.service_platform import (
+    ServiceDescription,
+    async_get_platforms,
+)
+
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    MockPlatform,
+    MockPlatformService,
+    mock_integration,
+    mock_platform,
+)
+
+_LOGGER = logging.getLogger(__name__)
+DOMAIN = "test_domain"
+ENTRY_DOMAIN = "entry_domain"
+MOCK_SERVICES_YAML = {
+    "mock": {
+        "name": "Mock a service",
+        "description": "This service mocks a service.",
+        "fields": {},
+    }
+}
+
+
+async def test_platforms_shutdown_on_stop(hass):
+    """Test that we shutdown platforms on stop."""
+    mock_setup_entry = AsyncMock()
+    mock_integration(hass, MockModule(ENTRY_DOMAIN))
+    mock_platform(
+        hass,
+        f"{ENTRY_DOMAIN}.{DOMAIN}",
+        MockPlatform(async_setup_entry=mock_setup_entry),
+    )
+    entry = MockConfigEntry(domain=ENTRY_DOMAIN)
+    service_integration = ServiceIntegration(hass, _LOGGER, DOMAIN, {DOMAIN: None})
+
+    await service_integration.async_setup()
+    assert await service_integration.async_setup_entry(entry)
+    await hass.async_block_till_done()
+
+    assert len(mock_setup_entry.mock_calls) == 1
+    p_hass, p_entry, _ = mock_setup_entry.mock_calls[0][1]
+    assert p_hass is hass
+    assert p_entry is entry
+    assert f"{DOMAIN}.{ENTRY_DOMAIN}" in hass.config.components
+
+    platforms = async_get_platforms(hass, ENTRY_DOMAIN)
+
+    assert platforms
+
+    test_platform = platforms[0]
+
+    with patch.object(test_platform, "async_shutdown") as mock_async_shutdown:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+    assert mock_async_shutdown.called
+
+
+async def test_setup_dependencies_platform(hass):
+    """Test we setup the dependencies of a platform.
+
+    We're explicitly testing that we process dependencies even if a component
+    with the same name has already been loaded.
+    """
+    mock_setup_entry = AsyncMock()
+    mock_integration(
+        hass, MockModule("test_integration", dependencies=["test_integration2"])
+    )
+    mock_integration(hass, MockModule("test_integration2"))
+    mock_platform(
+        hass,
+        "test_integration.test_domain",
+        MockPlatform(async_setup_entry=mock_setup_entry),
+    )
+    entry = MockConfigEntry(domain="test_integration")
+    service_integration = ServiceIntegration(hass, _LOGGER, DOMAIN, {DOMAIN: None})
+
+    await service_integration.async_setup()
+    assert await service_integration.async_setup_entry(entry)
+    await hass.async_block_till_done()
+
+    assert "test_integration" in hass.config.components
+    assert "test_integration2" in hass.config.components
+    assert "test_domain.test_integration" in hass.config.components
+
+
+async def test_setup_entry(hass):
+    """Test setup entry calls async_setup_entry on platform."""
+    mock_integration(hass, MockModule(ENTRY_DOMAIN))
+    mock_setup_entry = AsyncMock()
+    mock_platform(
+        hass,
+        f"{ENTRY_DOMAIN}.{DOMAIN}",
+        MockPlatform(async_setup_entry=mock_setup_entry),
+    )
+    entry = MockConfigEntry(domain=ENTRY_DOMAIN)
+    service_integration = ServiceIntegration(hass, _LOGGER, DOMAIN, {DOMAIN: None})
+
+    assert await service_integration.async_setup_entry(entry)
+    assert len(mock_setup_entry.mock_calls) == 1
+    p_hass, p_entry, _ = mock_setup_entry.mock_calls[0][1]
+    assert p_hass is hass
+    assert p_entry is entry
+
+
+async def test_setup_entry_platform_not_exist(hass):
+    """Test setup entry fails if platform does not exist."""
+    entry = MockConfigEntry(domain="non_existing")
+    service_integration = ServiceIntegration(hass, _LOGGER, DOMAIN, {DOMAIN: None})
+
+    assert (await service_integration.async_setup_entry(entry)) is False
+
+
+async def test_setup_entry_fails_duplicate(hass):
+    """Test we don't allow setting up a config entry twice."""
+    mock_integration(hass, MockModule(ENTRY_DOMAIN))
+    mock_setup_entry = AsyncMock()
+    mock_platform(
+        hass,
+        f"{ENTRY_DOMAIN}.{DOMAIN}",
+        MockPlatform(async_setup_entry=mock_setup_entry),
+    )
+    entry = MockConfigEntry(domain=ENTRY_DOMAIN)
+    service_integration = ServiceIntegration(hass, _LOGGER, DOMAIN, {DOMAIN: None})
+
+    assert await service_integration.async_setup_entry(entry)
+
+    with pytest.raises(ValueError):
+        await service_integration.async_setup_entry(entry)
+
+
+async def test_unload_entry_resets_platform(hass):
+    """Test unloading an entry removes all entities."""
+    test_domain_integration = mock_integration(hass, MockModule(DOMAIN))
+    test_domain_integration.file_path = Path("mock_path")
+    mock_setup_entry = AsyncMock()
+    mock_platform(
+        hass,
+        f"{ENTRY_DOMAIN}.{DOMAIN}",
+        MockPlatform(async_setup_entry=mock_setup_entry),
+    )
+    entry = MockConfigEntry(domain=ENTRY_DOMAIN)
+    service_integration = ServiceIntegration(hass, _LOGGER, DOMAIN, {DOMAIN: None})
+
+    assert await service_integration.async_setup_entry(entry)
+
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    async_add_services = mock_setup_entry.mock_calls[0][1][2]
+    with patch(
+        "homeassistant.helpers.service.load_yaml", return_value=MOCK_SERVICES_YAML
+    ):
+        async_add_services(
+            [
+                MockPlatformService(
+                    service_name="test_service_mock",
+                    service_description=ServiceDescription(
+                        "mock",
+                        "test_service_mock",
+                        "Test a service",
+                        "Description for testing a service",
+                    ),
+                    service_schema=vol.Schema({}),
+                )
+            ]
+        )
+        await hass.async_block_till_done()
+
+    assert len(hass.services.async_services()) == 1
+    assert len(list(service_integration.services)) == 1
+
+    assert await service_integration.async_unload_entry(entry)
+
+    assert len(hass.services.async_services()) == 0
+    assert len(list(service_integration.services)) == 0
+
+
+async def test_unload_entry_fails_if_never_loaded(hass):
+    """Test unload entry fails if not loaded."""
+    entry = MockConfigEntry(domain=ENTRY_DOMAIN)
+    service_integration = ServiceIntegration(hass, _LOGGER, DOMAIN, {DOMAIN: None})
+
+    with pytest.raises(ValueError):
+        await service_integration.async_unload_entry(entry)

--- a/tests/helpers/test_service_platform.py
+++ b/tests/helpers/test_service_platform.py
@@ -1,0 +1,695 @@
+"""Test the service platform helper."""
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
+from homeassistant.helpers.service_integration import ServiceIntegration
+from homeassistant.helpers.service_platform import (
+    SLOW_SETUP_WARNING,
+    AddServicesCallback,
+    PlatformService,
+    ServiceDescription,
+    ServicePlatform,
+    async_get_platforms,
+)
+from homeassistant.util.dt import utcnow
+
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    MockPlatform,
+    MockPlatformService,
+    async_fire_time_changed,
+    mock_integration,
+    mock_platform as mock_platform_helper,
+)
+
+_LOGGER = logging.getLogger(__name__)
+DOMAIN = "test_domain"
+ENTRY_DOMAIN = "entry_domain"
+HELLO_SERVICE_YAML = {
+    "hello": {
+        "name": "Say hello",
+        "description": "This service says hello.",
+        "fields": {},
+    }
+}
+GOODBYE_SERVICE_YAML = {
+    "goodbye": {
+        "name": "Say goodbye",
+        "description": "This service says goodbye.",
+        "fields": {},
+    }
+}
+MOCK_SERVICES_YAML = {
+    "mock": {
+        "name": "Mock a service",
+        "description": "This service mocks a service.",
+        "fields": {},
+    }
+}
+PLATFORM = "test_platform"
+ORIGINAL_EXCEPTION = HomeAssistantError("The device dropped the connection")
+PLATFORM_EXCEPTION = PlatformNotReady()
+PLATFORM_EXCEPTION.__cause__ = ORIGINAL_EXCEPTION
+
+
+@pytest.fixture(name="mock_service_integration")
+async def mock_service_integration_fixture(
+    hass, mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry]
+) -> ServiceIntegration:
+    """Mock a service integration."""
+    test_domain_integration = mock_integration(hass, MockModule(DOMAIN))
+    test_domain_integration.file_path = Path("mock_path")
+    service_integration = ServiceIntegration(hass, _LOGGER, DOMAIN, {DOMAIN: None})
+    return service_integration
+
+
+@pytest.fixture(name="mock_service_platform")
+async def mock_service_platform_fixture(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_integration: ServiceIntegration,
+) -> ServicePlatform:
+    """Mock a service platform."""
+    platform, mock_setup_entry, entry = mock_platform
+    service_platform = ServicePlatform(
+        hass=hass,
+        logger=_LOGGER,
+        domain=DOMAIN,
+        platform_name=entry.domain,
+        platform=platform,
+    )
+    return service_platform
+
+
+@pytest.fixture(name="mock_platform")
+async def mock_platform_fixture(
+    hass: HomeAssistant,
+) -> tuple[MockPlatform, AsyncMock, ConfigEntry]:
+    """Mock a service platform module."""
+    mock_integration(hass, MockModule(ENTRY_DOMAIN))
+    mock_setup_entry = AsyncMock()
+    platform = mock_platform_helper(
+        hass,
+        f"{ENTRY_DOMAIN}.{DOMAIN}",
+        MockPlatform(async_setup_entry=mock_setup_entry),
+    )
+    entry = MockConfigEntry(domain=ENTRY_DOMAIN)
+    return platform, mock_setup_entry, entry
+
+
+@pytest.fixture(name="mock_platform_service")
+def mock_platform_service_fixture() -> PlatformService:
+    """Mock a platform service."""
+    return MockPlatformService(
+        service_name="test_service_mock",
+        service_description=ServiceDescription(
+            "mock",
+            "test_service_mock",
+            "Test a service",
+            "Description for testing a service",
+        ),
+        service_schema=vol.Schema({}),
+    )
+
+
+@pytest.fixture(autouse=True)
+async def mock_load_services_yaml(hass):
+    """Mock services yaml descriptions."""
+    with patch(
+        "homeassistant.helpers.service.load_yaml", return_value=MOCK_SERVICES_YAML
+    ) as load_yaml:
+        yield load_yaml
+
+
+async def test_platform_warn_slow_setup(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_integration: ServiceIntegration,
+) -> None:
+    """Warn we log when platform setup takes a long time."""
+    entry = mock_platform[2]
+
+    with patch.object(hass.loop, "call_later") as mock_call:
+        await mock_service_integration.async_setup()
+        assert await mock_service_integration.async_setup_entry(entry)
+        await hass.async_block_till_done()
+        assert mock_call.called
+
+        # mock_calls[0] is the warning message for integration setup
+        # mock_calls[3] is the warning message for platform setup
+        timeout, logger_method = mock_call.mock_calls[3][1][:2]
+
+        assert timeout == SLOW_SETUP_WARNING
+        assert logger_method == _LOGGER.warning
+        assert mock_call().cancel.called
+
+
+async def test_platform_error_slow_setup(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_integration: ServiceIntegration,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Don't block startup more than SLOW_SETUP_MAX_WAIT."""
+    platform, _, entry = mock_platform
+    called = []
+
+    async def mock_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_services: AddServicesCallback,
+    ) -> None:
+        called.append(1)
+        await asyncio.sleep(1)
+
+    platform.async_setup_entry = mock_setup_entry
+
+    with patch("homeassistant.helpers.service_platform.SLOW_SETUP_MAX_WAIT", 0):
+        await mock_service_integration.async_setup()
+        assert not await mock_service_integration.async_setup_entry(entry)
+        await hass.async_block_till_done()
+
+    assert len(called) == 1
+    assert f"{DOMAIN}.{ENTRY_DOMAIN}" not in hass.config.components
+    assert (
+        f"Setup of platform {ENTRY_DOMAIN} is taking longer than 0 seconds"
+        in caplog.text
+    )
+
+
+@pytest.mark.parametrize(
+    "parallel_updates_constant, parallel_updates",
+    [(None, asyncio.Semaphore(1)), (0, None), (2, asyncio.Semaphore(2))],
+)
+async def test_parallel_updates(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_integration: ServiceIntegration,
+    mock_platform_service: PlatformService,
+    parallel_updates_constant: int | None,
+    parallel_updates: asyncio.Semaphore | None,
+) -> None:
+    """Test platform parallel_updates limit."""
+    platform, mock_setup_entry, entry = mock_platform
+    platform.PARALLEL_UPDATES = parallel_updates_constant  # type: ignore[attr-defined]
+
+    await mock_service_integration.async_setup()
+    assert await mock_service_integration.async_setup_entry(entry)
+    await hass.async_block_till_done()
+
+    async_add_services = mock_setup_entry.mock_calls[0][1][2]
+    with patch(
+        "homeassistant.helpers.service.load_yaml", return_value=MOCK_SERVICES_YAML
+    ):
+        async_add_services([mock_platform_service])
+        await hass.async_block_till_done()
+
+    platform_services = list(mock_service_integration.services)
+    assert platform_services
+
+    platform_service = platform_services[0]
+    assert type(platform_service.parallel_updates) == type(parallel_updates)
+    assert getattr(platform_service.parallel_updates, "_value", None) == getattr(
+        parallel_updates, "_value", None
+    )
+
+
+async def test_setup_entry_and_reset(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_platform: ServicePlatform,
+    mock_platform_service: PlatformService,
+) -> None:
+    """Test we can set up an entry and reset the platform."""
+    platform, _, entry = mock_platform
+    full_platform_name = f"{mock_service_platform.domain}.{entry.domain}"
+
+    async def mock_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_services: AddServicesCallback,
+    ) -> None:
+        """Mock setup entry method."""
+        async_add_services([mock_platform_service])
+
+    platform.async_setup_entry = mock_setup_entry
+
+    assert full_platform_name not in hass.config.components
+    assert len(hass.services.async_services()) == 0
+
+    assert await mock_service_platform.async_setup_entry(entry)
+    await hass.async_block_till_done()
+
+    assert full_platform_name in hass.config.components
+    assert len(hass.services.async_services()) == 1
+    assert hass.services.has_service(
+        mock_service_platform.domain, mock_platform_service.service_name
+    )
+    assert mock_service_platform.config_entry is entry
+
+    await mock_service_platform.async_reset()
+
+    assert len(hass.services.async_services()) == 0
+
+
+@pytest.mark.parametrize(
+    "error, log_text, call_later_calls",
+    [
+        (PlatformNotReady(), "Platform entry_domain not ready yet", 1),
+        (
+            PlatformNotReady("lp0 on fire"),
+            "Platform entry_domain not ready yet: lp0 on fire",
+            1,
+        ),
+        (
+            PLATFORM_EXCEPTION,
+            "Platform entry_domain not ready yet: The device dropped the connection",
+            1,
+        ),
+        (
+            Exception("Boom"),
+            f"Error while setting up {ENTRY_DOMAIN} platform for {DOMAIN}",
+            0,
+        ),
+    ],
+)
+async def test_setup_entry_platform_error(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_platform: ServicePlatform,
+    caplog: pytest.LogCaptureFixture,
+    error: Exception,
+    log_text: str,
+    call_later_calls: int,
+) -> None:
+    """Test when an entry has an error during platform setup."""
+    platform, _, entry = mock_platform
+    mock_setup_entry = AsyncMock(side_effect=error)
+    platform.async_setup_entry = mock_setup_entry
+
+    with patch(
+        "homeassistant.helpers.service_platform.async_call_later"
+    ) as mock_call_later:
+        assert not await mock_service_platform.async_setup_entry(entry)
+
+    full_name = f"{mock_service_platform.domain}.{entry.domain}"
+    assert full_name not in hass.config.components
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert log_text in caplog.text
+    assert len(mock_call_later.mock_calls) == call_later_calls
+
+
+async def test_setup_entry_platform_try_again(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_platform: ServicePlatform,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test when an entry wants to try again to setup platform."""
+    platform, _, entry = mock_platform
+    mock_setup_entry = AsyncMock(side_effect=PlatformNotReady("Too slow"))
+    platform.async_setup_entry = mock_setup_entry
+
+    assert not await mock_service_platform.async_setup_entry(entry)
+
+    full_name = f"{mock_service_platform.domain}.{entry.domain}"
+    assert full_name not in hass.config.components
+    assert len(mock_setup_entry.mock_calls) == 1
+    log_message = (
+        f"Platform {ENTRY_DOMAIN} not ready yet: Too slow; "
+        "Retrying in background in 30 seconds"
+    )
+    assert (__name__, logging.WARNING, log_message) in caplog.record_tuples
+
+    caplog.clear()
+    retry_time = utcnow() + timedelta(seconds=30)
+    async_fire_time_changed(hass, retry_time)
+    await hass.async_block_till_done()
+
+    assert full_name not in hass.config.components
+    assert len(mock_setup_entry.mock_calls) == 2
+    log_message = (
+        f"Platform {ENTRY_DOMAIN} not ready yet: Too slow; Retrying in 60 seconds"
+    )
+    assert (__name__, logging.DEBUG, log_message) in caplog.record_tuples
+
+
+@pytest.mark.parametrize("platform_call", ["async_reset", "async_shutdown"])
+@pytest.mark.parametrize(
+    "core_state, call_later_calls, retry_listeners",
+    [(CoreState.running, 1, 0), (CoreState.starting, 0, 1)],
+)
+async def test_platform_cancels_retry_setup(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_platform: ServicePlatform,
+    core_state: CoreState,
+    call_later_calls: int,
+    retry_listeners: int,
+    platform_call: str,
+) -> None:
+    """Test resetting or shutting down a platform will cancel setup retry."""
+    hass.state = core_state
+    initial_listeners = hass.bus.async_listeners()[EVENT_HOMEASSISTANT_STARTED]
+    platform, _, entry = mock_platform
+    mock_setup_entry = AsyncMock(side_effect=PlatformNotReady())
+    platform.async_setup_entry = mock_setup_entry
+
+    with patch(
+        "homeassistant.helpers.service_platform.async_call_later"
+    ) as mock_call_later:
+        assert not await mock_service_platform.async_setup_entry(entry)
+        await hass.async_block_till_done()
+
+    assert len(mock_call_later.mock_calls) == call_later_calls
+    assert len(mock_call_later.return_value.mock_calls) == 0
+    assert (
+        hass.bus.async_listeners()[EVENT_HOMEASSISTANT_STARTED]
+        == initial_listeners + retry_listeners
+    )
+    assert mock_service_platform._async_cancel_retry_setup is not None
+
+    await getattr(mock_service_platform, platform_call)()
+    await hass.async_block_till_done()
+
+    assert len(mock_call_later.return_value.mock_calls) == call_later_calls
+    assert hass.bus.async_listeners()[EVENT_HOMEASSISTANT_STARTED] == initial_listeners
+    assert mock_service_platform._async_cancel_retry_setup is None
+
+
+async def test_remove_service(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_integration: ServiceIntegration,
+    mock_platform_service: PlatformService,
+) -> None:
+    """Remove a service from a platform."""
+    _, mock_setup_entry, entry = mock_platform
+
+    await mock_service_integration.async_setup()
+    assert await mock_service_integration.async_setup_entry(entry)
+    await hass.async_block_till_done()
+
+    async_add_services = mock_setup_entry.mock_calls[0][1][2]
+
+    with patch(
+        "homeassistant.helpers.service.load_yaml", return_value=MOCK_SERVICES_YAML
+    ):
+        async_add_services([mock_platform_service])
+        await hass.async_block_till_done()
+
+    assert len(hass.services.async_services()) == 1
+    await mock_platform_service.async_remove()
+    assert len(hass.services.async_services()) == 0
+
+
+async def test_adding_empty_services(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_integration: ServiceIntegration,
+) -> None:
+    """Test not failing when getting empty services list."""
+    _, mock_setup_entry, entry = mock_platform
+
+    await mock_service_integration.async_setup()
+    assert await mock_service_integration.async_setup_entry(entry)
+    await hass.async_block_till_done()
+
+    async_add_services = mock_setup_entry.mock_calls[0][1][2]
+
+    with patch(
+        "homeassistant.helpers.service.load_yaml", return_value=MOCK_SERVICES_YAML
+    ):
+        async_add_services([])
+        await hass.async_block_till_done()
+
+    assert len(hass.services.async_services()) == 0
+
+
+async def test_adding_removing_same_service_twice(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_platform: ServicePlatform,
+    mock_platform_service: PlatformService,
+) -> None:
+    """Test adding the same service twice."""
+    # Test adding the same service twice at the same time.
+    with patch(
+        "homeassistant.helpers.service.load_yaml", return_value=MOCK_SERVICES_YAML
+    ), pytest.raises(HomeAssistantError):
+        await mock_service_platform.async_add_services(
+            [mock_platform_service, mock_platform_service]
+        )
+
+    # Flush out remaining running service registration.
+    await hass.async_block_till_done()
+    assert len(hass.services.async_services()) == 1
+
+    await mock_service_platform.async_reset()
+
+    assert len(hass.services.async_services()) == 0
+
+    # Test adding the same service in two different calls.
+    with patch(
+        "homeassistant.helpers.service.load_yaml", return_value=MOCK_SERVICES_YAML
+    ):
+        await mock_service_platform.async_add_services([mock_platform_service])
+
+    assert len(hass.services.async_services()) == 1
+    assert hass.services.has_service(DOMAIN, mock_platform_service.service_name)
+
+    with patch(
+        "homeassistant.helpers.service.load_yaml", return_value=MOCK_SERVICES_YAML
+    ), pytest.raises(HomeAssistantError):
+        await mock_service_platform.async_add_services([mock_platform_service])
+
+    assert len(hass.services.async_services()) == 1
+    assert hass.services.has_service(DOMAIN, mock_platform_service.service_name)
+
+    await mock_service_platform.async_reset()
+
+    assert len(hass.services.async_services()) == 0
+
+    # Test removing the same service again.
+    with pytest.raises(HomeAssistantError):
+        await mock_platform_service.async_remove()
+
+
+async def test_timeout_when_adding_service(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_platform: ServicePlatform,
+    mock_platform_service: PlatformService,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test timeout when adding a service."""
+
+    async def slow_get_integration(*args):
+        await asyncio.sleep(1)
+
+    with patch(
+        "homeassistant.helpers.service_platform.async_get_integration",
+        side_effect=slow_get_integration,
+    ), patch(
+        "homeassistant.helpers.service_platform.SLOW_ADD_SERVICE_MAX_WAIT", new=0
+    ), patch(
+        "homeassistant.helpers.service_platform.SLOW_ADD_MIN_TIMEOUT", new=0
+    ):
+        await mock_service_platform.async_add_services([mock_platform_service])
+
+    assert len(hass.services.async_services()) == 0
+    assert (
+        f"Timed out adding service for domain {mock_service_platform.domain} "
+        f"with platform {mock_service_platform.platform_name}" in caplog.text
+    )
+
+
+async def test_error_when_adding_service(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_platform: ServicePlatform,
+    mock_platform_service: PlatformService,
+) -> None:
+    """Test error when adding a service."""
+    with patch(
+        "homeassistant.helpers.service.load_yaml", side_effect=HomeAssistantError()
+    ), pytest.raises(HomeAssistantError):
+        await mock_service_platform.async_add_services([mock_platform_service])
+
+    assert len(hass.services.async_services()) == 0
+
+    # Test that we can add the same service if the error is resolved.
+
+    with patch(
+        "homeassistant.helpers.service.load_yaml", return_value=MOCK_SERVICES_YAML
+    ):
+        await mock_service_platform.async_add_services([mock_platform_service])
+
+    assert len(hass.services.async_services()) == 1
+    assert hass.services.has_service(DOMAIN, mock_platform_service.service_name)
+
+
+async def test_platforms_sharing_services(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_integration: ServiceIntegration,
+) -> None:
+    """Test platforms share services."""
+    # Add three platforms and three services for the same config entry
+    # where two platforms share the same domain and the same service name.
+    different_domain = "different_integration"
+    platform, _, entry = mock_platform
+    service_platform_1 = ServicePlatform(
+        hass=hass,
+        logger=_LOGGER,
+        domain=DOMAIN,
+        platform_name=entry.domain,
+        platform=platform,
+    )
+    service_1 = MockPlatformService(
+        service_name="test_hello",
+        service_description=ServiceDescription(
+            "hello",
+            "test_hello",
+            "Test saying hello",
+            "Description for hello",
+        ),
+        service_schema=vol.Schema({}),
+    )
+    service_1.async_handle_service = AsyncMock()  # type: ignore[assignment]
+    service_platform_2 = ServicePlatform(
+        hass=hass,
+        logger=_LOGGER,
+        domain=DOMAIN,
+        platform_name=entry.domain,
+        platform=platform,
+    )
+    service_2 = MockPlatformService(
+        service_name="test_hello",
+        service_description=ServiceDescription(
+            "hello",
+            "test_hello",
+            "Test saying hello",
+            "Description for hello",
+        ),
+        service_schema=vol.Schema({}),
+    )
+    service_2.async_handle_service = AsyncMock()  # type: ignore[assignment]
+    service_platform_3 = ServicePlatform(
+        hass=hass,
+        logger=_LOGGER,
+        domain=different_domain,
+        platform_name=entry.domain,
+        platform=platform,
+    )
+    service_3 = MockPlatformService(
+        service_name="test_goodbye",
+        service_description=ServiceDescription(
+            "goodbye",
+            "test_goodbye",
+            "Test saying goodbye",
+            "Description for goodbye",
+        ),
+        service_schema=vol.Schema({}),
+    )
+    service_3.async_handle_service = AsyncMock()  # type: ignore[assignment]
+
+    different_domain_integration = mock_integration(hass, MockModule(different_domain))
+    different_domain_integration.file_path = Path("mock_different_path")
+    different_service_integration = ServiceIntegration(
+        hass, _LOGGER, different_domain, {different_domain: None}
+    )
+    platform = mock_platform_helper(
+        hass,
+        f"{ENTRY_DOMAIN}.{different_domain}",
+        MockPlatform(async_setup_entry=AsyncMock()),
+    )
+    await mock_service_integration.async_setup()
+    assert await mock_service_integration.async_setup_entry(entry)
+    await different_service_integration.async_setup()
+    assert await different_service_integration.async_setup_entry(entry)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.helpers.service.load_yaml",
+        side_effect=[HELLO_SERVICE_YAML, GOODBYE_SERVICE_YAML],
+    ):
+        await service_platform_1.async_add_services([service_1])
+        await service_platform_2.async_add_services([service_2])
+        await service_platform_3.async_add_services([service_3])
+
+    await hass.services.async_call(DOMAIN, "test_hello", blocking=True)
+
+    # Both services of platform 1 and 2 should be called,
+    # but not the service of platform 3.
+    assert service_1.async_handle_service.call_count == 1
+    assert service_2.async_handle_service.call_count == 1
+    assert service_3.async_handle_service.call_count == 0
+
+    await hass.services.async_call(different_domain, "test_goodbye", blocking=True)
+
+    # Service 3 should be called,
+    # but the calls of services of platform 1 and 2 are still at 1 each.
+    assert service_1.async_handle_service.call_count == 1
+    assert service_2.async_handle_service.call_count == 1
+    assert service_3.async_handle_service.call_count == 1
+
+    await service_1.async_remove()
+
+    # The test_hello service is still registered with the core
+    # since service 2 is not removed.
+    assert hass.services.has_service(DOMAIN, "test_hello")
+    assert hass.services.has_service(different_domain, "test_goodbye")
+
+    await service_2.async_remove()
+
+    # The test_hello service is not registered with the core anymore
+    # since service 2 is now also removed.
+    assert not hass.services.has_service(DOMAIN, "test_hello")
+    assert hass.services.has_service(different_domain, "test_goodbye")
+
+
+async def test_get_platforms(
+    hass: HomeAssistant,
+    mock_platform: tuple[MockPlatform, AsyncMock, ConfigEntry],
+    mock_service_integration: ServiceIntegration,
+) -> None:
+    """Test get platforms with helper function."""
+    platform, _, entry = mock_platform
+
+    platforms = async_get_platforms(hass, ENTRY_DOMAIN)
+
+    assert len(platforms) == 0
+
+    service_platform = ServicePlatform(
+        hass=hass,
+        logger=_LOGGER,
+        domain=DOMAIN,
+        platform_name=entry.domain,
+        platform=platform,
+    )
+
+    platforms = async_get_platforms(hass, ENTRY_DOMAIN)
+
+    assert len(platforms) == 1
+    assert platforms[0] is service_platform
+
+    await service_platform.async_reset()
+    platforms = async_get_platforms(hass, ENTRY_DOMAIN)
+
+    # Resetting the platform doesn't remove the platform.
+    assert len(platforms) == 1
+    assert platforms[0] is service_platform

--- a/tests/helpers/test_service_platform.py
+++ b/tests/helpers/test_service_platform.py
@@ -694,6 +694,7 @@ async def test_get_platforms(
     await service_platform.async_destroy()
     platforms = async_get_platforms(hass, ENTRY_DOMAIN)
 
-    # Resetting the platform doesn't remove the platform.
-    assert len(platforms) == 1
-    assert platforms[0] is service_platform
+    assert not platforms
+
+    with pytest.raises(ValueError):
+        await service_platform.async_destroy()

--- a/tests/helpers/test_service_platform.py
+++ b/tests/helpers/test_service_platform.py
@@ -260,7 +260,7 @@ async def test_setup_entry_and_reset(
     )
     assert mock_service_platform.config_entry is entry
 
-    await mock_service_platform.async_destroy()
+    mock_service_platform.async_destroy()
 
     assert len(hass.services.async_services()) == 0
 
@@ -382,7 +382,7 @@ async def test_platform_cancels_retry_setup(
     )
     assert mock_service_platform._async_cancel_retry_setup is not None
 
-    await getattr(mock_service_platform, platform_call)()
+    getattr(mock_service_platform, platform_call)()
     await hass.async_block_till_done()
 
     assert len(mock_call_later.return_value.mock_calls) == call_later_calls
@@ -412,7 +412,7 @@ async def test_remove_service(
         await hass.async_block_till_done()
 
     assert len(hass.services.async_services()) == 1
-    await mock_platform_service.async_remove()
+    mock_platform_service.async_remove()
     assert len(hass.services.async_services()) == 0
 
 
@@ -458,9 +458,8 @@ async def test_adding_removing_same_service_twice(
     await hass.async_block_till_done()
     assert len(hass.services.async_services()) == 1
 
-    await asyncio.gather(
-        *[service.async_remove() for service in mock_service_platform.services.values()]
-    )
+    for service in list(mock_service_platform.services.values()):
+        service.async_remove()
 
     assert len(hass.services.async_services()) == 0
 
@@ -481,15 +480,14 @@ async def test_adding_removing_same_service_twice(
     assert len(hass.services.async_services()) == 1
     assert hass.services.has_service(DOMAIN, mock_platform_service.service_name)
 
-    await asyncio.gather(
-        *[service.async_remove() for service in mock_service_platform.services.values()]
-    )
+    for service in list(mock_service_platform.services.values()):
+        service.async_remove()
 
     assert len(hass.services.async_services()) == 0
 
     # Test removing the same service again.
     with pytest.raises(HomeAssistantError):
-        await mock_platform_service.async_remove()
+        mock_platform_service.async_remove()
 
 
 async def test_timeout_when_adding_service(
@@ -651,14 +649,14 @@ async def test_platforms_sharing_services(
     assert service_2.async_handle_service.call_count == 1
     assert service_3.async_handle_service.call_count == 1
 
-    await service_1.async_remove()
+    service_1.async_remove()
 
     # The test_hello service is still registered with the core
     # since service 2 is not removed.
     assert hass.services.has_service(DOMAIN, "test_hello")
     assert hass.services.has_service(different_domain, "test_goodbye")
 
-    await service_2.async_remove()
+    service_2.async_remove()
 
     # The test_hello service is not registered with the core anymore
     # since service 2 is now also removed.
@@ -691,10 +689,10 @@ async def test_get_platforms(
     assert len(platforms) == 1
     assert platforms[0] is service_platform
 
-    await service_platform.async_destroy()
+    service_platform.async_destroy()
     platforms = async_get_platforms(hass, ENTRY_DOMAIN)
 
     assert not platforms
 
     with pytest.raises(ValueError):
-        await service_platform.async_destroy()
+        service_platform.async_destroy()

--- a/tests/helpers/test_service_platform.py
+++ b/tests/helpers/test_service_platform.py
@@ -83,7 +83,7 @@ async def mock_service_platform_fixture(
     mock_service_integration: ServiceIntegration,
 ) -> ServicePlatform:
     """Mock a service platform."""
-    platform, mock_setup_entry, entry = mock_platform
+    platform, _, entry = mock_platform
     service_platform = ServicePlatform(
         hass=hass,
         logger=_LOGGER,
@@ -221,6 +221,7 @@ async def test_parallel_updates(
     assert platform_services
 
     platform_service = platform_services[0]
+    # pylint: disable=unidiomatic-typecheck
     assert type(platform_service.parallel_updates) == type(parallel_updates)
     assert getattr(platform_service.parallel_updates, "_value", None) == getattr(
         parallel_updates, "_value", None
@@ -362,6 +363,7 @@ async def test_platform_cancels_retry_setup(
     platform_call: str,
 ) -> None:
     """Test resetting or shutting down a platform will cancel setup retry."""
+    # pylint: disable=protected-access
     hass.state = core_state
     initial_listeners = hass.bus.async_listeners()[EVENT_HOMEASSISTANT_STARTED]
     platform, _, entry = mock_platform

--- a/tests/testing_config/custom_components/test/__init__.py
+++ b/tests/testing_config/custom_components/test/__init__.py
@@ -1,1 +1,17 @@
 """An integration with several platforms used with unit tests."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+PLATFORMS = ["notify"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up the test integration config entry."""
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload the test integration config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/tests/testing_config/custom_components/test/config_flow.py
+++ b/tests/testing_config/custom_components/test/config_flow.py
@@ -1,0 +1,6 @@
+"""Provide a mock config flow for the test integration."""
+from homeassistant.config_entries import ConfigFlow
+
+
+class TestConfigFlow(ConfigFlow, domain="test"):
+    """Handle a config flow for test."""

--- a/tests/testing_config/custom_components/test/notify.py
+++ b/tests/testing_config/custom_components/test/notify.py
@@ -1,0 +1,24 @@
+"""Provide a mock notify platform."""
+from typing import Any
+
+from homeassistant.components.notify import NotifyService
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_platform import AddServicesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_services: AddServicesCallback
+) -> None:
+    """Set up the notify platform."""
+    async_add_services([NotificationService()])
+
+
+class NotificationService(NotifyService):
+    """A test class for notification services."""
+
+    def send_message(self, message: str, **kwargs: Any) -> None:
+        """Send a message.
+
+        kwargs can contain ATTR_TITLE to specify a title.
+        """


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add helpers for service integrations, eg notify and tts.
- The helpers are three levels, service integration, `ServiceIntegration` in `service_integration.py` (eg used by `notify`), service platform, `ServicePlatform` in `service_platform.py` (eg used by `telegram`) and platform service, `PlatformService` in `service_platform.py` (eg `notify.telegram_notify` used by `telegram`).
- Only config entries based integrations are supported to implement platforms using the service integration helper API.
- The service integration helper API is very similar to the entity integration helper API (entity_component.py, entity_platform.py and entity.py)
- Supported API features:
  - Use `async_setup_entry` to set up a service platform.
  - Raise `PlatformNotReady` during platform setup to retry platform setup later.
  - Set `PARALLEL_UPDATES` constant in the platform to limit concurrent service calls for the platform.
  - Timeouts during service platform setup exist as for entity platforms.
  - A service platform can add one or many services per platform instance.
  - The service platform implements the final target service handler of the platform service (eg `send_message`).
  - A service platform (eg `telegram`) can override the platform service name and service schema. Defaults are set by the service integration (eg `notify`). This allows each implementing integration to tailor the service call and service validation.
  - Use platform service callback `async_on_remove` to register callbacks to run during service removal.
- Add POC to the demo notify platform.

### TODO

- [x] Allow overriding service description dict with custom selectors from implementing integration.
- [x] Clean up hass.data when resetting platform.
- [ ] Add dev docs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
