### PR TITLE
Add button to litterrobot

### DIFF
--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -2,6 +2,11 @@
 
 from pylitterbot.exceptions import LitterRobotException, LitterRobotLoginException
 
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -9,7 +14,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from .const import DOMAIN
 from .hub import LitterRobotHub
 
-PLATFORMS = ["select", "sensor", "switch", "vacuum"]
+PLATFORMS = [BUTTON_DOMAIN, SELECT_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN, VACUUM_DOMAIN]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/litterrobot/button.py
+++ b/homeassistant/components/litterrobot/button.py
@@ -1,0 +1,43 @@
+"""Support for Litter-Robot button."""
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import LitterRobotEntity
+from .hub import LitterRobotHub
+
+TYPE_RESET_WASTE_DRAWER = "Reset Waste Drawer"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Litter-Robot cleaner using config entry."""
+    hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [
+            LitterRobotResetWasteDrawerButton(
+                robot=robot, entity_type=TYPE_RESET_WASTE_DRAWER, hub=hub
+            )
+            for robot in hub.account.robots
+        ]
+    )
+
+
+class LitterRobotResetWasteDrawerButton(LitterRobotEntity, ButtonEntity):
+    """Litter-Robot reset waste drawer button."""
+
+    _attr_icon = "mdi:delete-variant"
+    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self.robot.reset_waste_drawer()
+        self.coordinator.async_set_updated_data(True)

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -1,6 +1,7 @@
 """Support for Litter-Robot "Vacuum"."""
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from pylitterbot.enums import LitterBoxStatus
@@ -28,6 +29,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .entity import LitterRobotControlEntity
 from .hub import LitterRobotHub
+
+_LOGGER = logging.getLogger(__name__)
 
 SUPPORT_LITTERROBOT = (
     SUPPORT_START | SUPPORT_STATE | SUPPORT_STATUS | SUPPORT_TURN_OFF | SUPPORT_TURN_ON
@@ -121,6 +124,13 @@ class LitterRobotCleaner(LitterRobotControlEntity, StateVacuumEntity):
 
     async def async_reset_waste_drawer(self) -> None:
         """Reset the waste drawer level."""
+        # The Litter-Robot reset waste drawer service has been replaced by a
+        # dedicated button entity and marked as deprecated
+        _LOGGER.warning(
+            "The 'litterrobot.reset_waste_drawer' service is deprecated and "
+            "replaced by a dedicated reset waste drawer button entity; Please "
+            "use that entity to reset the waste drawer instead"
+        )
         await self.robot.reset_waste_drawer()
         self.coordinator.async_set_updated_data(True)
 
@@ -136,6 +146,13 @@ class LitterRobotCleaner(LitterRobotControlEntity, StateVacuumEntity):
 
     async def async_set_wait_time(self, minutes: int) -> None:
         """Set the wait time."""
+        # The Litter-Robot set wait time service has been replaced by a
+        # dedicated select entity and marked as deprecated
+        _LOGGER.warning(
+            "The 'litterrobot.set_wait_time' service is deprecated and "
+            "replaced by a dedicated set wait time select entity; Please "
+            "use that entity to set the wait time instead"
+        )
         await self.perform_action_and_refresh(self.robot.set_wait_time, minutes)
 
     @property

--- a/tests/components/litterrobot/test_button.py
+++ b/tests/components/litterrobot/test_button.py
@@ -1,0 +1,41 @@
+"""Test the Litter-Robot button entity."""
+from unittest.mock import MagicMock
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_ICON,
+    ENTITY_CATEGORY_CONFIG,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import setup_integration
+
+BUTTON_ENTITY = "button.test_reset_waste_drawer"
+
+
+async def test_button(hass: HomeAssistant, mock_account: MagicMock) -> None:
+    """Test the creation and values of the Litter-Robot button."""
+    await setup_integration(hass, mock_account, BUTTON_DOMAIN)
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get(BUTTON_ENTITY)
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:delete-variant"
+    assert state.state == STATE_UNKNOWN
+
+    entry = entity_registry.async_get(BUTTON_ENTITY)
+    assert entry
+    assert entry.entity_category == ENTITY_CATEGORY_CONFIG
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: BUTTON_ENTITY},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert mock_account.robots[0].reset_waste_drawer.call_count == 1
+    mock_account.robots[0].reset_waste_drawer.assert_called_with()

--- a/tests/components/litterrobot/test_button.py
+++ b/tests/components/litterrobot/test_button.py
@@ -1,6 +1,8 @@
 """Test the Litter-Robot button entity."""
 from unittest.mock import MagicMock
 
+from freezegun import freeze_time
+
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -16,6 +18,7 @@ from .conftest import setup_integration
 BUTTON_ENTITY = "button.test_reset_waste_drawer"
 
 
+@freeze_time("2021-11-15 17:37:00", tz_offset=-7)
 async def test_button(hass: HomeAssistant, mock_account: MagicMock) -> None:
     """Test the creation and values of the Litter-Robot button."""
     await setup_integration(hass, mock_account, BUTTON_DOMAIN)
@@ -39,3 +42,7 @@ async def test_button(hass: HomeAssistant, mock_account: MagicMock) -> None:
     await hass.async_block_till_done()
     assert mock_account.robots[0].reset_waste_drawer.call_count == 1
     mock_account.robots[0].reset_waste_drawer.assert_called_with()
+
+    state = hass.states.get(BUTTON_ENTITY)
+    assert state
+    assert state.state == "2021-11-15T10:37:00+00:00"

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -1,4 +1,6 @@
 """Test the Litter-Robot vacuum entity."""
+from __future__ import annotations
+
 from datetime import timedelta
 from typing import Any
 from unittest.mock import MagicMock

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -1,5 +1,7 @@
 """Test the Litter-Robot vacuum entity."""
 from datetime import timedelta
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from voluptuous.error import MultipleInvalid
@@ -36,7 +38,7 @@ COMPONENT_SERVICE_DOMAIN = {
 }
 
 
-async def test_vacuum(hass: HomeAssistant, mock_account):
+async def test_vacuum(hass: HomeAssistant, mock_account: MagicMock) -> None:
     """Tests the vacuum entity was set up."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
     assert hass.services.has_service(DOMAIN, SERVICE_RESET_WASTE_DRAWER)
@@ -48,8 +50,8 @@ async def test_vacuum(hass: HomeAssistant, mock_account):
 
 
 async def test_vacuum_status_when_sleeping(
-    hass: HomeAssistant, mock_account_with_sleeping_robot
-):
+    hass: HomeAssistant, mock_account_with_sleeping_robot: MagicMock
+) -> None:
     """Tests the vacuum status when sleeping."""
     await setup_integration(hass, mock_account_with_sleeping_robot, PLATFORM_DOMAIN)
 
@@ -58,14 +60,18 @@ async def test_vacuum_status_when_sleeping(
     assert vacuum.attributes.get(ATTR_STATUS) == "Ready (Sleeping)"
 
 
-async def test_no_robots(hass: HomeAssistant, mock_account_with_no_robots):
+async def test_no_robots(
+    hass: HomeAssistant, mock_account_with_no_robots: MagicMock
+) -> None:
     """Tests the vacuum entity was set up."""
     await setup_integration(hass, mock_account_with_no_robots, PLATFORM_DOMAIN)
 
     assert not hass.services.has_service(DOMAIN, SERVICE_RESET_WASTE_DRAWER)
 
 
-async def test_vacuum_with_error(hass: HomeAssistant, mock_account_with_error):
+async def test_vacuum_with_error(
+    hass: HomeAssistant, mock_account_with_error: MagicMock
+) -> None:
     """Tests a vacuum entity with an error."""
     await setup_integration(hass, mock_account_with_error, PLATFORM_DOMAIN)
 
@@ -80,39 +86,34 @@ async def test_vacuum_with_error(hass: HomeAssistant, mock_account_with_error):
         (SERVICE_START, "start_cleaning", None),
         (SERVICE_TURN_OFF, "set_power_status", None),
         (SERVICE_TURN_ON, "set_power_status", None),
-        (
-            SERVICE_RESET_WASTE_DRAWER,
-            "reset_waste_drawer",
-            None,
-        ),
+        (SERVICE_RESET_WASTE_DRAWER, "reset_waste_drawer", {"deprecated": True}),
         (
             SERVICE_SET_SLEEP_MODE,
             "set_sleep_mode",
-            {"enabled": True, "start_time": "22:30"},
+            {"data": {"enabled": True, "start_time": "22:30"}},
         ),
+        (SERVICE_SET_SLEEP_MODE, "set_sleep_mode", {"data": {"enabled": True}}),
+        (SERVICE_SET_SLEEP_MODE, "set_sleep_mode", {"data": {"enabled": False}}),
         (
-            SERVICE_SET_SLEEP_MODE,
-            "set_sleep_mode",
-            {"enabled": True},
-        ),
-        (
-            SERVICE_SET_SLEEP_MODE,
-            "set_sleep_mode",
-            {"enabled": False},
+            SERVICE_SET_WAIT_TIME,
+            "set_wait_time",
+            {"data": {"minutes": 3}, "deprecated": True},
         ),
         (
             SERVICE_SET_WAIT_TIME,
             "set_wait_time",
-            {"minutes": 3},
-        ),
-        (
-            SERVICE_SET_WAIT_TIME,
-            "set_wait_time",
-            {"minutes": "15"},
+            {"data": {"minutes": "15"}, "deprecated": True},
         ),
     ],
 )
-async def test_commands(hass: HomeAssistant, mock_account, service, command, extra):
+async def test_commands(
+    hass: HomeAssistant,
+    mock_account: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+    service: str,
+    command: str,
+    extra: dict[str, Any],
+) -> None:
     """Test sending commands to the vacuum."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
 
@@ -120,9 +121,9 @@ async def test_commands(hass: HomeAssistant, mock_account, service, command, ext
     assert vacuum
     assert vacuum.state == STATE_DOCKED
 
-    data = {ATTR_ENTITY_ID: VACUUM_ENTITY_ID}
-    if extra:
-        data.update(extra)
+    extra = extra or {}
+    data = {ATTR_ENTITY_ID: VACUUM_ENTITY_ID, **extra.get("data", {})}
+    deprecated = extra.get("deprecated", False)
 
     await hass.services.async_call(
         COMPONENT_SERVICE_DOMAIN.get(service, PLATFORM_DOMAIN),
@@ -133,9 +134,10 @@ async def test_commands(hass: HomeAssistant, mock_account, service, command, ext
     future = utcnow() + timedelta(seconds=REFRESH_WAIT_TIME_SECONDS)
     async_fire_time_changed(hass, future)
     getattr(mock_account.robots[0], command).assert_called_once()
+    assert (f"'{DOMAIN}.{service}' service is deprecated" in caplog.text) is deprecated
 
 
-async def test_invalid_wait_time(hass: HomeAssistant, mock_account):
+async def test_invalid_wait_time(hass: HomeAssistant, mock_account: MagicMock) -> None:
     """Test an attempt to send an invalid wait time to the vacuum."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new button entity to litterrobot
Mark old services as deprecated that have been replaced by new entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
