### PR TITLE
Add entity_category to Rituals Entities

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/binary_sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -38,6 +39,7 @@ class DiffuserBatteryChargingBinarySensor(DiffuserEntity, BinarySensorEntity):
     """Representation of a diffuser battery charging binary sensor."""
 
     _attr_device_class = DEVICE_CLASS_BATTERY_CHARGING
+    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
 
     def __init__(
         self, diffuser: Diffuser, coordinator: RitualsDataUpdateCoordinator

--- a/homeassistant/components/rituals_perfume_genie/select.py
+++ b/homeassistant/components/rituals_perfume_genie/select.py
@@ -5,7 +5,7 @@ from pyrituals import Diffuser
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import AREA_SQUARE_METERS
+from homeassistant.const import AREA_SQUARE_METERS, ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -36,6 +36,7 @@ class DiffuserRoomSize(DiffuserEntity, SelectEntity):
     _attr_icon = "mdi:ruler-square"
     _attr_unit_of_measurement = AREA_SQUARE_METERS
     _attr_options = ["15", "30", "60", "100"]
+    _attr_entity_category = ENTITY_CATEGORY_CONFIG
 
     def __init__(
         self, diffuser: Diffuser, coordinator: RitualsDataUpdateCoordinator

--- a/homeassistant/components/rituals_perfume_genie/sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_SIGNAL_STRENGTH,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     PERCENTAGE,
 )
 from homeassistant.core import HomeAssistant
@@ -92,6 +93,7 @@ class DiffuserBatterySensor(DiffuserEntity, SensorEntity):
 
     _attr_device_class = DEVICE_CLASS_BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
 
     def __init__(
         self, diffuser: Diffuser, coordinator: RitualsDataUpdateCoordinator
@@ -110,6 +112,7 @@ class DiffuserWifiSensor(DiffuserEntity, SensorEntity):
 
     _attr_device_class = DEVICE_CLASS_SIGNAL_STRENGTH
     _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
 
     def __init__(
         self, diffuser: Diffuser, coordinator: RitualsDataUpdateCoordinator

--- a/tests/components/rituals_perfume_genie/test_binary_sensor.py
+++ b/tests/components/rituals_perfume_genie/test_binary_sensor.py
@@ -1,7 +1,7 @@
 """Tests for the Rituals Perfume Genie binary sensor platform."""
 from homeassistant.components.binary_sensor import DEVICE_CLASS_BATTERY_CHARGING
 from homeassistant.components.rituals_perfume_genie.binary_sensor import CHARGING_SUFFIX
-from homeassistant.const import ATTR_DEVICE_CLASS, STATE_ON
+from homeassistant.const import ATTR_DEVICE_CLASS, ENTITY_CATEGORY_DIAGNOSTIC, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 
@@ -28,3 +28,4 @@ async def test_binary_sensors(hass: HomeAssistant) -> None:
     entry = registry.async_get("binary_sensor.genie_battery_charging")
     assert entry
     assert entry.unique_id == f"{hublot}{CHARGING_SUFFIX}"
+    assert entry.entity_category == ENTITY_CATEGORY_DIAGNOSTIC

--- a/tests/components/rituals_perfume_genie/test_select.py
+++ b/tests/components/rituals_perfume_genie/test_select.py
@@ -9,6 +9,7 @@ from homeassistant.const import (
     AREA_SQUARE_METERS,
     ATTR_ENTITY_ID,
     ATTR_ICON,
+    ENTITY_CATEGORY_CONFIG,
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.core import HomeAssistant
@@ -36,6 +37,7 @@ async def test_select_entity(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == f"{diffuser.hublot}{ROOM_SIZE_SUFFIX}"
     assert entry.unit_of_measurement == AREA_SQUARE_METERS
+    assert entry.entity_category == ENTITY_CATEGORY_CONFIG
 
 
 async def test_select_option(hass: HomeAssistant) -> None:

--- a/tests/components/rituals_perfume_genie/test_sensor.py
+++ b/tests/components/rituals_perfume_genie/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_SIGNAL_STRENGTH,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     PERCENTAGE,
 )
 from homeassistant.core import HomeAssistant
@@ -59,6 +60,7 @@ async def test_sensors_diffuser_v1_battery_cartridge(hass: HomeAssistant) -> Non
     entry = registry.async_get("sensor.genie_battery")
     assert entry
     assert entry.unique_id == f"{hublot}{BATTERY_SUFFIX}"
+    assert entry.entity_category == ENTITY_CATEGORY_DIAGNOSTIC
 
     state = hass.states.get("sensor.genie_wifi")
     assert state
@@ -69,6 +71,7 @@ async def test_sensors_diffuser_v1_battery_cartridge(hass: HomeAssistant) -> Non
     entry = registry.async_get("sensor.genie_wifi")
     assert entry
     assert entry.unique_id == f"{hublot}{WIFI_SUFFIX}"
+    assert entry.entity_category == ENTITY_CATEGORY_DIAGNOSTIC
 
 
 async def test_sensors_diffuser_v2_no_battery_no_cartridge(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

Set entity_category of the room size entity to config and set the entity_category of the wifi and battery entities to diagnostic.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
