### PR TITLE
Upgrade to newer Python pip>=21.0

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -112,7 +112,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install packaging
-          python3 -m pip install . --use-deprecated=legacy-resolver
+          python3 -m pip install --use-deprecated=legacy-resolver .
           python3 script/version_bump.py nightly
           version="$(python setup.py -V)"
 

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -112,7 +112,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install packaging
-          python3 -m pip install .
+          python3 -m pip install . --use-deprecated=legacy-resolver
           python3 script/version_bump.py nightly
           version="$(python setup.py -V)"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,7 +192,7 @@ jobs:
           . venv/bin/activate
           python --version
           pip install --cache-dir=$PIP_CACHE -U "pip>=21.0" setuptools wheel
-          pip install --cache-dir=$PIP_CACHE -r requirements.txt -r requirements_test.txt
+          pip install --cache-dir=$PIP_CACHE -r requirements.txt -r requirements_test.txt --use-deprecated=legacy-resolver
       - name: Generate partial pre-commit restore key
         id: generate-pre-commit-key
         run: >-
@@ -584,8 +584,8 @@ jobs:
           . venv/bin/activate
           python --version
           pip install --cache-dir=$PIP_CACHE -U "pip>=21.0" setuptools wheel
-          pip install --cache-dir=$PIP_CACHE -r requirements_all.txt
-          pip install --cache-dir=$PIP_CACHE -r requirements_test.txt
+          pip install --cache-dir=$PIP_CACHE -r requirements_all.txt --use-deprecated=legacy-resolver
+          pip install --cache-dir=$PIP_CACHE -r requirements_test.txt --use-deprecated=legacy-resolver
           pip install -e .
 
   pylint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,7 +191,7 @@ jobs:
           python -m venv venv
           . venv/bin/activate
           python --version
-          pip install --cache-dir=$PIP_CACHE -U "pip<20.3" setuptools wheel
+          pip install --cache-dir=$PIP_CACHE -U "pip>=21.0" setuptools wheel
           pip install --cache-dir=$PIP_CACHE -r requirements.txt -r requirements_test.txt
       - name: Generate partial pre-commit restore key
         id: generate-pre-commit-key
@@ -583,7 +583,7 @@ jobs:
           python -m venv venv
           . venv/bin/activate
           python --version
-          pip install --cache-dir=$PIP_CACHE -U "pip<20.3" setuptools wheel
+          pip install --cache-dir=$PIP_CACHE -U "pip>=21.0" setuptools wheel
           pip install --cache-dir=$PIP_CACHE -r requirements_all.txt
           pip install --cache-dir=$PIP_CACHE -r requirements_test.txt
           pip install -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,7 +191,7 @@ jobs:
           python -m venv venv
           . venv/bin/activate
           python --version
-          pip install --cache-dir=$PIP_CACHE -U "pip>=21.0" setuptools wheel
+          pip install --cache-dir=$PIP_CACHE -U "pip>=21.0,<22.1" setuptools wheel
           pip install --cache-dir=$PIP_CACHE -r requirements.txt -r requirements_test.txt --use-deprecated=legacy-resolver
       - name: Generate partial pre-commit restore key
         id: generate-pre-commit-key
@@ -583,7 +583,7 @@ jobs:
           python -m venv venv
           . venv/bin/activate
           python --version
-          pip install --cache-dir=$PIP_CACHE -U "pip>=21.0" setuptools wheel
+          pip install --cache-dir=$PIP_CACHE -U "pip>=21.0,<22.1" setuptools wheel
           pip install --cache-dir=$PIP_CACHE -r requirements_all.txt --use-deprecated=legacy-resolver
           pip install --cache-dir=$PIP_CACHE -r requirements_test.txt --use-deprecated=legacy-resolver
           pip install -e .

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -88,7 +88,7 @@
     {
       "label": "Install all Requirements",
       "type": "shell",
-      "command": "pip3 install -r requirements_all.txt",
+      "command": "pip3 install --use-deprecated=legacy-resolver -r requirements_all.txt",
       "group": {
         "kind": "build",
         "isDefault": true
@@ -102,7 +102,7 @@
     {
       "label": "Install all Test Requirements",
       "type": "shell",
-      "command": "pip3 install -r requirements_test_all.txt",
+      "command": "pip3 install --use-deprecated=legacy-resolver -r requirements_test_all.txt",
       "group": {
         "kind": "build",
         "isDefault": true

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,17 @@ COPY requirements.txt homeassistant/
 COPY homeassistant/package_constraints.txt homeassistant/homeassistant/
 RUN \
     pip3 install --no-cache-dir --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
-    -r homeassistant/requirements.txt
+    -r homeassistant/requirements.txt --use-deprecated=legacy-resolver
 COPY requirements_all.txt homeassistant/
 RUN \
     pip3 install --no-cache-dir --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
-    -r homeassistant/requirements_all.txt
+    -r homeassistant/requirements_all.txt --use-deprecated=legacy-resolver
 
 ## Setup Home Assistant Core
 COPY . homeassistant/
 RUN \
     pip3 install --no-cache-dir --no-index --only-binary=:all: --find-links "${WHEELS_LINKS}" \
-    -e ./homeassistant \
+    -e ./homeassistant --use-deprecated=legacy-resolver \
     && python3 -m compileall homeassistant/homeassistant
 
 # Fix Bug with Alpine 3.14 and sqlite 3.35

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -33,9 +33,9 @@ WORKDIR /workspaces
 # Install Python dependencies from requirements
 COPY requirements.txt ./
 COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r requirements.txt --use-deprecated=legacy-resolver
 COPY requirements_test.txt requirements_test_pre_commit.txt ./
-RUN pip3 install -r requirements_test.txt
+RUN pip3 install -r requirements_test.txt --use-deprecated=legacy-resolver
 RUN rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/
 
 # Set the default shell to bash instead of sh

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -21,7 +21,7 @@ ifaddr==0.1.7
 jinja2==3.0.3
 paho-mqtt==1.6.1
 pillow==9.0.1
-pip>=21.0
+pip>=21.0,<22.1
 pyserial==3.5
 python-slugify==4.0.1
 pyudev==0.22.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -21,7 +21,7 @@ ifaddr==0.1.7
 jinja2==3.0.3
 paho-mqtt==1.6.1
 pillow==9.0.1
-pip>=8.0.3,<20.3
+pip>=21.0
 pyserial==3.5
 python-slugify==4.0.1
 pyudev==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ ifaddr==0.1.7
 jinja2==3.0.3
 PyJWT==2.1.0
 cryptography==35.0.0
-pip>=21.0
+pip>=21.0,<22.1
 python-slugify==4.0.1
 pyyaml==6.0
 requests==2.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ ifaddr==0.1.7
 jinja2==3.0.3
 PyJWT==2.1.0
 cryptography==35.0.0
-pip>=8.0.3,<20.3
+pip>=21.0
 python-slugify==4.0.1
 pyyaml==6.0
 requests==2.27.1

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -8,4 +8,4 @@ cd "$(dirname "$0")/.."
 
 echo "Installing development dependencies..."
 python3 -m pip install wheel --constraint homeassistant/package_constraints.txt
-python3 -m pip install tox tox-pip-version colorlog pre-commit $(grep mypy requirements_test.txt) $(grep stdlib-list requirements_test.txt) $(grep tqdm requirements_test.txt) $(grep pipdeptree requirements_test.txt) $(grep awesomeversion requirements.txt) --constraint homeassistant/package_constraints.txt
+python3 -m pip install tox tox-pip-version colorlog pre-commit $(grep mypy requirements_test.txt) $(grep stdlib-list requirements_test.txt) $(grep tqdm requirements_test.txt) $(grep pipdeptree requirements_test.txt) $(grep awesomeversion requirements.txt) --constraint homeassistant/package_constraints.txt --use-deprecated=legacy-resolver

--- a/script/setup
+++ b/script/setup
@@ -24,7 +24,7 @@ fi
 script/bootstrap
 
 pre-commit install
-python3 -m pip install -e . --constraint homeassistant/package_constraints.txt
+python3 -m pip install -e . --constraint homeassistant/package_constraints.txt --use-deprecated=legacy-resolver
 
 hass --script ensure_config -c config
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     PyJWT==2.1.0
     # PyJWT has loose dependency. We want the latest one.
     cryptography==35.0.0
-    pip>=21.0
+    pip>=21.0,<22.1
     python-slugify==4.0.1
     pyyaml==6.0
     requests==2.27.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     PyJWT==2.1.0
     # PyJWT has loose dependency. We want the latest one.
     cryptography==35.0.0
-    pip>=8.0.3,<20.3
+    pip>=21.0
     python-slugify==4.0.1
     pyyaml==6.0
     requests==2.27.1

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ ignore_basepython_conflict = True
 [testenv]
 basepython = {env:PYTHON3_PATH:python3}
 # pip version duplicated in homeassistant/package_constraints.txt
-pip_version = pip>=8.0.3,<20.3
+pip_version = pip>=21.0
 commands =
      {envpython} -X dev -m pytest --timeout=9 --durations=10 -n auto --dist=loadfile -qq -o console_output_style=count -p no:sugar {posargs}
      {toxinidir}/script/check_dirty

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ ignore_basepython_conflict = True
 [testenv]
 basepython = {env:PYTHON3_PATH:python3}
 # pip version duplicated in homeassistant/package_constraints.txt
-pip_version = pip>=21.0
+pip_version = pip>=21.0,<22.1
 install_command = python -m pip install --use-deprecated legacy-resolver {opts} {packages}
 commands =
      {envpython} -X dev -m pytest --timeout=9 --durations=10 -n auto --dist=loadfile -qq -o console_output_style=count -p no:sugar {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ ignore_basepython_conflict = True
 basepython = {env:PYTHON3_PATH:python3}
 # pip version duplicated in homeassistant/package_constraints.txt
 pip_version = pip>=21.0
+install_command = python -m pip install --use-deprecated legacy-resolver {opts} {packages}
 commands =
      {envpython} -X dev -m pytest --timeout=9 --durations=10 -n auto --dist=loadfile -qq -o console_output_style=count -p no:sugar {posargs}
      {toxinidir}/script/check_dirty


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We currently lock `pip` to <20.3.
This will work for a while and doesn't cause problems right now. But in the long run, will become problematic. This PR serves as a draft to monitor progress towards getting it upgraded.

ℹ️ We now have a pip-check script in CI in place to protect us against creating more conflicts.
We are currently down to 11 conflicts (some have a PR open, others will probably end up being disabled as an integration).

⚠️ I've adjusted this PR to use the legacy resolver, this gives us an upgrade path for now, and will help with Python 3.10 handling as well (#59729).

Todo:

- [x] Fix aiohttp dependency range on crownstone-sse==2.0.2
  - https://github.com/crownstone/crownstone-lib-python-sse/issues/1
  - #60428
- [x] Fix aiohttp dependency range on pyatmo==6.1.0
  - https://github.com/jabesq/pyatmo/issues/163
  - #59975
- [x] Fix aiohttp dependency range on python-smarttub==0.0.27
  - #60391
- [x] Fix click dependency range on python-miio==0.5.8
  - #60650
- [x] Fix croniter dependency range on python-miio==0.5.8
  - #60650
- [x] Fix cryptography dependency range on python-miio==0.5.8
  - #60650
- [x] Fix PyYAML dependency range on python-miio==0.5.8
  - #60650
- [x] Fix httpx dependency range devolo-plc-api==0.6.2
   - https://github.com/home-assistant/core/pull/59991
- [x] Fix async_timeout range on hangups<=0.4.16
  - https://github.com/tdryer/hangups/pull/524
- [x] Fix cryptography range on hass-nabucasa<=0.51.0
  - maybe this? https://github.com/NabuCasa/hass-nabucasa/pull/297
- [x] Fix async_timeout range on enturclient==0.2.2
  - https://github.com/hfurubotten/enturclient/pull/39
- [ ] Disable Discord integration
  - Not fixable dependency issues, upstream = archived
- [x] Fix async_timeout on hole==0.6.0
  - Bump to 0.7.0
  - #60779
- [x] Fix async_timeout & httpx on lufdaten==0.6.5
  - Bump to 0.7.0 (for removal of loop and async_timeout)
  - Bump to 0.7.1 (for httpx)
  - https://github.com/home-assistant-ecosystem/python-luftdaten/issues/11
- [ ] Disable mycroft integration
  - mycroftapi 2.0 depends on websocket-client==0.44.0, repository no longer exists
- [x] plugwise 0.8.5 depends on async-timeout<4.0
  - https://github.com/plugwise/python-plugwise/pull/102, https://github.com/plugwise/python-plugwise/commit/988c234e1226a0a0bf423ae7e2f8925070a40964, fix available in >= 0.15.6
- [x] py17track 3.2.1 depends on attrs<21.0 and >=19.3
    - #60762
- [x] pydelijn 0.6.1-1.0.0 depends on async_timeout<4.0 and >=3.0.1
   - https://github.com/bollewolle/pydelijn/pull/12
- [ ] pyicloud 0.10.2 depends on click<=7.1.1 and >=6.0
   - https://github.com/picklepete/pyicloud/blob/master/requirements.txt
- [ ] pysmarty 0.8 depends on pymodbus==1.5.2
  - https://github.com/z0mbieprocess/pysmarty/issues/1
- [ ] surepy 0.7.2 depends on async-timeout<4.0.0 and >=3.0.1
  - https://github.com/benleb/surepy/pull/103


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #45444
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
