### PR TITLE
Add WLED firmware upgrade button

### DIFF
--- a/tests/components/wled/fixtures/rgb.json
+++ b/tests/components/wled/fixtures/rgb.json
@@ -48,6 +48,8 @@
   },
   "info": {
     "ver": "0.8.5",
+    "version_latest_stable": "0.12.0",
+    "version_latest_beta": "0.13.0b1",
     "vid": 1909122,
     "leds": {
       "count": 30,

--- a/tests/components/wled/fixtures/rgb_single_segment.json
+++ b/tests/components/wled/fixtures/rgb_single_segment.json
@@ -33,7 +33,9 @@
     ]
   },
   "info": {
-    "ver": "0.8.5",
+    "ver": "0.8.6b1",
+    "version_latest_stable": "0.8.5",
+    "version_latest_beta": "0.8.6b2",
     "vid": 1909122,
     "leds": {
       "count": 30,

--- a/tests/components/wled/fixtures/rgb_websocket.json
+++ b/tests/components/wled/fixtures/rgb_websocket.json
@@ -63,6 +63,8 @@
   },
   "info": {
       "ver": "0.12.0-b2",
+      "version_latest_stable": "0.11.0",
+      "version_latest_beta": "0.12.0-b2",
       "vid": 2103220,
       "leds": {
           "count": 13,

--- a/tests/components/wled/fixtures/rgbw.json
+++ b/tests/components/wled/fixtures/rgbw.json
@@ -33,7 +33,9 @@
     ]
   },
   "info": {
-    "ver": "0.8.6",
+    "ver": "0.8.6b4",
+    "version_latest_stable": "0.8.6",
+    "version_latest_beta": "0.8.6b5",
     "vid": 1910255,
     "leds": {
       "count": 13,

--- a/tests/components/wled/test_button.py
+++ b/tests/components/wled/test_button.py
@@ -164,3 +164,13 @@ async def test_button_upgrade_stay_beta(
     await hass.async_block_till_done()
     assert mock_wled.upgrade.call_count == 1
     mock_wled.upgrade.assert_called_with(version="0.8.6b2")
+
+
+@pytest.mark.parametrize("mock_wled", ["wled/rgb_websocket.json"], indirect=True)
+async def test_button_no_upgrade_available(
+    hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
+) -> None:
+    """Test the upgrade button. There is no update available."""
+    state = hass.states.get("button.wled_websocket_upgrade")
+    assert state
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/wled/test_button.py
+++ b/tests/components/wled/test_button.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry
 
 
-async def test_button(
+async def test_button_restart(
     hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
 ) -> None:
     """Test the creation and values of the WLED button."""
@@ -35,7 +35,6 @@ async def test_button(
     assert entry.unique_id == "aabbccddeeff_restart"
     assert entry.entity_category == ENTITY_CATEGORY_CONFIG
 
-    # Restart
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
@@ -92,3 +91,76 @@ async def test_button_connection_error(
     assert state
     assert state.state == STATE_UNAVAILABLE
     assert "Error communicating with API" in caplog.text
+
+
+async def test_button_upgrade_stay_stable(
+    hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
+) -> None:
+    """Test the upgrade button.
+
+    There is both an upgrade for beta and stable available, however, the device
+    is currently running a stable version. Therefore, the upgrade button should
+    upgrade the the next stable (even though beta is newer).
+    """
+    entity_registry = er.async_get(hass)
+
+    entry = entity_registry.async_get("button.wled_rgb_light_upgrade")
+    assert entry
+    assert entry.unique_id == "aabbccddeeff_upgrade"
+    assert entry.entity_category == ENTITY_CATEGORY_CONFIG
+
+    state = hass.states.get("button.wled_rgb_light_upgrade")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:cellphone-arrow-down"
+    assert state.state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.wled_rgb_light_upgrade"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert mock_wled.upgrade.call_count == 1
+    mock_wled.upgrade.assert_called_with(version="0.12.0")
+
+
+@pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
+async def test_button_upgrade_beta_to_stable(
+    hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
+) -> None:
+    """Test the upgrade button.
+
+    There is both an upgrade for beta and stable available the device
+    is currently a beta, however, a newer stable is available. Therefore, the
+    upgrade button should upgrade to the next stable.
+    """
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.wled_rgbw_light_upgrade"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert mock_wled.upgrade.call_count == 1
+    mock_wled.upgrade.assert_called_with(version="0.8.6")
+
+
+@pytest.mark.parametrize("mock_wled", ["wled/rgb_single_segment.json"], indirect=True)
+async def test_button_upgrade_stay_beta(
+    hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
+) -> None:
+    """Test the upgrade button.
+
+    There is an upgrade for beta and the device is currently a beta. Therefore,
+    the upgrade button should upgrade to the next beta.
+    """
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.wled_rgb_light_upgrade"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert mock_wled.upgrade.call_count == 1
+    mock_wled.upgrade.assert_called_with(version="0.8.6b2")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a firmware upgrade button for WLED.

It will offer an upgrade in case:

- You are running a stable version and a newer stable version is available
- You are running a beta version and a newer stable version is available
- You are running a beta version and a newer beta version is available

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
