### PR TITLE
Litter-Robot: use an assumed switch state until refresh callback is complete

### DIFF
--- a/homeassistant/components/litterrobot/hub.py
+++ b/homeassistant/components/litterrobot/hub.py
@@ -13,7 +13,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-UPDATE_INTERVAL_SECONDS = 10
+UPDATE_INTERVAL_SECONDS = 20
 
 
 class LitterRobotHub:

--- a/homeassistant/components/litterrobot/manifest.json
+++ b/homeassistant/components/litterrobot/manifest.json
@@ -3,7 +3,11 @@
   "name": "Litter-Robot",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/litterrobot",
-  "requirements": ["pylitterbot==2021.10.1"],
-  "codeowners": ["@natekspencer"],
+  "requirements": [
+    "pylitterbot==2021.11.0"
+  ],
+  "codeowners": [
+    "@natekspencer"
+  ],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -19,6 +19,8 @@ class LitterRobotNightLightModeSwitch(LitterRobotConfigEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
+        if self._refresh_callback is not None:
+            return self._assumed_state
         return self.robot.night_light_mode_enabled
 
     @property
@@ -28,11 +30,11 @@ class LitterRobotNightLightModeSwitch(LitterRobotConfigEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        await self.perform_action_and_refresh(self.robot.set_night_light, True)
+        await self.perform_action_and_assume_state(self.robot.set_night_light, True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        await self.perform_action_and_refresh(self.robot.set_night_light, False)
+        await self.perform_action_and_assume_state(self.robot.set_night_light, False)
 
 
 class LitterRobotPanelLockoutSwitch(LitterRobotConfigEntity, SwitchEntity):
@@ -41,6 +43,8 @@ class LitterRobotPanelLockoutSwitch(LitterRobotConfigEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
+        if self._refresh_callback is not None:
+            return self._assumed_state
         return self.robot.panel_lock_enabled
 
     @property
@@ -50,11 +54,11 @@ class LitterRobotPanelLockoutSwitch(LitterRobotConfigEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        await self.perform_action_and_refresh(self.robot.set_panel_lockout, True)
+        await self.perform_action_and_assume_state(self.robot.set_panel_lockout, True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        await self.perform_action_and_refresh(self.robot.set_panel_lockout, False)
+        await self.perform_action_and_assume_state(self.robot.set_panel_lockout, False)
 
 
 ROBOT_SWITCHES: list[tuple[type[LitterRobotConfigEntity], str]] = [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1604,7 +1604,7 @@ pylibrespot-java==0.1.0
 pylitejet==0.3.0
 
 # homeassistant.components.litterrobot
-pylitterbot==2021.10.1
+pylitterbot==2021.11.0
 
 # homeassistant.components.loopenergy
 pyloopenergy==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -968,7 +968,7 @@ pylibrespot-java==0.1.0
 pylitejet==0.3.0
 
 # homeassistant.components.litterrobot
-pylitterbot==2021.10.1
+pylitterbot==2021.11.0
 
 # homeassistant.components.lutron_caseta
 pylutron-caseta==0.11.0

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -1,5 +1,6 @@
 """Test the Litter-Robot switch entity."""
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,7 +10,13 @@ from homeassistant.components.switch import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ENTITY_CATEGORY_CONFIG, STATE_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ENTITY_CATEGORY_CONFIG,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from homeassistant.util.dt import utcnow
 
@@ -21,13 +28,13 @@ NIGHT_LIGHT_MODE_ENTITY_ID = "switch.test_night_light_mode"
 PANEL_LOCKOUT_ENTITY_ID = "switch.test_panel_lockout"
 
 
-async def test_switch(hass, mock_account):
+async def test_switch(hass: HomeAssistant, mock_account: MagicMock):
     """Tests the switch entity was set up."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
 
-    switch = hass.states.get(NIGHT_LIGHT_MODE_ENTITY_ID)
-    assert switch
-    assert switch.state == STATE_ON
+    state = hass.states.get(NIGHT_LIGHT_MODE_ENTITY_ID)
+    assert state
+    assert state.state == STATE_ON
 
     ent_reg = entity_registry.async_get(hass)
     entity_entry = ent_reg.async_get(NIGHT_LIGHT_MODE_ENTITY_ID)
@@ -42,12 +49,14 @@ async def test_switch(hass, mock_account):
         (PANEL_LOCKOUT_ENTITY_ID, "set_panel_lockout"),
     ],
 )
-async def test_on_off_commands(hass, mock_account, entity_id, robot_command):
+async def test_on_off_commands(
+    hass: HomeAssistant, mock_account: MagicMock, entity_id: str, robot_command: str
+):
     """Test sending commands to the switch."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
 
-    switch = hass.states.get(entity_id)
-    assert switch
+    state = hass.states.get(entity_id)
+    assert state
 
     data = {ATTR_ENTITY_ID: entity_id}
 
@@ -65,3 +74,6 @@ async def test_on_off_commands(hass, mock_account, entity_id, robot_command):
         future = utcnow() + timedelta(seconds=REFRESH_WAIT_TIME_SECONDS)
         async_fire_time_changed(hass, future)
         assert getattr(mock_account.robots[0], robot_command).call_count == count
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state == STATE_ON if service == SERVICE_TURN_ON else STATE_OFF


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reduces the likelihood of switches bouncing between on and off states when toggled due to the coordinator refreshes.
The pylitterbot dependency was bumped to help support this:
https://github.com/natekspencer/pylitterbot/compare/2021.10.1...2021.11.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/59780
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
