### PR TITLE
Fix for deviceless entities in Hue integration 

### DIFF
--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -36,9 +36,7 @@ class HueBaseEntity(Entity):
         self.bridge = bridge
         self.controller = controller
         self.resource = resource
-        self.device = (
-            controller.get_device(resource.id) or bridge.api.config.bridge_device
-        )
+        self.device = controller.get_device(resource.id)
         self.logger = bridge.logger.getChild(resource.type.value)
 
         # Entity class attributes

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -240,6 +240,8 @@ async def test_grouped_lights(hass, mock_bridge_v2, v2_resources_test_data):
         assert entity_entry
         assert entity_entry.disabled
         assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
+        # entity should not have a device assigned
+        assert entity_entry.device_id is None
 
         # enable the entity
         updated_entry = ent_reg.async_update_entity(

--- a/tests/components/hue/test_scene.py
+++ b/tests/components/hue/test_scene.py
@@ -1,6 +1,8 @@
 """Philips Hue scene platform tests for V2 bridge/api."""
 
 
+from homeassistant.helpers import entity_registry as er
+
 from .conftest import setup_platform
 from .const import FAKE_SCENE
 
@@ -38,6 +40,16 @@ async def test_scene(hass, mock_bridge_v2, v2_resources_test_data):
     assert test_entity.attributes["speed"] == 0.5
     assert test_entity.attributes["brightness"] == 100.0
     assert test_entity.attributes["is_dynamic"] is False
+
+    # scene entities should not have a device assigned
+    ent_reg = er.async_get(hass)
+    for entity_id in (
+        "scene.test_zone_dynamic_test_scene",
+        "scene.test_room_regular_test_scene",
+    ):
+        entity_entry = ent_reg.async_get(entity_id)
+        assert entity_entry
+        assert entity_entry.device_id is None
 
 
 async def test_scene_turn_on_service(hass, mock_bridge_v2, v2_resources_test_data):


### PR DESCRIPTION
## Proposed change
Very small adjustment after the recent refactor of the Hue integration.
Hue resources that are not a member of a device (e.g. scenes, lightgroups) should have no device attached in HA.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum


To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

