### PR TITLE
Add type hints to SSDP

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -132,7 +132,7 @@ class UpnpDescription(_UpnpDescriptionBase, total=False):
     modelNumber: str
     modelURL: str
     serialNumber: str
-    serviceList: str
+    serviceList: list[list[dict[str, str]]]
     UPC: str
     presentationURL: str
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -35,7 +35,7 @@ SCAN_INTERVAL = timedelta(seconds=60)
 IPV4_BROADCAST = IPv4Address("255.255.255.255")
 
 # Attributes for accessing info from SSDP response
-ATTR_SSDP_LOCATION = "ssdp_location"
+ATTR_SSDP_LOCATION: Final = "ssdp_location"
 ATTR_SSDP_ST = "ssdp_st"
 ATTR_SSDP_NT = "ssdp_nt"
 ATTR_SSDP_UDN = "ssdp_udn"

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -117,23 +117,25 @@ class SsdpDescription(_SsdpDescriptionBase, total=False):
 class _UpnpDescriptionBase(TypedDict, total=True):
     """Compulsory keys for UPnP info."""
 
+    deviceType: str
+    friendlyName: str
+    manufacturer: str
+    modelName: str
     UDN: str
 
 
 class UpnpDescription(_UpnpDescriptionBase, total=False):
     """UPnP info with optional keys."""
 
-    deviceType: str
-    friendlyName: str
-    manufacturer: str
     manufacturerURL: str
     modelDescription: str
-    modelName: str
     modelNumber: str
     modelURL: str
     serialNumber: str
-    serviceList: list[list[dict[str, str]]]
     UPC: str
+    iconList: dict[str, list[dict[str, str]]]
+    serviceList: dict[str, list[dict[str, str]]]
+    deviceList: dict[str, Any]
     presentationURL: str
 
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
 import logging
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Final, Mapping, cast
 
 from async_upnp_client.aiohttp import AiohttpSessionRequester
 from async_upnp_client.const import DeviceOrServiceType, SsdpHeaders, SsdpSource
@@ -15,6 +15,9 @@ from async_upnp_client.description_cache import DescriptionCache
 from async_upnp_client.ssdp import SSDP_PORT
 from async_upnp_client.ssdp_listener import SsdpDevice, SsdpListener
 from async_upnp_client.utils import CaseInsensitiveDict
+
+# Import from typing_extensions due to pylint(inherit-non-class) issue
+from typing_extensions import TypedDict
 
 from homeassistant import config_entries
 from homeassistant.components import network
@@ -56,7 +59,7 @@ ATTR_UPNP_UDN = "UDN"
 ATTR_UPNP_UPC = "UPC"
 ATTR_UPNP_PRESENTATION_URL = "presentationURL"
 # Attributes for accessing info added by Home Assistant
-ATTR_HA_MATCHING_DOMAINS = "x-homeassistant-matching-domains"
+ATTR_HA_MATCHING_DOMAINS: Final = "x-homeassistant-matching-domains"
 
 PRIMARY_MATCH_KEYS = [ATTR_UPNP_MANUFACTURER, "st", ATTR_UPNP_DEVICE_TYPE, "nt"]
 
@@ -85,6 +88,59 @@ SSDP_SOURCE_SSDP_CHANGE_MAPPING: Mapping[SsdpSource, SsdpChange] = {
 _LOGGER = logging.getLogger(__name__)
 
 
+_HaServiceInfoDescription = TypedDict(
+    "_HaServiceInfoDescription",
+    {
+        "x-homeassistant-matching-domains": set,
+    },
+    total=True,
+)
+
+
+class _SsdpDescriptionBase(TypedDict, total=True):
+    """Compulsory keys for SSDP info."""
+
+    ssdp_usn: str
+    ssdp_st: str
+
+
+class SsdpDescription(_SsdpDescriptionBase, total=False):
+    """SSDP info with optional keys."""
+
+    ssdp_location: str
+    ssdp_nt: str
+    ssdp_udn: str
+    ssdp_ext: str
+    ssdp_server: str
+
+
+class _UpnpDescriptionBase(TypedDict, total=True):
+    """Compulsory keys for UPnP info."""
+
+    UDN: str
+
+
+class UpnpDescription(_UpnpDescriptionBase, total=False):
+    """UPnP info with optional keys."""
+
+    deviceType: str
+    friendlyName: str
+    manufacturer: str
+    manufacturerURL: str
+    modelDescription: str
+    modelName: str
+    modelNumber: str
+    modelURL: str
+    serialNumber: str
+    serviceList: str
+    UPC: str
+    presentationURL: str
+
+
+class SsdpServiceInfo(SsdpDescription, UpnpDescription, _HaServiceInfoDescription):
+    """Prepared info from ssdp/upnp entries."""
+
+
 @bind_hass
 async def async_register_callback(
     hass: HomeAssistant,
@@ -102,7 +158,7 @@ async def async_register_callback(
 @bind_hass
 async def async_get_discovery_info_by_udn_st(  # pylint: disable=invalid-name
     hass: HomeAssistant, udn: str, st: str
-) -> dict[str, str] | None:
+) -> SsdpServiceInfo | None:
     """Fetch the discovery info cache."""
     scanner: Scanner = hass.data[DOMAIN]
     return await scanner.async_get_discovery_info_by_udn_st(udn, st)
@@ -111,7 +167,7 @@ async def async_get_discovery_info_by_udn_st(  # pylint: disable=invalid-name
 @bind_hass
 async def async_get_discovery_info_by_st(  # pylint: disable=invalid-name
     hass: HomeAssistant, st: str
-) -> list[dict[str, str]]:
+) -> list[SsdpServiceInfo]:
     """Fetch all the entries matching the st."""
     scanner: Scanner = hass.data[DOMAIN]
     return await scanner.async_get_discovery_info_by_st(st)
@@ -120,7 +176,7 @@ async def async_get_discovery_info_by_st(  # pylint: disable=invalid-name
 @bind_hass
 async def async_get_discovery_info_by_udn(
     hass: HomeAssistant, udn: str
-) -> list[dict[str, str]]:
+) -> list[SsdpServiceInfo]:
     """Fetch all the entries matching the udn."""
     scanner: Scanner = hass.data[DOMAIN]
     return await scanner.async_get_discovery_info_by_udn(udn)
@@ -141,7 +197,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def _async_process_callbacks(
     callbacks: list[SsdpCallback],
-    discovery_info: dict[str, str],
+    discovery_info: SsdpServiceInfo,
     ssdp_change: SsdpChange,
 ) -> None:
     for callback in callbacks:
@@ -427,7 +483,7 @@ class Scanner:
 
     async def _async_headers_to_discovery_info(
         self, headers: Mapping[str, Any]
-    ) -> dict[str, Any]:
+    ) -> SsdpServiceInfo:
         """Combine the headers and description into discovery_info.
 
         Building this is a bit expensive so we only do it on demand.
@@ -443,7 +499,7 @@ class Scanner:
 
     async def async_get_discovery_info_by_udn_st(  # pylint: disable=invalid-name
         self, udn: str, st: str
-    ) -> dict[str, Any] | None:
+    ) -> SsdpServiceInfo | None:
         """Return discovery_info for a udn and st."""
         if headers := self._all_headers_from_ssdp_devices.get((udn, st)):
             return await self._async_headers_to_discovery_info(headers)
@@ -451,7 +507,7 @@ class Scanner:
 
     async def async_get_discovery_info_by_st(  # pylint: disable=invalid-name
         self, st: str
-    ) -> list[dict[str, Any]]:
+    ) -> list[SsdpServiceInfo]:
         """Return matching discovery_infos for a st."""
         return [
             await self._async_headers_to_discovery_info(headers)
@@ -459,7 +515,7 @@ class Scanner:
             if udn_st[1] == st
         ]
 
-    async def async_get_discovery_info_by_udn(self, udn: str) -> list[dict[str, Any]]:
+    async def async_get_discovery_info_by_udn(self, udn: str) -> list[SsdpServiceInfo]:
         """Return matching discovery_infos for a udn."""
         return [
             await self._async_headers_to_discovery_info(headers)
@@ -470,7 +526,7 @@ class Scanner:
 
 def discovery_info_from_headers_and_description(
     info_with_desc: CaseInsensitiveDict,
-) -> dict[str, Any]:
+) -> SsdpServiceInfo:
     """Convert headers and description to discovery_info."""
     info = {
         DISCOVERY_MAPPING.get(k.lower(), k): v
@@ -485,7 +541,7 @@ def discovery_info_from_headers_and_description(
     if ATTR_SSDP_ST not in info and ATTR_SSDP_NT in info:
         info[ATTR_SSDP_ST] = info[ATTR_SSDP_NT]
 
-    return info
+    return cast(SsdpServiceInfo, info)
 
 
 def _udn_from_usn(usn: str | None) -> str | None:

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
 import logging
-from typing import Any, Callable, Final, Mapping, cast
+from typing import Any, Callable, Final, Mapping, TypedDict, cast
 
 from async_upnp_client.aiohttp import AiohttpSessionRequester
 from async_upnp_client.const import DeviceOrServiceType, SsdpHeaders, SsdpSource
@@ -15,9 +15,6 @@ from async_upnp_client.description_cache import DescriptionCache
 from async_upnp_client.ssdp import SSDP_PORT
 from async_upnp_client.ssdp_listener import SsdpDevice, SsdpListener
 from async_upnp_client.utils import CaseInsensitiveDict
-
-# Import from typing_extensions due to pylint(inherit-non-class) issue
-from typing_extensions import TypedDict
 
 from homeassistant import config_entries
 from homeassistant.components import network
@@ -59,7 +56,7 @@ ATTR_UPNP_UDN = "UDN"
 ATTR_UPNP_UPC = "UPC"
 ATTR_UPNP_PRESENTATION_URL = "presentationURL"
 # Attributes for accessing info added by Home Assistant
-ATTR_HA_MATCHING_DOMAINS: Final = "x-homeassistant-matching-domains"
+ATTR_HA_MATCHING_DOMAINS: Final = "x_homeassistant_matching_domains"
 
 PRIMARY_MATCH_KEYS = [ATTR_UPNP_MANUFACTURER, "st", ATTR_UPNP_DEVICE_TYPE, "nt"]
 
@@ -88,13 +85,10 @@ SSDP_SOURCE_SSDP_CHANGE_MAPPING: Mapping[SsdpSource, SsdpChange] = {
 _LOGGER = logging.getLogger(__name__)
 
 
-_HaServiceInfoDescription = TypedDict(
-    "_HaServiceInfoDescription",
-    {
-        "x-homeassistant-matching-domains": set,
-    },
-    total=True,
-)
+class _HaServiceInfoDescription(TypedDict, total=True):
+    """Keys added by HA."""
+
+    x_homeassistant_matching_domains: set[str]
 
 
 class _SsdpDescriptionBase(TypedDict, total=True):


### PR DESCRIPTION
## Breaking change
The value of constant `ATTR_HA_MATCHING_DOMAINS` was adjusted to replace dashes `-` with underscore `_`: 
`x-homeassistant-matching-domains` is now `x_homeassistant_matching_domains`.
Custom components using `x-homeassistant-matching-domains` as a string should replace it with the constant `ssdp.ATTR_HA_MATCHING_DOMAINS`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to SSDP, as preliminary work for #59779


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
