### PR TITLE
Add integration_entities template helper

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -50,7 +50,6 @@ from homeassistant.helpers import (
     entity_registry,
     location as loc_helper,
 )
-from homeassistant.helpers.entity import SOURCE_CONFIG_ENTRY, entity_sources
 from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.loader import bind_hass
 from homeassistant.util import convert, dt as dt_util, location as loc_util
@@ -934,8 +933,8 @@ def integration_entities(hass: HomeAssistant, entry_name: str) -> Iterable[str]:
     )
     return [
         entity_id
-        for entity_id, info in entity_sources(hass).items()
-        if (conf_entry is not None and info.get(SOURCE_CONFIG_ENTRY) == conf_entry)
+        for entity_id, info in hass.data.get("entity_info", {}).items()
+        if (conf_entry is not None and info.get("config_entry") == conf_entry)
         or (info["domain"] == entry_name)
     ]
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -50,6 +50,7 @@ from homeassistant.helpers import (
     entity_registry,
     location as loc_helper,
 )
+from homeassistant.helpers.entity import SOURCE_CONFIG_ENTRY, entity_sources
 from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.loader import bind_hass
 from homeassistant.util import convert, dt as dt_util, location as loc_util
@@ -933,8 +934,8 @@ def integration_entities(hass: HomeAssistant, entry_name: str) -> Iterable[str]:
     )
     return [
         entity_id
-        for entity_id, info in hass.data.get("entity_info", {}).items()
-        if (conf_entry is not None and info.get("config_entry") == conf_entry)
+        for entity_id, info in entity_sources(hass).items()
+        if (conf_entry is not None and info.get(SOURCE_CONFIG_ENTRY) == conf_entry)
         or (info["domain"] == entry_name)
     ]
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -916,27 +916,23 @@ def device_entities(hass: HomeAssistant, _device_id: str) -> Iterable[str]:
     return [entry.entity_id for entry in entries]
 
 
-def integration_entities(
-    hass: HomeAssistant, entry_name: str, platform: str | None = None
-) -> Iterable[str]:
+def integration_entities(hass: HomeAssistant, entry_name: str) -> Iterable[str]:
     """
     Get entity ids for entities tied to an integration/domain.
 
     Provide entry_name as domain to get all entity id's for a integration/domain
     or provide a config entry title for filtering between instances of the same integration.
-    Optionally provide platform to only return entities for that platform.
     """
     entity_reg = entity_registry.async_get(hass)
     conf_entries = [
         entry.entry_id
         for entry in hass.config_entries.async_entries()
-        if entry.domain == entry_name or entry.title == entry_name
+        if entry_name in (entry.domain, entry.title)
     ]
     return [
         item.entity_id
         for item in entity_reg.entities.values()
         if item.config_entry_id in conf_entries
-        and (platform is None or item.domain == platform)
     ]
 
 

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -923,16 +923,19 @@ def integration_entities(hass: HomeAssistant, entry_name: str) -> Iterable[str]:
     Provide entry_name as domain to get all entity id's for a integration/domain
     or provide a config entry title for filtering between instances of the same integration.
     """
-    entity_reg = entity_registry.async_get(hass)
-    conf_entries = [
-        entry.entry_id
-        for entry in hass.config_entries.async_entries()
-        if entry_name in (entry.domain, entry.title)
-    ]
+    conf_entry = next(
+        (
+            entry.entry_id
+            for entry in hass.config_entries.async_entries()
+            if entry_name == entry.title
+        ),
+        None,
+    )
     return [
-        item.entity_id
-        for item in entity_reg.entities.values()
-        if item.config_entry_id in conf_entries
+        entity_id
+        for entity_id, info in hass.data.get("entity_info", {}).items()
+        if (conf_entry is not None and info.get("config_entry") == conf_entry)
+        or (info["domain"] == entry_name)
     ]
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1,5 +1,6 @@
 """Test Home Assistant template helper methods."""
-from datetime import datetime
+from datetime import datetime, timedelta
+import logging
 import math
 import random
 from unittest.mock import patch
@@ -18,7 +19,8 @@ from homeassistant.const import (
     VOLUME_LITERS,
 )
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import device_registry as dr, template
+from homeassistant.helpers import device_registry as dr, entity, template
+from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import UnitSystem
@@ -1837,6 +1839,44 @@ async def test_device_entities(hass):
     assert_result_info(
         info, "light.hue_5678, light.hue_abcd", ["light.hue_5678", "light.hue_abcd"]
     )
+    assert info.rate_limit is None
+
+
+async def test_integration_entities(hass):
+    """Test integration_entities function."""
+    entity_registry = mock_registry(hass)
+
+    # test entities for given config entry title
+    config_entry = MockConfigEntry(domain="mock", title="Mock bridge 2")
+    config_entry.add_to_hass(hass)
+    entity_entry = entity_registry.async_get_or_create(
+        "sensor", "mock", "test", config_entry=config_entry
+    )
+    info = render_to_info(hass, "{{ integration_entities('Mock bridge 2') }}")
+    assert_result_info(info, [entity_entry.entity_id])
+    assert info.rate_limit is None
+
+    # test integration entities not in entity registry
+    mock_entity = entity.Entity()
+    mock_entity.hass = hass
+    mock_entity.entity_id = "light.test_entity"
+    mock_entity.platform = EntityPlatform(
+        hass=hass,
+        logger=logging.getLogger(__name__),
+        domain="light",
+        platform_name="entryless_integration",
+        platform=None,
+        scan_interval=timedelta(seconds=30),
+        entity_namespace=None,
+    )
+    await mock_entity.async_internal_added_to_hass()
+    info = render_to_info(hass, "{{ integration_entities('entryless_integration') }}")
+    assert_result_info(info, ["light.test_entity"])
+    assert info.rate_limit is None
+
+    # Test non existing integration/entry title
+    info = render_to_info(hass, "{{ integration_entities('abc123') }}")
+    assert_result_info(info, [])
     assert info.rate_limit is None
 
 


### PR DESCRIPTION
## Proposed change
This adds a template extension to quickly find all entities belonging to an integration.

**examples:**

Get all entity id's for the hue integration:
`{{ integration_entities('hue')  }}`

Get all entity id's for a specific bridge/instance of the Hue platform:
`{{ integration_entities('Philips hue bridge 1')  }}`

And it will also work for integrations that are not setup with the UI, for example:
`{{ integration_entities('template')  }}`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #59820
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20371

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
