### PR TITLE
Ensure powerview setup is retried on error

### DIFF
--- a/homeassistant/components/hunterdouglas_powerview/__init__.py
+++ b/homeassistant/components/hunterdouglas_powerview/__init__.py
@@ -89,12 +89,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 (await shades.get_resources())[SHADE_DATA]
             )
     except HUB_EXCEPTIONS as err:
-        _LOGGER.error("Connection error to PowerView hub: %s", hub_address)
-        raise ConfigEntryNotReady from err
-
+        raise ConfigEntryNotReady(
+            f"Connection error to PowerView hub: {hub_address}: {err}"
+        ) from err
     if not device_info:
-        _LOGGER.error("Unable to initialize PowerView hub: %s", hub_address)
-        raise ConfigEntryNotReady
+        raise ConfigEntryNotReady(f"Unable to initialize PowerView hub: {hub_address}")
 
     async def async_update_data():
         """Fetch data from shade endpoint."""

--- a/homeassistant/components/hunterdouglas_powerview/const.py
+++ b/homeassistant/components/hunterdouglas_powerview/const.py
@@ -3,7 +3,7 @@
 import asyncio
 
 from aiohttp.client_exceptions import ServerDisconnectedError
-from aiopvapi.helpers.aiorequest import PvApiConnectionError
+from aiopvapi.helpers.aiorequest import PvApiConnectionError, PvApiResponseStatusError
 
 DOMAIN = "hunterdouglas_powerview"
 
@@ -62,7 +62,12 @@ PV_SHADE_DATA = "pv_shade_data"
 PV_ROOM_DATA = "pv_room_data"
 COORDINATOR = "coordinator"
 
-HUB_EXCEPTIONS = (ServerDisconnectedError, asyncio.TimeoutError, PvApiConnectionError)
+HUB_EXCEPTIONS = (
+    ServerDisconnectedError,
+    asyncio.TimeoutError,
+    PvApiConnectionError,
+    PvApiResponseStatusError,
+)
 
 LEGACY_DEVICE_SUB_REVISION = 1
 LEGACY_DEVICE_REVISION = 0


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes integration failing to setup on transient 502 error
```
2021-11-16 19:25:32 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry PowerView-Hub for hunterdouglas_powerview
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/config_entries.py", line 310, in async_setup
    result = await component.async_setup_entry(hass, self)  # type: ignore
  File "/Users/bdraco/home-assistant/homeassistant/components/hunterdouglas_powerview/__init__.py", line 74, in async_setup_entry
    device_info = await async_get_device_info(pv_request)
  File "/Users/bdraco/home-assistant/homeassistant/components/hunterdouglas_powerview/__init__.py", line 134, in async_get_device_info
    resources = await userdata.get_resources()
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aiopvapi/helpers/api_base.py", line 91, in get_resources
    resources = await self.request.get(self._base_path, **kwargs)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aiopvapi/helpers/aiorequest.py", line 67, in get
    return await check_response(response, [200, 204])
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/aiopvapi/helpers/aiorequest.py", line 35, in check_response
    raise PvApiResponseStatusError(response.status)
aiopvapi.helpers.aiorequest.PvApiResponseStatusError: 502
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
