### PR TITLE
Add apparent_power for ZHA ElectricalMeasurement

### DIFF
--- a/homeassistant/components/zha/core/channels/homeautomation.py
+++ b/homeassistant/components/zha/core/channels/homeautomation.py
@@ -65,6 +65,7 @@ class ElectricalMeasurementChannel(ZigbeeChannel):
     REPORT_CONFIG = (
         {"attr": "active_power", "config": REPORT_CONFIG_OP},
         {"attr": "active_power_max", "config": REPORT_CONFIG_DEFAULT},
+        {"attr": "apparent_power", "config": REPORT_CONFIG_OP},
         {"attr": "rms_current", "config": REPORT_CONFIG_OP},
         {"attr": "rms_current_max", "config": REPORT_CONFIG_DEFAULT},
         {"attr": "rms_voltage", "config": REPORT_CONFIG_OP},

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -38,6 +38,7 @@ from homeassistant.const import (
     ENTITY_CATEGORY_DIAGNOSTIC,
     LIGHT_LUX,
     PERCENTAGE,
+    POWER_VOLT_AMPERE,
     POWER_WATT,
     PRESSURE_HPA,
     TEMP_CELSIUS,
@@ -311,6 +312,23 @@ class ElectricalMeasurement(Sensor):
         if not self.available:
             return
         await super().async_update()
+
+
+@MULTI_MATCH(channel_names=CHANNEL_ELECTRICAL_MEASUREMENT)
+class ElectricalMeasurementApparentPower(
+    ElectricalMeasurement, id_suffix="apparent_power"
+):
+    """Apparent power measurement."""
+
+    SENSOR_ATTR = "apparent_power"
+    _device_class = DEVICE_CLASS_POWER
+    _unit = POWER_VOLT_AMPERE
+    _div_mul_prefix = "ac_power"
+
+    @property
+    def should_poll(self) -> bool:
+        """Poll indirectly by ElectricalMeasurementSensor."""
+        return False
 
 
 @MULTI_MATCH(channel_names=CHANNEL_ELECTRICAL_MEASUREMENT)

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -158,6 +158,7 @@ async def poll_control_device(zha_device_restored, zigpy_device_mock):
             {
                 "active_power",
                 "active_power_max",
+                "apparent_power",
                 "rms_current",
                 "rms_current_max",
                 "rms_voltage",

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     LIGHT_LUX,
     PERCENTAGE,
+    POWER_VOLT_AMPERE,
     POWER_WATT,
     PRESSURE_HPA,
     STATE_UNAVAILABLE,
@@ -174,6 +175,24 @@ async def async_test_electrical_measurement(hass, cluster, entity_id):
     assert hass.states.get(entity_id).attributes["active_power_max"] == "8.8"
 
 
+async def async_test_em_apparent_power(hass, cluster, entity_id):
+    """Test electrical measurement Apparent Power sensor."""
+    # update divisor cached value
+    await send_attributes_report(hass, cluster, {"ac_power_divisor": 1})
+    await send_attributes_report(hass, cluster, {0: 1, 0x050F: 100, 10: 1000})
+    assert_state(hass, entity_id, "100", POWER_VOLT_AMPERE)
+
+    await send_attributes_report(hass, cluster, {0: 1, 0x050F: 99, 10: 1000})
+    assert_state(hass, entity_id, "99", POWER_VOLT_AMPERE)
+
+    await send_attributes_report(hass, cluster, {"ac_power_divisor": 10})
+    await send_attributes_report(hass, cluster, {0: 1, 0x050F: 1000, 10: 5000})
+    assert_state(hass, entity_id, "100", POWER_VOLT_AMPERE)
+
+    await send_attributes_report(hass, cluster, {0: 1, 0x050F: 99, 10: 5000})
+    assert_state(hass, entity_id, "9.9", POWER_VOLT_AMPERE)
+
+
 async def async_test_em_rms_current(hass, cluster, entity_id):
     """Test electrical measurement RMS Current sensor."""
 
@@ -292,7 +311,15 @@ async def async_test_powerconfiguration(hass, cluster, entity_id):
             async_test_electrical_measurement,
             7,
             {"ac_power_divisor": 1000, "ac_power_multiplier": 1},
-            {"rms_current", "rms_voltage"},
+            {"apparent_power", "rms_current", "rms_voltage"},
+        ),
+        (
+            homeautomation.ElectricalMeasurement.cluster_id,
+            "electrical_measurement_apparent_power",
+            async_test_em_apparent_power,
+            7,
+            {"ac_power_divisor": 1000, "ac_power_multiplier": 1},
+            {"active_power", "rms_current", "rms_voltage"},
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
@@ -300,7 +327,7 @@ async def async_test_powerconfiguration(hass, cluster, entity_id):
             async_test_em_rms_current,
             7,
             {"ac_current_divisor": 1000, "ac_current_multiplier": 1},
-            {"active_power", "rms_voltage"},
+            {"active_power", "apparent_power", "rms_voltage"},
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
@@ -308,7 +335,7 @@ async def async_test_powerconfiguration(hass, cluster, entity_id):
             async_test_em_rms_voltage,
             7,
             {"ac_voltage_divisor": 10, "ac_voltage_multiplier": 1},
-            {"active_power", "rms_current"},
+            {"active_power", "apparent_power", "rms_current"},
         ),
         (
             general.PowerConfiguration.cluster_id,

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -580,14 +580,14 @@ async def test_electrical_measurement_init(
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
-            set(),  # {"apparent_power"},  # set(),
+            set(),
             {
                 "electrical_measurement_rms_voltage",
                 "electrical_measurement",
                 "electrical_measurement_apparent_power",
                 "electrical_measurement_rms_current",
             },
-            set(),  # {"electrical_measurement_apparent_power"},  # set(),
+            set(),
         ),
         (
             smartenergy.Metering.cluster_id,

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -290,7 +290,7 @@ async def async_test_powerconfiguration(hass, cluster, entity_id):
             homeautomation.ElectricalMeasurement.cluster_id,
             "electrical_measurement",
             async_test_electrical_measurement,
-            6,
+            7,
             {"ac_power_divisor": 1000, "ac_power_multiplier": 1},
             {"rms_current", "rms_voltage"},
         ),
@@ -298,7 +298,7 @@ async def async_test_powerconfiguration(hass, cluster, entity_id):
             homeautomation.ElectricalMeasurement.cluster_id,
             "electrical_measurement_rms_current",
             async_test_em_rms_current,
-            6,
+            7,
             {"ac_current_divisor": 1000, "ac_current_multiplier": 1},
             {"active_power", "rms_voltage"},
         ),
@@ -306,7 +306,7 @@ async def async_test_powerconfiguration(hass, cluster, entity_id):
             homeautomation.ElectricalMeasurement.cluster_id,
             "electrical_measurement_rms_voltage",
             async_test_em_rms_voltage,
-            6,
+            7,
             {"ac_voltage_divisor": 10, "ac_voltage_multiplier": 1},
             {"active_power", "rms_current"},
         ),
@@ -561,28 +561,33 @@ async def test_electrical_measurement_init(
     (
         (
             homeautomation.ElectricalMeasurement.cluster_id,
-            {"rms_voltage", "rms_current"},
+            {"apparent_power", "rms_voltage", "rms_current"},
             {"electrical_measurement"},
             {
+                "electrical_measurement_apparent_power",
                 "electrical_measurement_rms_voltage",
                 "electrical_measurement_rms_current",
             },
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
-            {"rms_current"},
+            {"apparent_power", "rms_current"},
             {"electrical_measurement_rms_voltage", "electrical_measurement"},
-            {"electrical_measurement_rms_current"},
+            {
+                "electrical_measurement_apparent_power",
+                "electrical_measurement_rms_current",
+            },
         ),
         (
             homeautomation.ElectricalMeasurement.cluster_id,
-            set(),
+            set(),  # {"apparent_power"},  # set(),
             {
                 "electrical_measurement_rms_voltage",
                 "electrical_measurement",
+                "electrical_measurement_apparent_power",
                 "electrical_measurement_rms_current",
             },
-            set(),
+            set(),  # {"electrical_measurement_apparent_power"},  # set(),
         ),
         (
             smartenergy.Metering.cluster_id,
@@ -853,6 +858,7 @@ async def test_elec_measurement_skip_unsupported_attribute(
     all_attrs = {
         "active_power",
         "active_power_max",
+        "apparent_power",
         "rms_current",
         "rms_current_max",
         "rms_voltage",

--- a/tests/components/zha/zha_devices_list.py
+++ b/tests/components/zha/zha_devices_list.py
@@ -117,6 +117,8 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.centralite_3210_l_77665544_electrical_measurement",
+            "sensor.centralite_3210_l_77665544_electrical_measurement_apparent_power",
+            "sensor.centralite_3210_l_77665544_electrical_measurement_apparent_power",
             "sensor.centralite_3210_l_77665544_electrical_measurement_rms_current",
             "sensor.centralite_3210_l_77665544_electrical_measurement_rms_voltage",
             "sensor.centralite_3210_l_77665544_smartenergy_metering",
@@ -143,6 +145,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.centralite_3210_l_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -1448,6 +1455,7 @@ DEVICES = [
             "sensor.lumi_lumi_plug_maus01_77665544_analog_input",
             "sensor.lumi_lumi_plug_maus01_77665544_analog_input_2",
             "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement",
+            "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_apparent_power",
             "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_rms_current",
             "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_rms_voltage",
             "switch.lumi_lumi_plug_maus01_77665544_on_off",
@@ -1472,6 +1480,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_plug_maus01_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -1517,6 +1530,7 @@ DEVICES = [
             "light.lumi_lumi_relay_c2acn01_77665544_on_off",
             "light.lumi_lumi_relay_c2acn01_77665544_on_off_2",
             "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement",
+            "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement_apparent_power",
             "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement_rms_current",
             "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement_rms_voltage",
         ],
@@ -1530,6 +1544,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.lumi_lumi_relay_c2acn01_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -2602,6 +2621,7 @@ DEVICES = [
         DEV_SIG_ENTITIES: [
             "light.osram_lightify_rt_tunable_white_77665544_level_light_color_on_off",
             "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement",
+            "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement_apparent_power",
             "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement_rms_current",
             "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement_rms_voltage",
         ],
@@ -2615,6 +2635,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-3-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.osram_lightify_rt_tunable_white_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-3-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -2646,6 +2671,7 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.osram_plug_01_77665544_electrical_measurement",
+            "sensor.osram_plug_01_77665544_electrical_measurement_apparent_power",
             "sensor.osram_plug_01_77665544_electrical_measurement_rms_current",
             "sensor.osram_plug_01_77665544_electrical_measurement_rms_voltage",
             "switch.osram_plug_01_77665544_on_off",
@@ -2660,6 +2686,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.osram_plug_01_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-3-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.osram_plug_01_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-3-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -2930,6 +2961,7 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.securifi_ltd_unk_model_77665544_electrical_measurement",
+            "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_apparent_power",
             "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_rms_current",
             "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_rms_voltage",
             "switch.securifi_ltd_unk_model_77665544_on_off",
@@ -2944,6 +2976,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.securifi_ltd_unk_model_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.securifi_ltd_unk_model_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -3020,6 +3057,7 @@ DEVICES = [
         DEV_SIG_ENTITIES: [
             "light.sercomm_corp_sz_esw01_77665544_on_off",
             "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement",
+            "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_apparent_power",
             "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_rms_current",
             "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_rms_voltage",
             "sensor.sercomm_corp_sz_esw01_77665544_smartenergy_metering",
@@ -3045,6 +3083,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.sercomm_corp_sz_esw01_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -3119,6 +3162,7 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement",
+            "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_apparent_power",
             "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_rms_current",
             "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_rms_voltage",
             "switch.sinope_technologies_rm3250zb_77665544_on_off",
@@ -3133,6 +3177,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_rm3250zb_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -3171,6 +3220,7 @@ DEVICES = [
         DEV_SIG_ENTITIES: [
             "climate.sinope_technologies_th1123zb_77665544_thermostat",
             "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement",
+            "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_apparent_power",
             "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_rms_current",
             "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_rms_voltage",
             "sensor.sinope_technologies_th1123zb_77665544_temperature",
@@ -3191,6 +3241,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -3234,6 +3289,7 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement",
+            "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_apparent_power",
             "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_rms_current",
             "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_rms_voltage",
             "sensor.sinope_technologies_th1124zb_77665544_temperature",
@@ -3260,6 +3316,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1124zb_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
@@ -3291,6 +3352,7 @@ DEVICES = [
         },
         DEV_SIG_ENTITIES: [
             "sensor.smartthings_outletv4_77665544_electrical_measurement",
+            "sensor.smartthings_outletv4_77665544_electrical_measurement_apparent_power",
             "sensor.smartthings_outletv4_77665544_electrical_measurement_rms_current",
             "sensor.smartthings_outletv4_77665544_electrical_measurement_rms_voltage",
             "switch.smartthings_outletv4_77665544_on_off",
@@ -3305,6 +3367,11 @@ DEVICES = [
                 DEV_SIG_CHANNELS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurement",
                 DEV_SIG_ENT_MAP_ID: "sensor.smartthings_outletv4_77665544_electrical_measurement",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
+                DEV_SIG_CHANNELS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: "sensor.smartthings_outletv4_77665544_electrical_measurement_apparent_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
                 DEV_SIG_CHANNELS: ["electrical_measurement"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This Pull Request adds sensors for apparent power (in Volt-Ampere) which is different from active power (in Watt), which is already added.
This will allow user to see power reports from smart energy meters such as the french Linky, through TIC modules.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This Pull Request adds sensors for apparent power (in Volt-Ampere) which is different from active power (in Watt).
- I have tested locally with a [ZLinky_TIC](https://lixee.fr/produits/37-zigate-usb-ttl-3770014375148.html) and confirmed it is working.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
