### PR TITLE
Add additional statistics characteristics, remove attributes

### DIFF
--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -330,8 +330,11 @@ class StatisticsSensor(SensorEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
+        extra_attr = {}
+        if self._samples_max_age is not None:
+            extra_attr = {STAT_AGE_COVERAGE_RATIO: self.attr[STAT_AGE_COVERAGE_RATIO]}
         return {
-            STAT_AGE_COVERAGE_RATIO: self.attr[STAT_AGE_COVERAGE_RATIO],
+            **extra_attr,
             STAT_BUFFER_USAGE_RATIO: self.attr[STAT_BUFFER_USAGE_RATIO],
             STAT_SOURCE_VALUE_VALID: self._source_value_valid,
         }

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -226,7 +226,7 @@ class StatisticsSensor(SensorEntity):
     def _add_state_to_queue(self, new_state):
         """Add the state to the queue."""
         self._available = new_state.state != STATE_UNAVAILABLE
-        if new_state.state in (STATE_UNAVAILABLE):
+        if new_state.state == STATE_UNAVAILABLE:
             self._source_value_valid = None
             return
         if new_state.state in (STATE_UNKNOWN, None):

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -41,7 +41,9 @@ STAT_BUFFER_USAGE_RATIO = "buffer_usage_ratio"
 STAT_CHANGE = "change"
 STAT_CHANGE_RATE = "change_rate"
 STAT_COUNT = "count"
-STAT_DIFFERENCE = "difference"
+STAT_DISTANCE_95P = "distance_95_percent_of_values"
+STAT_DISTANCE_99P = "distance_99_percent_of_values"
+STAT_DISTANCE_ABSOLUTE = "distance_absolute"
 STAT_MAX_AGE = "max_age"
 STAT_MAX_VALUE = "max_value"
 STAT_MEAN = "mean"
@@ -87,7 +89,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 STAT_CHANGE_RATE,
                 STAT_CHANGE,
                 STAT_COUNT,
-                STAT_DIFFERENCE,
+                STAT_DISTANCE_95P,
+                STAT_DISTANCE_99P,
+                STAT_DISTANCE_ABSOLUTE,
                 STAT_MAX_AGE,
                 STAT_MAX_VALUE,
                 STAT_MEAN,
@@ -178,13 +182,15 @@ class StatisticsSensor(SensorEntity):
             STAT_VARIANCE: STATE_UNKNOWN,
             STAT_MIN_VALUE: STATE_UNKNOWN,
             STAT_MAX_VALUE: STATE_UNKNOWN,
-            STAT_DIFFERENCE: STATE_UNKNOWN,
+            STAT_DISTANCE_ABSOLUTE: STATE_UNKNOWN,
             STAT_MIN_AGE: STATE_UNKNOWN,
             STAT_MAX_AGE: STATE_UNKNOWN,
             STAT_AGE_RANGE: STATE_UNKNOWN,
             STAT_CHANGE: STATE_UNKNOWN,
             STAT_AVERAGE_CHANGE: STATE_UNKNOWN,
             STAT_CHANGE_RATE: STATE_UNKNOWN,
+            STAT_DISTANCE_95P: STATE_UNKNOWN,
+            STAT_DISTANCE_99P: STATE_UNKNOWN,
             STAT_NOISINESS: STATE_UNKNOWN,
             STAT_QUANTILES: STATE_UNKNOWN,
         }
@@ -249,7 +255,9 @@ class StatisticsSensor(SensorEntity):
             unit = None
         elif self._state_characteristic in (
             STAT_CHANGE,
-            STAT_DIFFERENCE,
+            STAT_DISTANCE_95P,
+            STAT_DISTANCE_99P,
+            STAT_DISTANCE_ABSOLUTE,
             STAT_MAX_VALUE,
             STAT_MEAN,
             STAT_MEDIAN,
@@ -383,9 +391,13 @@ class StatisticsSensor(SensorEntity):
         if states_count >= 2:
             self.attr[STAT_STANDARD_DEVIATION] = statistics.stdev(self.states)
             self.attr[STAT_VARIANCE] = statistics.variance(self.states)
+            self.attr[STAT_DISTANCE_95P] = 2 * 1.96 * self.attr[STAT_STANDARD_DEVIATION]
+            self.attr[STAT_DISTANCE_99P] = 2 * 2.58 * self.attr[STAT_STANDARD_DEVIATION]
         else:
             self.attr[STAT_STANDARD_DEVIATION] = STATE_UNKNOWN
             self.attr[STAT_VARIANCE] = STATE_UNKNOWN
+            self.attr[STAT_DISTANCE_95P] = STATE_UNKNOWN
+            self.attr[STAT_DISTANCE_99P] = STATE_UNKNOWN
 
         if states_count >= 2:
             self.attr[STAT_NOISINESS] = sum(
@@ -411,7 +423,7 @@ class StatisticsSensor(SensorEntity):
             self.attr[STAT_MEDIAN] = STATE_UNKNOWN
             self.attr[STAT_TOTAL] = STATE_UNKNOWN
             self.attr[STAT_MIN_VALUE] = self.attr[STAT_MAX_VALUE] = STATE_UNKNOWN
-            self.attr[STAT_DIFFERENCE] = STATE_UNKNOWN
+            self.attr[STAT_DISTANCE_ABSOLUTE] = STATE_UNKNOWN
             self.attr[STAT_MIN_AGE] = self.attr[STAT_MAX_AGE] = STATE_UNKNOWN
             self.attr[STAT_AGE_RANGE] = STATE_UNKNOWN
             self.attr[STAT_CHANGE] = self.attr[STAT_AVERAGE_CHANGE] = STATE_UNKNOWN
@@ -426,7 +438,7 @@ class StatisticsSensor(SensorEntity):
         self.attr[STAT_TOTAL] = sum(self.states)
         self.attr[STAT_MIN_VALUE] = min(self.states)
         self.attr[STAT_MAX_VALUE] = max(self.states)
-        self.attr[STAT_DIFFERENCE] = (
+        self.attr[STAT_DISTANCE_ABSOLUTE] = (
             self.attr[STAT_MAX_VALUE] - self.attr[STAT_MIN_VALUE]
         )
 

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -34,8 +34,8 @@ from . import DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
+STAT_AGE_COVERAGE_RATIO = "age_coverage_ratio"
 STAT_AGE_RANGE = "age_range"
-STAT_AGE_USAGE_RATIO = "age_usage_ratio"
 STAT_AVERAGE_CHANGE = "average_change"
 STAT_BUFFER_USAGE_RATIO = "buffer_usage_ratio"
 STAT_CHANGE = "change"
@@ -80,12 +80,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_STATE_CHARACTERISTIC, default=STAT_MEAN): vol.In(
             [
+                STAT_AGE_COVERAGE_RATIO,
                 STAT_AGE_RANGE,
-                STAT_AGE_USAGE_RATIO,
                 STAT_AVERAGE_CHANGE,
                 STAT_BUFFER_USAGE_RATIO,
-                STAT_CHANGE,
                 STAT_CHANGE_RATE,
+                STAT_CHANGE,
                 STAT_COUNT,
                 STAT_DIFFERENCE,
                 STAT_MAX_AGE,
@@ -168,7 +168,7 @@ class StatisticsSensor(SensorEntity):
         self.states = deque(maxlen=self._samples_max_buffer_size)
         self.ages = deque(maxlen=self._samples_max_buffer_size)
         self.attr = {
-            STAT_AGE_USAGE_RATIO: STATE_UNKNOWN,
+            STAT_AGE_COVERAGE_RATIO: STATE_UNKNOWN,
             STAT_BUFFER_USAGE_RATIO: STATE_UNKNOWN,
             STAT_COUNT: STATE_UNKNOWN,
             STAT_TOTAL: STATE_UNKNOWN,
@@ -269,7 +269,7 @@ class StatisticsSensor(SensorEntity):
         elif self._state_characteristic in (STAT_AGE_RANGE,):
             unit = "s"
         elif self._state_characteristic in (
-            STAT_AGE_USAGE_RATIO,
+            STAT_AGE_COVERAGE_RATIO,
             STAT_BUFFER_USAGE_RATIO,
         ):
             unit = "%"
@@ -416,7 +416,7 @@ class StatisticsSensor(SensorEntity):
             self.attr[STAT_AGE_RANGE] = STATE_UNKNOWN
             self.attr[STAT_CHANGE] = self.attr[STAT_AVERAGE_CHANGE] = STATE_UNKNOWN
             self.attr[STAT_CHANGE_RATE] = STATE_UNKNOWN
-            self.attr[STAT_AGE_USAGE_RATIO] = STATE_UNKNOWN
+            self.attr[STAT_AGE_COVERAGE_RATIO] = STATE_UNKNOWN
             self.attr[STAT_BUFFER_USAGE_RATIO] = 0
             return
 
@@ -450,11 +450,11 @@ class StatisticsSensor(SensorEntity):
         self.attr[STAT_CHANGE_RATE] = self.attr[STAT_CHANGE_RATE]
 
         if self._samples_max_age is not None:
-            self.attr[STAT_AGE_USAGE_RATIO] = (
+            self.attr[STAT_AGE_COVERAGE_RATIO] = (
                 100 * self.attr[STAT_AGE_RANGE] / self._samples_max_age.total_seconds()
             )
         else:
-            self.attr[STAT_AGE_USAGE_RATIO] = STATE_UNKNOWN
+            self.attr[STAT_AGE_COVERAGE_RATIO] = STATE_UNKNOWN
         self.attr[STAT_BUFFER_USAGE_RATIO] = (
             100 * self.attr[STAT_COUNT] / self._samples_max_buffer_size
         )

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -526,11 +526,10 @@ class StatisticsSensor(SensorEntity):
         return STATE_UNKNOWN
 
     def _stat_change_second(self):
-        if len(self.states) <= 1:
-            return STATE_UNKNOWN
-        age_range_seconds = (self.ages[-1] - self.ages[0]).total_seconds()
-        if age_range_seconds > 0:
-            return (self.states[-1] - self.states[0]) / age_range_seconds
+        if len(self.states) > 1:
+            age_range_seconds = (self.ages[-1] - self.ages[0]).total_seconds()
+            if age_range_seconds > 0:
+                return (self.states[-1] - self.states[0]) / age_range_seconds
         return STATE_UNKNOWN
 
     def _stat_count(self):

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -145,7 +145,7 @@ class TestStatisticsSensor(unittest.TestCase):
         assert self.average_change == state.attributes.get("average_change")
         assert self.noisiness == state.attributes.get("noisiness")
 
-        assert state.attributes.get("age_usage_ratio") == STATE_UNKNOWN
+        assert state.attributes.get("age_coverage_ratio") == STATE_UNKNOWN
 
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
         assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
@@ -305,7 +305,7 @@ class TestStatisticsSensor(unittest.TestCase):
         assert state.attributes.get("min_value") == 6
         assert state.attributes.get("max_value") == 14
         assert state.attributes.get("age_range") == (3 - 1) * 60
-        assert state.attributes.get("age_usage_ratio") == 100 / 150 * 120
+        assert state.attributes.get("age_coverage_ratio") == 100 / 150 * 120
         assert state.attributes.get("buffer_usage_ratio") == 100 / 20 * 3
 
     def test_max_age_without_sensor_change(self):

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -45,12 +45,14 @@ class TestStatisticsSensor(unittest.TestCase):
         self.count = len(self.values)
         self.min = min(self.values)
         self.max = max(self.values)
-        self.difference = self.max - self.min
+        self.distance_abs = self.max - self.min
         self.total = sum(self.values)
         self.mean = round(sum(self.values) / len(self.values), 2)
         self.median = round(statistics.median(self.values), 2)
         self.deviation = round(statistics.stdev(self.values), 2)
         self.variance = round(statistics.variance(self.values), 2)
+        self.distance_95p = round(2 * 1.96 * statistics.stdev(self.values), 2)
+        self.distance_99p = round(2 * 2.58 * statistics.stdev(self.values), 2)
         self.quantiles = [
             round(quantile, 2) for quantile in statistics.quantiles(self.values)
         ]
@@ -133,7 +135,13 @@ class TestStatisticsSensor(unittest.TestCase):
         assert str(self.mean) == state.state
         assert self.min == state.attributes.get("min_value")
         assert self.max == state.attributes.get("max_value")
-        assert self.difference == state.attributes.get("difference")
+        assert self.distance_abs == state.attributes.get("distance_absolute")
+        assert self.distance_95p == state.attributes.get(
+            "distance_95_percent_of_values"
+        )
+        assert self.distance_99p == state.attributes.get(
+            "distance_99_percent_of_values"
+        )
         assert self.variance == state.attributes.get("variance")
         assert self.median == state.attributes.get("median")
         assert self.deviation == state.attributes.get("standard_deviation")

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -101,9 +101,9 @@ class TestStatisticsSensor(unittest.TestCase):
         assert state.state == str(len(values))
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
         assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
-        assert state.attributes.get("age_coverage_ratio") == STATE_UNKNOWN
         assert state.attributes.get("buffer_usage_ratio") == round(7 / 20, 2)
         assert state.attributes.get("source_value_valid") is True
+        assert "age_coverage_ratio" not in state.attributes
 
         state = self.hass.states.get("sensor.test_unitless")
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
@@ -140,9 +140,9 @@ class TestStatisticsSensor(unittest.TestCase):
         assert state.state == str(self.mean)
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
         assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
-        assert state.attributes.get("age_coverage_ratio") == STATE_UNKNOWN
         assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
         assert state.attributes.get("source_value_valid") is True
+        assert "age_coverage_ratio" not in state.attributes
 
         # Source sensor turns unavailable, then available with valid value,
         # statistics sensor should follow
@@ -309,8 +309,8 @@ class TestStatisticsSensor(unittest.TestCase):
             state = self.hass.states.get("sensor.test")
             new_mean = round(sum(self.values[-5:]) / len(self.values[-5:]), 2)
             assert state.state == str(new_mean)
-            assert state.attributes.get("age_coverage_ratio") == 1.0
             assert state.attributes.get("buffer_usage_ratio") == round(5 / 20, 2)
+            assert state.attributes.get("age_coverage_ratio") == 1.0
 
             # Values expire over time. Only two are left
 
@@ -321,8 +321,8 @@ class TestStatisticsSensor(unittest.TestCase):
             state = self.hass.states.get("sensor.test")
             new_mean = round(sum(self.values[-2:]) / len(self.values[-2:]), 2)
             assert state.state == str(new_mean)
-            assert state.attributes.get("age_coverage_ratio") == 1 / 4
             assert state.attributes.get("buffer_usage_ratio") == round(2 / 20, 2)
+            assert state.attributes.get("age_coverage_ratio") == 1 / 4
 
             # Values expire over time. Only one is left
 
@@ -333,8 +333,8 @@ class TestStatisticsSensor(unittest.TestCase):
             state = self.hass.states.get("sensor.test")
             new_mean = float(self.values[-1])
             assert state.state == str(new_mean)
-            assert state.attributes.get("age_coverage_ratio") == 0
             assert state.attributes.get("buffer_usage_ratio") == round(1 / 20, 2)
+            assert state.attributes.get("age_coverage_ratio") == 0
 
             # Values expire over time. Memory is empty
 
@@ -344,8 +344,8 @@ class TestStatisticsSensor(unittest.TestCase):
 
             state = self.hass.states.get("sensor.test")
             assert state.state == STATE_UNKNOWN
-            assert state.attributes.get("age_coverage_ratio") == STATE_UNKNOWN
             assert state.attributes.get("buffer_usage_ratio") == round(0 / 20, 2)
+            assert state.attributes.get("age_coverage_ratio") == STATE_UNKNOWN
 
     def test_precision_0(self):
         """Test correct result with precision=0 as integer."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Statistic characteristics are no longer available as state attributes, hence users will need to adapt their configuration by adding sensors exposing the wanted characteristics. Additional template sensors to expose attributes are not necessary anymore.

The following state attributes have been removed and are now available through the configuration parameter `state_characteristic`:
`sampling_size`, `count`, `mean`, `median`, `quantiles`, `standard_deviation`, `variance`, `total`, `min_value`, `max_value`, `min_age`, `max_age`, `change`, `average_change`, `change_rate`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a few new values/attributes to the statistics sensor.
Statistic characteristics are no longer available as attributes, hence users will need to adapt their configuration.

**Attributes:**
* All characteristic attributes are removed, see the breaking change section for details
* Added `age_coverage_ratio`
* Added `buffer_usage_ratio`
* Added `source_value_valid`

**Characteristics:**
* Added `average_linear`
* Added `average_step`
* Added `average_timeless`
* Added `distance_absolute`
* Added `distance_95_percent_of_values`
* Added `distance_99_percent_of_values`
* Added `noisiness`
* Renamed `average_change` to `change_sample`
* Renamed `change_rate` to `change_second`
* Renamed `max_age` to `datetime_newest`
* Renamed `min_age` to `datetime_oldest`
* Renamed `max_value` to `value_max`
* Renamed `min_value` to `value_min`
* the mathematical results of old and renamed characteristics are unchanged.

All attributes and characteristics are documented in the [docu PR](https://github.com/home-assistant/home-assistant.io/pull/20347).

**Rationale for renaming:** Some old names (like `max_age`) were ambiguous. Also, as this is a breaking change, users will need to reconfigure their `statistics` sensors, look at documentation and build a new valid setup. A better opportunity to deal with this won't come up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20347

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
