### PR TITLE
Import `greeneye_monitor` config entry from YAML

### DIFF
--- a/homeassistant/components/greeneye_monitor/__init__.py
+++ b/homeassistant/components/greeneye_monitor/__init__.py
@@ -140,7 +140,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_monitors)
 
-    hass.create_task(
+    hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
     )
 

--- a/homeassistant/components/greeneye_monitor/config_flow.py
+++ b/homeassistant/components/greeneye_monitor/config_flow.py
@@ -1,0 +1,26 @@
+"""Config flows for greeneye_monitor."""
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.const import CONF_PORT
+from homeassistant.helpers.typing import DiscoveryInfoType
+
+from .const import CONF_MONITORS, DOMAIN
+
+
+class GreeneyeMonitorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Config flow for greeneye_monitor."""
+
+    async def async_step_import(
+        self, discovery_info: DiscoveryInfoType
+    ) -> data_entry_flow.FlowResult:
+        """Create a config entry from YAML configuration."""
+        data = {CONF_PORT: discovery_info[CONF_PORT]}
+        options = {CONF_MONITORS: discovery_info[CONF_MONITORS]}
+        if entry := await self.async_set_unique_id(DOMAIN):
+            self.hass.config_entries.async_update_entry(
+                entry, data=data, options=options
+            )
+            self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title="GreenEye Monitor", data=data, options=options
+        )

--- a/homeassistant/components/greeneye_monitor/const.py
+++ b/homeassistant/components/greeneye_monitor/const.py
@@ -1,9 +1,8 @@
-"""Shared constants for the greeneye_monitor integration."""
+"""Constants for the greeneye_monitor component."""
 
 CONF_CHANNELS = "channels"
 CONF_COUNTED_QUANTITY = "counted_quantity"
 CONF_COUNTED_QUANTITY_PER_PULSE = "counted_quantity_per_pulse"
-CONF_MONITOR_SERIAL_NUMBER = "monitor"
 CONF_MONITORS = "monitors"
 CONF_NET_METERING = "net_metering"
 CONF_NUMBER = "number"
@@ -14,11 +13,7 @@ CONF_TIME_UNIT = "time_unit"
 CONF_VOLTAGE_SENSORS = "voltage"
 
 DATA_GREENEYE_MONITOR = "greeneye_monitor"
-DOMAIN = "greeneye_monitor"
 
-SENSOR_TYPE_CURRENT = "current_sensor"
-SENSOR_TYPE_PULSE_COUNTER = "pulse_counter"
-SENSOR_TYPE_TEMPERATURE = "temperature_sensor"
-SENSOR_TYPE_VOLTAGE = "voltage_sensor"
+DOMAIN = "greeneye_monitor"
 
 TEMPERATURE_UNIT_CELSIUS = "C"

--- a/homeassistant/components/greeneye_monitor/const.py
+++ b/homeassistant/components/greeneye_monitor/const.py
@@ -1,4 +1,4 @@
-"""Constants for the greeneye_monitor component."""
+"""Shared constants for the greeneye_monitor integration."""
 
 CONF_CHANNELS = "channels"
 CONF_COUNTED_QUANTITY = "counted_quantity"

--- a/homeassistant/components/greeneye_monitor/manifest.json
+++ b/homeassistant/components/greeneye_monitor/manifest.json
@@ -11,5 +11,6 @@
   "iot_class": "local_push",
   "loggers": [
     "greeneye"
-  ]
+  ],
+  "config_flow": true
 }

--- a/homeassistant/components/greeneye_monitor/sensor.py
+++ b/homeassistant/components/greeneye_monitor/sensor.py
@@ -6,6 +6,7 @@ from typing import Any, Union
 import greeneye
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_NAME,
     CONF_SENSORS,
@@ -18,7 +19,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import (
     CONF_CHANNELS,
@@ -43,17 +43,13 @@ UNIT_WATTS = POWER_WATT
 COUNTER_ICON = "mdi:counter"
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
+    config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up a single GEM temperature sensor."""
-    if not discovery_info:
-        return
-
-    monitor_configs = discovery_info[CONF_MONITORS]
+    """Set up GEM sensors from the config entry."""
+    monitor_configs = config_entry.options[CONF_MONITORS]
 
     def on_new_monitor(monitor: greeneye.monitor.Monitor) -> None:
         monitor_config = next(

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -127,6 +127,7 @@ FLOWS = [
     "google_travel_time",
     "gpslogger",
     "gree",
+    "greeneye_monitor",
     "growatt_server",
     "guardian",
     "habitica",

--- a/tests/components/greeneye_monitor/common.py
+++ b/tests/components/greeneye_monitor/common.py
@@ -46,7 +46,6 @@ def make_single_monitor_config_with_sensors(sensors: dict[str, Any]) -> dict[str
     }
 
 
-SINGLE_MONITOR_CONFIG_NO_SENSORS = make_single_monitor_config_with_sensors({})
 SINGLE_MONITOR_CONFIG_PULSE_COUNTERS = make_single_monitor_config_with_sensors(
     {
         CONF_PULSE_COUNTERS: [

--- a/tests/components/greeneye_monitor/common.py
+++ b/tests/components/greeneye_monitor/common.py
@@ -28,6 +28,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 
+from tests.common import assert_setup_component
+
 SINGLE_MONITOR_SERIAL_NUMBER = 110011
 
 
@@ -161,14 +163,17 @@ async def setup_greeneye_monitor_component_with_config(
     hass: HomeAssistant, config: ConfigType
 ) -> bool:
     """Set up the greeneye_monitor component with the given config. Return True if successful, False otherwise."""
-    result = await async_setup_component(
-        hass,
-        DOMAIN,
-        config,
-    )
-    await hass.async_block_till_done()
+    with assert_setup_component(2, DOMAIN):
+        result = await async_setup_component(
+            hass,
+            DOMAIN,
+            config,
+        )
+        await hass.async_block_till_done()
 
-    return result
+        assert f"sensor.{DOMAIN}" in hass.config.components
+
+        return result
 
 
 def mock_with_listeners() -> MagicMock:

--- a/tests/components/greeneye_monitor/test_init.py
+++ b/tests/components/greeneye_monitor/test_init.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-import pytest
-
 from homeassistant.components.greeneye_monitor import (
     CONF_MONITORS,
     CONFIG_SCHEMA,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is part of a series of pull requests aiming to support the energy dashboard and long-term statistics in the greeneye_monitor component (tracking issue: #55112).

This PR is the first of two that will migrate this integration from YAML config to a UI config flow, which is required by Home Assistant policy before I can make the configuration changes necessary to support the energy dashboard and long-term statistics.

With this PR, the `greeneye_monitor` integration will import its YAML configuration into a
config entry on startup, then drive the rest of component setup from the config entry.
Thus from the user's point of view the component is still configured via YAML, but it 
will now appear in the integrations screen along with components that were configured using
config flows. Once this PR is merged, I will put up another to add a real UI config flow. Then in a few releases I'll remove the YAML importing support.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
