### PR TITLE
Update minio dependency to 5.0.10

### DIFF
--- a/homeassistant/components/minio/manifest.json
+++ b/homeassistant/components/minio/manifest.json
@@ -2,7 +2,7 @@
   "domain": "minio",
   "name": "Minio",
   "documentation": "https://www.home-assistant.io/integrations/minio",
-  "requirements": ["minio==4.0.9"],
+  "requirements": ["minio==5.0.10"],
   "codeowners": ["@tkislan"],
   "iot_class": "cloud_push"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1014,7 +1014,7 @@ miflora==0.7.0
 millheater==0.8.0
 
 # homeassistant.components.minio
-minio==4.0.9
+minio==5.0.10
 
 # homeassistant.components.mitemp_bt
 mitemp_bt==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -612,7 +612,7 @@ micloud==0.4
 millheater==0.8.0
 
 # homeassistant.components.minio
-minio==4.0.9
+minio==5.0.10
 
 # homeassistant.components.motion_blinds
 motionblinds==0.5.8


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/threading.py", line 973, in _bootstrap_inner
    self.run()
  File "/usr/src/homeassistant/homeassistant/components/minio/minio_helper.py", line 121, in run
    minio_client = create_minio_client(
  File "/usr/src/homeassistant/homeassistant/components/minio/minio_helper.py", line 38, in create_minio_client
    return Minio(endpoint, access_key, secret_key, secure)
  File "/usr/local/lib/python3.9/site-packages/minio/api.py", line 143, in __init__
    is_valid_endpoint(endpoint)
  File "/usr/local/lib/python3.9/site-packages/minio/helpers.py", line 292, in is_valid_endpoint
    raise InvalidEndpointError('Hostname cannot have a scheme.')
minio.error.InvalidEndpointError: InvalidEndpointError: message: Hostname cannot have a scheme.
```
Getting this error on my Docker installation

It's related to this:
https://github.com/minio/minio-py/issues/737
https://github.com/minio/minio-py/issues/835

Was fixed upstream in https://github.com/minio/minio-py/releases/tag/5.0.6
Upgrading to latest patch version of major version 5
Newer major versions 6 and 7 contain some breaking API changes, which I can address in separate PR later on

https://github.com/minio/minio-py/compare/4.0.9...5.0.10

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
