### PR TITLE
Fix BMW ConnectedDrive, update to My BMW API

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -347,9 +347,9 @@ class BMWConnectedDriveBaseEntity(Entity):
         }
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, vehicle.vin)},
-            manufacturer=vehicle.attributes.get("brand"),
+            manufacturer=vehicle.brand.name,
             model=vehicle.name,
-            name=f'{vehicle.attributes.get("brand")} {vehicle.name}',
+            name=f"{vehicle.brand.name} {vehicle.name}",
         )
 
     def update_callback(self) -> None:

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -15,6 +15,9 @@ from bimmer_connected.vehicle_status import (
 )
 
 from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_BATTERY_CHARGING,
+    DEVICE_CLASS_LIGHT,
+    DEVICE_CLASS_LOCK,
     DEVICE_CLASS_OPENING,
     DEVICE_CLASS_PLUG,
     DEVICE_CLASS_PROBLEM,
@@ -169,14 +172,14 @@ SENSOR_TYPES: tuple[BMWBinarySensorEntityDescription, ...] = (
     BMWBinarySensorEntityDescription(
         key="door_lock_state",
         name="Door lock state",
-        device_class="lock",
+        device_class=DEVICE_CLASS_LOCK,
         icon="mdi:car-key",
         value_fn=_are_doors_locked,
     ),
     BMWBinarySensorEntityDescription(
         key="lights_parking",
         name="Parking lights",
-        device_class="light",
+        device_class=DEVICE_CLASS_LIGHT,
         icon="mdi:car-parking-lights",
         value_fn=_are_parking_lights_on,
     ),
@@ -198,7 +201,7 @@ SENSOR_TYPES: tuple[BMWBinarySensorEntityDescription, ...] = (
     BMWBinarySensorEntityDescription(
         key="charging_status",
         name="Charging status",
-        device_class="power",
+        device_class=DEVICE_CLASS_BATTERY_CHARGING,
         icon="mdi:ev-station",
         value_fn=_is_vehicle_charging,
     ),

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -6,9 +6,13 @@ from dataclasses import dataclass
 import logging
 from typing import Any, cast
 
-from bimmer_connected.state import ChargingState, LockState, VehicleState
 from bimmer_connected.vehicle import ConnectedDriveVehicle
-from bimmer_connected.vehicle_status import ConditionBasedServiceReport
+from bimmer_connected.vehicle_status import (
+    ChargingState,
+    ConditionBasedServiceReport,
+    LockState,
+    VehicleStatus,
+)
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_OPENING,
@@ -18,7 +22,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import LENGTH_KILOMETERS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.unit_system import UnitSystem
@@ -28,13 +31,13 @@ from . import (
     BMWConnectedDriveAccount,
     BMWConnectedDriveBaseEntity,
 )
-from .const import CONF_ACCOUNT, DATA_ENTRIES
+from .const import CONF_ACCOUNT, DATA_ENTRIES, UNIT_MAP
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def _are_doors_closed(
-    vehicle_state: VehicleState, extra_attributes: dict[str, Any], *args: Any
+    vehicle_state: VehicleStatus, extra_attributes: dict[str, Any], *args: Any
 ) -> bool:
     # device class opening: On means open, Off means closed
     _LOGGER.debug("Status of lid: %s", vehicle_state.all_lids_closed)
@@ -44,7 +47,7 @@ def _are_doors_closed(
 
 
 def _are_windows_closed(
-    vehicle_state: VehicleState, extra_attributes: dict[str, Any], *args: Any
+    vehicle_state: VehicleStatus, extra_attributes: dict[str, Any], *args: Any
 ) -> bool:
     # device class opening: On means open, Off means closed
     for window in vehicle_state.windows:
@@ -53,7 +56,7 @@ def _are_windows_closed(
 
 
 def _are_doors_locked(
-    vehicle_state: VehicleState, extra_attributes: dict[str, Any], *args: Any
+    vehicle_state: VehicleStatus, extra_attributes: dict[str, Any], *args: Any
 ) -> bool:
     # device class lock: On means unlocked, Off means locked
     # Possible values: LOCKED, SECURED, SELECTIVE_LOCKED, UNLOCKED
@@ -63,7 +66,7 @@ def _are_doors_locked(
 
 
 def _are_parking_lights_on(
-    vehicle_state: VehicleState, extra_attributes: dict[str, Any], *args: Any
+    vehicle_state: VehicleStatus, extra_attributes: dict[str, Any], *args: Any
 ) -> bool:
     # device class light: On means light detected, Off means no light
     extra_attributes["lights_parking"] = vehicle_state.parking_lights.value
@@ -71,7 +74,7 @@ def _are_parking_lights_on(
 
 
 def _are_problems_detected(
-    vehicle_state: VehicleState,
+    vehicle_state: VehicleStatus,
     extra_attributes: dict[str, Any],
     unit_system: UnitSystem,
 ) -> bool:
@@ -82,7 +85,7 @@ def _are_problems_detected(
 
 
 def _check_control_messages(
-    vehicle_state: VehicleState, extra_attributes: dict[str, Any], *args: Any
+    vehicle_state: VehicleStatus, extra_attributes: dict[str, Any], *args: Any
 ) -> bool:
     # device class problem: On means problem detected, Off means no problem
     check_control_messages = vehicle_state.check_control_messages
@@ -96,7 +99,7 @@ def _check_control_messages(
 
 
 def _is_vehicle_charging(
-    vehicle_state: VehicleState, extra_attributes: dict[str, Any], *args: Any
+    vehicle_state: VehicleStatus, extra_attributes: dict[str, Any], *args: Any
 ) -> bool:
     # device class power: On means power detected, Off means no power
     extra_attributes["charging_status"] = vehicle_state.charging_status.value
@@ -107,7 +110,7 @@ def _is_vehicle_charging(
 
 
 def _is_vehicle_plugged_in(
-    vehicle_state: VehicleState, extra_attributes: dict[str, Any], *args: Any
+    vehicle_state: VehicleStatus, extra_attributes: dict[str, Any], *args: Any
 ) -> bool:
     # device class plug: On means device is plugged in,
     #                    Off means device is unplugged
@@ -124,7 +127,12 @@ def _format_cbs_report(
     if report.due_date is not None:
         result[f"{service_type} date"] = report.due_date.strftime("%Y-%m-%d")
     if report.due_distance is not None:
-        distance = round(unit_system.length(report.due_distance, LENGTH_KILOMETERS))
+        distance = round(
+            unit_system.length(
+                report.due_distance[0],
+                UNIT_MAP.get(report.due_distance[1], report.due_distance[1]),
+            )
+        )
         result[f"{service_type} distance"] = f"{distance} {unit_system.length_unit}"
     return result
 
@@ -133,7 +141,7 @@ def _format_cbs_report(
 class BMWRequiredKeysMixin:
     """Mixin for required keys."""
 
-    value_fn: Callable[[VehicleState, dict[str, Any], UnitSystem], bool]
+    value_fn: Callable[[VehicleStatus, dict[str, Any], UnitSystem], bool]
 
 
 @dataclass
@@ -245,7 +253,8 @@ class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, BinarySensorEntity):
 
     def update(self) -> None:
         """Read new state data from the library."""
-        vehicle_state = self._vehicle.state
+        _LOGGER.debug("Updating binary sensors of %s", self._vehicle.name)
+        vehicle_state = self._vehicle.status
         result = self._attrs.copy()
 
         self._attr_is_on = self.entity_description.value_fn(

--- a/homeassistant/components/bmw_connected_drive/const.py
+++ b/homeassistant/components/bmw_connected_drive/const.py
@@ -1,7 +1,14 @@
 """Const file for the BMW Connected Drive integration."""
+from homeassistant.const import (
+    LENGTH_KILOMETERS,
+    LENGTH_MILES,
+    VOLUME_GALLONS,
+    VOLUME_LITERS,
+)
+
 ATTRIBUTION = "Data provided by BMW Connected Drive"
 
-CONF_ALLOWED_REGIONS = ["china", "north_america", "rest_of_world"]
+CONF_ALLOWED_REGIONS = ["north_america", "rest_of_world"]
 CONF_READ_ONLY = "read_only"
 CONF_USE_LOCATION = "use_location"
 
@@ -9,3 +16,10 @@ CONF_ACCOUNT = "account"
 
 DATA_HASS_CONFIG = "hass_config"
 DATA_ENTRIES = "entries"
+
+UNIT_MAP = {
+    "KILOMETERS": LENGTH_KILOMETERS,
+    "MILES": LENGTH_MILES,
+    "LITERS": VOLUME_LITERS,
+    "GALLONS": VOLUME_GALLONS,
+}

--- a/homeassistant/components/bmw_connected_drive/const.py
+++ b/homeassistant/components/bmw_connected_drive/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import (
 
 ATTRIBUTION = "Data provided by BMW Connected Drive"
 
-CONF_ALLOWED_REGIONS = ["north_america", "rest_of_world"]
+CONF_ALLOWED_REGIONS = ["china", "north_america", "rest_of_world"]
 CONF_READ_ONLY = "read_only"
 CONF_USE_LOCATION = "use_location"
 

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
 
     for vehicle in account.account.vehicles:
         entities.append(BMWDeviceTracker(account, vehicle))
-        if not vehicle.state.is_vehicle_tracking_enabled:
+        if not vehicle.status.is_vehicle_tracking_enabled:
             _LOGGER.info(
                 "Tracking is (currently) disabled for vehicle %s (%s), defaulting to unknown",
                 vehicle.name,
@@ -59,7 +59,7 @@ class BMWDeviceTracker(BMWConnectedDriveBaseEntity, TrackerEntity):
         super().__init__(account, vehicle)
 
         self._attr_unique_id = vehicle.vin
-        self._location = pos if (pos := vehicle.state.gps_position) else None
+        self._location = pos if (pos := vehicle.status.gps_position) else None
         self._attr_name = vehicle.name
 
     @property
@@ -79,9 +79,10 @@ class BMWDeviceTracker(BMWConnectedDriveBaseEntity, TrackerEntity):
 
     def update(self) -> None:
         """Update state of the decvice tracker."""
+        _LOGGER.debug("Updating device tracker of %s", self._vehicle.name)
         self._attr_extra_state_attributes = self._attrs
         self._location = (
-            self._vehicle.state.gps_position
-            if self._vehicle.state.is_vehicle_tracking_enabled
+            self._vehicle.status.gps_position
+            if self._vehicle.status.is_vehicle_tracking_enabled
             else None
         )

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -2,8 +2,8 @@
 import logging
 from typing import Any
 
-from bimmer_connected.state import LockState
 from bimmer_connected.vehicle import ConnectedDriveVehicle
+from bimmer_connected.vehicle_status import LockState
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
@@ -78,8 +78,10 @@ class BMWLock(BMWConnectedDriveBaseEntity, LockEntity):
 
     def update(self) -> None:
         """Update state of the lock."""
-        _LOGGER.debug("%s: updating data for %s", self._vehicle.name, self._attribute)
-        vehicle_state = self._vehicle.state
+        _LOGGER.debug(
+            "Updating lock data for '%s' of %s", self._attribute, self._vehicle.name
+        )
+        vehicle_state = self._vehicle.status
         if not self.door_lock_state_available:
             self._attr_is_locked = None
         else:

--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -2,7 +2,7 @@
   "domain": "bmw_connected_drive",
   "name": "BMW Connected Drive",
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
-  "requirements": ["bimmer_connected==0.7.21"],
+  "requirements": ["bimmer_connected==0.8.0"],
   "codeowners": ["@gerard33", "@rikroe"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -2,7 +2,7 @@
   "domain": "bmw_connected_drive",
   "name": "BMW Connected Drive",
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
-  "requirements": ["bimmer_connected==0.8.1"],
+  "requirements": ["bimmer_connected==0.8.2"],
   "codeowners": ["@gerard33", "@rikroe"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/bmw_connected_drive/manifest.json
+++ b/homeassistant/components/bmw_connected_drive/manifest.json
@@ -2,7 +2,7 @@
   "domain": "bmw_connected_drive",
   "name": "BMW Connected Drive",
   "documentation": "https://www.home-assistant.io/integrations/bmw_connected_drive",
-  "requirements": ["bimmer_connected==0.8.0"],
+  "requirements": ["bimmer_connected==0.8.1"],
   "codeowners": ["@gerard33", "@rikroe"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -9,8 +9,6 @@ from bimmer_connected.vehicle import ConnectedDriveVehicle
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TARGET,
-    ATTR_TITLE,
-    ATTR_TITLE_DEFAULT,
     BaseNotificationService,
 )
 from homeassistant.const import ATTR_LATITUDE, ATTR_LOCATION, ATTR_LONGITUDE, ATTR_NAME
@@ -63,7 +61,6 @@ class BMWNotificationService(BaseNotificationService):
             _LOGGER.debug("Sending message to %s", vehicle.name)
 
             # Extract params from data dict
-            title: str = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
             data = kwargs.get(ATTR_DATA)
 
             # Check if message is a POI
@@ -84,6 +81,4 @@ class BMWNotificationService(BaseNotificationService):
 
                 vehicle.remote_services.trigger_send_poi(location_dict)
             else:
-                vehicle.remote_services.trigger_send_message(
-                    {ATTR_TEXT: message, ATTR_SUBJECT: title}
-                )
+                raise ValueError(f"'data.{ATTR_LOCATION}' is required.")

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import SensorEntity, SensorEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_UNIT_SYSTEM_IMPERIAL,
+    DEVICE_CLASS_BATTERY,
     LENGTH_KILOMETERS,
     LENGTH_MILES,
     PERCENTAGE,
@@ -54,8 +55,7 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
     ),
     "charging_status": BMWSensorEntityDescription(
         key="charging_status",
-        icon="mdi:battery-charging",
-        device_class="battery",
+        icon="mdi:ev-station",
         value=lambda x, y: x.value,
     ),
     # No icon as this is dealt with directly as a special case in icon()
@@ -63,6 +63,7 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
         key="charging_level_hv",
         unit_metric=PERCENTAGE,
         unit_imperial=PERCENTAGE,
+        device_class=DEVICE_CLASS_BATTERY,
     ),
     # --- Specific ---
     "mileage": BMWSensorEntityDescription(

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -158,6 +158,9 @@ class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, SensorEntity):
         super().__init__(account, vehicle)
         self.entity_description = description
 
+        self._attr_name = f"{vehicle.name} {description.key}"
+        self._attr_unique_id = f"{vehicle.vin}-{description.key}"
+
         if unit_system.name == CONF_UNIT_SYSTEM_IMPERIAL:
             self._attr_native_unit_of_measurement = description.unit_imperial
         else:

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -1,12 +1,13 @@
 """Support for reading vehicle status from BMW connected drive portal."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 import logging
+from typing import cast
 
 from bimmer_connected.const import SERVICE_STATUS
 from bimmer_connected.vehicle import ConnectedDriveVehicle
-from bimmer_connected.vehicle_status import ChargingState
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -21,7 +22,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.icon import icon_for_battery_level
+from homeassistant.helpers.typing import StateType
 from homeassistant.util.unit_system import UnitSystem
 
 from . import (
@@ -40,6 +41,7 @@ class BMWSensorEntityDescription(SensorEntityDescription):
 
     unit_metric: str | None = None
     unit_imperial: str | None = None
+    value: Callable = lambda x, y: x
 
 
 SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
@@ -53,6 +55,8 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
     "charging_status": BMWSensorEntityDescription(
         key="charging_status",
         icon="mdi:battery-charging",
+        device_class="battery",
+        value=lambda x, y: x.value,
     ),
     # No icon as this is dealt with directly as a special case in icon()
     "charging_level_hv": BMWSensorEntityDescription(
@@ -66,36 +70,54 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
         icon="mdi:speedometer",
         unit_metric=LENGTH_KILOMETERS,
         unit_imperial=LENGTH_MILES,
+        value=lambda x, hass: round(
+            hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1]))
+        ),
     ),
     "remaining_range_total": BMWSensorEntityDescription(
         key="remaining_range_total",
         icon="mdi:map-marker-distance",
         unit_metric=LENGTH_KILOMETERS,
         unit_imperial=LENGTH_MILES,
+        value=lambda x, hass: round(
+            hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1]))
+        ),
     ),
     "remaining_range_electric": BMWSensorEntityDescription(
         key="remaining_range_electric",
         icon="mdi:map-marker-distance",
         unit_metric=LENGTH_KILOMETERS,
         unit_imperial=LENGTH_MILES,
+        value=lambda x, hass: round(
+            hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1]))
+        ),
     ),
     "remaining_range_fuel": BMWSensorEntityDescription(
         key="remaining_range_fuel",
         icon="mdi:map-marker-distance",
         unit_metric=LENGTH_KILOMETERS,
         unit_imperial=LENGTH_MILES,
+        value=lambda x, hass: round(
+            hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1]))
+        ),
     ),
     "max_range_electric": BMWSensorEntityDescription(
         key="max_range_electric",
         icon="mdi:map-marker-distance",
         unit_metric=LENGTH_KILOMETERS,
         unit_imperial=LENGTH_MILES,
+        value=lambda x, hass: round(
+            hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1]))
+        ),
     ),
     "remaining_fuel": BMWSensorEntityDescription(
         key="remaining_fuel",
         icon="mdi:gas-station",
         unit_metric=VOLUME_LITERS,
         unit_imperial=VOLUME_GALLONS,
+        value=lambda x, hass: round(
+            hass.config.units.volume(x[0], UNIT_MAP.get(x[1], x[1]))
+        ),
     ),
     "fuel_percent": BMWSensorEntityDescription(
         key="fuel_percent",
@@ -118,7 +140,6 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the BMW ConnectedDrive sensors from config entry."""
-    # pylint: disable=too-many-nested-blocks
     unit_system = hass.config.units
     account: BMWConnectedDriveAccount = hass.data[BMW_DOMAIN][DATA_ENTRIES][
         config_entry.entry_id
@@ -171,47 +192,8 @@ class BMWConnectedDriveSensor(BMWConnectedDriveBaseEntity, SensorEntity):
         else:
             self._attr_native_unit_of_measurement = description.unit_metric
 
-    def update(self) -> None:
-        """Read new state data from the library."""
-        _LOGGER.debug("Updating sensors of %s", self._vehicle.name)
-        vehicle_state = self._vehicle.status
-        sensor_key = self.entity_description.key
-        sensor_value = None
-
-        if sensor_key == "charging_status":
-            sensor_value = getattr(vehicle_state, sensor_key).value
-        elif self._service is None:
-            sensor_value = getattr(vehicle_state, sensor_key)
-
-            if isinstance(sensor_value, tuple):
-                sensor_unit = UNIT_MAP.get(sensor_value[1], sensor_value[1])
-                sensor_value = sensor_value[0]
-                sensor_value_org = sensor_value
-
-                if self.unit_of_measurement in [LENGTH_KILOMETERS, LENGTH_MILES]:
-                    sensor_value = round(
-                        self.hass.config.units.length(sensor_value, sensor_unit)
-                    )
-                elif self.unit_of_measurement in [VOLUME_LITERS, VOLUME_GALLONS]:
-                    sensor_value = round(
-                        self.hass.config.units.volume(sensor_value, sensor_unit)
-                    )
-
-                _LOGGER.debug(
-                    "UoM Conversion for %s. HA: %s %s, Vehicle: %s %s",
-                    sensor_key,
-                    sensor_value,
-                    self.unit_of_measurement,
-                    sensor_value_org,
-                    sensor_unit,
-                )
-
-        self._attr_native_value = sensor_value
-
-        if sensor_key == "charging_level_hv":
-            charging_state = self._vehicle.status.charging_status in {
-                ChargingState.CHARGING
-            }
-            self._attr_icon = icon_for_battery_level(
-                battery_level=vehicle_state.charging_level_hv, charging=charging_state
-            )
+    @property
+    def native_value(self) -> StateType:
+        """Return the state."""
+        state = getattr(self._vehicle.status, self.entity_description.key)
+        return cast(StateType, self.entity_description.value(state, self.hass))

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -100,15 +100,6 @@ SENSOR_TYPES: dict[str, BMWSensorEntityDescription] = {
             hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1]))
         ),
     ),
-    "max_range_electric": BMWSensorEntityDescription(
-        key="max_range_electric",
-        icon="mdi:map-marker-distance",
-        unit_metric=LENGTH_KILOMETERS,
-        unit_imperial=LENGTH_MILES,
-        value=lambda x, hass: round(
-            hass.config.units.length(x[0], UNIT_MAP.get(x[1], x[1]))
-        ),
-    ),
     "remaining_fuel": BMWSensorEntityDescription(
         key="remaining_fuel",
         icon="mdi:gas-station",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -387,7 +387,7 @@ beautifulsoup4==4.10.0
 bellows==0.28.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.7.21
+bimmer_connected==0.8.0
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -387,7 +387,7 @@ beautifulsoup4==4.10.0
 bellows==0.28.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.8.1
+bimmer_connected==0.8.2
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -387,7 +387,7 @@ beautifulsoup4==4.10.0
 bellows==0.28.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.8.0
+bimmer_connected==0.8.1
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -254,7 +254,7 @@ base36==0.1.1
 bellows==0.28.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.7.21
+bimmer_connected==0.8.0
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -254,7 +254,7 @@ base36==0.1.1
 bellows==0.28.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.8.1
+bimmer_connected==0.8.2
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -254,7 +254,7 @@ base36==0.1.1
 bellows==0.28.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.8.0
+bimmer_connected==0.8.1
 
 # homeassistant.components.blebox
 blebox_uniapi==1.3.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- The following services/sensors have been removed due to not being available using the My BMW API: `alltrips_*`, `lasttrips_*`,  `chargingconnectiontype`, `charginginductivepositioning`, `lastchargingendreason`, `lastchargingendresult`, `maxelectricrange`
- `notify` requires a location attribute at `data.location`, as the MyBMW API only supports sending POI and not messages.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update `bimmer_connected` to `0.8.2` to adapt to new APIs by BMW. 
As these APIs return very different structures, a lot of changes were needed in the library and therefore some adjustments in the component as well.

The changes have been thoroughly tested via a custom component (see https://github.com/home-assistant/core/issues/59403).

Library release notes: 
- https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.8.0
- https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.8.1
- https://github.com/bimmerconnected/bimmer_connected/releases/tag/0.8.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59403
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20433

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
