### PR TITLE
Yeelight disable polling

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -406,7 +406,9 @@ def _async_setup_services(hass: HomeAssistant):
         SERVICE_SET_MUSIC_MODE, SERVICE_SCHEMA_SET_MUSIC_MODE, "async_set_music_mode"
     )
     platform.async_register_entity_service(
-        SERVICE_FORCE_UPDATE, {}, "async_force_update",
+        SERVICE_FORCE_UPDATE,
+        {},
+        "async_force_update",
     )
 
 

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -322,7 +322,7 @@ async def async_setup_entry(
             device.name,
         )
 
-    async_add_entities(lights, True)
+    async_add_entities(lights)
     _async_setup_services(hass)
 
 

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -83,7 +83,6 @@ SERVICE_SET_HSV_SCENE = "set_hsv_scene"
 SERVICE_SET_COLOR_TEMP_SCENE = "set_color_temp_scene"
 SERVICE_SET_COLOR_FLOW_SCENE = "set_color_flow_scene"
 SERVICE_SET_AUTO_DELAY_OFF_SCENE = "set_auto_delay_off_scene"
-SERVICE_FORCE_UPDATE = "force_update"
 
 EFFECT_DISCO = "Disco"
 EFFECT_TEMP = "Slow Temp"
@@ -405,11 +404,6 @@ def _async_setup_services(hass: HomeAssistant):
     platform.async_register_entity_service(
         SERVICE_SET_MUSIC_MODE, SERVICE_SCHEMA_SET_MUSIC_MODE, "async_set_music_mode"
     )
-    platform.async_register_entity_service(
-        SERVICE_FORCE_UPDATE,
-        {},
-        "async_force_update",
-    )
 
 
 class YeelightGenericLight(YeelightEntity, LightEntity):
@@ -417,6 +411,7 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
 
     _attr_color_mode = COLOR_MODE_BRIGHTNESS
     _attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS}
+    _attr_should_poll = False
 
     def __init__(self, device, entry, custom_effects=None):
         """Initialize the Yeelight light."""
@@ -597,10 +592,6 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
 
     async def async_update(self):
         """Update light properties."""
-        await self.device.async_update()
-
-    async def async_force_update(self):
-        """Force an update of the light properties."""
         await self.device.async_update(True)
 
     async def async_set_music_mode(self, music_mode) -> None:

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -83,6 +83,7 @@ SERVICE_SET_HSV_SCENE = "set_hsv_scene"
 SERVICE_SET_COLOR_TEMP_SCENE = "set_color_temp_scene"
 SERVICE_SET_COLOR_FLOW_SCENE = "set_color_flow_scene"
 SERVICE_SET_AUTO_DELAY_OFF_SCENE = "set_auto_delay_off_scene"
+SERVICE_FORCE_UPDATE = "force_update"
 
 EFFECT_DISCO = "Disco"
 EFFECT_TEMP = "Slow Temp"
@@ -404,6 +405,9 @@ def _async_setup_services(hass: HomeAssistant):
     platform.async_register_entity_service(
         SERVICE_SET_MUSIC_MODE, SERVICE_SCHEMA_SET_MUSIC_MODE, "async_set_music_mode"
     )
+    platform.async_register_entity_service(
+        SERVICE_FORCE_UPDATE, {}, "async_force_update",
+    )
 
 
 class YeelightGenericLight(YeelightEntity, LightEntity):
@@ -592,6 +596,10 @@ class YeelightGenericLight(YeelightEntity, LightEntity):
     async def async_update(self):
         """Update light properties."""
         await self.device.async_update()
+
+    async def async_force_update(self):
+        """Force an update of the light properties."""
+        await self.device.async_update(True)
 
     async def async_set_music_mode(self, music_mode) -> None:
         """Set the music mode on or off."""

--- a/homeassistant/components/yeelight/services.yaml
+++ b/homeassistant/components/yeelight/services.yaml
@@ -191,10 +191,3 @@ set_music_mode:
       required: true
       selector:
         boolean:
-force_update:
-  name: Force update
-  description: Force a update of the state
-  target:
-    entity:
-      integration: yeelight
-      domain: light

--- a/homeassistant/components/yeelight/services.yaml
+++ b/homeassistant/components/yeelight/services.yaml
@@ -191,3 +191,10 @@ set_music_mode:
       required: true
       selector:
         boolean:
+force_update:
+  name: Force update
+  description: Force a update of the state
+  target:
+    entity:
+      integration: yeelight
+      domain: light

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_ID,
     CONF_NAME,
+    STATE_ON,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
@@ -530,12 +531,14 @@ async def test_connection_dropped_resyncs_properties(hass: HomeAssistant):
         assert len(mocked_bulb.async_get_properties.mock_calls) == 1
         mocked_bulb._async_callback({KEY_CONNECTED: False})
         await hass.async_block_till_done()
+        assert hass.states.get("light.test_name").state == STATE_UNAVAILABLE
         assert len(mocked_bulb.async_get_properties.mock_calls) == 1
         mocked_bulb._async_callback({KEY_CONNECTED: True})
         async_fire_time_changed(
             hass, dt_util.utcnow() + timedelta(seconds=STATE_CHANGE_TIME)
         )
         await hass.async_block_till_done()
+        assert hass.states.get("light.test_name").state == STATE_ON
         assert len(mocked_bulb.async_get_properties.mock_calls) == 2
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
~Add a force update service to the yeelight integration.
The regular `homeassistant.update_entity` does not work for the yeelight integration since updates are not executed as long as the device is available (polling is turned on but if the device is available the update function emidiatly returns withouth doing the update, if the device is unavailable the update is actually executed).
This new force update service will actually update the device even if it is available.~

Disable polling of the yeelight integration and let it be handeld by the upstream lib.
Make the async_update function force and update such that `homeassistant.update_entity` will actually get the state from the bulb.

relevant lines: https://github.com/home-assistant/core/blob/1609c0cc2c0b0652ad43d06151a0d78bcd06af02/homeassistant/components/yeelight/__init__.py#L643-L647

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
