### PR TITLE
Only accept valid hvac actions sent via mqtt

### DIFF
--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -13,6 +13,7 @@ from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
+    CURRENT_HVAC_ACTIONS,
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_TEMP,
     FAN_AUTO,
@@ -405,9 +406,15 @@ class MqttClimate(MqttEntity, ClimateEntity):
         def handle_action_received(msg):
             """Handle receiving action via MQTT."""
             payload = render_template(msg, CONF_ACTION_TEMPLATE)
-
-            self._action = payload
-            self.async_write_ha_state()
+            if payload is None or payload in CURRENT_HVAC_ACTIONS:
+                self._action = payload
+                self.async_write_ha_state()
+            else:
+                _LOGGER.error(
+                    "Invalid %s action: %s",
+                    CURRENT_HVAC_ACTIONS,
+                    payload,
+                )
 
         add_subscription(topics, CONF_ACTION_TOPIC, handle_action_received)
 

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -406,7 +406,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
         def handle_action_received(msg):
             """Handle receiving action via MQTT."""
             payload = render_template(msg, CONF_ACTION_TEMPLATE)
-            if payload is None or payload in CURRENT_HVAC_ACTIONS:
+            if payload in CURRENT_HVAC_ACTIONS:
                 self._action = payload
                 self.async_write_ha_state()
             else:

--- a/homeassistant/components/mqtt/climate.py
+++ b/homeassistant/components/mqtt/climate.py
@@ -410,7 +410,7 @@ class MqttClimate(MqttEntity, ClimateEntity):
                 self._action = payload
                 self.async_write_ha_state()
             else:
-                _LOGGER.error(
+                _LOGGER.warning(
                     "Invalid %s action: %s",
                     CURRENT_HVAC_ACTIONS,
                     payload,

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.components.climate import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP
 from homeassistant.components.climate.const import (
+    ATTR_HVAC_ACTION,
     DOMAIN as CLIMATE_DOMAIN,
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
@@ -442,22 +443,14 @@ async def test_receive_mqtt_action_received(hass, mqtt_mock):
     # Cycle through valid modes and also check for wrong input such as "None" (str(None))
     async_fire_mqtt_message(hass, "action", "None")
     state = hass.states.get(ENTITY_CLIMATE)
-    hvac_action = state.attributes.get("hvac_mode")
+    hvac_action = state.attributes.get(ATTR_HVAC_ACTION)
     assert hvac_action is None
     # Redefine actions according to https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action
-    actions = [
-        "off",
-        "heating",
-        "cooling",
-        "drying",
-        "idle",
-        "fan",
-        None,
-    ]
+    actions = ["off", "heating", "cooling", "drying", "idle", "fan"]
     for action in actions:
         async_fire_mqtt_message(hass, "action", action)
         state = hass.states.get(ENTITY_CLIMATE)
-        hvac_action = state.attributes.get("hvac_mode")
+        hvac_action = state.attributes.get(ATTR_HVAC_ACTION)
         assert hvac_action == action
 
 

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -433,7 +433,7 @@ async def test_receive_mqtt_temperature(hass, mqtt_mock):
     assert state.attributes.get("current_temperature") == 47
 
 
-async def test_receive_mqtt_action_received(hass, mqtt_mock):
+async def test_handle_action_received(hass, mqtt_mock):
     """Test getting the action received via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)
     config["climate"]["action_topic"] = "action"
@@ -512,21 +512,6 @@ async def test_set_away_mode(hass, mqtt_mock):
     )
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("preset_mode") == "away"
-
-
-async def test_set_hvac_action(hass, mqtt_mock):
-    """Test setting of the HVAC action."""
-    config = copy.deepcopy(DEFAULT_CONFIG)
-    config["climate"]["action_topic"] = "action"
-    assert await async_setup_component(hass, CLIMATE_DOMAIN, config)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("hvac_action") is None
-
-    async_fire_mqtt_message(hass, "action", "cool")
-    state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("hvac_action") == "cool"
 
 
 async def test_set_hold_pessimistic(hass, mqtt_mock):
@@ -801,9 +786,9 @@ async def test_get_with_templates(hass, mqtt_mock, caplog):
     assert state.attributes.get("current_temperature") == 74656
 
     # Action
-    async_fire_mqtt_message(hass, "action", '"cool"')
+    async_fire_mqtt_message(hass, "action", '"cooling"')
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("hvac_action") == "cool"
+    assert state.attributes.get("hvac_action") == "cooling"
 
 
 async def test_set_with_templates(hass, mqtt_mock, caplog):

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant.components.climate import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP
 from homeassistant.components.climate.const import (
     ATTR_HVAC_ACTION,
+    CURRENT_HVAC_ACTIONS,
     DOMAIN as CLIMATE_DOMAIN,
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
@@ -447,6 +448,7 @@ async def test_handle_action_received(hass, mqtt_mock):
     assert hvac_action is None
     # Redefine actions according to https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action
     actions = ["off", "heating", "cooling", "drying", "idle", "fan"]
+    assert all(elem in actions for elem in CURRENT_HVAC_ACTIONS)
     for action in actions:
         async_fire_mqtt_message(hass, "action", action)
         state = hass.states.get(ENTITY_CLIMATE)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Given issue #59330 and PR #59575 (and especially the remarks by @bdraco ), I went ahead and added analogous checks for the hvac action being set in https://github.com/home-assistant/core/blob/dev/homeassistant/components/mqtt/climate.py#L407
I do still suspect the "mode" attr is still being set to "none" (str) based on debugging the test I added. Not sure if the mode is valid that way.
Either way, the test has the list of actions to check hardcoded. I did consider crosschecking against the list at https://github.com/home-assistant/core/blob/dev/homeassistant/components/climate/const.py#L90 given the diff to the documentation https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action (missing CURRENT_HVAC_FAN).

Either way, I still think PR #59575 was a valid PR since the homekit code should handle data more robust.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes
- This PR is related to issue:  #59330
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
