### PR TITLE
Fix error on tuya devices not following strictly specs

### DIFF
--- a/homeassistant/components/tuya/base.py
+++ b/homeassistant/components/tuya/base.py
@@ -27,6 +27,13 @@ class IntegerTypeData:
     step: float
     unit: str | None = None
 
+    def __post_init__(self):
+        """Cast params to their proper types."""
+        self.min = int(self.min)
+        self.max = int(self.max)
+        self.scale = float(self.scale)
+        self.step = float(self.step)
+
     @property
     def max_scaled(self) -> float:
         """Return the max scaled."""

--- a/tests/components/tuya/test_climate.py
+++ b/tests/components/tuya/test_climate.py
@@ -1,0 +1,140 @@
+"""Tests for the Tuya base class."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from tuya_iot import TuyaDevice
+
+from homeassistant.components.tuya.climate import (
+    CLIMATE_DESCRIPTIONS,
+    TuyaClimateEntity,
+)
+from homeassistant.components.tuya.const import DPCode
+
+
+def create_tuya_device(
+    id: str,
+    category: str,
+    status: dict[str, Any],
+    status_range: dict[str, SimpleNamespace],
+) -> TuyaDevice:
+    """Test helper method to create a tuya device."""
+    device = TuyaDevice()
+    device.id = id
+    device.category = category
+    device.name = id + "_name"
+    device.status = status
+    device.status_range = status_range
+    return device
+
+
+DEVICE_FOLLOWING_SPECS = create_tuya_device(
+    "int_device_following_specs",
+    "kt",
+    {
+        DPCode.SWITCH + "": False,
+        DPCode.TEMP_SET + "": 20,
+        DPCode.TEMP_CURRENT + "": 20,
+        DPCode.C_F + "": "C",
+    },
+    {
+        DPCode.SWITCH
+        + "": SimpleNamespace(
+            **{
+                "code": DPCode.SWITCH + "",
+                "type": "Boolean",
+                "values": "{}",
+            }
+        ),
+        DPCode.TEMP_SET
+        + "": SimpleNamespace(
+            **{
+                "code": DPCode.TEMP_SET + "",
+                "type": "Integer",
+                "values": '{"unit":"C","min":16,"max":86,"scale":0,"step":1}',
+            }
+        ),
+        DPCode.C_F
+        + "": SimpleNamespace(
+            **{
+                "code": DPCode.C_F + "",
+                "type": "Enum",
+                "values": '{"range":["C","F"]}',
+            }
+        ),
+        DPCode.TEMP_CURRENT
+        + "": SimpleNamespace(
+            **{
+                "code": DPCode.TEMP_CURRENT + "",
+                "type": "Integer",
+                "values": '{"unit":"C","min":-7,"max":98,"scale":0,"step":1}',
+            }
+        ),
+    },
+)
+
+DEVICE_NOT_FOLLOWING_SPECS = create_tuya_device(
+    "int_device_not_following_specs",
+    "kt",
+    {
+        DPCode.SWITCH + "": False,
+        DPCode.TEMP_SET + "": 20,
+        DPCode.TEMP_CURRENT + "": 20,
+        DPCode.C_F + "": "C",
+    },
+    {
+        DPCode.SWITCH
+        + "": SimpleNamespace(
+            **{
+                "code": DPCode.SWITCH + "",
+                "type": "Boolean",
+                "values": "{}",
+            }
+        ),
+        DPCode.TEMP_SET
+        + "": SimpleNamespace(
+            **{
+                "code": DPCode.TEMP_SET + "",
+                "type": "Integer",
+                "values": '{"unit":"C","min":"16","max":"86","scale":"0","step":"1"}',
+            }
+        ),
+        DPCode.C_F
+        + "": SimpleNamespace(
+            **{
+                "code": DPCode.C_F + "",
+                "type": "Enum",
+                "values": '{"range":["C","F"]}',
+            }
+        ),
+        DPCode.TEMP_CURRENT
+        + "": SimpleNamespace(
+            **{
+                "code": DPCode.TEMP_CURRENT + "",
+                "type": "Integer",
+                "values": '{"unit":"C","min":"-7","max":"98","scale":"0","step":"1"}',
+            }
+        ),
+    },
+)
+
+
+@pytest.mark.parametrize(
+    "device",
+    [DEVICE_FOLLOWING_SPECS, DEVICE_NOT_FOLLOWING_SPECS],
+)
+def test_entity_climate_build(
+    device: TuyaDevice,
+):
+    """Test TuyaClimateEntity ctor with different specs, matching or diverging from the doc."""
+
+    tuya_climate_entity = TuyaClimateEntity(
+        device,
+        MagicMock(),
+        CLIMATE_DESCRIPTIONS[device.category],
+    )
+
+    assert tuya_climate_entity._attr_target_temperature_step == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
For some devices, the json returned by the API are not following what the specs are saying [Standard Instruction Set](https://developer.tuya.com/en/docs/iot/f?id=K9gf46qujdmwb) with Data type Integer. To be able to use these devices, we cast the fields to their supposed types.

Add tests to be sure nothing is breaking the existing feature and add a test to check if a device that is not following the specs can be build.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59299
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
