### PR TITLE
Add guard for already migrated Hue entity

### DIFF
--- a/homeassistant/components/hue/migration.py
+++ b/homeassistant/components/hue/migration.py
@@ -147,7 +147,6 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
                         ent.unique_id,
                         new_unique_id,
                     )
-                    ent_reg.async_get_entity_id
                     try:
                         ent_reg.async_update_entity(
                             ent.entity_id, new_unique_id=sensor.id

--- a/homeassistant/components/hue/migration.py
+++ b/homeassistant/components/hue/migration.py
@@ -147,7 +147,19 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
                         ent.unique_id,
                         new_unique_id,
                     )
-                    ent_reg.async_update_entity(ent.entity_id, new_unique_id=sensor.id)
+                    ent_reg.async_get_entity_id
+                    try:
+                        ent_reg.async_update_entity(
+                            ent.entity_id, new_unique_id=sensor.id
+                        )
+                    except ValueError:
+                        # assume edge case where the entity was already migrated in a previous run
+                        # which got aborted somehow and we do not want
+                        # to crash the entire integration init
+                        LOGGER.warning(
+                            "Skip migration of %s because it already exists",
+                            ent.entity_id,
+                        )
                     break
 
         # migrate entities that are not connected to a device (groups)
@@ -170,5 +182,14 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
                 ent.unique_id,
                 new_unique_id,
             )
-            ent_reg.async_update_entity(ent.entity_id, new_unique_id=new_unique_id)
+            try:
+                ent_reg.async_update_entity(ent.entity_id, new_unique_id=new_unique_id)
+            except ValueError:
+                # assume edge case where the entity was already migrated in a previous run
+                # which got aborted somehow and we do not want
+                # to crash the entire integration init
+                LOGGER.warning(
+                    "Skip migration of %s because it already exists",
+                    ent.entity_id,
+                )
     LOGGER.info("Migration of devices and entities to support API schema 2 finished")


### PR DESCRIPTION
## Proposed change
A bit theoretical but it might happen that the entity migration was aborted half way through.
In that case some entities are already migrated while others are not.
While there already was a basic check for the same unique id for an auto-matched entity, this will add a guard for this edge case by ignoring a valuerror raised by the entity registry when updating the unique id.
In that case the migration continues and thus the hue setup.



## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
