### PR TITLE
Use dataclass for SsdpServiceInfo

### DIFF
--- a/homeassistant/components/axis/config_flow.py
+++ b/homeassistant/components/axis/config_flow.py
@@ -6,7 +6,7 @@ from urllib.parse import urlsplit
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
+from homeassistant.components import dhcp, ssdp, zeroconf
 from homeassistant.config_entries import SOURCE_IGNORE
 from homeassistant.const import (
     CONF_HOST,
@@ -163,7 +163,7 @@ class AxisFlowHandler(config_entries.ConfigFlow, domain=AXIS_DOMAIN):
             }
         )
 
-    async def async_step_ssdp(self, discovery_info: dict):
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo):
         """Prepare configuration for a SSDP discovered Axis device."""
         url = urlsplit(discovery_info["presentationURL"])
         return await self._process_discovered_device(

--- a/homeassistant/components/directv/config_flow.py
+++ b/homeassistant/components/directv/config_flow.py
@@ -8,13 +8,12 @@ from urllib.parse import urlparse
 from directv import DIRECTV, DIRECTVError
 import voluptuous as vol
 
-from homeassistant.components.ssdp import ATTR_SSDP_LOCATION, ATTR_UPNP_SERIAL
+from homeassistant.components import ssdp
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import CONF_RECEIVER_ID, DOMAIN
 
@@ -67,13 +66,13 @@ class DirecTVConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
 
-    async def async_step_ssdp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle SSDP discovery."""
-        host = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
+        host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
         receiver_id = None
 
-        if discovery_info.get(ATTR_UPNP_SERIAL):
-            receiver_id = discovery_info[ATTR_UPNP_SERIAL][4:]  # strips off RID-
+        if discovery_info.get(ssdp.ATTR_UPNP_SERIAL):
+            receiver_id = discovery_info[ssdp.ATTR_UPNP_SERIAL][4:]  # strips off RID-
 
         self.context.update({"title_placeholders": {"name": host}})
 

--- a/homeassistant/components/directv/config_flow.py
+++ b/homeassistant/components/directv/config_flow.py
@@ -9,6 +9,7 @@ from directv import DIRECTV, DIRECTVError
 import voluptuous as vol
 
 from homeassistant.components import ssdp
+from homeassistant.components.ssdp import ATTR_SSDP_LOCATION, ATTR_UPNP_SERIAL
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -68,11 +69,11 @@ class DirecTVConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle SSDP discovery."""
-        host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
+        host = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
         receiver_id = None
 
-        if discovery_info.get(ssdp.ATTR_UPNP_SERIAL):
-            receiver_id = discovery_info[ssdp.ATTR_UPNP_SERIAL][4:]  # strips off RID-
+        if discovery_info.get(ATTR_UPNP_SERIAL):
+            receiver_id = discovery_info[ATTR_UPNP_SERIAL][4:]  # strips off RID-
 
         self.context.update({"title_placeholders": {"name": host}})
 

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -248,7 +248,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
             "SSDP %s notification of device %s at %s",
             change,
             info[ssdp.ATTR_SSDP_USN],
-            info.ssdp_location,
+            info.get(ssdp.ATTR_SSDP_LOCATION),
         )
 
         try:

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 import contextlib
 from datetime import datetime, timedelta
 import functools
@@ -241,14 +241,14 @@ class DlnaDmrEntity(MediaPlayerEntity):
         await self._device_disconnect()
 
     async def async_ssdp_callback(
-        self, info: Mapping[str, Any], change: ssdp.SsdpChange
+        self, info: ssdp.SsdpServiceInfo, change: ssdp.SsdpChange
     ) -> None:
         """Handle notification from SSDP of device state change."""
         _LOGGER.debug(
             "SSDP %s notification of device %s at %s",
             change,
             info[ssdp.ATTR_SSDP_USN],
-            info.get(ssdp.ATTR_SSDP_LOCATION),
+            info.ssdp_location,
         )
 
         try:

--- a/homeassistant/components/fritz/config_flow.py
+++ b/homeassistant/components/fritz/config_flow.py
@@ -9,20 +9,15 @@ from urllib.parse import ParseResult, urlparse
 from fritzconnection.core.exceptions import FritzConnectionException, FritzSecurityError
 import voluptuous as vol
 
+from homeassistant.components import ssdp
 from homeassistant.components.device_tracker.const import (
     CONF_CONSIDER_HOME,
     DEFAULT_CONSIDER_HOME,
-)
-from homeassistant.components.ssdp import (
-    ATTR_SSDP_LOCATION,
-    ATTR_UPNP_FRIENDLY_NAME,
-    ATTR_UPNP_UDN,
 )
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .common import FritzBoxTools
 from .const import (
@@ -115,17 +110,17 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_ssdp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a flow initialized by discovery."""
-        ssdp_location: ParseResult = urlparse(discovery_info[ATTR_SSDP_LOCATION])
+        ssdp_location: ParseResult = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION])
         self._host = ssdp_location.hostname
         self._port = ssdp_location.port
         self._name = (
-            discovery_info.get(ATTR_UPNP_FRIENDLY_NAME) or self.fritz_tools.model
+            discovery_info.get(ssdp.ATTR_UPNP_FRIENDLY_NAME) or self.fritz_tools.model
         )
         self.context[CONF_HOST] = self._host
 
-        if uuid := discovery_info.get(ATTR_UPNP_UDN):
+        if uuid := discovery_info.get(ssdp.ATTR_UPNP_UDN):
             if uuid.startswith("uuid:"):
                 uuid = uuid[5:]
             await self.async_set_unique_id(uuid)

--- a/homeassistant/components/fritz/config_flow.py
+++ b/homeassistant/components/fritz/config_flow.py
@@ -14,6 +14,11 @@ from homeassistant.components.device_tracker.const import (
     CONF_CONSIDER_HOME,
     DEFAULT_CONSIDER_HOME,
 )
+from homeassistant.components.ssdp import (
+    ATTR_SSDP_LOCATION,
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_UDN,
+)
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import callback
@@ -112,15 +117,15 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a flow initialized by discovery."""
-        ssdp_location: ParseResult = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION])
+        ssdp_location: ParseResult = urlparse(discovery_info[ATTR_SSDP_LOCATION])
         self._host = ssdp_location.hostname
         self._port = ssdp_location.port
         self._name = (
-            discovery_info.get(ssdp.ATTR_UPNP_FRIENDLY_NAME) or self.fritz_tools.model
+            discovery_info.get(ATTR_UPNP_FRIENDLY_NAME) or self.fritz_tools.model
         )
         self.context[CONF_HOST] = self._host
 
-        if uuid := discovery_info.get(ssdp.ATTR_UPNP_UDN):
+        if uuid := discovery_info.get(ATTR_UPNP_UDN):
             if uuid.startswith("uuid:"):
                 uuid = uuid[5:]
             await self.async_set_unique_id(uuid)

--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -8,15 +8,10 @@ from pyfritzhome import Fritzhome, LoginError
 from requests.exceptions import HTTPError
 import voluptuous as vol
 
-from homeassistant.components.ssdp import (
-    ATTR_SSDP_LOCATION,
-    ATTR_UPNP_FRIENDLY_NAME,
-    ATTR_UPNP_UDN,
-)
+from homeassistant.components import ssdp
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import DEFAULT_HOST, DEFAULT_USERNAME, DOMAIN
 
@@ -119,13 +114,13 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=DATA_SCHEMA_USER, errors=errors
         )
 
-    async def async_step_ssdp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a flow initialized by discovery."""
-        host = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
+        host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
         assert isinstance(host, str)
         self.context[CONF_HOST] = host
 
-        if uuid := discovery_info.get(ATTR_UPNP_UDN):
+        if uuid := discovery_info.get(ssdp.ATTR_UPNP_UDN):
             if uuid.startswith("uuid:"):
                 uuid = uuid[5:]
             await self.async_set_unique_id(uuid)
@@ -143,7 +138,7 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="already_configured")
 
         self._host = host
-        self._name = str(discovery_info.get(ATTR_UPNP_FRIENDLY_NAME) or host)
+        self._name = str(discovery_info.get(ssdp.ATTR_UPNP_FRIENDLY_NAME) or host)
 
         self.context["title_placeholders"] = {"name": self._name}
         return await self.async_step_confirm()

--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -9,6 +9,11 @@ from requests.exceptions import HTTPError
 import voluptuous as vol
 
 from homeassistant.components import ssdp
+from homeassistant.components.ssdp import (
+    ATTR_SSDP_LOCATION,
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_UDN,
+)
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
@@ -116,11 +121,11 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a flow initialized by discovery."""
-        host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
+        host = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
         assert isinstance(host, str)
         self.context[CONF_HOST] = host
 
-        if uuid := discovery_info.get(ssdp.ATTR_UPNP_UDN):
+        if uuid := discovery_info.get(ATTR_UPNP_UDN):
             if uuid.startswith("uuid:"):
                 uuid = uuid[5:]
             await self.async_set_unique_id(uuid)
@@ -138,7 +143,7 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="already_configured")
 
         self._host = host
-        self._name = str(discovery_info.get(ssdp.ATTR_UPNP_FRIENDLY_NAME) or host)
+        self._name = str(discovery_info.get(ATTR_UPNP_FRIENDLY_NAME) or host)
 
         self.context["title_placeholders"] = {"name": self._name}
         return await self.async_step_confirm()

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -31,7 +31,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import (
     CONF_TRACK_WIRED_CLIENTS,
@@ -202,7 +201,7 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=title, data=user_input)
 
-    async def async_step_ssdp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle SSDP initiated config flow."""
         await self.async_set_unique_id(discovery_info[ssdp.ATTR_UPNP_UDN])
         self._abort_if_unique_id_configured()

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.const import CONF_API_KEY, CONF_HOST
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_ALLOW_HUE_GROUPS,
@@ -186,7 +186,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_ssdp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a discovered Hue bridge.
 
         This flow is triggered by the SSDP component. It will check if the
@@ -213,7 +213,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="not_hue_bridge")
 
         host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
-        bridge = await self._get_bridge(host, discovery_info[ssdp.ATTR_UPNP_SERIAL])  # type: ignore[arg-type]
+        bridge = await self._get_bridge(host, discovery_info[ssdp.ATTR_UPNP_SERIAL])
 
         await self.async_set_unique_id(bridge.id)
         self._abort_if_unique_id_configured(

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 from hyperion import client, const
 import voluptuous as vol
 
-from homeassistant.components.ssdp import ATTR_SSDP_LOCATION, ATTR_UPNP_SERIAL
+from homeassistant.components import ssdp
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
     ConfigEntry,
@@ -151,7 +151,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="cannot_connect")
             return await self._advance_to_auth_step_if_necessary(hyperion_client)
 
-    async def async_step_ssdp(self, discovery_info: dict[str, Any]) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a flow initiated by SSDP."""
         # Sample data provided by SSDP: {
         #   'ssdp_location': 'http://192.168.0.1:8090/description.xml',
@@ -188,9 +188,11 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # SSDP requires user confirmation.
         self._require_confirm = True
-        self._data[CONF_HOST] = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
+        self._data[CONF_HOST] = urlparse(
+            discovery_info[ssdp.ATTR_SSDP_LOCATION]
+        ).hostname
         try:
-            self._port_ui = urlparse(discovery_info[ATTR_SSDP_LOCATION]).port
+            self._port_ui = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).port
         except ValueError:
             self._port_ui = const.DEFAULT_PORT_UI
 
@@ -203,7 +205,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
         except ValueError:
             self._data[CONF_PORT] = const.DEFAULT_PORT_JSON
 
-        if not (hyperion_id := discovery_info.get(ATTR_UPNP_SERIAL)):
+        if not (hyperion_id := discovery_info.get(ssdp.ATTR_UPNP_SERIAL)):
             return self.async_abort(reason="no_id")
 
         # For discovery mechanisms, we set the unique_id as early as possible to

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -11,6 +11,7 @@ from hyperion import client, const
 import voluptuous as vol
 
 from homeassistant.components import ssdp
+from homeassistant.components.ssdp import ATTR_SSDP_LOCATION, ATTR_UPNP_SERIAL
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
     ConfigEntry,
@@ -188,11 +189,9 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # SSDP requires user confirmation.
         self._require_confirm = True
-        self._data[CONF_HOST] = urlparse(
-            discovery_info[ssdp.ATTR_SSDP_LOCATION]
-        ).hostname
+        self._data[CONF_HOST] = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
         try:
-            self._port_ui = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).port
+            self._port_ui = urlparse(discovery_info[ATTR_SSDP_LOCATION]).port
         except ValueError:
             self._port_ui = const.DEFAULT_PORT_UI
 
@@ -205,7 +204,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
         except ValueError:
             self._data[CONF_PORT] = const.DEFAULT_PORT_JSON
 
-        if not (hyperion_id := discovery_info.get(ssdp.ATTR_UPNP_SERIAL)):
+        if not (hyperion_id := discovery_info.get(ATTR_UPNP_SERIAL)):
             return self.async_abort(reason="no_id")
 
         # For discovery mechanisms, we set the unique_id as early as possible to

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -9,11 +9,10 @@ from aionanoleaf import InvalidToken, Nanoleaf, Unauthorized, Unavailable
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
+from homeassistant.components import ssdp, zeroconf
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.util.json import load_json, save_json
 
 from .const import DOMAIN
@@ -114,7 +113,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             discovery_info[zeroconf.ATTR_PROPERTIES][zeroconf.ATTR_PROPERTIES_ID],
         )
 
-    async def async_step_ssdp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle Nanoleaf SSDP discovery."""
         _LOGGER.debug("SSDP discovered: %s", discovery_info)
         return await self._async_discovery_handler(

--- a/homeassistant/components/roku/config_flow.py
+++ b/homeassistant/components/roku/config_flow.py
@@ -7,18 +7,12 @@ from urllib.parse import urlparse
 from rokuecp import Roku, RokuError
 import voluptuous as vol
 
-from homeassistant.components import zeroconf
-from homeassistant.components.ssdp import (
-    ATTR_SSDP_LOCATION,
-    ATTR_UPNP_FRIENDLY_NAME,
-    ATTR_UPNP_SERIAL,
-)
+from homeassistant.components import ssdp, zeroconf
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import DOMAIN
 
@@ -115,11 +109,11 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_discovery_confirm()
 
-    async def async_step_ssdp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a flow initialized by discovery."""
-        host = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
-        name = discovery_info[ATTR_UPNP_FRIENDLY_NAME]
-        serial_number = discovery_info[ATTR_UPNP_SERIAL]
+        host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
+        name = discovery_info[ssdp.ATTR_UPNP_FRIENDLY_NAME]
+        serial_number = discovery_info[ssdp.ATTR_UPNP_SERIAL]
 
         await self.async_set_unique_id(serial_number)
         self._abort_if_unique_id_configured(updates={CONF_HOST: host})

--- a/homeassistant/components/roku/config_flow.py
+++ b/homeassistant/components/roku/config_flow.py
@@ -8,6 +8,11 @@ from rokuecp import Roku, RokuError
 import voluptuous as vol
 
 from homeassistant.components import ssdp, zeroconf
+from homeassistant.components.ssdp import (
+    ATTR_SSDP_LOCATION,
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_SERIAL,
+)
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
@@ -111,9 +116,9 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a flow initialized by discovery."""
-        host = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname
-        name = discovery_info[ssdp.ATTR_UPNP_FRIENDLY_NAME]
-        serial_number = discovery_info[ssdp.ATTR_UPNP_SERIAL]
+        host = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
+        name = discovery_info[ATTR_UPNP_FRIENDLY_NAME]
+        serial_number = discovery_info[ATTR_UPNP_SERIAL]
 
         await self.async_set_unique_id(serial_number)
         self._abort_if_unique_id_configured(updates={CONF_HOST: host})

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -12,6 +12,12 @@ import voluptuous as vol
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import dhcp, ssdp, zeroconf
+from homeassistant.components.ssdp import (
+    ATTR_SSDP_LOCATION,
+    ATTR_UPNP_MANUFACTURER,
+    ATTR_UPNP_MODEL_NAME,
+    ATTR_UPNP_UDN,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_MAC,
@@ -263,12 +269,12 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by ssdp discovery."""
         LOGGER.debug("Samsung device found via SSDP: %s", discovery_info)
-        model_name: str = discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME) or ""
-        self._udn = _strip_uuid(discovery_info[ssdp.ATTR_UPNP_UDN])
-        if hostname := urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname:
+        model_name: str = discovery_info.get(ATTR_UPNP_MODEL_NAME) or ""
+        self._udn = _strip_uuid(discovery_info[ATTR_UPNP_UDN])
+        if hostname := urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname:
             self._host = hostname
         await self._async_set_unique_id_from_udn()
-        self._manufacturer = discovery_info[ssdp.ATTR_UPNP_MANUFACTURER]
+        self._manufacturer = discovery_info[ATTR_UPNP_MANUFACTURER]
         self._abort_if_manufacturer_is_not_samsung()
         if not await self._async_get_and_check_device_info():
             # If we cannot get device info for an SSDP discovery

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -11,13 +11,7 @@ import getmac
 import voluptuous as vol
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components import dhcp, zeroconf
-from homeassistant.components.ssdp import (
-    ATTR_SSDP_LOCATION,
-    ATTR_UPNP_MANUFACTURER,
-    ATTR_UPNP_MODEL_NAME,
-    ATTR_UPNP_UDN,
-)
+from homeassistant.components import dhcp, ssdp, zeroconf
 from homeassistant.const import (
     CONF_HOST,
     CONF_MAC,
@@ -28,7 +22,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
-from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .bridge import (
     SamsungTVBridge,
@@ -266,16 +259,16 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             raise data_entry_flow.AbortFlow(RESULT_NOT_SUPPORTED)
 
     async def async_step_ssdp(
-        self, discovery_info: DiscoveryInfoType
+        self, discovery_info: ssdp.SsdpServiceInfo
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by ssdp discovery."""
         LOGGER.debug("Samsung device found via SSDP: %s", discovery_info)
-        model_name: str = discovery_info.get(ATTR_UPNP_MODEL_NAME) or ""
-        self._udn = _strip_uuid(discovery_info[ATTR_UPNP_UDN])
-        if hostname := urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname:
+        model_name: str = discovery_info.get(ssdp.ATTR_UPNP_MODEL_NAME) or ""
+        self._udn = _strip_uuid(discovery_info[ssdp.ATTR_UPNP_UDN])
+        if hostname := urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION]).hostname:
             self._host = hostname
         await self._async_set_unique_id_from_udn()
-        self._manufacturer = discovery_info[ATTR_UPNP_MANUFACTURER]
+        self._manufacturer = discovery_info[ssdp.ATTR_UPNP_MANUFACTURER]
         self._abort_if_manufacturer_is_not_samsung()
         if not await self._async_get_and_check_device_info():
             # If we cannot get device info for an SSDP discovery

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -63,16 +63,6 @@ ATTR_HA_MATCHING_DOMAINS = "x_homeassistant_matching_domains"
 
 PRIMARY_MATCH_KEYS = [ATTR_UPNP_MANUFACTURER, "st", ATTR_UPNP_DEVICE_TYPE, "nt"]
 
-DISCOVERY_MAPPING = {
-    "usn": ATTR_SSDP_USN,
-    "ext": ATTR_SSDP_EXT,
-    "server": ATTR_SSDP_SERVER,
-    "st": ATTR_SSDP_ST,
-    "location": ATTR_SSDP_LOCATION,
-    "_udn": ATTR_SSDP_UDN,
-    "nt": ATTR_SSDP_NT,
-}
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -496,7 +496,9 @@ class Scanner:
         if not callbacks and not matching_domains:
             return
 
-        discovery_info = discovery_info_from_headers_and_description(info_with_desc)
+        discovery_info = discovery_info_from_headers_and_description(
+            info_with_desc, info_desc
+        )
         discovery_info[ATTR_HA_MATCHING_DOMAINS] = matching_domains
         ssdp_change = SSDP_SOURCE_SSDP_CHANGE_MAPPING[source]
         await _async_process_callbacks(callbacks, discovery_info, ssdp_change)
@@ -534,7 +536,7 @@ class Scanner:
             await self._description_cache.async_get_description_dict(location) or {}
         )
         return discovery_info_from_headers_and_description(
-            CaseInsensitiveDict(headers, **info_desc)
+            CaseInsensitiveDict(headers, **info_desc), info_desc
         )
 
     async def async_get_discovery_info_by_udn_st(  # pylint: disable=invalid-name
@@ -566,7 +568,8 @@ class Scanner:
 
 def discovery_info_from_headers_and_description(
     info_with_desc: CaseInsensitiveDict,
-) -> dict[str, Any]:
+    info_desc: Mapping[str, str],
+) -> SsdpServiceInfo:
     """Convert headers and description to discovery_info."""
     info = {
         DISCOVERY_MAPPING.get(k.lower(), k): v
@@ -580,6 +583,9 @@ def discovery_info_from_headers_and_description(
     # Increase compatibility.
     if ATTR_SSDP_ST not in info and ATTR_SSDP_NT in info:
         info[ATTR_SSDP_ST] = info[ATTR_SSDP_NT]
+
+    # Duplicate upnp data
+    info.upnp = info_desc
 
     return info
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -586,6 +586,8 @@ def discovery_info_from_headers_and_description(
 
     # Duplicate upnp data
     info.upnp = info_desc
+    if ATTR_UPNP_UDN not in info.upnp:
+        info.upnp[ATTR_UPNP_UDN] = udn
 
     return info
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -499,7 +499,7 @@ class Scanner:
         discovery_info = discovery_info_from_headers_and_description(
             info_with_desc, info_desc
         )
-        discovery_info[ATTR_HA_MATCHING_DOMAINS] = matching_domains
+        discovery_info.x_homeassistant_matching_domains = matching_domains
         ssdp_change = SSDP_SOURCE_SSDP_CHANGE_MAPPING[source]
         await _async_process_callbacks(callbacks, discovery_info, ssdp_change)
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -2,13 +2,13 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Iterator
+from collections.abc import Awaitable, Iterator, Mapping
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
 import logging
-from typing import Any, Callable, Mapping
+from typing import Any, Callable
 
 from async_upnp_client.aiohttp import AiohttpSessionRequester
 from async_upnp_client.const import DeviceOrServiceType, SsdpHeaders, SsdpSource
@@ -73,18 +73,6 @@ DISCOVERY_MAPPING = {
     "nt": ATTR_SSDP_NT,
 }
 
-SsdpChange = Enum("SsdpChange", "ALIVE BYEBYE UPDATE")
-SsdpCallback = Callable[[Mapping[str, Any], SsdpChange], Awaitable]
-
-
-SSDP_SOURCE_SSDP_CHANGE_MAPPING: Mapping[SsdpSource, SsdpChange] = {
-    SsdpSource.SEARCH_ALIVE: SsdpChange.ALIVE,
-    SsdpSource.SEARCH_CHANGED: SsdpChange.ALIVE,
-    SsdpSource.ADVERTISEMENT_ALIVE: SsdpChange.ALIVE,
-    SsdpSource.ADVERTISEMENT_BYEBYE: SsdpChange.BYEBYE,
-    SsdpSource.ADVERTISEMENT_UPDATE: SsdpChange.UPDATE,
-}
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -100,19 +88,20 @@ class _SsdpServiceDescription:
     """SSDP info with optional keys."""
 
     ssdp_usn: str
-    ssdp_st: str
+    ssdp_st: str | None = None
     ssdp_location: str | None = None
     ssdp_nt: str | None = None
     ssdp_udn: str | None = None
     ssdp_ext: str | None = None
     ssdp_server: str | None = None
+    ssdp_headers: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class _UpnpServiceDescription:
     """UPnP info."""
 
-    upnp: dict[str, Any]
+    upnp: Mapping[str, Any]
 
 
 @dataclass
@@ -144,6 +133,8 @@ class SsdpServiceInfo(
         # Use a property if it is available, fallback to upnp data
         if hasattr(self, name):
             return getattr(self, name)
+        if name in self.ssdp_headers and name not in self.upnp:
+            return self.ssdp_headers.get(name)
         return self.upnp[name]
 
     def get(self, name: str, default: Any = None) -> Any:
@@ -181,6 +172,18 @@ class SsdpServiceInfo(
         return self.upnp.__iter__()
 
 
+SsdpChange = Enum("SsdpChange", "ALIVE BYEBYE UPDATE")
+SsdpCallback = Callable[[SsdpServiceInfo, SsdpChange], Awaitable]
+
+SSDP_SOURCE_SSDP_CHANGE_MAPPING: Mapping[SsdpSource, SsdpChange] = {
+    SsdpSource.SEARCH_ALIVE: SsdpChange.ALIVE,
+    SsdpSource.SEARCH_CHANGED: SsdpChange.ALIVE,
+    SsdpSource.ADVERTISEMENT_ALIVE: SsdpChange.ALIVE,
+    SsdpSource.ADVERTISEMENT_BYEBYE: SsdpChange.BYEBYE,
+    SsdpSource.ADVERTISEMENT_UPDATE: SsdpChange.UPDATE,
+}
+
+
 @bind_hass
 async def async_register_callback(
     hass: HomeAssistant,
@@ -198,7 +201,7 @@ async def async_register_callback(
 @bind_hass
 async def async_get_discovery_info_by_udn_st(  # pylint: disable=invalid-name
     hass: HomeAssistant, udn: str, st: str
-) -> dict[str, str] | None:
+) -> SsdpServiceInfo | None:
     """Fetch the discovery info cache."""
     scanner: Scanner = hass.data[DOMAIN]
     return await scanner.async_get_discovery_info_by_udn_st(udn, st)
@@ -207,7 +210,7 @@ async def async_get_discovery_info_by_udn_st(  # pylint: disable=invalid-name
 @bind_hass
 async def async_get_discovery_info_by_st(  # pylint: disable=invalid-name
     hass: HomeAssistant, st: str
-) -> list[dict[str, str]]:
+) -> list[SsdpServiceInfo]:
     """Fetch all the entries matching the st."""
     scanner: Scanner = hass.data[DOMAIN]
     return await scanner.async_get_discovery_info_by_st(st)
@@ -216,7 +219,7 @@ async def async_get_discovery_info_by_st(  # pylint: disable=invalid-name
 @bind_hass
 async def async_get_discovery_info_by_udn(
     hass: HomeAssistant, udn: str
-) -> list[dict[str, str]]:
+) -> list[SsdpServiceInfo]:
     """Fetch all the entries matching the udn."""
     scanner: Scanner = hass.data[DOMAIN]
     return await scanner.async_get_discovery_info_by_udn(udn)
@@ -237,7 +240,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def _async_process_callbacks(
     callbacks: list[SsdpCallback],
-    discovery_info: dict[str, str],
+    discovery_info: SsdpServiceInfo,
     ssdp_change: SsdpChange,
 ) -> None:
     for callback in callbacks:
@@ -497,7 +500,7 @@ class Scanner:
             return
 
         discovery_info = discovery_info_from_headers_and_description(
-            info_with_desc, info_desc
+            combined_headers, info_desc
         )
         discovery_info.x_homeassistant_matching_domains = matching_domains
         ssdp_change = SSDP_SOURCE_SSDP_CHANGE_MAPPING[source]
@@ -506,6 +509,8 @@ class Scanner:
         # Config flows should only be created for alive/update messages from alive devices
         if ssdp_change == SsdpChange.BYEBYE:
             return
+
+        _LOGGER.debug("Discovery info: %s", discovery_info)
 
         for domain in matching_domains:
             _LOGGER.debug("Discovered %s at %s", domain, location)
@@ -525,7 +530,7 @@ class Scanner:
 
     async def _async_headers_to_discovery_info(
         self, headers: Mapping[str, Any]
-    ) -> dict[str, Any]:
+    ) -> SsdpServiceInfo:
         """Combine the headers and description into discovery_info.
 
         Building this is a bit expensive so we only do it on demand.
@@ -535,13 +540,11 @@ class Scanner:
         info_desc = (
             await self._description_cache.async_get_description_dict(location) or {}
         )
-        return discovery_info_from_headers_and_description(
-            CaseInsensitiveDict(headers, **info_desc), info_desc
-        )
+        return discovery_info_from_headers_and_description(headers, info_desc)
 
     async def async_get_discovery_info_by_udn_st(  # pylint: disable=invalid-name
         self, udn: str, st: str
-    ) -> dict[str, Any] | None:
+    ) -> SsdpServiceInfo | None:
         """Return discovery_info for a udn and st."""
         if headers := self._all_headers_from_ssdp_devices.get((udn, st)):
             return await self._async_headers_to_discovery_info(headers)
@@ -549,7 +552,7 @@ class Scanner:
 
     async def async_get_discovery_info_by_st(  # pylint: disable=invalid-name
         self, st: str
-    ) -> list[dict[str, Any]]:
+    ) -> list[SsdpServiceInfo]:
         """Return matching discovery_infos for a st."""
         return [
             await self._async_headers_to_discovery_info(headers)
@@ -557,7 +560,7 @@ class Scanner:
             if udn_st[1] == st
         ]
 
-    async def async_get_discovery_info_by_udn(self, udn: str) -> list[dict[str, Any]]:
+    async def async_get_discovery_info_by_udn(self, udn: str) -> list[SsdpServiceInfo]:
         """Return matching discovery_infos for a udn."""
         return [
             await self._async_headers_to_discovery_info(headers)
@@ -567,27 +570,30 @@ class Scanner:
 
 
 def discovery_info_from_headers_and_description(
-    info_with_desc: CaseInsensitiveDict,
-    info_desc: Mapping[str, str],
+    combined_headers: Mapping[str, Any],
+    info_desc: Mapping[str, Any],
 ) -> SsdpServiceInfo:
     """Convert headers and description to discovery_info."""
-    info = {
-        DISCOVERY_MAPPING.get(k.lower(), k): v
-        for k, v in info_with_desc.as_dict().items()
-    }
-
-    if ATTR_UPNP_UDN not in info and ATTR_SSDP_USN in info:
-        if udn := _udn_from_usn(info[ATTR_SSDP_USN]):
-            info[ATTR_UPNP_UDN] = udn
+    upnp_info = {**info_desc}
+    info = SsdpServiceInfo(
+        ssdp_usn=combined_headers["usn"],
+        ssdp_ext=combined_headers.get("ext"),
+        ssdp_server=combined_headers.get("server"),
+        ssdp_st=combined_headers.get("st"),
+        ssdp_location=combined_headers.get("location"),
+        ssdp_udn=combined_headers.get("_udn"),
+        ssdp_nt=combined_headers.get("nt"),
+        ssdp_headers=combined_headers,
+        upnp=upnp_info,
+    )
 
     # Increase compatibility.
-    if ATTR_SSDP_ST not in info and ATTR_SSDP_NT in info:
-        info[ATTR_SSDP_ST] = info[ATTR_SSDP_NT]
+    if not info.ssdp_st and info.ssdp_nt:
+        info.ssdp_st = info.ssdp_nt
 
-    # Duplicate upnp data
-    info.upnp = info_desc
     if ATTR_UPNP_UDN not in info.upnp:
-        info.upnp[ATTR_UPNP_UDN] = udn
+        if udn := _udn_from_usn(info.ssdp_usn):
+            upnp_info[ATTR_UPNP_UDN] = udn
 
     return info
 

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -237,7 +237,7 @@ class SynologyDSMFlowHandler(ConfigFlow, domain=DOMAIN):
             return self._show_form(step)
         return await self.async_validate_input_create_entry(user_input, step_id=step)
 
-    async def async_step_ssdp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a discovered synology_dsm."""
         parsed_url = urlparse(discovery_info[ssdp.ATTR_SSDP_LOCATION])
         friendly_name = (

--- a/homeassistant/components/yamaha_musiccast/__init__.py
+++ b/homeassistant/components/yamaha_musiccast/__init__.py
@@ -31,11 +31,11 @@ SCAN_INTERVAL = timedelta(seconds=60)
 async def get_upnp_desc(hass: HomeAssistant, host: str):
     """Get the upnp description URL for a given host, using the SSPD scanner."""
     ssdp_entries = await ssdp.async_get_discovery_info_by_st(hass, "upnp:rootdevice")
-    matches = [w for w in ssdp_entries if w.get("_host", "") == host]
+    matches = [w for w in ssdp_entries if w.upnp.get("_host", "") == host]
     upnp_desc = None
     for match in matches:
-        if match.get(ssdp.ATTR_SSDP_LOCATION):
-            upnp_desc = match[ssdp.ATTR_SSDP_LOCATION]
+        if match.ssdp_location:
+            upnp_desc = match.ssdp_location
             break
 
     if not upnp_desc:

--- a/homeassistant/components/yamaha_musiccast/__init__.py
+++ b/homeassistant/components/yamaha_musiccast/__init__.py
@@ -31,11 +31,11 @@ SCAN_INTERVAL = timedelta(seconds=60)
 async def get_upnp_desc(hass: HomeAssistant, host: str):
     """Get the upnp description URL for a given host, using the SSPD scanner."""
     ssdp_entries = await ssdp.async_get_discovery_info_by_st(hass, "upnp:rootdevice")
-    matches = [w for w in ssdp_entries if w.upnp.get("_host", "") == host]
+    matches = [w for w in ssdp_entries if w.get("_host", "") == host]
     upnp_desc = None
     for match in matches:
-        if match.ssdp_location:
-            upnp_desc = match.ssdp_location
+        if match.get(ssdp.ATTR_SSDP_LOCATION):
+            upnp_desc = match[ssdp.ATTR_SSDP_LOCATION]
             break
 
     if not upnp_desc:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -35,6 +35,7 @@ import homeassistant.util.uuid as uuid_util
 if TYPE_CHECKING:
     from homeassistant.components.dhcp import DhcpServiceInfo
     from homeassistant.components.mqtt.discovery import MqttServiceInfo
+    from homeassistant.components.ssdp import SsdpServiceInfo
     from homeassistant.components.usb import UsbServiceInfo
     from homeassistant.components.zeroconf import ZeroconfServiceInfo
 
@@ -1370,10 +1371,10 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         return await self.async_step_discovery(dataclasses.asdict(discovery_info))
 
     async def async_step_ssdp(
-        self, discovery_info: DiscoveryInfoType
+        self, discovery_info: SsdpServiceInfo
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by SSDP discovery."""
-        return await self.async_step_discovery(discovery_info)
+        return await self.async_step_discovery(dataclasses.asdict(discovery_info))
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, Awaitable, Callable, Union
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
+from homeassistant.components import dhcp, ssdp, zeroconf
 from homeassistant.components.mqtt import discovery as mqtt
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
@@ -123,7 +123,14 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
 
         return await self.async_step_confirm()
 
-    async_step_ssdp = async_step_discovery
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
+        """Handle a flow initialized by Ssdp discovery."""
+        if self._async_in_progress() or self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        await self.async_set_unique_id(self._domain)
+
+        return await self.async_step_confirm()
 
     async def async_step_import(self, _: dict[str, Any] | None) -> FlowResult:
         """Handle a flow initialized by import."""

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -64,19 +64,7 @@ async def test_ssdp_flow_dispatched_on_st(mock_get_ssdp, hass, caplog, mock_flow
     assert mock_flow_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_SSDP
     }
-    mock_call_data = mock_flow_init.mock_calls[0][2]["data"]
-    assert isinstance(mock_call_data, ssdp.SsdpServiceInfo)
-    # Compatibility with old dict access (to be removed after 2022.6)
-    assert mock_call_data[ssdp.ATTR_SSDP_ST] == "mock-st"
-    assert mock_call_data[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
-    assert mock_call_data[ssdp.ATTR_SSDP_USN] == "uuid:mock-udn::mock-st"
-    assert mock_call_data[ssdp.ATTR_SSDP_SERVER] == "mock-server"
-    assert mock_call_data[ssdp.ATTR_SSDP_EXT] == ""
-    assert mock_call_data[ssdp.ATTR_UPNP_UDN] == "uuid:mock-udn"
-    assert mock_call_data[ssdp.ATTR_SSDP_UDN] == ANY
-    assert mock_call_data["_timestamp"] == ANY
-    assert mock_call_data[ssdp.ATTR_HA_MATCHING_DOMAINS] == {"mock-domain"}
-    # Compatibility with new dataclass access
+    mock_call_data: ssdp.SsdpServiceInfo = mock_flow_init.mock_calls[0][2]["data"]
     assert mock_call_data.ssdp_st == "mock-st"
     assert mock_call_data.ssdp_location == "http://1.1.1.1"
     assert mock_call_data.ssdp_usn == "uuid:mock-udn::mock-st"
@@ -87,6 +75,17 @@ async def test_ssdp_flow_dispatched_on_st(mock_get_ssdp, hass, caplog, mock_flow
     assert mock_call_data.x_homeassistant_matching_domains == {"mock-domain"}
     assert mock_call_data.upnp == {ssdp.ATTR_UPNP_UDN: "uuid:mock-udn"}
     assert "Failed to fetch ssdp data" not in caplog.text
+    # Compatibility with old dict access (to be removed after 2022.6)
+    assert mock_call_data[ssdp.ATTR_SSDP_ST] == "mock-st"
+    assert mock_call_data[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
+    assert mock_call_data[ssdp.ATTR_SSDP_USN] == "uuid:mock-udn::mock-st"
+    assert mock_call_data[ssdp.ATTR_SSDP_SERVER] == "mock-server"
+    assert mock_call_data[ssdp.ATTR_SSDP_EXT] == ""
+    assert mock_call_data[ssdp.ATTR_UPNP_UDN] == "uuid:mock-udn"
+    assert mock_call_data[ssdp.ATTR_SSDP_UDN] == ANY
+    assert mock_call_data["_timestamp"] == ANY
+    assert mock_call_data[ssdp.ATTR_HA_MATCHING_DOMAINS] == {"mock-domain"}
+    # End compatibility checks
 
 
 @pytest.mark.usefixtures("mock_get_source_ip")
@@ -360,23 +359,7 @@ async def test_discovery_from_advertisement_sets_ssdp_st(
     await hass.async_block_till_done()
 
     discovery_info = await ssdp.async_get_discovery_info_by_udn(hass, "uuid:mock-udn")
-    assert len(discovery_info) == 1
     discovery_info = discovery_info[0]
-    assert isinstance(discovery_info, ssdp.SsdpServiceInfo)
-
-    # Compatibility with old dict access (to be removed after 2022.6)
-    assert discovery_info[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
-    assert discovery_info[ssdp.ATTR_SSDP_NT] == "mock-st"
-    # Set by ssdp component, not in original advertisement.
-    assert discovery_info[ssdp.ATTR_SSDP_ST] == "mock-st"
-    assert discovery_info[ssdp.ATTR_SSDP_USN] == "uuid:mock-udn::mock-st"
-    assert discovery_info[ssdp.ATTR_UPNP_UDN] == "uuid:mock-udn"
-    assert discovery_info[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
-    assert discovery_info[ssdp.ATTR_SSDP_UDN] == ANY
-    assert discovery_info["nts"] == "ssdp:alive"
-    assert discovery_info["_timestamp"] == ANY
-
-    # Compatibility with new dataclass access
     assert discovery_info.ssdp_location == "http://1.1.1.1"
     assert discovery_info.ssdp_nt == "mock-st"
     # Set by ssdp component, not in original advertisement.
@@ -389,6 +372,18 @@ async def test_discovery_from_advertisement_sets_ssdp_st(
         ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
         ssdp.ATTR_UPNP_UDN: "uuid:mock-udn",
     }
+    # Compatibility with old dict access (to be removed after 2022.6)
+    assert discovery_info[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
+    assert discovery_info[ssdp.ATTR_SSDP_NT] == "mock-st"
+    # Set by ssdp component, not in original advertisement.
+    assert discovery_info[ssdp.ATTR_SSDP_ST] == "mock-st"
+    assert discovery_info[ssdp.ATTR_SSDP_USN] == "uuid:mock-udn::mock-st"
+    assert discovery_info[ssdp.ATTR_UPNP_UDN] == "uuid:mock-udn"
+    assert discovery_info[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
+    assert discovery_info[ssdp.ATTR_SSDP_UDN] == ANY
+    assert discovery_info["nts"] == "ssdp:alive"
+    assert discovery_info["_timestamp"] == ANY
+    # End compatibility checks
 
 
 @patch(  # XXX TODO: Isn't this duplicate with mock_get_source_ip?
@@ -481,9 +476,23 @@ async def test_scan_with_registered_callback(
     assert async_integration_match_all_not_present_callback1.call_count == 0
     assert async_match_any_callback1.call_count == 1
     assert async_not_matching_integration_callback1.call_count == 0
-    assert isinstance(async_integration_callback.call_args[0][0], ssdp.SsdpServiceInfo)
     assert async_integration_callback.call_args[0][1] == ssdp.SsdpChange.ALIVE
-    mock_call_data = async_integration_callback.call_args[0][0]
+    mock_call_data: ssdp.SsdpServiceInfo = async_integration_callback.call_args[0][0]
+    assert mock_call_data.ssdp_ext == ""
+    assert mock_call_data.ssdp_location == "http://1.1.1.1"
+    assert mock_call_data.ssdp_server == "mock-server"
+    assert mock_call_data.ssdp_st == "mock-st"
+    assert (
+        mock_call_data.ssdp_usn == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::mock-st"
+    )
+    assert mock_call_data.ssdp_headers["x-rincon-bootseq"] == "55"
+    assert mock_call_data.ssdp_udn == ANY
+    assert mock_call_data.ssdp_headers["_timestamp"] == ANY
+    assert mock_call_data.x_homeassistant_matching_domains == set()
+    assert mock_call_data.upnp == {
+        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
+    }
     # Compatibility with old dict access (to be removed after 2022.6)
     assert mock_call_data[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
     assert mock_call_data[ssdp.ATTR_SSDP_EXT] == ""
@@ -502,17 +511,13 @@ async def test_scan_with_registered_callback(
     assert mock_call_data[ssdp.ATTR_SSDP_UDN] == ANY
     assert mock_call_data["_timestamp"] == ANY
     assert mock_call_data[ssdp.ATTR_HA_MATCHING_DOMAINS] == set()
-    assert mock_call_data.upnp == {
-        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-    }
+    # End of compatibility checks
     assert "Failed to callback info" in caplog.text
 
     async_integration_callback_from_cache = AsyncMock()
     await ssdp.async_register_callback(
         hass, async_integration_callback_from_cache, {"st": "mock-st"}
     )
-
     assert async_integration_callback_from_cache.call_count == 1
 
 
@@ -548,8 +553,22 @@ async def test_getting_existing_headers(
     await ssdp_listener._on_search(mock_ssdp_search_response)
 
     discovery_info_by_st = await ssdp.async_get_discovery_info_by_st(hass, "mock-st")
-    assert len(discovery_info_by_st) == 1
     discovery_info_by_st = discovery_info_by_st[0]
+    assert discovery_info_by_st.ssdp_ext == ""
+    assert discovery_info_by_st.ssdp_location == "http://1.1.1.1"
+    assert discovery_info_by_st.ssdp_server == "mock-server"
+    assert discovery_info_by_st.ssdp_st == "mock-st"
+    assert (
+        discovery_info_by_st.ssdp_usn
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3"
+    )
+    assert discovery_info_by_st.ssdp_udn == ANY
+    assert discovery_info_by_st.ssdp_headers["_timestamp"] == ANY
+    assert discovery_info_by_st.upnp == {
+        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
+    }
+    # Compatibility with old dict access (to be removed after 2022.6)
     assert discovery_info_by_st[ssdp.ATTR_SSDP_EXT] == ""
     assert discovery_info_by_st[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
     assert discovery_info_by_st[ssdp.ATTR_SSDP_SERVER] == "mock-server"
@@ -565,16 +584,27 @@ async def test_getting_existing_headers(
     assert discovery_info_by_st[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
     assert discovery_info_by_st[ssdp.ATTR_SSDP_UDN] == ANY
     assert discovery_info_by_st["_timestamp"] == ANY
-    assert discovery_info_by_st.upnp == {
-        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-    }
+    # End of compatibility checks
 
     discovery_info_by_udn = await ssdp.async_get_discovery_info_by_udn(
         hass, "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL"
     )
-    assert len(discovery_info_by_udn) == 1
     discovery_info_by_udn = discovery_info_by_udn[0]
+    assert discovery_info_by_udn.ssdp_ext == ""
+    assert discovery_info_by_udn.ssdp_location == "http://1.1.1.1"
+    assert discovery_info_by_udn.ssdp_server == "mock-server"
+    assert discovery_info_by_udn.ssdp_st == "mock-st"
+    assert (
+        discovery_info_by_udn.ssdp_usn
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3"
+    )
+    assert discovery_info_by_udn.ssdp_udn == ANY
+    assert discovery_info_by_udn.ssdp_headers["_timestamp"] == ANY
+    assert discovery_info_by_udn.upnp == {
+        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
+    }
+    # Compatibility with old dict access (to be removed after 2022.6)
     assert discovery_info_by_udn[ssdp.ATTR_SSDP_EXT] == ""
     assert discovery_info_by_udn[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
     assert discovery_info_by_udn[ssdp.ATTR_SSDP_SERVER] == "mock-server"
@@ -590,15 +620,26 @@ async def test_getting_existing_headers(
     assert discovery_info_by_udn[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
     assert discovery_info_by_udn[ssdp.ATTR_SSDP_UDN] == ANY
     assert discovery_info_by_udn["_timestamp"] == ANY
-    assert discovery_info_by_udn.upnp == {
-        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-    }
+    # End of compatibility checks
 
     discovery_info_by_udn_st = await ssdp.async_get_discovery_info_by_udn_st(
         hass, "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL", "mock-st"
     )
-    assert isinstance(discovery_info_by_udn_st, ssdp.SsdpServiceInfo)
+    assert discovery_info_by_udn_st.ssdp_ext == ""
+    assert discovery_info_by_udn_st.ssdp_location == "http://1.1.1.1"
+    assert discovery_info_by_udn_st.ssdp_server == "mock-server"
+    assert discovery_info_by_udn_st.ssdp_st == "mock-st"
+    assert (
+        discovery_info_by_udn_st.ssdp_usn
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3"
+    )
+    assert discovery_info_by_udn_st.ssdp_udn[ssdp.ATTR_SSDP_UDN] == ANY
+    assert discovery_info_by_udn_st.ssdp_headers["_timestamp"] == ANY
+    assert discovery_info_by_udn_st.upnp == {
+        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
+    }
+    # Compatibility with old dict access (to be removed after 2022.6)
     assert discovery_info_by_udn_st[ssdp.ATTR_SSDP_EXT] == ""
     assert discovery_info_by_udn_st[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
     assert discovery_info_by_udn_st[ssdp.ATTR_SSDP_SERVER] == "mock-server"
@@ -614,10 +655,7 @@ async def test_getting_existing_headers(
     assert discovery_info_by_udn_st[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
     assert discovery_info_by_udn_st[ssdp.ATTR_SSDP_UDN] == ANY
     assert discovery_info_by_udn_st["_timestamp"] == ANY
-    assert discovery_info_by_udn_st.upnp == {
-        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-    }
+    # End of compatibility checks
 
     assert (
         await ssdp.async_get_discovery_info_by_udn_st(hass, "wrong", "mock-st") is None

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -1,4 +1,6 @@
 """Test the SSDP integration."""
+# pylint: disable=protected-access
+
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address, IPv6Address
 from unittest.mock import ANY, AsyncMock, patch
@@ -62,20 +64,28 @@ async def test_ssdp_flow_dispatched_on_st(mock_get_ssdp, hass, caplog, mock_flow
     assert mock_flow_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_SSDP
     }
-    assert mock_flow_init.mock_calls[0][2]["data"] == {
-        ssdp.ATTR_SSDP_ST: "mock-st",
-        ssdp.ATTR_SSDP_LOCATION: "http://1.1.1.1",
-        ssdp.ATTR_SSDP_USN: "uuid:mock-udn::mock-st",
-        ssdp.ATTR_SSDP_SERVER: "mock-server",
-        ssdp.ATTR_SSDP_EXT: "",
-        ssdp.ATTR_UPNP_UDN: "uuid:mock-udn",
-        ssdp.ATTR_SSDP_UDN: ANY,
-        "_timestamp": ANY,
-        ssdp.ATTR_HA_MATCHING_DOMAINS: {"mock-domain"},
-        ssdp.ATTR_UPNP: {
-            ssdp.ATTR_UPNP_UDN: "uuid:mock-udn",
-        },
-    }
+    mock_call_data = mock_flow_init.mock_calls[0][2]["data"]
+    assert isinstance(mock_call_data, ssdp.SsdpServiceInfo)
+    # Compatibility with old dict access (to be removed after 2022.6)
+    assert mock_call_data[ssdp.ATTR_SSDP_ST] == "mock-st"
+    assert mock_call_data[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
+    assert mock_call_data[ssdp.ATTR_SSDP_USN] == "uuid:mock-udn::mock-st"
+    assert mock_call_data[ssdp.ATTR_SSDP_SERVER] == "mock-server"
+    assert mock_call_data[ssdp.ATTR_SSDP_EXT] == ""
+    assert mock_call_data[ssdp.ATTR_UPNP_UDN] == "uuid:mock-udn"
+    assert mock_call_data[ssdp.ATTR_SSDP_UDN] == ANY
+    assert mock_call_data["_timestamp"] == ANY
+    assert mock_call_data[ssdp.ATTR_HA_MATCHING_DOMAINS] == {"mock-domain"}
+    # Compatibility with new dataclass access
+    assert mock_call_data.ssdp_st == "mock-st"
+    assert mock_call_data.ssdp_location == "http://1.1.1.1"
+    assert mock_call_data.ssdp_usn == "uuid:mock-udn::mock-st"
+    assert mock_call_data.ssdp_server == "mock-server"
+    assert mock_call_data.ssdp_ext == ""
+    assert mock_call_data.ssdp_udn == ANY
+    assert mock_call_data.ssdp_headers["_timestamp"] == ANY
+    assert mock_call_data.x_homeassistant_matching_domains == {"mock-domain"}
+    assert mock_call_data.upnp == {ssdp.ATTR_UPNP_UDN: "uuid:mock-udn"}
     assert "Failed to fetch ssdp data" not in caplog.text
 
 
@@ -350,23 +360,35 @@ async def test_discovery_from_advertisement_sets_ssdp_st(
     await hass.async_block_till_done()
 
     discovery_info = await ssdp.async_get_discovery_info_by_udn(hass, "uuid:mock-udn")
-    assert discovery_info == [
-        {
-            ssdp.ATTR_SSDP_LOCATION: "http://1.1.1.1",
-            ssdp.ATTR_SSDP_NT: "mock-st",
-            ssdp.ATTR_SSDP_ST: "mock-st",  # Set by ssdp component, not in original advertisement.
-            ssdp.ATTR_SSDP_USN: "uuid:mock-udn::mock-st",
-            ssdp.ATTR_UPNP_UDN: "uuid:mock-udn",
-            ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-            ssdp.ATTR_SSDP_UDN: ANY,
-            "nts": "ssdp:alive",
-            "_timestamp": ANY,
-            ssdp.ATTR_UPNP: {
-                ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-                ssdp.ATTR_UPNP_UDN: "uuid:mock-udn",
-            },
-        }
-    ]
+    assert len(discovery_info) == 1
+    discovery_info = discovery_info[0]
+    assert isinstance(discovery_info, ssdp.SsdpServiceInfo)
+
+    # Compatibility with old dict access (to be removed after 2022.6)
+    assert discovery_info[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
+    assert discovery_info[ssdp.ATTR_SSDP_NT] == "mock-st"
+    # Set by ssdp component, not in original advertisement.
+    assert discovery_info[ssdp.ATTR_SSDP_ST] == "mock-st"
+    assert discovery_info[ssdp.ATTR_SSDP_USN] == "uuid:mock-udn::mock-st"
+    assert discovery_info[ssdp.ATTR_UPNP_UDN] == "uuid:mock-udn"
+    assert discovery_info[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
+    assert discovery_info[ssdp.ATTR_SSDP_UDN] == ANY
+    assert discovery_info["nts"] == "ssdp:alive"
+    assert discovery_info["_timestamp"] == ANY
+
+    # Compatibility with new dataclass access
+    assert discovery_info.ssdp_location == "http://1.1.1.1"
+    assert discovery_info.ssdp_nt == "mock-st"
+    # Set by ssdp component, not in original advertisement.
+    assert discovery_info.ssdp_st == "mock-st"
+    assert discovery_info.ssdp_usn == "uuid:mock-udn::mock-st"
+    assert discovery_info.ssdp_udn == ANY
+    assert discovery_info.ssdp_headers["nts"] == "ssdp:alive"
+    assert discovery_info.ssdp_headers["_timestamp"] == ANY
+    assert discovery_info.upnp == {
+        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+        ssdp.ATTR_UPNP_UDN: "uuid:mock-udn",
+    }
 
 
 @patch(  # XXX TODO: Isn't this duplicate with mock_get_source_ip?
@@ -459,26 +481,31 @@ async def test_scan_with_registered_callback(
     assert async_integration_match_all_not_present_callback1.call_count == 0
     assert async_match_any_callback1.call_count == 1
     assert async_not_matching_integration_callback1.call_count == 0
-    assert async_integration_callback.call_args[0] == (
-        {
-            ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-            ssdp.ATTR_SSDP_EXT: "",
-            ssdp.ATTR_SSDP_LOCATION: "http://1.1.1.1",
-            ssdp.ATTR_SSDP_SERVER: "mock-server",
-            ssdp.ATTR_SSDP_ST: "mock-st",
-            ssdp.ATTR_SSDP_USN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::mock-st",
-            ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-            "x-rincon-bootseq": "55",
-            ssdp.ATTR_SSDP_UDN: ANY,
-            "_timestamp": ANY,
-            ssdp.ATTR_HA_MATCHING_DOMAINS: set(),
-            ssdp.ATTR_UPNP: {
-                ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-                ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-            },
-        },
-        ssdp.SsdpChange.ALIVE,
+    assert isinstance(async_integration_callback.call_args[0][0], ssdp.SsdpServiceInfo)
+    assert async_integration_callback.call_args[0][1] == ssdp.SsdpChange.ALIVE
+    mock_call_data = async_integration_callback.call_args[0][0]
+    # Compatibility with old dict access (to be removed after 2022.6)
+    assert mock_call_data[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
+    assert mock_call_data[ssdp.ATTR_SSDP_EXT] == ""
+    assert mock_call_data[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
+    assert mock_call_data[ssdp.ATTR_SSDP_SERVER] == "mock-server"
+    assert mock_call_data[ssdp.ATTR_SSDP_ST] == "mock-st"
+    assert (
+        mock_call_data[ssdp.ATTR_SSDP_USN]
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::mock-st"
     )
+    assert (
+        mock_call_data[ssdp.ATTR_UPNP_UDN]
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL"
+    )
+    assert mock_call_data["x-rincon-bootseq"] == "55"
+    assert mock_call_data[ssdp.ATTR_SSDP_UDN] == ANY
+    assert mock_call_data["_timestamp"] == ANY
+    assert mock_call_data[ssdp.ATTR_HA_MATCHING_DOMAINS] == set()
+    assert mock_call_data.upnp == {
+        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
+    }
     assert "Failed to callback info" in caplog.text
 
     async_integration_callback_from_cache = AsyncMock()
@@ -521,62 +548,75 @@ async def test_getting_existing_headers(
     await ssdp_listener._on_search(mock_ssdp_search_response)
 
     discovery_info_by_st = await ssdp.async_get_discovery_info_by_st(hass, "mock-st")
-    assert discovery_info_by_st == [
-        {
-            ssdp.ATTR_SSDP_EXT: "",
-            ssdp.ATTR_SSDP_LOCATION: "http://1.1.1.1",
-            ssdp.ATTR_SSDP_SERVER: "mock-server",
-            ssdp.ATTR_SSDP_ST: "mock-st",
-            ssdp.ATTR_SSDP_USN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3",
-            ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-            ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-            ssdp.ATTR_SSDP_UDN: ANY,
-            "_timestamp": ANY,
-            ssdp.ATTR_UPNP: {
-                ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-                ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-            },
-        }
-    ]
+    assert len(discovery_info_by_st) == 1
+    discovery_info_by_st = discovery_info_by_st[0]
+    assert discovery_info_by_st[ssdp.ATTR_SSDP_EXT] == ""
+    assert discovery_info_by_st[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
+    assert discovery_info_by_st[ssdp.ATTR_SSDP_SERVER] == "mock-server"
+    assert discovery_info_by_st[ssdp.ATTR_SSDP_ST] == "mock-st"
+    assert (
+        discovery_info_by_st[ssdp.ATTR_SSDP_USN]
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3"
+    )
+    assert (
+        discovery_info_by_st[ssdp.ATTR_UPNP_UDN]
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL"
+    )
+    assert discovery_info_by_st[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
+    assert discovery_info_by_st[ssdp.ATTR_SSDP_UDN] == ANY
+    assert discovery_info_by_st["_timestamp"] == ANY
+    assert discovery_info_by_st.upnp == {
+        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
+    }
 
     discovery_info_by_udn = await ssdp.async_get_discovery_info_by_udn(
         hass, "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL"
     )
-    assert discovery_info_by_udn == [
-        {
-            ssdp.ATTR_SSDP_EXT: "",
-            ssdp.ATTR_SSDP_LOCATION: "http://1.1.1.1",
-            ssdp.ATTR_SSDP_SERVER: "mock-server",
-            ssdp.ATTR_SSDP_ST: "mock-st",
-            ssdp.ATTR_SSDP_USN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3",
-            ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-            ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-            ssdp.ATTR_SSDP_UDN: ANY,
-            "_timestamp": ANY,
-            ssdp.ATTR_UPNP: {
-                ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-                ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-            },
-        }
-    ]
+    assert len(discovery_info_by_udn) == 1
+    discovery_info_by_udn = discovery_info_by_udn[0]
+    assert discovery_info_by_udn[ssdp.ATTR_SSDP_EXT] == ""
+    assert discovery_info_by_udn[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
+    assert discovery_info_by_udn[ssdp.ATTR_SSDP_SERVER] == "mock-server"
+    assert discovery_info_by_udn[ssdp.ATTR_SSDP_ST] == "mock-st"
+    assert (
+        discovery_info_by_udn[ssdp.ATTR_SSDP_USN]
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3"
+    )
+    assert (
+        discovery_info_by_udn[ssdp.ATTR_UPNP_UDN]
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL"
+    )
+    assert discovery_info_by_udn[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
+    assert discovery_info_by_udn[ssdp.ATTR_SSDP_UDN] == ANY
+    assert discovery_info_by_udn["_timestamp"] == ANY
+    assert discovery_info_by_udn.upnp == {
+        ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
+    }
 
     discovery_info_by_udn_st = await ssdp.async_get_discovery_info_by_udn_st(
         hass, "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL", "mock-st"
     )
-    assert discovery_info_by_udn_st == {
-        ssdp.ATTR_SSDP_EXT: "",
-        ssdp.ATTR_SSDP_LOCATION: "http://1.1.1.1",
-        ssdp.ATTR_SSDP_SERVER: "mock-server",
-        ssdp.ATTR_SSDP_ST: "mock-st",
-        ssdp.ATTR_SSDP_USN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3",
-        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
+    assert isinstance(discovery_info_by_udn_st, ssdp.SsdpServiceInfo)
+    assert discovery_info_by_udn_st[ssdp.ATTR_SSDP_EXT] == ""
+    assert discovery_info_by_udn_st[ssdp.ATTR_SSDP_LOCATION] == "http://1.1.1.1"
+    assert discovery_info_by_udn_st[ssdp.ATTR_SSDP_SERVER] == "mock-server"
+    assert discovery_info_by_udn_st[ssdp.ATTR_SSDP_ST] == "mock-st"
+    assert (
+        discovery_info_by_udn_st[ssdp.ATTR_SSDP_USN]
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3"
+    )
+    assert (
+        discovery_info_by_udn_st[ssdp.ATTR_UPNP_UDN]
+        == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL"
+    )
+    assert discovery_info_by_udn_st[ssdp.ATTR_UPNP_DEVICE_TYPE] == "Paulus"
+    assert discovery_info_by_udn_st[ssdp.ATTR_SSDP_UDN] == ANY
+    assert discovery_info_by_udn_st["_timestamp"] == ANY
+    assert discovery_info_by_udn_st.upnp == {
         ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-        ssdp.ATTR_SSDP_UDN: ANY,
-        "_timestamp": ANY,
-        ssdp.ATTR_UPNP: {
-            ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
-            ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
-        },
+        ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
     }
 
     assert (

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -72,6 +72,7 @@ async def test_ssdp_flow_dispatched_on_st(mock_get_ssdp, hass, caplog, mock_flow
         ssdp.ATTR_SSDP_UDN: ANY,
         "_timestamp": ANY,
         ssdp.ATTR_HA_MATCHING_DOMAINS: {"mock-domain"},
+        ssdp.ATTR_UPNP: {},
     }
     assert "Failed to fetch ssdp data" not in caplog.text
 
@@ -358,6 +359,9 @@ async def test_discovery_from_advertisement_sets_ssdp_st(
             ssdp.ATTR_SSDP_UDN: ANY,
             "nts": "ssdp:alive",
             "_timestamp": ANY,
+            ssdp.ATTR_UPNP: {
+                ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+            },
         }
     ]
 
@@ -465,6 +469,9 @@ async def test_scan_with_registered_callback(
             ssdp.ATTR_SSDP_UDN: ANY,
             "_timestamp": ANY,
             ssdp.ATTR_HA_MATCHING_DOMAINS: set(),
+            ssdp.ATTR_UPNP: {
+                ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+            },
         },
         ssdp.SsdpChange.ALIVE,
     )
@@ -521,6 +528,9 @@ async def test_getting_existing_headers(
             ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
             ssdp.ATTR_SSDP_UDN: ANY,
             "_timestamp": ANY,
+            ssdp.ATTR_UPNP: {
+                ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+            },
         }
     ]
 
@@ -538,6 +548,9 @@ async def test_getting_existing_headers(
             ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
             ssdp.ATTR_SSDP_UDN: ANY,
             "_timestamp": ANY,
+            ssdp.ATTR_UPNP: {
+                ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+            },
         }
     ]
 
@@ -554,6 +567,9 @@ async def test_getting_existing_headers(
         ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
         ssdp.ATTR_SSDP_UDN: ANY,
         "_timestamp": ANY,
+        ssdp.ATTR_UPNP: {
+            ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+        },
     }
 
     assert (

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -633,7 +633,7 @@ async def test_getting_existing_headers(
         discovery_info_by_udn_st.ssdp_usn
         == "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL::urn:mdx-netflix-com:service:target:3"
     )
-    assert discovery_info_by_udn_st.ssdp_udn[ssdp.ATTR_SSDP_UDN] == ANY
+    assert discovery_info_by_udn_st.ssdp_udn == ANY
     assert discovery_info_by_udn_st.ssdp_headers["_timestamp"] == ANY
     assert discovery_info_by_udn_st.upnp == {
         ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -72,7 +72,9 @@ async def test_ssdp_flow_dispatched_on_st(mock_get_ssdp, hass, caplog, mock_flow
         ssdp.ATTR_SSDP_UDN: ANY,
         "_timestamp": ANY,
         ssdp.ATTR_HA_MATCHING_DOMAINS: {"mock-domain"},
-        ssdp.ATTR_UPNP: {},
+        ssdp.ATTR_UPNP: {
+            ssdp.ATTR_UPNP_UDN: "uuid:mock-udn",
+        },
     }
     assert "Failed to fetch ssdp data" not in caplog.text
 
@@ -361,6 +363,7 @@ async def test_discovery_from_advertisement_sets_ssdp_st(
             "_timestamp": ANY,
             ssdp.ATTR_UPNP: {
                 ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+                ssdp.ATTR_UPNP_UDN: "uuid:mock-udn",
             },
         }
     ]
@@ -471,6 +474,7 @@ async def test_scan_with_registered_callback(
             ssdp.ATTR_HA_MATCHING_DOMAINS: set(),
             ssdp.ATTR_UPNP: {
                 ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+                ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
             },
         },
         ssdp.SsdpChange.ALIVE,
@@ -530,6 +534,7 @@ async def test_getting_existing_headers(
             "_timestamp": ANY,
             ssdp.ATTR_UPNP: {
                 ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+                ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
             },
         }
     ]
@@ -550,6 +555,7 @@ async def test_getting_existing_headers(
             "_timestamp": ANY,
             ssdp.ATTR_UPNP: {
                 ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+                ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
             },
         }
     ]
@@ -569,6 +575,7 @@ async def test_getting_existing_headers(
         "_timestamp": ANY,
         ssdp.ATTR_UPNP: {
             ssdp.ATTR_UPNP_DEVICE_TYPE: "Paulus",
+            ssdp.ATTR_UPNP_UDN: "uuid:TIVRTLSR7ANF-D6E-1557809135086-RETAIL",
         },
     }
 

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -237,7 +237,9 @@ async def test_abort_discovered_multiple(hass, flow_handler, local_impl):
     )
 
     result = await hass.config_entries.flow.async_init(
-        TEST_DOMAIN, context={"source": config_entries.SOURCE_SSDP}
+        TEST_DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data=data_entry_flow.BaseServiceInfo(),
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -267,7 +269,9 @@ async def test_abort_discovered_existing_entries(hass, flow_handler, local_impl)
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        TEST_DOMAIN, context={"source": config_entries.SOURCE_SSDP}
+        TEST_DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data=data_entry_flow.BaseServiceInfo(),
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2351,7 +2351,7 @@ async def test_async_setup_update_entry(hass):
     "discovery_source",
     (
         (config_entries.SOURCE_DISCOVERY, {}),
-        (config_entries.SOURCE_SSDP, {}),
+        (config_entries.SOURCE_SSDP, BaseServiceInfo()),
         (config_entries.SOURCE_USB, BaseServiceInfo()),
         (config_entries.SOURCE_HOMEKIT, BaseServiceInfo()),
         (config_entries.SOURCE_DHCP, BaseServiceInfo()),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Ssdp discovery now uses a dataclass instead of a dictionary object.
Access using `__getitem__` will fail in version 2022.6.
Please use `<cls>.<name>` or `<cls>.upnp.<name>` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ssdp discovery now uses a dataclass instead of a dictionary object.
Access using `__getitem__` will fail in version 2022.6.
Please use `<cls>.<name>` or `<cls>.upnp.<name>` instead.

Linked to this comment in the architecture discussion https://github.com/home-assistant/architecture/discussions/662#discussioncomment-1674270

## This is a central PR to see what needs to be done:
1. Revert incorrect `SsdpServiceInfo(TypedDict)`: 
- #60270
2. Rename matching domains as the current value prevents use as property :
-  #60283
3. Introduce new `SsdpServiceInfo(BaseServiceInfo)` class: 
- #60284
4. Update all tests in components to use the new `SsdpServiceInfo(BaseServiceInfo)` class: 
- basic: #60320
- `ssdp_location` needs to be optional: #60322
- `get` needs to be implemented: #60334
- `__iter__` needs to be implemented: #60339
- fix an issue with `in` checks #60340
5. (this PR) Update ssdp to use the new `SsdpServiceInfo(BaseServiceInfo)` in `discovery_flow.async_create_flow`
6. Update all components to use the new `SsdpServiceInfo` in `async_step_ssdp`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
