### PR TITLE
Store: copy pending data

### DIFF
--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from contextlib import suppress
+from copy import deepcopy
 import inspect
 from json import JSONEncoder
 import logging
@@ -133,6 +134,10 @@ class Store:
             # If we didn't generate data yet, do it now.
             if "data_func" in data:
                 data["data"] = data.pop("data_func")()
+
+            # We make a copy because code might assume it's safe to mutate loaded data
+            # and we don't want that to mess with what we're trying to store.
+            data = deepcopy(data)
         else:
             data = await self.hass.async_add_executor_job(
                 json_util.load_json, self.path

--- a/tests/components/trace/fixtures/automation_saved_traces.json
+++ b/tests/components/trace/fixtures/automation_saved_traces.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "minor_version": 1,
     "key": "trace.saved_traces",
     "data": {
         "automation.sun": [

--- a/tests/components/trace/fixtures/script_saved_traces.json
+++ b/tests/components/trace/fixtures/script_saved_traces.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "minor_version": 1,
     "key": "trace.saved_traces",
     "data": {
         "script.sun": [

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -49,7 +49,7 @@ import homeassistant.util.dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-DEFAULT_CONFIG_ENTRY_ID = 1
+DEFAULT_CONFIG_ENTRY_ID = "1"
 DEFAULT_HOST = "1.2.3.4"
 DEFAULT_SITE = "site_id"
 

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -1089,7 +1089,7 @@ async def test_restoring_client(hass, aioclient_mock):
         data=ENTRY_CONFIG,
         source="test",
         options={},
-        entry_id=1,
+        entry_id="1",
     )
 
     registry = er.async_get(hass)

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -14,7 +14,7 @@ from .test_controller import (
     setup_unifi_integration,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, flush_store
 
 
 async def test_setup_with_no_config(hass):
@@ -110,6 +110,7 @@ async def test_wireless_clients(hass, hass_storage, aioclient_mock):
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, clients_response=[client_1, client_2]
     )
+    await flush_store(hass.data[unifi.UNIFI_WIRELESS_CLIENTS]._store)
 
     for mac in [
         "00:00:00:00:00:00",

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .test_controller import (
     CONTROLLER_HOST,
+    DEFAULT_CONFIG_ENTRY_ID,
     DESCRIPTION,
     ENTRY_CONFIG,
     setup_unifi_integration,
@@ -857,7 +858,7 @@ async def test_restore_client_succeed(hass, aioclient_mock):
         data=ENTRY_CONFIG,
         source="test",
         options={},
-        entry_id=1,
+        entry_id=DEFAULT_CONFIG_ENTRY_ID,
     )
 
     registry = er.async_get(hass)
@@ -947,7 +948,7 @@ async def test_restore_client_no_old_state(hass, aioclient_mock):
         data=ENTRY_CONFIG,
         source="test",
         options={},
-        entry_id=1,
+        entry_id=DEFAULT_CONFIG_ENTRY_ID,
     )
 
     registry = er.async_get(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Code calling `store.async_load_data()` assume they can mutate the data that is returned.

However, when there was a pending write, the data to be written would be returned. If that data got mutated it would mess with the data to be written to disk.

This bug fix will make sure we always return a copy of the pending written data.

Related to #58143

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
