### PR TITLE
Use native datetime value inMobile App sensors

### DIFF
--- a/homeassistant/components/mobile_app/sensor.py
+++ b/homeassistant/components/mobile_app/sensor.py
@@ -2,10 +2,17 @@
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import CONF_NAME, CONF_UNIQUE_ID, CONF_WEBHOOK_ID
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+    CONF_WEBHOOK_ID,
+    DEVICE_CLASS_DATE,
+    DEVICE_CLASS_TIMESTAMP,
+)
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTR_DEVICE_NAME,
@@ -81,7 +88,20 @@ class MobileAppSensor(MobileAppEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state of the sensor."""
-        return self._config[ATTR_SENSOR_STATE]
+        if (
+            (state := self._config[ATTR_SENSOR_STATE]) is not None
+            and self.device_class
+            in (
+                DEVICE_CLASS_DATE,
+                DEVICE_CLASS_TIMESTAMP,
+            )
+            and (timestamp := dt_util.parse_datetime(state)) is not None
+        ):
+            if self.device_class == DEVICE_CLASS_DATE:
+                return timestamp.date()
+            return timestamp
+
+        return state
 
     @property
     def native_unit_of_measurement(self):

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -1,6 +1,9 @@
 """Entity tests for mobile_app."""
 from http import HTTPStatus
 
+import pytest
+
+from homeassistant.components.sensor import DEVICE_CLASS_DATE, DEVICE_CLASS_TIMESTAMP
 from homeassistant.const import PERCENTAGE, STATE_UNKNOWN
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -276,3 +279,59 @@ async def test_update_sensor_no_state(hass, create_registrations, webhook_client
 
     updated_entity = hass.states.get("sensor.test_1_battery_state")
     assert updated_entity.state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "device_class,native_value,state_value",
+    [
+        (DEVICE_CLASS_DATE, "2021-11-18", "2021-11-18"),
+        (
+            DEVICE_CLASS_TIMESTAMP,
+            "2021-11-18T20:25:00",
+            "2021-11-18T20:25:00",
+        ),
+        (
+            DEVICE_CLASS_TIMESTAMP,
+            "2021-11-18 20:25:00",
+            "2021-11-18T20:25:00",
+        ),
+        (
+            DEVICE_CLASS_TIMESTAMP,
+            "2021-11-18 20:25:00+01:00",
+            "2021-11-18T20:25:00+01:00",
+        ),
+    ],
+)
+async def test_sensor_datetime(
+    hass, create_registrations, webhook_client, device_class, native_value, state_value
+):
+    """Test that sensors can be registered and updated."""
+    webhook_id = create_registrations[1]["webhook_id"]
+    webhook_url = f"/api/webhook/{webhook_id}"
+
+    reg_resp = await webhook_client.post(
+        webhook_url,
+        json={
+            "type": "register_sensor",
+            "data": {
+                "device_class": device_class,
+                "name": "Datetime sensor test",
+                "state": native_value,
+                "type": "sensor",
+                "unique_id": "super_unique",
+            },
+        },
+    )
+
+    assert reg_resp.status == HTTPStatus.CREATED
+
+    json = await reg_resp.json()
+    assert json == {"success": True}
+    await hass.async_block_till_done()
+
+    entity = hass.states.get("sensor.test_1_datetime_sensor_test")
+    assert entity is not None
+
+    assert entity.attributes["device_class"] == device_class
+    assert entity.domain == "sensor"
+    assert entity.state == state_value


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As introduced in #52671, sensors now should return a native date(time) when using the date(time) device classes.

This PR adjusts Mobile App to comply with that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59937
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
