### PR TITLE
Prevent executor overload when starting many homekit instances

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -1,4 +1,6 @@
 """Support for Apple HomeKit."""
+from __future__ import annotations
+
 import asyncio
 import ipaddress
 import logging
@@ -172,7 +174,7 @@ UNPAIR_SERVICE_SCHEMA = vol.All(
 )
 
 
-def _async_all_homekit_instances(hass: HomeAssistant) -> list["HomeKit"]:
+def _async_all_homekit_instances(hass: HomeAssistant) -> list[HomeKit]:
     """All active HomeKit instances."""
     return [
         data[HOMEKIT]

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -91,6 +91,7 @@ from .const import (
     HOMEKIT_PAIRING_QR,
     HOMEKIT_PAIRING_QR_SECRET,
     MANUFACTURER,
+    PERSIST_LOCK,
     SERVICE_HOMEKIT_RESET_ACCESSORY,
     SERVICE_HOMEKIT_START,
     SERVICE_HOMEKIT_UNPAIR,
@@ -171,6 +172,15 @@ UNPAIR_SERVICE_SCHEMA = vol.All(
 )
 
 
+def _async_all_homekit_instances(hass: HomeAssistant) -> list["HomeKit"]:
+    """All active HomeKit instances."""
+    return [
+        data[HOMEKIT]
+        for data in hass.data[DOMAIN].values()
+        if isinstance(data, dict) and HOMEKIT in data
+    ]
+
+
 def _async_get_entries_by_name(current_entries):
     """Return a dict of the entries by name."""
 
@@ -181,7 +191,7 @@ def _async_get_entries_by_name(current_entries):
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the HomeKit from yaml."""
-    hass.data.setdefault(DOMAIN, {})
+    hass.data.setdefault(DOMAIN, {})[PERSIST_LOCK] = asyncio.Lock()
 
     _async_register_events_and_services(hass)
 
@@ -360,10 +370,7 @@ def _async_register_events_and_services(hass: HomeAssistant):
 
     async def async_handle_homekit_reset_accessory(service):
         """Handle reset accessory HomeKit service call."""
-        for entry_id in hass.data[DOMAIN]:
-            if HOMEKIT not in hass.data[DOMAIN][entry_id]:
-                continue
-            homekit = hass.data[DOMAIN][entry_id][HOMEKIT]
+        for homekit in _async_all_homekit_instances(hass):
             if homekit.status != STATUS_RUNNING:
                 _LOGGER.warning(
                     "HomeKit is not running. Either it is waiting to be "
@@ -393,16 +400,11 @@ def _async_register_events_and_services(hass: HomeAssistant):
                 for ctype, cval in dev_reg_ent.connections
                 if ctype == device_registry.CONNECTION_NETWORK_MAC
             ]
-            domain_data = hass.data[DOMAIN]
             matching_instances = [
-                domain_data[entry_id][HOMEKIT]
-                for entry_id in domain_data
-                if HOMEKIT in domain_data[entry_id]
-                and domain_data[entry_id][HOMEKIT].driver
-                and device_registry.format_mac(
-                    domain_data[entry_id][HOMEKIT].driver.state.mac
-                )
-                in macs
+                homekit
+                for homekit in _async_all_homekit_instances(hass)
+                if homekit.driver
+                and device_registry.format_mac(homekit.driver.state.mac) in macs
             ]
             if not matching_instances:
                 raise HomeAssistantError(
@@ -421,10 +423,7 @@ def _async_register_events_and_services(hass: HomeAssistant):
     async def async_handle_homekit_service_start(service):
         """Handle start HomeKit service call."""
         tasks = []
-        for entry_id in hass.data[DOMAIN]:
-            if HOMEKIT not in hass.data[DOMAIN][entry_id]:
-                continue
-            homekit = hass.data[DOMAIN][entry_id][HOMEKIT]
+        for homekit in _async_all_homekit_instances(hass):
             if homekit.status == STATUS_RUNNING:
                 _LOGGER.debug("HomeKit is already running")
                 continue
@@ -707,7 +706,8 @@ class HomeKit:
         self._async_register_bridge()
         _LOGGER.debug("Driver start for %s", self._name)
         await self.driver.async_start()
-        self.driver.async_persist()
+        async with self.hass.data[DOMAIN][PERSIST_LOCK]:
+            await self.hass.async_add_executor_job(self.driver.persist)
         self.status = STATUS_RUNNING
 
         if self.driver.state.paired:

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -12,6 +12,7 @@ HOMEKIT_PAIRING_QR_SECRET = "homekit-pairing-qr-secret"
 HOMEKIT = "homekit"
 SHUTDOWN_TIMEOUT = 30
 CONF_ENTRY_INDEX = "index"
+PERSIST_LOCK = "persist_lock"
 
 # ### Codecs ####
 VIDEO_CODEC_COPY = "copy"


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prevent executor overload when starting many homekit instances.

Calling `driver.async_persist` is a wrapper around `driver.persist`
If there are many bridges/accessories they will all compete for disk I/O.

We now do the write under a lock to prevent the executor from overloading.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
