### PR TITLE
Prevent OpenUV from blocking other integrations' startup

### DIFF
--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -64,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     # We disable the client's request retry abilities here to avoid a lengthy (and
-    # blocking startup). Instead, we allow HASS to handle retries:
+    # blocking) startup:
     openuv.client.disable_request_retries()
 
     try:

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -51,22 +51,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up OpenUV as config entry."""
     _verify_domain_control = verify_domain_control(hass, DOMAIN)
 
+    websession = aiohttp_client.async_get_clientsession(hass)
+    openuv = OpenUV(
+        entry,
+        Client(
+            entry.data[CONF_API_KEY],
+            entry.data.get(CONF_LATITUDE, hass.config.latitude),
+            entry.data.get(CONF_LONGITUDE, hass.config.longitude),
+            altitude=entry.data.get(CONF_ELEVATION, hass.config.elevation),
+            session=websession,
+        ),
+    )
+
+    # We disable the client's request retry abilities here to avoid a lengthy (and
+    # blocking startup). Instead, we allow HASS to handle retries:
+    openuv.client.disable_request_retries()
+
     try:
-        websession = aiohttp_client.async_get_clientsession(hass)
-        openuv = OpenUV(
-            entry,
-            Client(
-                entry.data[CONF_API_KEY],
-                entry.data.get(CONF_LATITUDE, hass.config.latitude),
-                entry.data.get(CONF_LONGITUDE, hass.config.longitude),
-                altitude=entry.data.get(CONF_ELEVATION, hass.config.elevation),
-                session=websession,
-            ),
-        )
         await openuv.async_update()
     except OpenUvError as err:
         LOGGER.error("Config entry failed: %s", err)
         raise ConfigEntryNotReady from err
+
+    # Once we've successfully authenticated, we re-enable client request retries:
+    openuv.client.enable_request_retries()
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = openuv

--- a/homeassistant/components/openuv/manifest.json
+++ b/homeassistant/components/openuv/manifest.json
@@ -3,7 +3,7 @@
   "name": "OpenUV",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/openuv",
-  "requirements": ["pyopenuv==2.2.1"],
+  "requirements": ["pyopenuv==2021.11.0"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1688,7 +1688,7 @@ pyoctoprintapi==0.1.6
 pyombi==0.1.10
 
 # homeassistant.components.openuv
-pyopenuv==2.2.1
+pyopenuv==2021.11.0
 
 # homeassistant.components.opnsense
 pyopnsense==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1031,7 +1031,7 @@ pynzbgetapi==0.2.0
 pyoctoprintapi==0.1.6
 
 # homeassistant.components.openuv
-pyopenuv==2.2.1
+pyopenuv==2021.11.0
 
 # homeassistant.components.opnsense
 pyopnsense==0.2.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`pyopenuv` contains exponential retry logic. If a request fails during `async_entry_setup`, the integration can block others from loading. This PR alters things to disable the retry logic (and rely on HASS' built-in logic) during entry setup, then re-enabling it once setup is complete.

Changelog: https://github.com/bachya/pyopenuv/releases/tag/2021.11.0
Diff: https://github.com/bachya/pyopenuv/compare/2.2.1...2021.11.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/59947
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
