### PR TITLE
Use DhcpServiceInfo in dhcp tests

### DIFF
--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -171,11 +171,11 @@ async def test_dhcp_match_hostname_and_macaddress(hass):
     assert mock_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[0][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.210.56",
-        dhcp.HOSTNAME: "connect",
-        dhcp.MAC_ADDRESS: "b8b7f16db533",
-    }
+    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.210.56",
+        hostname="connect",
+        macaddress="b8b7f16db533",
+    )
 
 
 async def test_dhcp_renewal_match_hostname_and_macaddress(hass):
@@ -199,11 +199,11 @@ async def test_dhcp_renewal_match_hostname_and_macaddress(hass):
     assert mock_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[0][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.1.120",
-        dhcp.HOSTNAME: "irobot-ae9ec12dd3b04885bcbfa36afb01e1cc",
-        dhcp.MAC_ADDRESS: "50147903852c",
-    }
+    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.1.120",
+        hostname="irobot-ae9ec12dd3b04885bcbfa36afb01e1cc",
+        macaddress="50147903852c",
+    )
 
 
 async def test_dhcp_match_hostname(hass):
@@ -223,11 +223,11 @@ async def test_dhcp_match_hostname(hass):
     assert mock_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[0][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.210.56",
-        dhcp.HOSTNAME: "connect",
-        dhcp.MAC_ADDRESS: "b8b7f16db533",
-    }
+    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.210.56",
+        hostname="connect",
+        macaddress="b8b7f16db533",
+    )
 
 
 async def test_dhcp_match_macaddress(hass):
@@ -247,11 +247,11 @@ async def test_dhcp_match_macaddress(hass):
     assert mock_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[0][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.210.56",
-        dhcp.HOSTNAME: "connect",
-        dhcp.MAC_ADDRESS: "b8b7f16db533",
-    }
+    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.210.56",
+        hostname="connect",
+        macaddress="b8b7f16db533",
+    )
 
 
 async def test_dhcp_match_macaddress_without_hostname(hass):
@@ -271,11 +271,11 @@ async def test_dhcp_match_macaddress_without_hostname(hass):
     assert mock_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[0][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.107.151",
-        dhcp.HOSTNAME: "",
-        dhcp.MAC_ADDRESS: "606bbd59e4b4",
-    }
+    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.107.151",
+        hostname="",
+        macaddress="606bbd59e4b4",
+    )
 
 
 async def test_dhcp_nomatch(hass):
@@ -548,11 +548,11 @@ async def test_device_tracker_hostname_and_macaddress_exists_before_start(hass):
     assert mock_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[0][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.210.56",
-        dhcp.HOSTNAME: "connect",
-        dhcp.MAC_ADDRESS: "b8b7f16db533",
-    }
+    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.210.56",
+        hostname="connect",
+        macaddress="b8b7f16db533",
+    )
 
 
 async def test_device_tracker_hostname_and_macaddress_after_start(hass):
@@ -585,11 +585,11 @@ async def test_device_tracker_hostname_and_macaddress_after_start(hass):
     assert mock_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[0][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.210.56",
-        dhcp.HOSTNAME: "connect",
-        dhcp.MAC_ADDRESS: "b8b7f16db533",
-    }
+    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.210.56",
+        hostname="connect",
+        macaddress="b8b7f16db533",
+    )
 
 
 async def test_device_tracker_hostname_and_macaddress_after_start_not_home(hass):
@@ -731,11 +731,11 @@ async def test_aiodiscover_finds_new_hosts(hass):
     assert mock_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[0][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.210.56",
-        dhcp.HOSTNAME: "connect",
-        dhcp.MAC_ADDRESS: "b8b7f16db533",
-    }
+    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.210.56",
+        hostname="connect",
+        macaddress="b8b7f16db533",
+    )
 
 
 async def test_aiodiscover_does_not_call_again_on_shorter_hostname(hass):
@@ -786,20 +786,20 @@ async def test_aiodiscover_does_not_call_again_on_shorter_hostname(hass):
     assert mock_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[0][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.210.56",
-        dhcp.HOSTNAME: "irobot-abc",
-        dhcp.MAC_ADDRESS: "b8b7f16db533",
-    }
+    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.210.56",
+        hostname="irobot-abc",
+        macaddress="b8b7f16db533",
+    )
     assert mock_init.mock_calls[1][1][0] == "mock-domain"
     assert mock_init.mock_calls[1][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[1][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.210.56",
-        dhcp.HOSTNAME: "irobot-abcdef",
-        dhcp.MAC_ADDRESS: "b8b7f16db533",
-    }
+    assert mock_init.mock_calls[1][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.210.56",
+        hostname="irobot-abcdef",
+        macaddress="b8b7f16db533",
+    )
 
 
 async def test_aiodiscover_finds_new_hosts_after_interval(hass):
@@ -838,8 +838,8 @@ async def test_aiodiscover_finds_new_hosts_after_interval(hass):
     assert mock_init.mock_calls[0][2]["context"] == {
         "source": config_entries.SOURCE_DHCP
     }
-    assert mock_init.mock_calls[0][2]["data"] == {
-        dhcp.IP_ADDRESS: "192.168.210.56",
-        dhcp.HOSTNAME: "connect",
-        dhcp.MAC_ADDRESS: "b8b7f16db533",
-    }
+    assert mock_init.mock_calls[0][2]["data"] == dhcp.DhcpServiceInfo(
+        ip="192.168.210.56",
+        hostname="connect",
+        macaddress="b8b7f16db533",
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `DhcpServiceInfo` in `dhcp` tests

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
