### PR TITLE
Avoid removing zwave_js devices for non-ready nodes

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -355,6 +355,11 @@ async def async_setup_entry(  # noqa: C901
         assert device
         if replaced:
             discovered_value_ids.pop(device.id, None)
+
+            async_dispatcher_send(
+                hass,
+                f"{DOMAIN}_{client.driver.controller.home_id}.{node.node_id}.node_status_remove_entity",
+            )
         else:
             remove_device(device)
 

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from typing import Callable
 
 from async_timeout import timeout
 from zwave_js_server.client import Client as ZwaveClient
@@ -109,6 +110,56 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+@callback
+def register_node_in_dev_reg(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    dev_reg: device_registry.DeviceRegistry,
+    client: ZwaveClient,
+    node: ZwaveNode,
+    remove_device_func: Callable[[device_registry.DeviceEntry], None],
+) -> device_registry.DeviceEntry:
+    """Register node in dev reg."""
+    device_id = get_device_id(client, node)
+    device_id_ext = get_device_id_ext(client, node)
+    device = dev_reg.async_get_device({device_id})
+    device_name = device.name if device else None
+
+    # Replace the device if it can be determined that this node is not the
+    # same product as it was previously.
+    if (
+        device_id_ext
+        and device
+        and len(device.identifiers) == 2
+        and device_id_ext not in device.identifiers
+    ):
+        remove_device_func(device)
+        device = None
+
+    if device_id_ext:
+        ids = {device_id, device_id_ext}
+    else:
+        ids = {device_id}
+
+    params = {
+        ATTR_IDENTIFIERS: ids,
+        ATTR_SW_VERSION: node.firmware_version,
+        ATTR_NAME: node.name
+        or node.device_config.description
+        or device_name
+        or f"Node {node.node_id}",
+        ATTR_MODEL: node.device_config.label,
+        ATTR_MANUFACTURER: node.device_config.manufacturer,
+    }
+    if node.location:
+        params[ATTR_SUGGESTED_AREA] = node.location
+    device = dev_reg.async_get_or_create(config_entry_id=entry.entry_id, **params)
+
+    async_dispatcher_send(hass, EVENT_DEVICE_ADDED_TO_REGISTRY, device)
+
+    return device
+
+
 async def async_setup_entry(  # noqa: C901
     hass: HomeAssistant, entry: ConfigEntry
 ) -> bool:
@@ -134,48 +185,6 @@ async def async_setup_entry(  # noqa: C901
         dev_reg.async_remove_device(device.id)
         registered_unique_ids.pop(device.id, None)
         discovered_value_ids.pop(device.id, None)
-
-    @callback
-    def register_node_in_dev_reg(node: ZwaveNode) -> device_registry.DeviceEntry:
-        """Register node in dev reg."""
-        device_id = get_device_id(client, node)
-        device_id_ext = get_device_id_ext(client, node)
-        device = dev_reg.async_get_device({device_id})
-        device_name = device.name if device else None
-
-        # Replace the device if it can be determined that this node is not the
-        # same product as it was previously.
-        if (
-            device_id_ext
-            and device
-            and len(device.identifiers) == 2
-            and device_id_ext not in device.identifiers
-        ):
-            remove_device(device)
-            device = None
-
-        if device_id_ext:
-            ids = {device_id, device_id_ext}
-        else:
-            ids = {device_id}
-
-        params = {
-            ATTR_IDENTIFIERS: ids,
-            ATTR_SW_VERSION: node.firmware_version,
-            ATTR_NAME: node.name
-            or node.device_config.description
-            or device_name
-            or f"Node {node.node_id}",
-            ATTR_MODEL: node.device_config.label,
-            ATTR_MANUFACTURER: node.device_config.manufacturer,
-        }
-        if node.location:
-            params[ATTR_SUGGESTED_AREA] = node.location
-        device = dev_reg.async_get_or_create(config_entry_id=entry.entry_id, **params)
-
-        async_dispatcher_send(hass, EVENT_DEVICE_ADDED_TO_REGISTRY, device)
-
-        return device
 
     async def async_handle_discovery_info(
         device: device_registry.DeviceEntry,
@@ -230,7 +239,9 @@ async def async_setup_entry(  # noqa: C901
         """Handle node ready event."""
         LOGGER.debug("Processing node %s", node)
         # register (or update) node in device registry
-        device = register_node_in_dev_reg(node)
+        device = register_node_in_dev_reg(
+            hass, entry, dev_reg, client, node, remove_device
+        )
         # We only want to create the defaultdict once, even on reinterviews
         if device.id not in registered_unique_ids:
             registered_unique_ids[device.id] = defaultdict(set)
@@ -307,7 +318,7 @@ async def async_setup_entry(  # noqa: C901
         )
         # we do submit the node to device registry so user has
         # some visual feedback that something is (in the process of) being added
-        register_node_in_dev_reg(node)
+        register_node_in_dev_reg(hass, entry, dev_reg, client, node, remove_device)
 
     async def async_on_value_added(
         value_updates_disc_info: dict[str, ZwaveDiscoveryInfo], value: Value

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -122,16 +122,19 @@ def register_node_in_dev_reg(
     """Register node in dev reg."""
     device_id = get_device_id(client, node)
     device_id_ext = get_device_id_ext(client, node)
+    device = dev_reg.async_get_device({device_id})
+    device_name = device.name if device else None
 
     # Replace the device if it can be determined that this node is not the
     # same product as it was previously.
     if (
         device_id_ext
-        and (device := dev_reg.async_get_device({device_id}))
+        and device
         and len(device.identifiers) == 2
         and device_id_ext not in device.identifiers
     ):
         remove_device_func(device)
+        device = None
 
     if device_id_ext:
         ids = {device_id, device_id_ext}
@@ -143,6 +146,7 @@ def register_node_in_dev_reg(
         ATTR_SW_VERSION: node.firmware_version,
         ATTR_NAME: node.name
         or node.device_config.description
+        or device_name
         or f"Node {node.node_id}",
         ATTR_MODEL: node.device_config.label,
         ATTR_MANUFACTURER: node.device_config.manufacturer,

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -123,7 +123,6 @@ def register_node_in_dev_reg(
     device_id = get_device_id(client, node)
     device_id_ext = get_device_id_ext(client, node)
     device = dev_reg.async_get_device({device_id})
-    device_name = device.name if device else None
 
     # Replace the device if it can be determined that this node is not the
     # same product as it was previously.
@@ -146,7 +145,6 @@ def register_node_in_dev_reg(
         ATTR_SW_VERSION: node.firmware_version,
         ATTR_NAME: node.name
         or node.device_config.description
-        or device_name
         or f"Node {node.node_id}",
         ATTR_MODEL: node.device_config.label,
         ATTR_MANUFACTURER: node.device_config.manufacturer,

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from typing import Callable
+from collections.abc import Callable
 
 from async_timeout import timeout
 from zwave_js_server.client import Client as ZwaveClient

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -353,7 +353,9 @@ async def async_setup_entry(  # noqa: C901
         device = dev_reg.async_get_device({dev_id})
         # We assert because we know the device exists
         assert device
-        if not replaced:
+        if replaced:
+            discovered_value_ids.pop(device.id, None)
+        else:
             remove_device(device)
 
     @callback

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -20,6 +20,7 @@ from .migrate import async_add_migration_entity_value
 LOGGER = logging.getLogger(__name__)
 
 EVENT_VALUE_UPDATED = "value updated"
+EVENT_VALUE_REMOVED = "value removed"
 EVENT_DEAD = "dead"
 EVENT_ALIVE = "alive"
 
@@ -99,6 +100,10 @@ class ZWaveBaseEntity(Entity):
         self.async_on_remove(
             self.info.node.on(EVENT_VALUE_UPDATED, self._value_changed)
         )
+        self.async_on_remove(
+            self.info.node.on(EVENT_VALUE_REMOVED, self._value_removed)
+        )
+
         for status_event in (EVENT_ALIVE, EVENT_DEAD):
             self.async_on_remove(
                 self.info.node.on(status_event, self._node_status_alive_or_dead)
@@ -171,7 +176,7 @@ class ZWaveBaseEntity(Entity):
 
     @callback
     def _value_changed(self, event_data: dict) -> None:
-        """Call when (one of) our watched values changes.
+        """Call when a value associated with our node changes.
 
         Should not be overridden by subclasses.
         """
@@ -192,6 +197,25 @@ class ZWaveBaseEntity(Entity):
 
         self.on_value_update()
         self.async_write_ha_state()
+
+    @callback
+    def _value_removed(self, event_data: dict) -> None:
+        """Call when a value associated with our node is removed.
+
+        Should not be overridden by subclasses.
+        """
+        value_id = event_data["value"].value_id
+
+        if value_id != self.info.primary_value.value_id:
+            return
+
+        LOGGER.debug(
+            "[%s] Primary value %s is being removed",
+            self.entity_id,
+            value_id,
+        )
+
+        self.hass.async_create_task(self.async_remove())
 
     @callback
     def get_zwave_value(

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -72,9 +72,10 @@ def get_device_id_ext(client: ZwaveClient, node: ZwaveNode) -> tuple[str, str] |
     if None in (node.manufacturer_id, node.product_type, node.product_id):
         return None
 
+    domain, dev_id = get_device_id(client, node)
     return (
-        DOMAIN,
-        f"{client.driver.controller.home_id}-{node.node_id}-{node.manufacturer_id:04x}:{node.product_type:04x}:{node.product_id:04x}",
+        domain,
+        f"{dev_id}-{node.manufacturer_id:04x}:{node.product_type:04x}:{node.product_id:04x}",
     )
 
 

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -67,6 +67,18 @@ def get_device_id(client: ZwaveClient, node: ZwaveNode) -> tuple[str, str]:
 
 
 @callback
+def get_device_id_ext(client: ZwaveClient, node: ZwaveNode) -> tuple[str, str] | None:
+    """Get extended device registry identifier for Z-Wave node."""
+    if None in (node.manufacturer_id, node.product_type, node.product_id):
+        return None
+
+    return (
+        DOMAIN,
+        f"{client.driver.controller.home_id}-{node.node_id}-{node.manufacturer_id:04x}:{node.product_type:04x}:{node.product_id:04x}",
+    )
+
+
+@callback
 def get_home_and_node_id_from_device_id(device_id: tuple[str, ...]) -> list[str]:
     """
     Get home ID and node ID for Z-Wave device registry entry.

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -75,7 +75,7 @@ def get_device_id_ext(client: ZwaveClient, node: ZwaveNode) -> tuple[str, str] |
     domain, dev_id = get_device_id(client, node)
     return (
         domain,
-        f"{dev_id}-{node.manufacturer_id:04x}:{node.product_type:04x}:{node.product_id:04x}",
+        f"{dev_id}-{node.manufacturer_id}:{node.product_type}:{node.product_id}",
     )
 
 

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -502,4 +502,11 @@ class ZWaveNodeStatusSensor(SensorEntity):
                 self.async_poll_value,
             )
         )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_{self.unique_id}_remove_entity",
+                self.async_remove,
+            )
+        )
         self.async_write_ha_state()

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -479,6 +479,18 @@ def fortrezz_ssa3_siren_state_fixture():
     return json.loads(load_fixture("zwave_js/fortrezz_ssa3_siren_state.json"))
 
 
+@pytest.fixture(name="zp3111_not_ready_state", scope="session")
+def zp3111_not_ready_state_fixture():
+    """Load the zp3111 4-in-1 sensor not-ready node state fixture data."""
+    return json.loads(load_fixture("zwave_js/zp3111-5_not_ready_state.json"))
+
+
+@pytest.fixture(name="zp3111_state", scope="session")
+def zp3111_state_fixture():
+    """Load the zp3111 4-in-1 sensor node state fixture data."""
+    return json.loads(load_fixture("zwave_js/zp3111-5_state.json"))
+
+
 @pytest.fixture(name="client")
 def mock_client_fixture(controller_state, version_state, log_config_state):
     """Mock a client."""
@@ -919,3 +931,19 @@ def fortrezz_ssa3_siren_fixture(client, fortrezz_ssa3_siren_state):
 def firmware_file_fixture():
     """Return mock firmware file stream."""
     return io.BytesIO(bytes(10))
+
+
+@pytest.fixture(name="zp3111_not_ready")
+def zp3111_not_ready_fixture(client, zp3111_not_ready_state):
+    """Mock a zp3111 4-in-1 sensor node in a not-ready state."""
+    node = Node(client, copy.deepcopy(zp3111_not_ready_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="zp3111")
+def zp3111_fixture(client, zp3111_state):
+    """Mock a zp3111 4-in-1 sensor node."""
+    node = Node(client, copy.deepcopy(zp3111_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node

--- a/tests/components/zwave_js/fixtures/zp3111-5_not_ready_state.json
+++ b/tests/components/zwave_js/fixtures/zp3111-5_not_ready_state.json
@@ -1,0 +1,68 @@
+{
+    "nodeId": 22,
+    "index": 0,
+    "status": 1,
+    "ready": false,
+    "isListening": false,
+    "isRouting": true,
+    "isSecure": "unknown",
+    "interviewAttempts": 1,
+    "endpoints": [
+        {
+            "nodeId": 22,
+            "index": 0,
+            "deviceClass": {
+                "basic": {
+                    "key": 4,
+                    "label": "Routing Slave"
+                },
+                "generic": {
+                    "key": 7,
+                    "label": "Notification Sensor"
+                },
+                "specific": {
+                    "key": 1,
+                    "label": "Notification Sensor"
+                },
+                "mandatorySupportedCCs": [],
+                "mandatoryControlledCCs": []
+            }
+        }
+    ],
+    "values": [],
+    "isFrequentListening": false,
+    "maxDataRate": 100000,
+    "supportedDataRates": [
+        40000,
+        100000
+    ],
+    "protocolVersion": 3,
+    "supportsBeaming": true,
+    "supportsSecurity": false,
+    "nodeType": 1,
+    "deviceClass": {
+        "basic": {
+            "key": 4,
+            "label": "Routing Slave"
+        },
+        "generic": {
+            "key": 7,
+            "label": "Notification Sensor"
+        },
+        "specific": {
+            "key": 1,
+            "label": "Notification Sensor"
+        },
+        "mandatorySupportedCCs": [],
+        "mandatoryControlledCCs": []
+    },
+    "commandClasses": [],
+    "interviewStage": "ProtocolInfo",
+    "statistics": {
+        "commandsTX": 0,
+        "commandsRX": 0,
+        "commandsDroppedRX": 0,
+        "commandsDroppedTX": 0,
+        "timeoutResponse": 0
+    }
+}

--- a/tests/components/zwave_js/fixtures/zp3111-5_state.json
+++ b/tests/components/zwave_js/fixtures/zp3111-5_state.json
@@ -1,0 +1,706 @@
+{
+    "nodeId": 22,
+    "index": 0,
+    "installerIcon": 3079,
+    "userIcon": 3079,
+    "status": 2,
+    "ready": true,
+    "isListening": false,
+    "isRouting": true,
+    "isSecure": false,
+    "manufacturerId": 265,
+    "productId": 8449,
+    "productType": 8225,
+    "firmwareVersion": "5.1",
+    "zwavePlusVersion": 1,
+    "deviceConfig": {
+        "filename": "/cache/db/devices/0x0109/zp3111-5.json",
+        "isEmbedded": true,
+        "manufacturer": "Vision Security",
+        "manufacturerId": 265,
+        "label": "ZP3111-5",
+        "description": "4-in-1 Sensor",
+        "devices": [
+            {
+                "productType": 8225,
+                "productId": 8449
+            }
+        ],
+        "firmwareVersion": {
+            "min": "0.0",
+            "max": "255.255"
+        },
+        "paramInformation": {
+            "_map": {}
+        },
+        "metadata": {
+            "inclusion": "To add the ZP3111 to the Z-Wave network (inclusion), place the Z-Wave primary controller into inclusion mode. Press the Program Switch of ZP3111 for sending the NIF. After sending NIF, Z-Wave will send the auto inclusion, otherwise, ZP3111 will go to sleep after 20 seconds.",
+            "exclusion": "To remove the ZP3111 from the Z-Wave network (exclusion), place the Z-Wave primary controller into “exclusion” mode, and following its instruction to delete the ZP3111 to the controller. Press the Program Switch of ZP3111 once to be excluded.",
+            "reset": "Remove cover to trigged tamper switch, LED flash once & send out Alarm Report. Press Program Switch 10 times within 10 seconds, ZP3111 will send the “Device Reset Locally Notification” command and reset to the factory default. (Remark: This is to be used only in the case of primary controller being inoperable or otherwise unavailable.)",
+            "manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2479/ZP3111-5_R2_20170316.pdf"
+        }
+    },
+    "label": "ZP3111-5",
+    "interviewAttempts": 1,
+    "endpoints": [
+        {
+            "nodeId": 22,
+            "index": 0,
+            "installerIcon": 3079,
+            "userIcon": 3079,
+            "deviceClass": {
+                "basic": {
+                    "key": 4,
+                    "label": "Routing Slave"
+                },
+                "generic": {
+                    "key": 7,
+                    "label": "Notification Sensor"
+                },
+                "specific": {
+                    "key": 1,
+                    "label": "Notification Sensor"
+                },
+                "mandatorySupportedCCs": [],
+                "mandatoryControlledCCs": []
+            }
+        }
+    ],
+    "values": [
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "libraryType",
+            "propertyName": "libraryType",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Library type",
+                "states": {
+                    "0": "Unknown",
+                    "1": "Static Controller",
+                    "2": "Controller",
+                    "3": "Enhanced Slave",
+                    "4": "Slave",
+                    "5": "Installer",
+                    "6": "Routing Slave",
+                    "7": "Bridge Controller",
+                    "8": "Device under Test",
+                    "9": "N/A",
+                    "10": "AV Remote",
+                    "11": "AV Device"
+                }
+            },
+            "value": 3
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "protocolVersion",
+            "propertyName": "protocolVersion",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave protocol version"
+            },
+            "value": "4.5"
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "firmwareVersions",
+            "propertyName": "firmwareVersions",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "string[]",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave chip firmware versions"
+            },
+            "value": [
+                "5.1",
+                "10.1"
+            ]
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "hardwareVersion",
+            "propertyName": "hardwareVersion",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave chip hardware version"
+            },
+            "value": 1
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 114,
+            "commandClassName": "Manufacturer Specific",
+            "property": "manufacturerId",
+            "propertyName": "manufacturerId",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Manufacturer ID",
+                "min": 0,
+                "max": 65535
+            },
+            "value": 265
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 114,
+            "commandClassName": "Manufacturer Specific",
+            "property": "productType",
+            "propertyName": "productType",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Product type",
+                "min": 0,
+                "max": 65535
+            },
+            "value": 8225
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 114,
+            "commandClassName": "Manufacturer Specific",
+            "property": "productId",
+            "propertyName": "productId",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Product ID",
+                "min": 0,
+                "max": 65535
+            },
+            "value": 8449
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 128,
+            "commandClassName": "Battery",
+            "property": "level",
+            "propertyName": "level",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Battery level",
+                "min": 0,
+                "max": 100,
+                "unit": "%"
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 128,
+            "commandClassName": "Battery",
+            "property": "isLow",
+            "propertyName": "isLow",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "boolean",
+                "readable": true,
+                "writeable": false,
+                "label": "Low battery level"
+            },
+            "value": true
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 113,
+            "commandClassName": "Notification",
+            "property": "Home Security",
+            "propertyKey": "Cover status",
+            "propertyName": "Home Security",
+            "propertyKeyName": "Cover status",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Cover status",
+                "ccSpecific": {
+                    "notificationType": 7
+                },
+                "min": 0,
+                "max": 255,
+                "states": {
+                    "0": "idle",
+                    "3": "Tampering, product cover removed"
+                }
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 113,
+            "commandClassName": "Notification",
+            "property": "Home Security",
+            "propertyKey": "Motion sensor status",
+            "propertyName": "Home Security",
+            "propertyKeyName": "Motion sensor status",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Motion sensor status",
+                "ccSpecific": {
+                    "notificationType": 7
+                },
+                "min": 0,
+                "max": 255,
+                "states": {
+                    "0": "idle",
+                    "8": "Motion detection"
+                }
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 113,
+            "commandClassName": "Notification",
+            "property": "alarmType",
+            "propertyName": "alarmType",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Alarm Type",
+                "min": 0,
+                "max": 255
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 113,
+            "commandClassName": "Notification",
+            "property": "alarmLevel",
+            "propertyName": "alarmLevel",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Alarm Level",
+                "min": 0,
+                "max": 255
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 49,
+            "commandClassName": "Multilevel Sensor",
+            "property": "Air temperature",
+            "propertyName": "Air temperature",
+            "ccVersion": 7,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Air temperature",
+                "ccSpecific": {
+                    "sensorType": 1,
+                    "scale": 0
+                },
+                "unit": "°C"
+            },
+            "value": 21.98
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 49,
+            "commandClassName": "Multilevel Sensor",
+            "property": "Illuminance",
+            "propertyName": "Illuminance",
+            "ccVersion": 7,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Illuminance",
+                "ccSpecific": {
+                    "sensorType": 3,
+                    "scale": 0
+                },
+                "unit": "%"
+            },
+            "value": 7.31
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 49,
+            "commandClassName": "Multilevel Sensor",
+            "property": "Humidity",
+            "propertyName": "Humidity",
+            "ccVersion": 7,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Humidity",
+                "ccSpecific": {
+                    "sensorType": 5,
+                    "scale": 0
+                },
+                "unit": "%"
+            },
+            "value": 51.98
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 1,
+            "propertyName": "Temperature Scale",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Temperature Scale",
+                "default": 0,
+                "min": 0,
+                "max": 1,
+                "states": {
+                    "0": "Celsius",
+                    "1": "Fahrenheit"
+                },
+                "valueSize": 1,
+                "format": 0,
+                "allowManualEntry": false,
+                "isFromConfig": true
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 2,
+            "propertyName": "Temperature offset",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Temperature offset",
+                "default": 1,
+                "min": 0,
+                "max": 50,
+                "valueSize": 1,
+                "format": 0,
+                "allowManualEntry": true,
+                "isFromConfig": true
+            },
+            "value": 10
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 3,
+            "propertyName": "Humidity",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "description": "Configure Relative Humidity",
+                "label": "Humidity",
+                "default": 10,
+                "min": 1,
+                "max": 50,
+                "unit": "percent",
+                "valueSize": 1,
+                "format": 0,
+                "allowManualEntry": true,
+                "isFromConfig": true
+            },
+            "value": 10
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 4,
+            "propertyName": "Light Sensor",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Light Sensor",
+                "default": 10,
+                "min": 1,
+                "max": 50,
+                "unit": "percent",
+                "valueSize": 1,
+                "format": 0,
+                "allowManualEntry": true,
+                "isFromConfig": true
+            },
+            "value": 10
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 5,
+            "propertyName": "Trigger Interval",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "description": "Set the trigger interval for motion sensor re-activation.",
+                "label": "Trigger Interval",
+                "default": 180,
+                "min": 1,
+                "max": 255,
+                "unit": "seconds",
+                "valueSize": 1,
+                "format": 1,
+                "allowManualEntry": true,
+                "isFromConfig": true
+            },
+            "value": 3
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 6,
+            "propertyName": "Motion Sensor Sensitivity",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "description": "Adjust sensitivity of the motion sensor.",
+                "label": "Motion Sensor Sensitivity",
+                "default": 4,
+                "min": 1,
+                "max": 7,
+                "states": {
+                    "1": "highest",
+                    "2": "higher",
+                    "3": "high",
+                    "4": "normal",
+                    "5": "low",
+                    "6": "lower",
+                    "7": "lowest"
+                },
+                "valueSize": 1,
+                "format": 0,
+                "allowManualEntry": false,
+                "isFromConfig": true
+            },
+            "value": 4
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 7,
+            "propertyName": "LED indicator mode",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "LED indicator mode",
+                "default": 3,
+                "min": 1,
+                "max": 3,
+                "states": {
+                    "1": "Off",
+                    "2": "Pulsing Temperature, Flashing Motion",
+                    "3": "Flashing Temperature and Motion"
+                },
+                "valueSize": 1,
+                "format": 0,
+                "allowManualEntry": false,
+                "isFromConfig": true
+            },
+            "value": 3
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 132,
+            "commandClassName": "Wake Up",
+            "property": "wakeUpInterval",
+            "propertyName": "wakeUpInterval",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "number",
+                "default": 3600,
+                "readable": false,
+                "writeable": true,
+                "label": "Wake Up interval",
+                "min": 600,
+                "max": 604800,
+                "steps": 600
+            },
+            "value": 3600
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 132,
+            "commandClassName": "Wake Up",
+            "property": "controllerNodeId",
+            "propertyName": "controllerNodeId",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Node ID of the controller"
+            },
+            "value": 1
+        }
+    ],
+    "isFrequentListening": false,
+    "maxDataRate": 100000,
+    "supportedDataRates": [
+        40000,
+        100000
+    ],
+    "protocolVersion": 3,
+    "supportsBeaming": true,
+    "supportsSecurity": false,
+    "nodeType": 1,
+    "zwavePlusNodeType": 0,
+    "zwavePlusRoleType": 6,
+    "deviceClass": {
+        "basic": {
+            "key": 4,
+            "label": "Routing Slave"
+        },
+        "generic": {
+            "key": 7,
+            "label": "Notification Sensor"
+        },
+        "specific": {
+            "key": 1,
+            "label": "Notification Sensor"
+        },
+        "mandatorySupportedCCs": [],
+        "mandatoryControlledCCs": []
+    },
+    "commandClasses": [
+        {
+            "id": 94,
+            "name": "Z-Wave Plus Info",
+            "version": 2,
+            "isSecure": false
+        },
+        {
+            "id": 134,
+            "name": "Version",
+            "version": 2,
+            "isSecure": false
+        },
+        {
+            "id": 114,
+            "name": "Manufacturer Specific",
+            "version": 2,
+            "isSecure": false
+        },
+        {
+            "id": 90,
+            "name": "Device Reset Locally",
+            "version": 1,
+            "isSecure": false
+        },
+        {
+            "id": 133,
+            "name": "Association",
+            "version": 2,
+            "isSecure": false
+        },
+        {
+            "id": 89,
+            "name": "Association Group Information",
+            "version": 1,
+            "isSecure": false
+        },
+        {
+            "id": 115,
+            "name": "Powerlevel",
+            "version": 1,
+            "isSecure": false
+        },
+        {
+            "id": 128,
+            "name": "Battery",
+            "version": 1,
+            "isSecure": false
+        },
+        {
+            "id": 113,
+            "name": "Notification",
+            "version": 4,
+            "isSecure": false
+        },
+        {
+            "id": 49,
+            "name": "Multilevel Sensor",
+            "version": 7,
+            "isSecure": false
+        },
+        {
+            "id": 112,
+            "name": "Configuration",
+            "version": 1,
+            "isSecure": false
+        },
+        {
+            "id": 132,
+            "name": "Wake Up",
+            "version": 2,
+            "isSecure": false
+        },
+        {
+            "id": 122,
+            "name": "Firmware Update Meta Data",
+            "version": 2,
+            "isSecure": false
+        }
+    ],
+    "interviewStage": "Complete",
+    "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0109:0x2021:0x2101:5.1",
+    "statistics": {
+        "commandsTX": 39,
+        "commandsRX": 38,
+        "commandsDroppedRX": 0,
+        "commandsDroppedTX": 0,
+        "timeoutResponse": 0
+    },
+    "highestSecurityClass": -1
+}

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1156,6 +1156,32 @@ async def test_node_model_change(hass, zp3111, client, integration):
     assert state.name == "Custom Entity Name"
 
 
+async def test_disabled_node_status_entity_on_node_replaced(
+    hass, zp3111_state, zp3111, client, integration
+):
+    """Test that when a node replacement event is received the node status sensor is disabled."""
+    node_status_entity = "sensor.4_in_1_sensor_node_status"
+    state = hass.states.get(node_status_entity)
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    event = Event(
+        type="node removed",
+        data={
+            "source": "controller",
+            "event": "node removed",
+            "replaced": True,
+            "node": zp3111_state,
+        },
+    )
+    client.driver.receive_event(event)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(node_status_entity)
+    assert state
+    assert state.state == STATE_UNAVAILABLE
+
+
 async def test_disabled_entity_on_value_removed(hass, zp3111, client, integration):
     """Test that when entity primary values are removed the entity is disabled."""
     er_reg = er.async_get(hass)

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -221,7 +221,10 @@ async def test_existing_node_ready(hass, client, multisensor_6, integration):
     dev_reg = dr.async_get(hass)
     node = multisensor_6
     air_temperature_device_id = f"{client.driver.controller.home_id}-{node.node_id}"
-    air_temperature_device_id_ext = f"{air_temperature_device_id}-{node.manufacturer_id}:{node.product_type}:{node.product_id}"
+    air_temperature_device_id_ext = (
+        f"{air_temperature_device_id}-{node.manufacturer_id}:"
+        f"{node.product_type}:{node.product_id}"
+    )
 
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)
 
@@ -259,13 +262,19 @@ async def test_existing_node_not_ready(hass, zp3111_not_ready, client, integrati
 async def test_existing_node_not_replaced_when_not_ready(
     hass, zp3111, zp3111_not_ready_state, zp3111_state, client, integration
 ):
-    """Test that an existing node is not replaced, and no customization lost, when a node added event with a non-ready node is received."""
+    """Test when a node added event with a non-ready node is received.
+    
+    The existing node should not be replaced, and no customization should be lost.
+    """
     dev_reg = dr.async_get(hass)
     er_reg = er.async_get(hass)
     kitchen_area = ar.async_get(hass).async_create("Kitchen")
 
     device_id = f"{client.driver.controller.home_id}-{zp3111.node_id}"
-    device_id_ext = f"{device_id}-{zp3111.manufacturer_id}:{zp3111.product_type}:{zp3111.product_id}"
+    device_id_ext = (
+        f"{device_id}-{zp3111.manufacturer_id}:"
+        f"{zp3111.product_type}:{zp3111.product_id}"
+    )
 
     device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
     assert device
@@ -853,7 +862,10 @@ async def test_replace_same_node(
     multisensor_6_state = deepcopy(multisensor_6_state)
 
     device_id = f"{client.driver.controller.home_id}-{node_id}"
-    multisensor_6_device_id = f"{device_id}-{multisensor_6.manufacturer_id}:{multisensor_6.product_type}:{multisensor_6.product_id}"
+    multisensor_6_device_id = (
+        f"{device_id}-{multisensor_6.manufacturer_id}:"
+        f"{multisensor_6.product_type}:{multisensor_6.product_id}"
+    )
 
     device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
     assert device
@@ -866,7 +878,8 @@ async def test_replace_same_node(
 
     assert hass.states.get(AIR_TEMPERATURE_SENSOR)
 
-    # A replace node event has the extra field "replaced" set to True to distinguish it from an exclusion
+    # A replace node event has the extra field "replaced" set to True
+    # to distinguish it from an exclusion
     event = Event(
         type="node removed",
         data={
@@ -959,8 +972,15 @@ async def test_replace_different_node(
     hank_binary_switch_state["nodeId"] = node_id
 
     device_id = f"{client.driver.controller.home_id}-{node_id}"
-    multisensor_6_device_id = f"{device_id}-{multisensor_6.manufacturer_id}:{multisensor_6.product_type}:{multisensor_6.product_id}"
-    hank_device_id = f"{device_id}-{hank_binary_switch_state['manufacturerId']}:{hank_binary_switch_state['productType']}:{hank_binary_switch_state['productId']}"
+    multisensor_6_device_id = (
+        f"{device_id}-{multisensor_6.manufacturer_id}:"
+        f"{multisensor_6.product_type}:{multisensor_6.product_id}"
+    )
+    hank_device_id = (
+        f"{device_id}-{hank_binary_switch_state['manufacturerId']}:"
+        f"{hank_binary_switch_state['productType']}:"
+        f"{hank_binary_switch_state['productId']}"
+    )
 
     device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
     assert device
@@ -973,7 +993,8 @@ async def test_replace_different_node(
 
     assert hass.states.get(AIR_TEMPERATURE_SENSOR)
 
-    # A replace node event has the extra field "replaced" set to True to distinguish it from an exclusion
+    # A replace node event has the extra field "replaced" set to True
+    # to distinguish it from an exclusion
     event = Event(
         type="node removed",
         data={
@@ -1054,14 +1075,23 @@ async def test_replace_different_node(
 
 
 async def test_node_model_change(hass, zp3111, zp3111_state, client, integration):
-    """Test that when a node's model is changed due to an updated device config file, the device and entities are not removed."""
-    # This is not 100% realistic test, since the model change would be seen when the integration is loaded, not via a runtime event. The same registration code path is used though, so it practically similar
+    """Test when a node's model is changed due to an updated device config file.
+    
+    The device and entities should not be removed.
+    """
+    # This is not 100% realistic test,
+    # since the model change would be seen when the integration is loaded,
+    # not via a runtime event.
+    # The same registration code path is used though, so it's practically similar.
     dev_reg = dr.async_get(hass)
     er_reg = er.async_get(hass)
     zp3111_state = deepcopy(zp3111_state)
 
     device_id = f"{client.driver.controller.home_id}-{zp3111.node_id}"
-    device_id_ext = f"{device_id}-{zp3111.manufacturer_id}:{zp3111.product_type}:{zp3111.product_id}"
+    device_id_ext = (
+        f"{device_id}-{zp3111.manufacturer_id}:"
+        f"{zp3111.product_type}:{zp3111.product_id}"
+    )
 
     device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
     assert device
@@ -1109,7 +1139,7 @@ async def test_node_model_change(hass, zp3111, zp3111_state, client, integration
     client.driver.receive_event(event)
     await hass.async_block_till_done()
 
-    # Device name changes, but the cusomization is the same
+    # Device name changes, but the customization is the same
     device = dev_reg.async_get(dev_id)
     assert device
     assert device.name == "New Device Description"

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -263,7 +263,7 @@ async def test_existing_node_not_replaced_when_not_ready(
     hass, zp3111, zp3111_not_ready_state, zp3111_state, client, integration
 ):
     """Test when a node added event with a non-ready node is received.
-    
+
     The existing node should not be replaced, and no customization should be lost.
     """
     dev_reg = dr.async_get(hass)
@@ -1076,7 +1076,7 @@ async def test_replace_different_node(
 
 async def test_node_model_change(hass, zp3111, zp3111_state, client, integration):
     """Test when a node's model is changed due to an updated device config file.
-    
+
     The device and entities should not be removed.
     """
     # This is not 100% realistic test,

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -844,57 +844,25 @@ async def test_node_removed(hass, multisensor_6_state, client, integration):
     assert not dev_reg.async_get(old_device.id)
 
 
-async def test_replace_same_node(hass, multisensor_6_state, client, integration):
+async def test_replace_same_node(
+    hass, multisensor_6, multisensor_6_state, client, integration
+):
     """Test when a node is replaced with itself that the device remains."""
     dev_reg = dr.async_get(hass)
-    node = Node(client, deepcopy(multisensor_6_state))
-    device_id = f"{client.driver.controller.home_id}-{node.node_id}"
-    event = {"node": node}
-
-    client.driver.controller.emit("node added", event)
-    await hass.async_block_till_done()
-    old_device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
-    assert old_device.id
-
-    event = {"node": node, "replaced": True}
-
-    client.driver.controller.emit("node removed", event)
-    await hass.async_block_till_done()
-    # Assert device has remained
-    assert dev_reg.async_get(old_device.id)
-
-    event = {"node": node}
-
-    client.driver.controller.emit("node added", event)
-    await hass.async_block_till_done()
-    # Assert device has remained
-    assert dev_reg.async_get(old_device.id)
-
-
-async def test_replace_different_node(
-    hass,
-    multisensor_6,
-    multisensor_6_state,
-    hank_binary_switch_state,
-    client,
-    integration,
-):
-    """Test when a node is replaced with a different node."""
     node_id = multisensor_6.node_id
-    hank_binary_switch_state = deepcopy(hank_binary_switch_state)
-    hank_binary_switch_state["nodeId"] = node_id
+    multisensor_6_state = deepcopy(multisensor_6_state)
 
     device_id = f"{client.driver.controller.home_id}-{node_id}"
     multisensor_6_device_id = f"{device_id}-{multisensor_6.manufacturer_id}:{multisensor_6.product_type}:{multisensor_6.product_id}"
-    hank_device_id = f"{device_id}-{hank_binary_switch_state['manufacturerId']}:{hank_binary_switch_state['productType']}:{hank_binary_switch_state['productId']}"
 
-    dev_reg = dr.async_get(hass)
-    multisensor_6_device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
-    assert multisensor_6_device == dev_reg.async_get_device(
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
+    assert device
+    assert device == dev_reg.async_get_device(
         identifiers={(DOMAIN, multisensor_6_device_id)}
     )
-    assert multisensor_6_device.manufacturer == "AEON Labs"
-    assert multisensor_6_device.model == "ZW100"
+    assert device.manufacturer == "AEON Labs"
+    assert device.model == "ZW100"
+    dev_id = device.id
 
     assert hass.states.get(AIR_TEMPERATURE_SENSOR)
 
@@ -908,11 +876,118 @@ async def test_replace_different_node(
             "node": multisensor_6_state,
         },
     )
-
     client.driver.receive_event(event)
     await hass.async_block_till_done()
+
     # Device should still be there after the node was removed
-    device = dev_reg.async_get(multisensor_6_device.id)
+    device = dev_reg.async_get(dev_id)
+    assert device
+
+    # When the node is replaced, a non-ready node added event is emitted
+    event = Event(
+        type="node added",
+        data={
+            "source": "controller",
+            "event": "node added",
+            "node": {
+                "nodeId": node_id,
+                "index": 0,
+                "status": 4,
+                "ready": False,
+                "isSecure": "unknown",
+                "interviewAttempts": 1,
+                "endpoints": [{"nodeId": node_id, "index": 0, "deviceClass": None}],
+                "values": [],
+                "deviceClass": None,
+                "commandClasses": [],
+                "interviewStage": "None",
+                "statistics": {
+                    "commandsTX": 0,
+                    "commandsRX": 0,
+                    "commandsDroppedRX": 0,
+                    "commandsDroppedTX": 0,
+                    "timeoutResponse": 0,
+                },
+            },
+        },
+    )
+
+    # Device is still not removed
+    client.driver.receive_event(event)
+    await hass.async_block_till_done()
+
+    device = dev_reg.async_get(dev_id)
+    assert device
+
+    event = Event(
+        type="ready",
+        data={
+            "source": "node",
+            "event": "ready",
+            "nodeId": node_id,
+            "nodeState": multisensor_6_state,
+        },
+    )
+    client.driver.receive_event(event)
+    await hass.async_block_till_done()
+
+    # Device is the same
+    device = dev_reg.async_get(dev_id)
+    assert device
+    assert device == dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
+    assert device == dev_reg.async_get_device(
+        identifiers={(DOMAIN, multisensor_6_device_id)}
+    )
+    assert device.manufacturer == "AEON Labs"
+    assert device.model == "ZW100"
+
+    assert hass.states.get(AIR_TEMPERATURE_SENSOR)
+
+
+async def test_replace_different_node(
+    hass,
+    multisensor_6,
+    multisensor_6_state,
+    hank_binary_switch_state,
+    client,
+    integration,
+):
+    """Test when a node is replaced with a different node."""
+    dev_reg = dr.async_get(hass)
+    node_id = multisensor_6.node_id
+    hank_binary_switch_state = deepcopy(hank_binary_switch_state)
+    hank_binary_switch_state["nodeId"] = node_id
+
+    device_id = f"{client.driver.controller.home_id}-{node_id}"
+    multisensor_6_device_id = f"{device_id}-{multisensor_6.manufacturer_id}:{multisensor_6.product_type}:{multisensor_6.product_id}"
+    hank_device_id = f"{device_id}-{hank_binary_switch_state['manufacturerId']}:{hank_binary_switch_state['productType']}:{hank_binary_switch_state['productId']}"
+
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
+    assert device
+    assert device == dev_reg.async_get_device(
+        identifiers={(DOMAIN, multisensor_6_device_id)}
+    )
+    assert device.manufacturer == "AEON Labs"
+    assert device.model == "ZW100"
+    dev_id = device.id
+
+    assert hass.states.get(AIR_TEMPERATURE_SENSOR)
+
+    # A replace node event has the extra field "replaced" set to True to distinguish it from an exclusion
+    event = Event(
+        type="node removed",
+        data={
+            "source": "controller",
+            "event": "node removed",
+            "replaced": True,
+            "node": multisensor_6_state,
+        },
+    )
+    client.driver.receive_event(event)
+    await hass.async_block_till_done()
+
+    # Device should still be there after the node was removed
+    device = dev_reg.async_get(dev_id)
     assert device
 
     # When the node is replaced, a non-ready node added event is emitted
@@ -950,7 +1025,7 @@ async def test_replace_different_node(
     client.driver.receive_event(event)
     await hass.async_block_till_done()
 
-    device = dev_reg.async_get(multisensor_6_device.id)
+    device = dev_reg.async_get(dev_id)
     assert device
 
     event = Event(
@@ -966,7 +1041,7 @@ async def test_replace_different_node(
     await hass.async_block_till_done()
 
     # Old device and entities were removed, but the ID is re-used
-    device = dev_reg.async_get(multisensor_6_device.id)
+    device = dev_reg.async_get(dev_id)
     assert device
     assert device == dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
     assert device == dev_reg.async_get_device(identifiers={(DOMAIN, hank_device_id)})

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -225,12 +225,18 @@ async def test_existing_node_ready(hass, client, multisensor_6, integration):
     dev_reg = dr.async_get(hass)
     node = multisensor_6
     air_temperature_device_id = f"{client.driver.controller.home_id}-{node.node_id}"
+    air_temperature_device_id_ext = f"{air_temperature_device_id}-{node.manufacturer_id}:{node.product_type}:{node.product_id}"
 
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)
 
     assert state  # entity and device added
     assert state.state != STATE_UNAVAILABLE
-    assert dev_reg.async_get_device(identifiers={(DOMAIN, air_temperature_device_id)})
+
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, air_temperature_device_id)})
+    assert device
+    assert device == dev_reg.async_get_device(
+        identifiers={(DOMAIN, air_temperature_device_id_ext)}
+    )
 
 
 async def test_null_name(hass, client, null_name_check, integration):

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -305,6 +305,11 @@ async def test_existing_node_not_ready(
     assert device.model is None
     assert device.sw_version is None
 
+    state = hass.states.get(motion_entity_new)
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+    assert state.name == "Custom Sensor Name"
+
 
 async def test_start_addon(
     hass, addon_installed, install_addon, addon_options, set_addon_options, start_addon

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1092,6 +1092,11 @@ async def test_node_model_change(hass, zp3111, client, integration):
     device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
     assert device
     assert device == dev_reg.async_get_device(identifiers={(DOMAIN, device_id_ext)})
+    assert device.manufacturer == "Vision Security"
+    assert device.model == "ZP3111-5"
+    assert device.name == "4-in-1 Sensor"
+    assert not device.name_by_user
+
     dev_id = device.id
 
     motion_entity = "binary_sensor.4_in_1_sensor_home_security_motion_detection"
@@ -1105,9 +1110,10 @@ async def test_node_model_change(hass, zp3111, client, integration):
     assert device
     assert device.id == dev_id
     assert device == dev_reg.async_get_device(identifiers={(DOMAIN, device_id_ext)})
+    assert device.manufacturer == "Vision Security"
+    assert device.model == "ZP3111-5"
     assert device.name == "4-in-1 Sensor"
     assert device.name_by_user == "Custom Device Name"
-    assert device.manufacturer == "Vision Security"
 
     custom_entity = "binary_sensor.custom_motion_sensor"
     er_reg.async_update_entity(
@@ -1139,10 +1145,10 @@ async def test_node_model_change(hass, zp3111, client, integration):
     device = dev_reg.async_get(dev_id)
     assert device
     assert device.id == dev_id
+    assert device.manufacturer == "New Device Manufacturer"
+    assert device.model == "New Device Model"
     assert device.name == "New Device Name"
     assert device.name_by_user == "Custom Device Name"
-    assert device.model == "New Device Model"
-    assert device.manufacturer == "New Device Manufacturer"
 
     assert not hass.states.get(motion_entity)
     state = hass.states.get(custom_entity)

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1159,7 +1159,7 @@ async def test_node_model_change(hass, zp3111, client, integration):
 async def test_disabled_node_status_entity_on_node_replaced(
     hass, zp3111_state, zp3111, client, integration
 ):
-    """Test that when a node replacement event is received the node status sensor is disabled."""
+    """Test that when a node replacement event is received the node status sensor is removed."""
     node_status_entity = "sensor.4_in_1_sensor_node_status"
     state = hass.states.get(node_status_entity)
     assert state
@@ -1183,7 +1183,7 @@ async def test_disabled_node_status_entity_on_node_replaced(
 
 
 async def test_disabled_entity_on_value_removed(hass, zp3111, client, integration):
-    """Test that when entity primary values are removed the entity is disabled."""
+    """Test that when entity primary values are removed the entity is removed."""
     er_reg = er.async_get(hass)
 
     # re-enable this default-disabled entity
@@ -1223,7 +1223,7 @@ async def test_disabled_entity_on_value_removed(hass, zp3111, client, integratio
         if state.state == STATE_UNAVAILABLE
     }
 
-    # This value ID removal does not disable any entity
+    # This value ID removal does not remove any entity
     event = Event(
         type="value removed",
         data={


### PR DESCRIPTION
## Proposed change
If the zwave_js integration receives a `"node added"` event for a node that is not ready but matches an already created device, it will remove the device and re-create it, even if the node is the correct/original one. Removing the device loses all of the user device and entity customization (naming, etc.). Normally, this kind of event is only seen when a node has been included for the first time. It is also emitted for the following scenarios:
1. A cache loss or corruption, where all the node info must be rediscovered
2. Replacing a failed node

Additionally, a third case also causes a device removal: a product name is changed in the driver config file. The device replacement logic mistakenly believes a different node has replaced the original since the labels no longer match.

To correct this, the device registration logic has two main changes:
1. Skip removing devices which don't have a manufacturer id / product id / product type. In this state it's impossible to determine if a node is being replaced or not. This fixes the first two issues listed.
2. Register the node's manufacturer id / product id / product type fields as an additional device ID and use that to determine whether a node is replacing an existing one or not. These IDs are static and take the place of the device labels. This fixes the second and third issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #58874
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
