### PR TITLE
Sensor: Handle local->UTC conversion and reject timezoneless timestamps

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -302,11 +302,15 @@ class SensorEntity(Entity):
             # Anyways, lets validate the date at least..
             try:
                 value = ciso8601.parse_datetime(str(value))
-            except (ValueError, IndexError) as error:
-                raise ValueError(
-                    f"Invalid date/datetime: {self.entity_id} provide state '{value}', "
-                    f"while it has device class '{device_class}'"
-                ) from error
+            except (ValueError, IndexError):
+                _LOGGER.error(
+                    "Invalid date/datetime: %s provide state '%s', "
+                    "while it has device class '%s'",
+                    self.entity_id,
+                    value,
+                    device_class,
+                )
+                return None
 
             # Convert the date object to a standardized state string.
             if device_class == DEVICE_CLASS_DATE:
@@ -330,21 +334,27 @@ class SensorEntity(Entity):
                     value = value.astimezone(timezone.utc)  # type: ignore
 
                 return value.isoformat(timespec="seconds")  # type: ignore
-            except (AttributeError, TypeError) as err:
-                raise ValueError(
-                    f"Invalid datetime: {self.entity_id} has a timestamp device class"
-                    f"but does not provide a datetime state but {type(value)}"
-                ) from err
+            except (AttributeError, TypeError):
+                _LOGGER.error(
+                    "Invalid datetime: %s has a timestamp device class"
+                    "but does not provide a datetime state but %s",
+                    self.entity_id,
+                    type(value),
+                )
+                return None
 
         # Received a date value
         if value is not None and device_class == DEVICE_CLASS_DATE:
             try:
                 return value.isoformat()  # type: ignore
-            except (AttributeError, TypeError) as err:
-                raise ValueError(
-                    f"Invalid date: {self.entity_id} has a date device class"
-                    f"but does not provide a date state but {type(value)}"
-                ) from err
+            except (AttributeError, TypeError):
+                _LOGGER.error(
+                    "Invalid date: %s has a date device class"
+                    "but does not provide a date state but %s",
+                    self.entity_id,
+                    type(value),
+                )
+                return None
 
         units = self.hass.config.units
         if (

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -308,12 +308,12 @@ class SensorEntity(Entity):
                     f"while it has device class '{device_class}'"
                 ) from error
 
+            if value.tzinfo is not None and value.tzinfo != timezone.utc:
+                value = value.astimezone(timezone.utc)
+
             # Convert the date object to a standardized state string.
             if device_class == DEVICE_CLASS_DATE:
                 return value.date().isoformat()
-
-            if value.tzinfo is not None and value.tzinfo != timezone.utc:
-                value = value.astimezone(timezone.utc)
 
             return value.isoformat(timespec="seconds")
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -324,16 +324,19 @@ class SensorEntity(Entity):
         # Received a datetime
         if value is not None and device_class == DEVICE_CLASS_TIMESTAMP:
             try:
-                if value.tzinfo is None:  # type: ignore
+                # We cast the value, to avoid using isinstance, but satisfy
+                # typechecking. The error are guarded in this try.
+                value = cast(datetime, value)
+                if value.tzinfo is None:
                     raise ValueError(
                         f"Invalid datetime: {self.entity_id} provides state '{value}', "
                         "which is missing timezone information"
                     )
 
-                if value.tzinfo != timezone.utc:  # type: ignore
-                    value = value.astimezone(timezone.utc)  # type: ignore
+                if value.tzinfo != timezone.utc:
+                    value = value.astimezone(timezone.utc)
 
-                return value.isoformat(timespec="seconds")  # type: ignore
+                return value.isoformat(timespec="seconds")
             except (AttributeError, TypeError):
                 _LOGGER.error(
                     "Invalid datetime: %s has a timestamp device class"

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -325,7 +325,7 @@ class SensorEntity(Entity):
         if value is not None and device_class == DEVICE_CLASS_TIMESTAMP:
             try:
                 # We cast the value, to avoid using isinstance, but satisfy
-                # typechecking. The error are guarded in this try.
+                # typechecking. The errors are guarded in this try.
                 value = cast(datetime, value)
                 if value.tzinfo is None:
                     raise ValueError(

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -316,10 +316,10 @@ class SensorEntity(Entity):
             if device_class == DEVICE_CLASS_DATE:
                 return value.date().isoformat()
 
-            if value.tzinfo != timezone.utc:
+            if value.tzinfo is not None and value.tzinfo != timezone.utc:
                 value = value.astimezone(timezone.utc)
 
-            return value.astimezone(timezone.utc).isoformat(timespec="seconds")
+            return value.isoformat(timespec="seconds")
 
         # Received a datetime
         if value is not None and device_class == DEVICE_CLASS_TIMESTAMP:

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -302,15 +302,11 @@ class SensorEntity(Entity):
             # Anyways, lets validate the date at least..
             try:
                 value = ciso8601.parse_datetime(str(value))
-            except (ValueError, IndexError):
-                _LOGGER.error(
-                    "Invalid date/datetime: %s provide state '%s', "
-                    "while it has device class '%s'",
-                    self.entity_id,
-                    value,
-                    device_class,
-                )
-                return None
+            except (ValueError, IndexError) as error:
+                raise ValueError(
+                    f"Invalid date/datetime: {self.entity_id} provide state '{value}', "
+                    f"while it has device class '{device_class}'"
+                ) from error
 
             # Convert the date object to a standardized state string.
             if device_class == DEVICE_CLASS_DATE:
@@ -337,27 +333,21 @@ class SensorEntity(Entity):
                     value = value.astimezone(timezone.utc)
 
                 return value.isoformat(timespec="seconds")
-            except (AttributeError, TypeError):
-                _LOGGER.error(
-                    "Invalid datetime: %s has a timestamp device class"
-                    "but does not provide a datetime state but %s",
-                    self.entity_id,
-                    type(value),
-                )
-                return None
+            except (AttributeError, TypeError) as err:
+                raise ValueError(
+                    f"Invalid datetime: {self.entity_id} has a timestamp device class"
+                    f"but does not provide a datetime state but {type(value)}"
+                ) from err
 
         # Received a date value
         if value is not None and device_class == DEVICE_CLASS_DATE:
             try:
                 return value.isoformat()  # type: ignore
-            except (AttributeError, TypeError):
-                _LOGGER.error(
-                    "Invalid date: %s has a date device class"
-                    "but does not provide a date state but %s",
-                    self.entity_id,
-                    type(value),
-                )
-                return None
+            except (AttributeError, TypeError) as err:
+                raise ValueError(
+                    f"Invalid date: {self.entity_id} has a date device class"
+                    f"but does not provide a date state but {type(value)}"
+                ) from err
 
         units = self.hass.config.units
         if (

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -287,18 +287,13 @@ async def test_update_sensor_no_state(hass, create_registrations, webhook_client
         (DEVICE_CLASS_DATE, "2021-11-18", "2021-11-18"),
         (
             DEVICE_CLASS_TIMESTAMP,
-            "2021-11-18T20:25:00",
-            "2021-11-18T20:25:00",
-        ),
-        (
-            DEVICE_CLASS_TIMESTAMP,
-            "2021-11-18 20:25:00",
-            "2021-11-18T20:25:00",
+            "2021-11-18T20:25:00+00:00",
+            "2021-11-18T20:25:00+00:00",
         ),
         (
             DEVICE_CLASS_TIMESTAMP,
             "2021-11-18 20:25:00+01:00",
-            "2021-11-18T20:25:00+01:00",
+            "2021-11-18T19:25:00+00:00",
         ),
     ],
 )

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -1,5 +1,5 @@
 """The tests for Octoptint binary sensor module."""
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from homeassistant.helpers import entity_registry as er
@@ -22,7 +22,8 @@ async def test_sensors(hass):
         "state": "Printing",
     }
     with patch(
-        "homeassistant.util.dt.utcnow", return_value=datetime(2020, 2, 20, 9, 10, 0)
+        "homeassistant.util.dt.utcnow",
+        return_value=datetime(2020, 2, 20, 9, 10, 0, tzinfo=timezone.utc),
     ):
         await init_integration(hass, "sensor", printer=printer, job=job)
 
@@ -65,14 +66,14 @@ async def test_sensors(hass):
 
     state = hass.states.get("sensor.octoprint_start_time")
     assert state is not None
-    assert state.state == "2020-02-20T09:00:00"
+    assert state.state == "2020-02-20T09:00:00+00:00"
     assert state.name == "OctoPrint Start Time"
     entry = entity_registry.async_get("sensor.octoprint_start_time")
     assert entry.unique_id == "Start Time-uuid"
 
     state = hass.states.get("sensor.octoprint_estimated_finish_time")
     assert state is not None
-    assert state.state == "2020-02-20T10:50:00"
+    assert state.state == "2020-02-20T10:50:00+00:00"
     assert state.name == "OctoPrint Estimated Finish Time"
     entry = entity_registry.async_get("sensor.octoprint_estimated_finish_time")
     assert entry.unique_id == "Estimated Finish Time-uuid"

--- a/tests/components/picnic/test_sensor.py
+++ b/tests/components/picnic/test_sensor.py
@@ -210,44 +210,44 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         )
         self._assert_sensor(
             "sensor.picnic_selected_slot_start",
-            "2021-03-03T14:45:00+01:00",
+            "2021-03-03T13:45:00+00:00",
             cls=DEVICE_CLASS_TIMESTAMP,
         )
         self._assert_sensor(
             "sensor.picnic_selected_slot_end",
-            "2021-03-03T15:45:00+01:00",
+            "2021-03-03T14:45:00+00:00",
             cls=DEVICE_CLASS_TIMESTAMP,
         )
         self._assert_sensor(
             "sensor.picnic_selected_slot_max_order_time",
-            "2021-03-02T22:00:00+01:00",
+            "2021-03-02T21:00:00+00:00",
             cls=DEVICE_CLASS_TIMESTAMP,
         )
         self._assert_sensor("sensor.picnic_selected_slot_min_order_value", "35.0")
         self._assert_sensor(
             "sensor.picnic_last_order_slot_start",
-            "2021-02-26T20:15:00+01:00",
+            "2021-02-26T19:15:00+00:00",
             cls=DEVICE_CLASS_TIMESTAMP,
         )
         self._assert_sensor(
             "sensor.picnic_last_order_slot_end",
-            "2021-02-26T21:15:00+01:00",
+            "2021-02-26T20:15:00+00:00",
             cls=DEVICE_CLASS_TIMESTAMP,
         )
         self._assert_sensor("sensor.picnic_last_order_status", "COMPLETED")
         self._assert_sensor(
             "sensor.picnic_last_order_eta_start",
-            "2021-02-26T20:54:00+01:00",
+            "2021-02-26T19:54:00+00:00",
             cls=DEVICE_CLASS_TIMESTAMP,
         )
         self._assert_sensor(
             "sensor.picnic_last_order_eta_end",
-            "2021-02-26T21:14:00+01:00",
+            "2021-02-26T20:14:00+00:00",
             cls=DEVICE_CLASS_TIMESTAMP,
         )
         self._assert_sensor(
             "sensor.picnic_last_order_delivery_time",
-            "2021-02-26T20:54:05+01:00",
+            "2021-02-26T19:54:05+00:00",
             cls=DEVICE_CLASS_TIMESTAMP,
         )
         self._assert_sensor(
@@ -305,10 +305,10 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         # Assert delivery time is not available, but eta is
         self._assert_sensor("sensor.picnic_last_order_delivery_time", STATE_UNAVAILABLE)
         self._assert_sensor(
-            "sensor.picnic_last_order_eta_start", "2021-02-26T20:54:00+01:00"
+            "sensor.picnic_last_order_eta_start", "2021-02-26T19:54:00+00:00"
         )
         self._assert_sensor(
-            "sensor.picnic_last_order_eta_end", "2021-02-26T21:14:00+01:00"
+            "sensor.picnic_last_order_eta_end", "2021-02-26T20:14:00+00:00"
         )
 
     async def test_sensors_use_detailed_eta_if_available(self):
@@ -322,8 +322,8 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
         self.picnic_mock().get_deliveries.return_value = [delivery_response]
         self.picnic_mock().get_delivery_position.return_value = {
             "eta_window": {
-                "start": "2021-03-05T11:19:20.452+01:00",
-                "end": "2021-03-05T11:39:20.452+01:00",
+                "start": "2021-03-05T10:19:20.452+00:00",
+                "end": "2021-03-05T10:39:20.452+00:00",
             }
         }
         await self._coordinator.async_refresh()
@@ -333,10 +333,10 @@ class TestPicnicSensor(unittest.IsolatedAsyncioTestCase):
             delivery_response["delivery_id"]
         )
         self._assert_sensor(
-            "sensor.picnic_last_order_eta_start", "2021-03-05T11:19:20+01:00"
+            "sensor.picnic_last_order_eta_start", "2021-03-05T10:19:20+00:00"
         )
         self._assert_sensor(
-            "sensor.picnic_last_order_eta_end", "2021-03-05T11:39:20+01:00"
+            "sensor.picnic_last_order_eta_end", "2021-03-05T10:39:20+00:00"
         )
 
     async def test_sensors_no_data(self):

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -184,6 +184,16 @@ async def test_datetime_conversion(hass, caplog, enable_custom_integrations):
             "2021-01-09 12:00:00+01:00",
             "2021-01-09T11:00:00+00:00",
         ),
+        (
+            DEVICE_CLASS_TIMESTAMP,
+            "2021-01-09 12:00:00",
+            "2021-01-09T12:00:00",
+        ),
+        (
+            DEVICE_CLASS_TIMESTAMP,
+            "2021-01-09T12:00:00",
+            "2021-01-09T12:00:00",
+        ),
     ],
 )
 async def test_deprecated_datetime_str(

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -117,6 +117,9 @@ async def test_deprecated_unit_of_measurement(hass, caplog, enable_custom_integr
 async def test_datetime_conversion(hass, caplog, enable_custom_integrations):
     """Test conversion of datetime."""
     test_timestamp = datetime(2017, 12, 19, 18, 29, 42, tzinfo=timezone.utc)
+    test_local_timestamp = test_timestamp.astimezone(
+        dt_util.get_time_zone("Europe/Amsterdam")
+    )
     test_date = date(2017, 12, 19)
     platform = getattr(hass.components, "test.sensor")
     platform.init(empty=True)
@@ -131,6 +134,11 @@ async def test_datetime_conversion(hass, caplog, enable_custom_integrations):
     )
     platform.ENTITIES["3"] = platform.MockSensor(
         name="Test", native_value=None, device_class=DEVICE_CLASS_DATE
+    )
+    platform.ENTITIES["4"] = platform.MockSensor(
+        name="Test",
+        native_value=test_local_timestamp,
+        device_class=DEVICE_CLASS_TIMESTAMP,
     )
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
@@ -148,16 +156,38 @@ async def test_datetime_conversion(hass, caplog, enable_custom_integrations):
     state = hass.states.get(platform.ENTITIES["3"].entity_id)
     assert state.state == STATE_UNKNOWN
 
+    state = hass.states.get(platform.ENTITIES["4"].entity_id)
+    assert state.state == test_timestamp.isoformat()
+
 
 @pytest.mark.parametrize(
-    "device_class,native_value",
+    "device_class,native_value,state_value",
     [
-        (DEVICE_CLASS_DATE, "2021-11-09"),
-        (DEVICE_CLASS_TIMESTAMP, "2021-01-09T12:00:00+00:00"),
+        (DEVICE_CLASS_DATE, "2021-11-09", "2021-11-09"),
+        (
+            DEVICE_CLASS_TIMESTAMP,
+            "2021-01-09T12:00:00+00:00",
+            "2021-01-09T12:00:00+00:00",
+        ),
+        (
+            DEVICE_CLASS_TIMESTAMP,
+            "2021-01-09 12:00:00+00:00",
+            "2021-01-09T12:00:00+00:00",
+        ),
+        (
+            DEVICE_CLASS_TIMESTAMP,
+            "2021-01-09T12:00:00+04:00",
+            "2021-01-09T08:00:00+00:00",
+        ),
+        (
+            DEVICE_CLASS_TIMESTAMP,
+            "2021-01-09 12:00:00+01:00",
+            "2021-01-09T11:00:00+00:00",
+        ),
     ],
 )
 async def test_deprecated_datetime_str(
-    hass, caplog, enable_custom_integrations, device_class, native_value
+    hass, caplog, enable_custom_integrations, device_class, native_value, state_value
 ):
     """Test warning on deprecated str for a date(time) value."""
     platform = getattr(hass.components, "test.sensor")
@@ -171,9 +201,29 @@ async def test_deprecated_datetime_str(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert state.state == native_value
+    assert state.state == state_value
     assert (
         "is providing a string for its state, while the device class is "
         f"'{device_class}', this is not valid and will be unsupported "
         "from Home Assistant 2022.2."
+    ) in caplog.text
+
+
+async def test_reject_timezoneless_datetime_str(
+    hass, caplog, enable_custom_integrations
+):
+    """Test rejection of timezone-less datetime objects as timestamp."""
+    test_timestamp = datetime(2017, 12, 19, 18, 29, 42, tzinfo=None)
+    platform = getattr(hass.components, "test.sensor")
+    platform.init(empty=True)
+    platform.ENTITIES["0"] = platform.MockSensor(
+        name="Test", native_value=test_timestamp, device_class=DEVICE_CLASS_TIMESTAMP
+    )
+
+    assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    assert (
+        "Invalid datetime: sensor.test provides state '2017-12-19 18:29:42', "
+        "which is missing timezone information"
     ) in caplog.text

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -165,6 +165,16 @@ async def test_datetime_conversion(hass, caplog, enable_custom_integrations):
     [
         (DEVICE_CLASS_DATE, "2021-11-09", "2021-11-09"),
         (
+            DEVICE_CLASS_DATE,
+            "2021-01-09T12:00:00+00:00",
+            "2021-01-09",
+        ),
+        (
+            DEVICE_CLASS_DATE,
+            "2021-01-09T00:00:00+01:00",
+            "2021-01-08",
+        ),
+        (
             DEVICE_CLASS_TIMESTAMP,
             "2021-01-09T12:00:00+00:00",
             "2021-01-09T12:00:00+00:00",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds timezone conversion to the Sensor entity component, in case the device class of the sensor is `timestamp`.

Datetime objects are converted from "whatever-timezone" to UTC. Datetime objects missing timezone information, are rejected.

Existing string-based timestamps have already been deprecated, these are handled gracefully at this point but are converted to UTC when timezone information is present.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1140

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
