### PR TITLE
Use ZeroconfServiceInfo in homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     async_get_registry as async_get_device_registry,
@@ -157,13 +158,13 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 continue
             record = device.info
             return await self.async_step_zeroconf(
-                {
-                    "host": record["address"],
-                    "port": record["port"],
-                    "hostname": record["name"],
-                    "type": "_hap._tcp.local.",
-                    "name": record["name"],
-                    "properties": {
+                zeroconf.ZeroconfServiceInfo(
+                    host=record["address"],
+                    port=record["port"],
+                    hostname=record["name"],
+                    type="_hap._tcp.local.",
+                    name=record["name"],
+                    properties={
                         "md": record["md"],
                         "pv": record["pv"],
                         "id": unique_id,
@@ -174,7 +175,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         "sf": record["sf"],
                         "sh": "",
                     },
-                }
+                )
             )
 
         return self.async_abort(reason="no_devices")
@@ -196,7 +197,9 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return False
 
-    async def async_step_zeroconf(self, discovery_info):
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
         """Handle a discovered HomeKit accessory.
 
         This flow is triggered by the discovery component.
@@ -205,7 +208,8 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # homekit_python has code to do this, but not in a form we can
         # easily use, so do the bare minimum ourselves here instead.
         properties = {
-            key.lower(): value for (key, value) in discovery_info["properties"].items()
+            key.lower(): value
+            for (key, value) in discovery_info[zeroconf.ATTR_PROPERTIES].items()
         }
 
         if "id" not in properties:
@@ -221,7 +225,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # It changes if a device is factory reset.
         hkid = properties["id"]
         model = properties["md"]
-        name = discovery_info["name"].replace("._hap._tcp.local.", "")
+        name = discovery_info[zeroconf.ATTR_NAME].replace("._hap._tcp.local.", "")
         status_flags = int(properties["sf"])
         paired = not status_flags & 0x01
 
@@ -239,8 +243,8 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         # Set unique-id and error out if it's already configured
         existing_entry = await self.async_set_unique_id(normalize_hkid(hkid))
         updated_ip_port = {
-            "AccessoryIP": discovery_info["host"],
-            "AccessoryPort": discovery_info["port"],
+            "AccessoryIP": discovery_info[zeroconf.ATTR_HOST],
+            "AccessoryPort": discovery_info[zeroconf.ATTR_PORT],
         }
 
         # If the device is already paired and known to us we should monitor c#

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -11,6 +11,7 @@ from aiohomekit.model.services import ServicesTypes
 import pytest
 
 from homeassistant import config_entries
+from homeassistant.components import zeroconf
 from homeassistant.components.homekit_controller import config_flow
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 from homeassistant.helpers import device_registry
@@ -133,16 +134,18 @@ def get_flow_context(hass, result):
     return flow["context"]
 
 
-def get_device_discovery_info(device, upper_case_props=False, missing_csharp=False):
+def get_device_discovery_info(
+    device, upper_case_props=False, missing_csharp=False
+) -> zeroconf.ZeroconfServiceInfo:
     """Turn a aiohomekit format zeroconf entry into a homeassistant one."""
     record = device.info
-    result = {
-        "host": record["address"],
-        "port": record["port"],
-        "hostname": record["name"],
-        "type": "_hap._tcp.local.",
-        "name": record["name"],
-        "properties": {
+    result = zeroconf.ZeroconfServiceInfo(
+        host=record["address"],
+        port=record["port"],
+        hostname=record["name"],
+        type="_hap._tcp.local.",
+        name=record["name"],
+        properties={
             "md": record["md"],
             "pv": record["pv"],
             "id": device.device_id,
@@ -153,7 +156,7 @@ def get_device_discovery_info(device, upper_case_props=False, missing_csharp=Fal
             "sf": 0x01,  # record["sf"],
             "sh": "",
         },
-    }
+    )
 
     if missing_csharp:
         del result["properties"]["c#"]
@@ -286,8 +289,8 @@ async def test_discovery_ignored_model(hass, controller):
     """Already paired."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
-    discovery_info["properties"]["id"] = "AA:BB:CC:DD:EE:FF"
-    discovery_info["properties"]["md"] = "HHKBridge1,1"
+    discovery_info[zeroconf.ATTR_PROPERTIES]["id"] = "AA:BB:CC:DD:EE:FF"
+    discovery_info[zeroconf.ATTR_PROPERTIES]["md"] = "HHKBridge1,1"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -314,7 +317,7 @@ async def test_discovery_ignored_hk_bridge(hass, controller):
         connections={(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)},
     )
 
-    discovery_info["properties"]["id"] = "AA:BB:CC:DD:EE:FF"
+    discovery_info[zeroconf.ATTR_PROPERTIES]["id"] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -341,7 +344,7 @@ async def test_discovery_does_not_ignore_non_homekit(hass, controller):
         connections={(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)},
     )
 
-    discovery_info["properties"]["id"] = "AA:BB:CC:DD:EE:FF"
+    discovery_info[zeroconf.ATTR_PROPERTIES]["id"] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -373,7 +376,7 @@ async def test_discovery_broken_pairing_flag(hass, controller):
     discovery_info = get_device_discovery_info(device)
 
     # Make sure that we are pairable
-    assert discovery_info["properties"]["sf"] != 0x0
+    assert discovery_info[zeroconf.ATTR_PROPERTIES]["sf"] != 0x0
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -445,7 +448,7 @@ async def test_discovery_already_configured(hass, controller):
     discovery_info = get_device_discovery_info(device)
 
     # Set device as already paired
-    discovery_info["properties"]["sf"] = 0x00
+    discovery_info[zeroconf.ATTR_PROPERTIES]["sf"] = 0x00
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -481,9 +484,9 @@ async def test_discovery_already_configured_update_csharp(hass, controller):
     discovery_info = get_device_discovery_info(device)
 
     # Set device as already paired
-    discovery_info["properties"]["sf"] = 0x00
-    discovery_info["properties"]["c#"] = 99999
-    discovery_info["properties"]["id"] = "AA:BB:CC:DD:EE:FF"
+    discovery_info[zeroconf.ATTR_PROPERTIES]["sf"] = 0x00
+    discovery_info[zeroconf.ATTR_PROPERTIES]["c#"] = 99999
+    discovery_info[zeroconf.ATTR_PROPERTIES]["id"] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and zeroconf constants) in `homekit_controller`

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
