### PR TITLE
Use ZeroconfServiceInfo in hue

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -232,7 +232,8 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         host is already configured and delegate to the import step if not.
         """
         bridge = await self._get_bridge(
-            discovery_info["host"], discovery_info["properties"]["bridgeid"]
+            discovery_info[zeroconf.ATTR_HOST],
+            discovery_info[zeroconf.ATTR_PROPERTIES]["bridgeid"],
         )
 
         await self.async_set_unique_id(bridge.id)
@@ -252,7 +253,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         as the unique identifier. Therefore, this method uses discovery without
         a unique ID.
         """
-        self.bridge = await self._get_bridge(discovery_info[CONF_HOST])
+        self.bridge = await self._get_bridge(discovery_info[zeroconf.ATTR_HOST])
         await self._async_handle_discovery_without_unique_id()
         return await self.async_step_link()
 

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -8,7 +8,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import ssdp
+from homeassistant.components import ssdp, zeroconf
 from homeassistant.components.hue import config_flow, const
 from homeassistant.components.hue.errors import CannotConnect
 
@@ -515,12 +515,9 @@ async def test_bridge_homekit(hass, aioclient_mock):
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data={
-            "host": "0.0.0.0",
-            "serial": "1234",
-            "manufacturerURL": config_flow.HUE_MANUFACTURERURL,
-            "properties": {"id": "aa:bb:cc:dd:ee:ff"},
-        },
+        data=zeroconf.ZeroconfServiceInfo(
+            host="0.0.0.0", properties={"id": "aa:bb:cc:dd:ee:ff"}
+        ),
     )
 
     assert result["type"] == "form"
@@ -560,7 +557,9 @@ async def test_bridge_homekit_already_configured(hass, aioclient_mock):
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data={"host": "0.0.0.0", "properties": {"id": "aa:bb:cc:dd:ee:ff"}},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="0.0.0.0", properties={"id": "aa:bb:cc:dd:ee:ff"}
+        ),
     )
 
     assert result["type"] == "abort"
@@ -659,18 +658,18 @@ async def test_bridge_zeroconf(hass, aioclient_mock):
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data={
-            "host": "192.168.1.217",
-            "port": 443,
-            "hostname": "Philips-hue.local.",
-            "type": "_hue._tcp.local.",
-            "name": "Philips Hue - ABCABC._hue._tcp.local.",
-            "properties": {
+        data=zeroconf.ZeroconfServiceInfo(
+            host="192.168.1.217",
+            port=443,
+            hostname="Philips-hue.local.",
+            type="_hue._tcp.local.",
+            name="Philips Hue - ABCABC._hue._tcp.local.",
+            properties={
                 "_raw": {"bridgeid": b"ecb5fafffeabcabc", "modelid": b"BSB002"},
                 "bridgeid": "ecb5fafffeabcabc",
                 "modelid": "BSB002",
             },
-        },
+        ),
     )
 
     assert result["type"] == "form"
@@ -690,18 +689,18 @@ async def test_bridge_zeroconf_already_exists(hass, aioclient_mock):
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data={
-            "host": "192.168.1.217",
-            "port": 443,
-            "hostname": "Philips-hue.local.",
-            "type": "_hue._tcp.local.",
-            "name": "Philips Hue - ABCABC._hue._tcp.local.",
-            "properties": {
+        data=zeroconf.ZeroconfServiceInfo(
+            host="192.168.1.217",
+            port=443,
+            hostname="Philips-hue.local.",
+            type="_hue._tcp.local.",
+            name="Philips Hue - ABCABC._hue._tcp.local.",
+            properties={
                 "_raw": {"bridgeid": b"ecb5faabcabc", "modelid": b"BSB002"},
                 "bridgeid": "ecb5faabcabc",
                 "modelid": "BSB002",
             },
-        },
+        ),
     )
 
     assert result["type"] == "abort"

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -516,7 +516,8 @@ async def test_bridge_homekit(hass, aioclient_mock):
         const.DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="0.0.0.0", properties={"id": "aa:bb:cc:dd:ee:ff"}
+            host="0.0.0.0",
+            properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
         ),
     )
 
@@ -558,7 +559,8 @@ async def test_bridge_homekit_already_configured(hass, aioclient_mock):
         const.DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="0.0.0.0", properties={"id": "aa:bb:cc:dd:ee:ff"}
+            host="0.0.0.0",
+            properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
         ),
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and zeroconf constants) in `hue`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
