### PR TITLE
Use ServiceInfo in hunterdouglas_powerview

### DIFF
--- a/homeassistant/components/hunterdouglas_powerview/config_flow.py
+++ b/homeassistant/components/hunterdouglas_powerview/config_flow.py
@@ -8,8 +8,9 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
-from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS
+from homeassistant.components import dhcp, zeroconf
 from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from . import async_get_device_info
@@ -85,25 +86,29 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return info, None
 
-    async def async_step_dhcp(self, discovery_info):
+    async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
         """Handle DHCP discovery."""
-        self.discovered_ip = discovery_info[IP_ADDRESS]
-        self.discovered_name = discovery_info[HOSTNAME]
+        self.discovered_ip = discovery_info[dhcp.IP_ADDRESS]
+        self.discovered_name = discovery_info[dhcp.HOSTNAME]
         return await self.async_step_discovery_confirm()
 
-    async def async_step_zeroconf(self, discovery_info):
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
         """Handle zeroconf discovery."""
-        self.discovered_ip = discovery_info[CONF_HOST]
-        name = discovery_info[CONF_NAME]
+        self.discovered_ip = discovery_info[zeroconf.ATTR_HOST]
+        name = discovery_info[zeroconf.ATTR_NAME]
         if name.endswith(POWERVIEW_SUFFIX):
             name = name[: -len(POWERVIEW_SUFFIX)]
         self.discovered_name = name
         return await self.async_step_discovery_confirm()
 
-    async def async_step_homekit(self, discovery_info):
+    async def async_step_homekit(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
         """Handle HomeKit discovery."""
-        self.discovered_ip = discovery_info[CONF_HOST]
-        name = discovery_info[CONF_NAME]
+        self.discovered_ip = discovery_info[zeroconf.ATTR_HOST]
+        name = discovery_info[zeroconf.ATTR_NAME]
         if name.endswith(HAP_SUFFIX):
             name = name[: -len(HAP_SUFFIX)]
         self.discovered_name = name

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -6,22 +6,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from homeassistant import config_entries
+from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.hunterdouglas_powerview.const import DOMAIN
 
 from tests.common import MockConfigEntry, load_fixture
 
-HOMEKIT_DISCOVERY_INFO = {
-    "name": "Hunter Douglas Powerview Hub._hap._tcp.local.",
-    "host": "1.2.3.4",
-    "properties": {"id": "AA::BB::CC::DD::EE::FF"},
-}
+HOMEKIT_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+    name="Hunter Douglas Powerview Hub._hap._tcp.local.",
+    host="1.2.3.4",
+    properties={"id": "AA::BB::CC::DD::EE::FF"},
+)
 
-ZEROCONF_DISCOVERY_INFO = {
-    "name": "Hunter Douglas Powerview Hub._powerview._tcp.local.",
-    "host": "1.2.3.4",
-}
+ZEROCONF_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+    name="Hunter Douglas Powerview Hub._powerview._tcp.local.",
+    host="1.2.3.4",
+)
 
-DHCP_DISCOVERY_INFO = {"hostname": "Hunter Douglas Powerview Hub", "ip": "1.2.3.4"}
+DHCP_DISCOVERY_INFO = dhcp.DhcpServiceInfo(
+    hostname="Hunter Douglas Powerview Hub", ip="1.2.3.4"
+)
 
 DISCOVERY_DATA = [
     (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `DhcpServiceInfo` and `ZeroconfServiceInfo` (and corresponding constants) in `hunterdouglas_powerview`

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
