### PR TITLE
Use ZeroconfServiceInfo in ipp

### DIFF
--- a/homeassistant/components/ipp/config_flow.py
+++ b/homeassistant/components/ipp/config_flow.py
@@ -15,6 +15,7 @@ from pyipp import (
 )
 import voluptuous as vol
 
+from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import (
     CONF_HOST,
@@ -99,25 +100,27 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
 
-    async def async_step_zeroconf(self, discovery_info: dict[str, Any]) -> FlowResult:
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
         """Handle zeroconf discovery."""
-        port = discovery_info[CONF_PORT]
-        zctype = discovery_info["type"]
-        name = discovery_info[CONF_NAME].replace(f".{zctype}", "")
+        port = discovery_info[zeroconf.ATTR_PORT]
+        zctype = discovery_info[zeroconf.ATTR_TYPE]
+        name = discovery_info[zeroconf.ATTR_NAME].replace(f".{zctype}", "")
         tls = zctype == "_ipps._tcp.local."
-        base_path = discovery_info["properties"].get("rp", "ipp/print")
+        base_path = discovery_info[zeroconf.ATTR_PROPERTIES].get("rp", "ipp/print")
 
         self.context.update({"title_placeholders": {"name": name}})
 
         self.discovery_info.update(
             {
-                CONF_HOST: discovery_info[CONF_HOST],
+                CONF_HOST: discovery_info[zeroconf.ATTR_HOST],
                 CONF_PORT: port,
                 CONF_SSL: tls,
                 CONF_VERIFY_SSL: False,
                 CONF_BASE_PATH: f"/{base_path}",
                 CONF_NAME: name,
-                CONF_UUID: discovery_info["properties"].get("UUID"),
+                CONF_UUID: discovery_info[zeroconf.ATTR_PROPERTIES].get("UUID"),
             }
         )
 

--- a/tests/components/ipp/__init__.py
+++ b/tests/components/ipp/__init__.py
@@ -2,15 +2,9 @@
 import aiohttp
 from pyipp import IPPConnectionUpgradeRequired, IPPError
 
+from homeassistant.components import zeroconf
 from homeassistant.components.ipp.const import CONF_BASE_PATH, CONF_UUID, DOMAIN
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PORT,
-    CONF_SSL,
-    CONF_TYPE,
-    CONF_VERIFY_SSL,
-)
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, get_fixture_path
@@ -40,23 +34,23 @@ MOCK_USER_INPUT = {
     CONF_BASE_PATH: BASE_PATH,
 }
 
-MOCK_ZEROCONF_IPP_SERVICE_INFO = {
-    CONF_TYPE: IPP_ZEROCONF_SERVICE_TYPE,
-    CONF_NAME: f"{ZEROCONF_NAME}.{IPP_ZEROCONF_SERVICE_TYPE}",
-    CONF_HOST: ZEROCONF_HOST,
-    ATTR_HOSTNAME: ZEROCONF_HOSTNAME,
-    CONF_PORT: ZEROCONF_PORT,
-    ATTR_PROPERTIES: {"rp": ZEROCONF_RP},
-}
+MOCK_ZEROCONF_IPP_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
+    type=IPP_ZEROCONF_SERVICE_TYPE,
+    name=f"{ZEROCONF_NAME}.{IPP_ZEROCONF_SERVICE_TYPE}",
+    host=ZEROCONF_HOST,
+    hostname=ZEROCONF_HOSTNAME,
+    port=ZEROCONF_PORT,
+    properties={"rp": ZEROCONF_RP},
+)
 
-MOCK_ZEROCONF_IPPS_SERVICE_INFO = {
-    CONF_TYPE: IPPS_ZEROCONF_SERVICE_TYPE,
-    CONF_NAME: f"{ZEROCONF_NAME}.{IPPS_ZEROCONF_SERVICE_TYPE}",
-    CONF_HOST: ZEROCONF_HOST,
-    ATTR_HOSTNAME: ZEROCONF_HOSTNAME,
-    CONF_PORT: ZEROCONF_PORT,
-    ATTR_PROPERTIES: {"rp": ZEROCONF_RP},
-}
+MOCK_ZEROCONF_IPPS_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
+    type=IPPS_ZEROCONF_SERVICE_TYPE,
+    name=f"{ZEROCONF_NAME}.{IPPS_ZEROCONF_SERVICE_TYPE}",
+    host=ZEROCONF_HOST,
+    hostname=ZEROCONF_HOSTNAME,
+    port=ZEROCONF_PORT,
+    properties={"rp": ZEROCONF_RP},
+)
 
 
 def load_fixture_binary(filename):

--- a/tests/components/ipp/test_config_flow.py
+++ b/tests/components/ipp/test_config_flow.py
@@ -1,6 +1,7 @@
 """Tests for the IPP config flow."""
 from unittest.mock import patch
 
+from homeassistant.components import zeroconf
 from homeassistant.components.ipp.const import CONF_BASE_PATH, CONF_UUID, DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SSL
@@ -281,7 +282,7 @@ async def test_zeroconf_with_uuid_device_exists_abort(
     discovery_info = {
         **MOCK_ZEROCONF_IPP_SERVICE_INFO,
         "properties": {
-            **MOCK_ZEROCONF_IPP_SERVICE_INFO["properties"],
+            **MOCK_ZEROCONF_IPP_SERVICE_INFO[zeroconf.ATTR_PROPERTIES],
             "UUID": "cfe92100-67c4-11d4-a45f-f8d027761251",
         },
     }
@@ -303,7 +304,10 @@ async def test_zeroconf_empty_unique_id(
 
     discovery_info = {
         **MOCK_ZEROCONF_IPP_SERVICE_INFO,
-        "properties": {**MOCK_ZEROCONF_IPP_SERVICE_INFO["properties"], "UUID": ""},
+        "properties": {
+            **MOCK_ZEROCONF_IPP_SERVICE_INFO[zeroconf.ATTR_PROPERTIES],
+            "UUID": "",
+        },
     }
     result = await hass.config_entries.flow.async_init(
         DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and corresponding constants) in `ipp`

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
