### PR TITLE
Use ZeroconfServiceInfo in kodi

### DIFF
--- a/tests/components/kodi/test_config_flow.py
+++ b/tests/components/kodi/test_config_flow.py
@@ -543,7 +543,9 @@ async def test_discovery_duplicate_data(hass):
     assert result["step_id"] == "discovery_confirm"
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=TEST_DISCOVERY
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=TEST_DISCOVERY,
     )
 
     assert result["type"] == "abort"

--- a/tests/components/kodi/test_config_flow.py
+++ b/tests/components/kodi/test_config_flow.py
@@ -543,9 +543,7 @@ async def test_discovery_duplicate_data(hass):
     assert result["step_id"] == "discovery_confirm"
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_ZEROCONF},
-        data=TEST_DISCOVERY,
+        DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=TEST_DISCOVERY
     )
 
     assert result["type"] == "abort"

--- a/tests/components/kodi/util.py
+++ b/tests/components/kodi/util.py
@@ -1,4 +1,5 @@
 """Test the Kodi config flow."""
+from homeassistant.components import zeroconf
 from homeassistant.components.kodi.const import DEFAULT_SSL
 
 TEST_HOST = {
@@ -14,24 +15,24 @@ TEST_CREDENTIALS = {"username": "username", "password": "password"}
 TEST_WS_PORT = {"ws_port": 9090}
 
 UUID = "11111111-1111-1111-1111-111111111111"
-TEST_DISCOVERY = {
-    "host": "1.1.1.1",
-    "port": 8080,
-    "hostname": "hostname.local.",
-    "type": "_xbmc-jsonrpc-h._tcp.local.",
-    "name": "hostname._xbmc-jsonrpc-h._tcp.local.",
-    "properties": {"uuid": UUID},
-}
+TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
+    host="1.1.1.1",
+    port=8080,
+    hostname="hostname.local.",
+    type="_xbmc-jsonrpc-h._tcp.local.",
+    name="hostname._xbmc-jsonrpc-h._tcp.local.",
+    properties={"uuid": UUID},
+)
 
 
-TEST_DISCOVERY_WO_UUID = {
-    "host": "1.1.1.1",
-    "port": 8080,
-    "hostname": "hostname.local.",
-    "type": "_xbmc-jsonrpc-h._tcp.local.",
-    "name": "hostname._xbmc-jsonrpc-h._tcp.local.",
-    "properties": {},
-}
+TEST_DISCOVERY_WO_UUID = zeroconf.ZeroconfServiceInfo(
+    host="1.1.1.1",
+    port=8080,
+    hostname="hostname.local.",
+    type="_xbmc-jsonrpc-h._tcp.local.",
+    name="hostname._xbmc-jsonrpc-h._tcp.local.",
+    properties={},
+)
 
 
 TEST_IMPORT = {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and corresponding constants) in `kodi`

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
