### PR TITLE
Add id constant for homekit discovery

### DIFF
--- a/homeassistant/components/gogogate2/config_flow.py
+++ b/homeassistant/components/gogogate2/config_flow.py
@@ -39,7 +39,9 @@ class Gogogate2FlowHandler(ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> data_entry_flow.FlowResult:
         """Handle homekit discovery."""
-        await self.async_set_unique_id(discovery_info[zeroconf.ATTR_PROPERTIES]["id"])
+        await self.async_set_unique_id(
+            discovery_info[zeroconf.ATTR_PROPERTIES][zeroconf.ATTR_PROPERTIES_ID]
+        )
         return await self._async_discovery_handler(discovery_info[zeroconf.ATTR_HOST])
 
     async def async_step_dhcp(

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -167,7 +167,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     properties={
                         "md": record["md"],
                         "pv": record["pv"],
-                        "id": unique_id,
+                        zeroconf.ATTR_PROPERTIES_ID: unique_id,
                         "c#": record["c#"],
                         "s#": record["s#"],
                         "ff": record["ff"],
@@ -212,7 +212,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             for (key, value) in discovery_info[zeroconf.ATTR_PROPERTIES].items()
         }
 
-        if "id" not in properties:
+        if zeroconf.ATTR_PROPERTIES_ID not in properties:
             # This can happen if the TXT record is received after the PTR record
             # we will wait for the next update in this case
             _LOGGER.debug(
@@ -223,7 +223,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         # The hkid is a unique random number that looks like a pairing code.
         # It changes if a device is factory reset.
-        hkid = properties["id"]
+        hkid = properties[zeroconf.ATTR_PROPERTIES_ID]
         model = properties["md"]
         name = discovery_info[zeroconf.ATTR_NAME].replace("._hap._tcp.local.", "")
         status_flags = int(properties["sf"])

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -68,6 +68,9 @@ ATTR_PORT: Final = "port"
 ATTR_PROPERTIES: Final = "properties"
 ATTR_TYPE: Final = "type"
 
+# Attributes for ZeroconfServiceInfo[ATTR_PROPERTIES]
+ATTR_PROPERTIES_ID: Final = "id"
+
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -108,7 +108,7 @@ async def test_form_homekit_unique_id_already_setup(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4", properties={"id": MOCK_MAC_ADDR}
+            host="1.2.3.4", properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR}
         ),
     )
     assert result["type"] == RESULT_TYPE_FORM
@@ -130,7 +130,7 @@ async def test_form_homekit_unique_id_already_setup(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4", properties={"id": MOCK_MAC_ADDR}
+            host="1.2.3.4", properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR}
         ),
     )
     assert result["type"] == RESULT_TYPE_ABORT
@@ -149,7 +149,7 @@ async def test_form_homekit_ip_address_already_setup(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4", properties={"id": MOCK_MAC_ADDR}
+            host="1.2.3.4", properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR}
         ),
     )
     assert result["type"] == RESULT_TYPE_ABORT
@@ -162,7 +162,7 @@ async def test_form_homekit_ip_address(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4", properties={"id": MOCK_MAC_ADDR}
+            host="1.2.3.4", properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR}
         ),
     )
     assert result["type"] == RESULT_TYPE_FORM
@@ -237,7 +237,7 @@ async def test_discovered_by_homekit_and_dhcp(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4", properties={"id": MOCK_MAC_ADDR}
+            host="1.2.3.4", properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR}
         ),
     )
     assert result["type"] == RESULT_TYPE_FORM

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -148,7 +148,7 @@ def get_device_discovery_info(
         properties={
             "md": record["md"],
             "pv": record["pv"],
-            "id": device.device_id,
+            zeroconf.ATTR_PROPERTIES_ID: device.device_id,
             "c#": record["c#"],
             "s#": record["s#"],
             "ff": record["ff"],
@@ -273,7 +273,7 @@ async def test_id_missing(hass, controller):
     discovery_info = get_device_discovery_info(device)
 
     # Remove id from device
-    del discovery_info["properties"]["id"]
+    del discovery_info[zeroconf.ATTR_PROPERTIES][zeroconf.ATTR_PROPERTIES_ID]
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -289,7 +289,9 @@ async def test_discovery_ignored_model(hass, controller):
     """Already paired."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
-    discovery_info[zeroconf.ATTR_PROPERTIES]["id"] = "AA:BB:CC:DD:EE:FF"
+    discovery_info[zeroconf.ATTR_PROPERTIES][
+        zeroconf.ATTR_PROPERTIES_ID
+    ] = "AA:BB:CC:DD:EE:FF"
     discovery_info[zeroconf.ATTR_PROPERTIES]["md"] = "HHKBridge1,1"
 
     # Device is discovered
@@ -317,7 +319,9 @@ async def test_discovery_ignored_hk_bridge(hass, controller):
         connections={(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)},
     )
 
-    discovery_info[zeroconf.ATTR_PROPERTIES]["id"] = "AA:BB:CC:DD:EE:FF"
+    discovery_info[zeroconf.ATTR_PROPERTIES][
+        zeroconf.ATTR_PROPERTIES_ID
+    ] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -344,7 +348,9 @@ async def test_discovery_does_not_ignore_non_homekit(hass, controller):
         connections={(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)},
     )
 
-    discovery_info[zeroconf.ATTR_PROPERTIES]["id"] = "AA:BB:CC:DD:EE:FF"
+    discovery_info[zeroconf.ATTR_PROPERTIES][
+        zeroconf.ATTR_PROPERTIES_ID
+    ] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -486,7 +492,9 @@ async def test_discovery_already_configured_update_csharp(hass, controller):
     # Set device as already paired
     discovery_info[zeroconf.ATTR_PROPERTIES]["sf"] = 0x00
     discovery_info[zeroconf.ATTR_PROPERTIES]["c#"] = 99999
-    discovery_info[zeroconf.ATTR_PROPERTIES]["id"] = "AA:BB:CC:DD:EE:FF"
+    discovery_info[zeroconf.ATTR_PROPERTIES][
+        zeroconf.ATTR_PROPERTIES_ID
+    ] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `ATTR_PROPERTIES_ID` constant to zeroconf, as requested by @bdraco in https://github.com/home-assistant/core/pull/59746#discussion_r749916315

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
