### PR TITLE
Set Ecobee precision to halves when displaying Celsius

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
     PRECISION_HALVES,
     PRECISION_TENTHS,
     STATE_ON,
+    TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -401,12 +402,11 @@ class Thermostat(ClimateEntity):
         """
         Return the precision of the system.
 
-        Ecobbe precision is tenths and the temp is kept in F.
+        Ecobee precision is tenths and the temp is kept in F.
         For configurations displaying in C, we set the precision
-        to HALVES to prevent differences in the ecobee and HA
-        display of temps due to rounding.
+        to HALVES to match the display behavior on the thermostat.
         """
-        if self.hass.config.units.temperature_unit != TEMP_FAHRENHEIT:
+        if self.hass.config.units.temperature_unit == TEMP_CELSIUS:
             return PRECISION_HALVES
         return PRECISION_TENTHS
 

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -398,7 +398,16 @@ class Thermostat(ClimateEntity):
 
     @property
     def precision(self) -> float:
-        """Return the precision of the system."""
+        """
+        Return the precision of the system.
+
+        Ecobbe precision is tenths and the temp is kept in F.
+        For configurations displaying in C, we set the precision
+        to HALVES to prevent differences in the ecobee and HA
+        display of temps due to rounding.
+        """
+        if self.hass.config.units.temperature_unit != TEMP_FAHRENHEIT:
+            return PRECISION_HALVES
         return PRECISION_TENTHS
 
     @property

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -46,7 +46,13 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.temperature import convert
 
-from .const import _LOGGER, DOMAIN, ECOBEE_MODEL_TO_NAME, MANUFACTURER
+from .const import (
+    _LOGGER,
+    DOMAIN,
+    ECOBEE_MODEL_TO_NAME,
+    ECOBEE_TEMPERATURE_UNIT,
+    MANUFACTURER,
+)
 from .util import ecobee_date, ecobee_time
 
 ATTR_COOL_TEMP = "cool_temp"
@@ -395,7 +401,7 @@ class Thermostat(ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        return TEMP_FAHRENHEIT
+        return ECOBEE_TEMPERATURE_UNIT
 
     @property
     def precision(self) -> float:

--- a/homeassistant/components/ecobee/const.py
+++ b/homeassistant/components/ecobee/const.py
@@ -14,7 +14,7 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_SUNNY,
     ATTR_CONDITION_WINDY,
 )
-from homeassistant.const import Platform
+from homeassistant.const import TEMP_FAHRENHEIT, Platform
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -47,6 +47,8 @@ PLATFORMS = [
 ]
 
 MANUFACTURER = "ecobee"
+
+ECOBEE_TEMPERATURE_UNIT = TEMP_FAHRENHEIT
 
 # Translates ecobee API weatherSymbol to Home Assistant usable names
 # https://www.ecobee.com/home/developer/api/documentation/v1/objects/WeatherForecast.shtml

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -121,12 +121,6 @@ class EcobeeSensor(SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the appropriate unit of measurement."""
-        if self._state in (
-            ECOBEE_STATE_CALIBRATING,
-            ECOBEE_STATE_UNKNOWN,
-            "unknown",
-        ):
-            return None
 
         if self.entity_description.key == "temperature":
             """

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -150,10 +150,6 @@ class EcobeeSensor(SensorEntity):
             else:
                 precision = PRECISION_TENTHS
 
-            # When displaying temp in C, we want to set the precision to halves
-            # to match the rounding of temperatures on the thermostat. We tell
-            # HA the native temp unit is the current config temperature_unit, and
-            # do our own conversion and rounding here.
             return display_temp(
                 self.hass, (float(self._state) / 10.0), TEMP_FAHRENHEIT, precision
             )

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -126,17 +126,13 @@ class EcobeeSensor(SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the appropriate unit of measurement."""
-
-        unit = None
         if self.entity_description.key == "temperature":
             # Tell HA that the entity's native unit is the same
             # as HA config's temperature unit. Then we will do
             # the needed conversion and rounding in native_value.
-            unit = self.hass.config.units.temperature_unit
-        elif self.entity_description.key == "humidity":
-            unit = PERCENTAGE
+            return self.hass.config.units.temperature_unit
 
-        return unit
+        return self.entity_description.native_unit_of_measurement
 
     @property
     def native_value(self):

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -10,7 +10,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, TEMP_FAHRENHEIT
+from homeassistant.const import (
+    PERCENTAGE,
+    PRECISION_HALVES,
+    PRECISION_TENTHS,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -22,7 +28,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="temperature",
         name="Temperature",
-        native_unit_of_measurement=TEMP_FAHRENHEIT,
+        native_unit_of_measurement=None,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -122,17 +128,16 @@ class EcobeeSensor(SensorEntity):
     def native_unit_of_measurement(self):
         """Return the appropriate unit of measurement."""
 
+        unit = None
         if self.entity_description.key == "temperature":
-            """
-            Tell HA that the entity's native unit is the same
-            as HA config's temperature unit. Then we will do
-            the needed conversion and rounding in native_value.
-            """
-            return self.hass.config.units.temperature_unit
+            # Tell HA that the entity's native unit is the same
+            # as HA config's temperature unit. Then we will do
+            # the needed conversion and rounding in native_value.
+            unit = self.hass.config.units.temperature_unit
         elif self.entity_description.key == "humidity":
-            return PERCENTAGE
-        else:
-            return None
+            unit = PERCENTAGE
+
+        return unit
 
     @property
     def native_value(self):
@@ -150,12 +155,10 @@ class EcobeeSensor(SensorEntity):
             else:
                 precision = PRECISION_TENTHS
 
-            """
-            When displaying temp in C, we want to set the precision to halves
-            to match the rounding of temperatures on the thermostat. We tell
-            HA the native temp unit is the current config temperature_unit, and
-            do our own conversion and rounding here.
-            """
+            # When displaying temp in C, we want to set the precision to halves
+            # to match the rounding of temperatures on the thermostat. We tell
+            # HA the native temp unit is the current config temperature_unit, and
+            # do our own conversion and rounding here.
             return display_temp(
                 self.hass, (float(self._state) / 10.0), TEMP_FAHRENHEIT, precision
             )

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -146,7 +146,7 @@ class EcobeeSensor(SensorEntity):
 
         if self.entity_description.key == "temperature":
             return display_temp(
-                self.hass, (float(self._state) / 10.0), TEMP_FAHRENHEIT, precision
+                self.hass, (float(self._state) / 10.0), self.temperature_unit, self.precision
             )
 
         return self._state

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -28,7 +28,6 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="temperature",
         name="Temperature",
-        native_unit_of_measurement=None,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -145,11 +145,6 @@ class EcobeeSensor(SensorEntity):
             return None
 
         if self.entity_description.key == "temperature":
-            if self.hass.config.units.temperature_unit == TEMP_CELSIUS:
-                precision = PRECISION_HALVES
-            else:
-                precision = PRECISION_TENTHS
-
             return display_temp(
                 self.hass, (float(self._state) / 10.0), TEMP_FAHRENHEIT, precision
             )

--- a/homeassistant/components/ecobee/sensor.py
+++ b/homeassistant/components/ecobee/sensor.py
@@ -15,14 +15,13 @@ from homeassistant.const import (
     PRECISION_HALVES,
     PRECISION_TENTHS,
     TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.temperature import display_temp
 
-from .const import DOMAIN, ECOBEE_MODEL_TO_NAME, MANUFACTURER
+from .const import DOMAIN, ECOBEE_MODEL_TO_NAME, ECOBEE_TEMPERATURE_UNIT, MANUFACTURER
 
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
@@ -146,10 +145,22 @@ class EcobeeSensor(SensorEntity):
 
         if self.entity_description.key == "temperature":
             return display_temp(
-                self.hass, (float(self._state) / 10.0), self.temperature_unit, self.precision
+                self.hass,
+                (float(self._state) / 10.0),
+                ECOBEE_TEMPERATURE_UNIT,
+                self.precision,
             )
 
         return self._state
+
+    @property
+    def precision(self):
+        """Return the precision of the sensor."""
+        if self.entity_description.key == "temperature":
+            if self.native_unit_of_measurement == TEMP_CELSIUS:
+                return PRECISION_HALVES
+            return PRECISION_TENTHS
+        return None
 
     async def async_update(self):
         """Get the latest state of the sensor."""


### PR DESCRIPTION
To clear up rounding errors when displaying temperatures in C
set precision to halves, which matches the native ecobee display
precision.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In my continuing journey to get the ecobee integration's Celsius display to match
up with the temperatures shown on the ecobee thermostat (as well as their other
interfaces), I've got one more change to make. 
This change sets the precision in the ecobee climate and sensor to halves if the 
temperature is displayed in Celsius. This will align the display precision when in Celsius 
to that of the Thermostat.
Without this change, the ecobee integration temperatures can be a couple tenths
off from the thermostat.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53098 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
