### PR TITLE
Use UsbServiceInfo in modem_callerid

### DIFF
--- a/homeassistant/components/modem_callerid/config_flow.py
+++ b/homeassistant/components/modem_callerid/config_flow.py
@@ -32,10 +32,10 @@ class PhoneModemFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_usb(self, discovery_info: usb.UsbServiceInfo) -> FlowResult:
         """Handle USB Discovery."""
-        device = discovery_info[usb.ATTR_DEVICE]
+        device = discovery_info["device"]
 
         dev_path = await self.hass.async_add_executor_job(usb.get_serial_by_id, device)
-        unique_id = f"{discovery_info[usb.ATTR_VID]}:{discovery_info[usb.ATTR_PID]}_{discovery_info[usb.ATTR_SERIAL_NUMBER]}_{discovery_info[usb.ATTR_MANUFACTURER]}_{discovery_info[usb.ATTR_DESCRIPTION]}"
+        unique_id = f"{discovery_info['vid']}:{discovery_info['pid']}_{discovery_info['serial_number']}_{discovery_info['manufacturer']}_{discovery_info['description']}"
         if (
             await self.validate_device_errors(dev_path=dev_path, unique_id=unique_id)
             is None

--- a/homeassistant/components/modem_callerid/config_flow.py
+++ b/homeassistant/components/modem_callerid/config_flow.py
@@ -32,10 +32,10 @@ class PhoneModemFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_usb(self, discovery_info: usb.UsbServiceInfo) -> FlowResult:
         """Handle USB Discovery."""
-        device = discovery_info["device"]
+        device = discovery_info[usb.ATTR_DEVICE]
 
         dev_path = await self.hass.async_add_executor_job(usb.get_serial_by_id, device)
-        unique_id = f"{discovery_info['vid']}:{discovery_info['pid']}_{discovery_info['serial_number']}_{discovery_info['manufacturer']}_{discovery_info['description']}"
+        unique_id = f"{discovery_info[usb.ATTR_VID]}:{discovery_info[usb.ATTR_PID]}_{discovery_info[usb.ATTR_SERIAL_NUMBER]}_{discovery_info[usb.ATTR_MANUFACTURER]}_{discovery_info[usb.ATTR_DESCRIPTION]}"
         if (
             await self.validate_device_errors(dev_path=dev_path, unique_id=unique_id)
             is None

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -6,7 +6,7 @@ import fnmatch
 import logging
 import os
 import sys
-from typing import TypedDict
+from typing import Final, TypedDict
 
 from serial.tools.list_ports import comports
 from serial.tools.list_ports_common import ListPortInfo
@@ -29,6 +29,15 @@ from .utils import usb_device_from_port
 _LOGGER = logging.getLogger(__name__)
 
 REQUEST_SCAN_COOLDOWN = 60  # 1 minute cooldown
+
+
+# Attributes for UsbServiceInfo
+ATTR_DESCRIPTION: Final = "description"
+ATTR_DEVICE: Final = "device"
+ATTR_MANUFACTURER: Final = "manufacturer"
+ATTR_PID: Final = "pid"
+ATTR_SERIAL_NUMBER: Final = "serial_number"
+ATTR_VID: Final = "vid"
 
 
 class UsbServiceInfo(TypedDict):

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -6,7 +6,7 @@ import fnmatch
 import logging
 import os
 import sys
-from typing import Final, TypedDict
+from typing import TypedDict
 
 from serial.tools.list_ports import comports
 from serial.tools.list_ports_common import ListPortInfo
@@ -29,15 +29,6 @@ from .utils import usb_device_from_port
 _LOGGER = logging.getLogger(__name__)
 
 REQUEST_SCAN_COOLDOWN = 60  # 1 minute cooldown
-
-
-# Attributes for UsbServiceInfo
-ATTR_DESCRIPTION: Final = "description"
-ATTR_DEVICE: Final = "device"
-ATTR_MANUFACTURER: Final = "manufacturer"
-ATTR_PID: Final = "pid"
-ATTR_SERIAL_NUMBER: Final = "serial_number"
-ATTR_VID: Final = "vid"
 
 
 class UsbServiceInfo(TypedDict):

--- a/tests/components/modem_callerid/test_config_flow.py
+++ b/tests/components/modem_callerid/test_config_flow.py
@@ -17,14 +17,14 @@ from homeassistant.data_entry_flow import (
 
 from . import _patch_config_flow_modem
 
-DISCOVERY_INFO = {
-    "device": phone_modem.DEFAULT_PORT,
-    "pid": "1340",
-    "vid": "0572",
-    "serial_number": "1234",
-    "description": "modem",
-    "manufacturer": "Connexant",
-}
+DISCOVERY_INFO = usb.UsbServiceInfo(
+    device=phone_modem.DEFAULT_PORT,
+    pid="1340",
+    vid="0572",
+    serial_number="1234",
+    description="modem",
+    manufacturer="Connexant",
+)
 
 
 def _patch_setup():


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `UsbServiceInfo` (and `usb` constants) in `modem_callerid`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
