### PR TITLE
Use ZeroconfServiceInfo in modern_forms

### DIFF
--- a/homeassistant/components/modern_forms/config_flow.py
+++ b/homeassistant/components/modern_forms/config_flow.py
@@ -30,14 +30,14 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle zeroconf discovery."""
-        host = discovery_info["hostname"].rstrip(".")
+        host = discovery_info[zeroconf.ATTR_HOSTNAME].rstrip(".")
         name, _ = host.rsplit(".")
 
         self.context.update(
             {
-                CONF_HOST: discovery_info["host"],
+                CONF_HOST: discovery_info[zeroconf.ATTR_HOST],
                 CONF_NAME: name,
-                CONF_MAC: discovery_info["properties"].get(CONF_MAC),
+                CONF_MAC: discovery_info[zeroconf.ATTR_PROPERTIES].get(CONF_MAC),
                 "title_placeholders": {"name": name},
             }
         )

--- a/tests/components/modern_forms/test_config_flow.py
+++ b/tests/components/modern_forms/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import aiohttp
 from aiomodernforms import ModernFormsConnectionError
 
+from homeassistant.components import zeroconf
 from homeassistant.components.modern_forms.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONTENT_TYPE_JSON
@@ -68,7 +69,9 @@ async def test_full_zeroconf_flow_implementation(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data={"host": "192.168.1.123", "hostname": "example.local.", "properties": {}},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="192.168.1.123", hostname="example.local.", properties={}
+        ),
     )
 
     flows = hass.config_entries.flow.async_progress()
@@ -130,7 +133,9 @@ async def test_zeroconf_connection_error(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data={"host": "192.168.1.123", "hostname": "example.local.", "properties": {}},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="192.168.1.123", hostname="example.local.", properties={}
+        ),
     )
 
     assert result.get("type") == RESULT_TYPE_ABORT
@@ -154,7 +159,9 @@ async def test_zeroconf_confirm_connection_error(
             CONF_HOST: "example.com",
             CONF_NAME: "test",
         },
-        data={"host": "192.168.1.123", "hostname": "example.com.", "properties": {}},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="192.168.1.123", hostname="example.com.", properties={}
+        ),
     )
 
     assert result.get("type") == RESULT_TYPE_ABORT
@@ -216,11 +223,11 @@ async def test_zeroconf_with_mac_device_exists_abort(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data={
-            "host": "192.168.1.123",
-            "hostname": "example.local.",
-            "properties": {CONF_MAC: "AA:BB:CC:DD:EE:FF"},
-        },
+        data=zeroconf.ZeroconfServiceInfo(
+            host="192.168.1.123",
+            hostname="example.local.",
+            properties={CONF_MAC: "AA:BB:CC:DD:EE:FF"},
+        ),
     )
 
     assert result.get("type") == RESULT_TYPE_ABORT


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and `zeroconf` constants) in `modern_forms`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
