### PR TITLE
Use ZeroconfServiceInfo in plugwise

### DIFF
--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -1,4 +1,6 @@
 """Config flow for Plugwise integration."""
+from __future__ import annotations
+
 import logging
 
 from plugwise.exceptions import InvalidAuthentication, PlugwiseException
@@ -99,34 +101,34 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self):
         """Initialize the Plugwise config flow."""
-        self.discovery_info = {}
+        self.discovery_info: zeroconf.ZeroconfServiceInfo | None = None
+        self._username: str = DEFAULT_USERNAME
 
     async def async_step_zeroconf(
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Prepare configuration for a discovered Plugwise Smile."""
         self.discovery_info = discovery_info
-        self.discovery_info[CONF_USERNAME] = DEFAULT_USERNAME
-        _properties = self.discovery_info[zeroconf.ATTR_PROPERTIES]
+        _properties = discovery_info[zeroconf.ATTR_PROPERTIES]
 
         # unique_id is needed here, to be able to determine whether the discovered device is known, or not.
-        unique_id = self.discovery_info[zeroconf.ATTR_HOSTNAME].split(".")[0]
+        unique_id = discovery_info[zeroconf.ATTR_HOSTNAME].split(".")[0]
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured(
-            {CONF_HOST: self.discovery_info[zeroconf.ATTR_HOST]}
+            {CONF_HOST: discovery_info[zeroconf.ATTR_HOST]}
         )
 
         if DEFAULT_USERNAME not in unique_id:
-            self.discovery_info[CONF_USERNAME] = STRETCH_USERNAME
+            self._username = STRETCH_USERNAME
         _product = _properties.get("product", None)
         _version = _properties.get("version", "n/a")
         _name = f"{ZEROCONF_MAP.get(_product, _product)} v{_version}"
 
         self.context["title_placeholders"] = {
-            CONF_HOST: self.discovery_info[zeroconf.ATTR_HOST],
+            CONF_HOST: discovery_info[zeroconf.ATTR_HOST],
             CONF_NAME: _name,
-            CONF_PORT: self.discovery_info[zeroconf.ATTR_PORT],
-            CONF_USERNAME: self.discovery_info[CONF_USERNAME],
+            CONF_PORT: discovery_info[zeroconf.ATTR_PORT],
+            CONF_USERNAME: self._username,
         }
         return await self.async_step_user_gateway()
 
@@ -141,9 +143,9 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input.pop(FLOW_TYPE, None)
 
             if self.discovery_info:
-                user_input[CONF_HOST] = self.discovery_info[CONF_HOST]
-                user_input[CONF_PORT] = self.discovery_info[CONF_PORT]
-                user_input[CONF_USERNAME] = self.discovery_info[CONF_USERNAME]
+                user_input[CONF_HOST] = self.discovery_info[zeroconf.ATTR_HOST]
+                user_input[CONF_PORT] = self.discovery_info[zeroconf.ATTR_PORT]
+                user_input[CONF_USERNAME] = self._username
 
             try:
                 api = await validate_gw_input(self.hass, user_input)

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -8,6 +8,7 @@ from plugwise.exceptions import (
 )
 import pytest
 
+from homeassistant.components import zeroconf
 from homeassistant.components.plugwise.const import (
     API,
     DEFAULT_PORT,
@@ -39,28 +40,28 @@ TEST_PORT = 81
 TEST_USERNAME = "smile"
 TEST_USERNAME2 = "stretch"
 
-TEST_DISCOVERY = {
-    "host": TEST_HOST,
-    "port": DEFAULT_PORT,
-    "hostname": f"{TEST_HOSTNAME}.local.",
-    "server": f"{TEST_HOSTNAME}.local.",
-    "properties": {
+TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
+    host=TEST_HOST,
+    port=DEFAULT_PORT,
+    hostname=f"{TEST_HOSTNAME}.local.",
+    server=f"{TEST_HOSTNAME}.local.",
+    properties={
         "product": "smile",
         "version": "1.2.3",
         "hostname": f"{TEST_HOSTNAME}.local.",
     },
-}
-TEST_DISCOVERY2 = {
-    "host": TEST_HOST,
-    "port": DEFAULT_PORT,
-    "hostname": f"{TEST_HOSTNAME2}.local.",
-    "server": f"{TEST_HOSTNAME2}.local.",
-    "properties": {
+)
+TEST_DISCOVERY2 = zeroconf.ZeroconfServiceInfo(
+    host=TEST_HOST,
+    port=DEFAULT_PORT,
+    hostname=f"{TEST_HOSTNAME2}.local.",
+    server=f"{TEST_HOSTNAME2}.local.",
+    properties={
         "product": "stretch",
         "version": "1.2.3",
         "hostname": f"{TEST_HOSTNAME2}.local.",
     },
-}
+)
 
 
 @pytest.fixture(name="mock_smile")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and `zeroconf` constants) in `plugwise`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
