### PR TITLE
Use ZeroconfServiceInfo in roku

### DIFF
--- a/homeassistant/components/roku/config_flow.py
+++ b/homeassistant/components/roku/config_flow.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from rokuecp import Roku, RokuError
 import voluptuous as vol
 
+from homeassistant.components import zeroconf
 from homeassistant.components.ssdp import (
     ATTR_SSDP_LOCATION,
     ATTR_UPNP_FRIENDLY_NAME,
@@ -84,14 +85,16 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=info["title"], data=user_input)
 
-    async def async_step_homekit(self, discovery_info):
+    async def async_step_homekit(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
         """Handle a flow initialized by homekit discovery."""
 
         # If we already have the host configured do
         # not open connections to it if we can avoid it.
-        self._async_abort_entries_match({CONF_HOST: discovery_info[CONF_HOST]})
+        self._async_abort_entries_match({CONF_HOST: discovery_info[zeroconf.ATTR_HOST]})
 
-        self.discovery_info.update({CONF_HOST: discovery_info[CONF_HOST]})
+        self.discovery_info.update({CONF_HOST: discovery_info[zeroconf.ATTR_HOST]})
 
         try:
             info = await validate_input(self.hass, self.discovery_info)
@@ -104,7 +107,7 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
 
         await self.async_set_unique_id(info["serial_number"])
         self._abort_if_unique_id_configured(
-            updates={CONF_HOST: discovery_info[CONF_HOST]},
+            updates={CONF_HOST: discovery_info[zeroconf.ATTR_HOST]},
         )
 
         self.context.update({"title_placeholders": {"name": info["title"]}})

--- a/tests/components/roku/__init__.py
+++ b/tests/components/roku/__init__.py
@@ -3,13 +3,14 @@ from http import HTTPStatus
 import re
 from socket import gaierror as SocketGIAError
 
+from homeassistant.components import zeroconf
 from homeassistant.components.roku.const import DOMAIN
 from homeassistant.components.ssdp import (
     ATTR_SSDP_LOCATION,
     ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_SERIAL,
 )
-from homeassistant.const import CONF_HOST, CONF_ID, CONF_NAME
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
@@ -31,13 +32,13 @@ MOCK_SSDP_DISCOVERY_INFO = {
 
 HOMEKIT_HOST = "192.168.1.161"
 
-MOCK_HOMEKIT_DISCOVERY_INFO = {
-    CONF_NAME: "onn._hap._tcp.local.",
-    CONF_HOST: HOMEKIT_HOST,
-    "properties": {
-        CONF_ID: "2d:97:da:ee:dc:99",
+MOCK_HOMEKIT_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+    name="onn._hap._tcp.local.",
+    host=HOMEKIT_HOST,
+    properties={
+        zeroconf.zeroconf.ATTR_PROPERTIES_ID: "2d:97:da:ee:dc:99",
     },
-}
+)
 
 
 def mock_connection(

--- a/tests/components/roku/__init__.py
+++ b/tests/components/roku/__init__.py
@@ -36,7 +36,7 @@ MOCK_HOMEKIT_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
     name="onn._hap._tcp.local.",
     host=HOMEKIT_HOST,
     properties={
-        zeroconf.zeroconf.ATTR_PROPERTIES_ID: "2d:97:da:ee:dc:99",
+        zeroconf.ATTR_PROPERTIES_ID: "2d:97:da:ee:dc:99",
     },
 )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and `zeroconf` constants) in `roku`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
