### PR TITLE
Use ZeroconfServiceInfo in rainmachine

### DIFF
--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -70,7 +70,7 @@ class RainMachineFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle discovery via zeroconf."""
-        ip_address = discovery_info["host"]
+        ip_address = discovery_info[zeroconf.ATTR_HOST]
 
         self._async_abort_entries_match({CONF_IP_ADDRESS: ip_address})
         # Handle IP change

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -5,6 +5,7 @@ import pytest
 from regenmaschine.errors import RainMachineError
 
 from homeassistant import config_entries, data_entry_flow
+from homeassistant.components import zeroconf
 from homeassistant.components.rainmachine import CONF_ZONE_RUN_TIME, DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL
 
@@ -171,7 +172,7 @@ async def test_step_homekit_zeroconf_ip_already_exists(hass, source):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": source},
-            data={"host": "192.168.1.100"},
+            data=zeroconf.ZeroconfServiceInfo(host="192.168.1.100"),
         )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -200,7 +201,7 @@ async def test_step_homekit_zeroconf_ip_change(hass, source):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": source},
-            data={"host": "192.168.1.2"},
+            data=zeroconf.ZeroconfServiceInfo(host="192.168.1.2"),
         )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -231,7 +232,7 @@ async def test_step_homekit_zeroconf_new_controller_when_some_exist(hass, source
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": source},
-            data={"host": "192.168.1.100"},
+            data=zeroconf.ZeroconfServiceInfo(host="192.168.1.100"),
         )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -275,7 +276,7 @@ async def test_discovery_by_homekit_and_zeroconf_same_time(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data={"host": "192.168.1.100"},
+            data=zeroconf.ZeroconfServiceInfo(host="192.168.1.100"),
         )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -288,7 +289,7 @@ async def test_discovery_by_homekit_and_zeroconf_same_time(hass):
         result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_HOMEKIT},
-            data={"host": "192.168.1.100"},
+            data=zeroconf.ZeroconfServiceInfo(host="192.168.1.100"),
         )
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and `zeroconf` constants) in `rainmachine`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
