### PR TITLE
Refactor ZHA entity matching process

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -36,6 +36,7 @@ CLASS_MAPPING = {
 }
 
 STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.BINARY_SENSOR)
+MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.BINARY_SENSOR)
 
 
 async def async_setup_entry(
@@ -103,7 +104,7 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
             self._state = attr_value
 
 
-@STRICT_MATCH(channel_names=CHANNEL_ACCELEROMETER)
+@MULTI_MATCH(channel_names=CHANNEL_ACCELEROMETER)
 class Accelerometer(BinarySensor):
     """ZHA BinarySensor."""
 
@@ -111,7 +112,7 @@ class Accelerometer(BinarySensor):
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.MOVING
 
 
-@STRICT_MATCH(channel_names=CHANNEL_OCCUPANCY)
+@MULTI_MATCH(channel_names=CHANNEL_OCCUPANCY)
 class Occupancy(BinarySensor):
     """ZHA BinarySensor."""
 
@@ -127,7 +128,7 @@ class Opening(BinarySensor):
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.OPENING
 
 
-@STRICT_MATCH(channel_names=CHANNEL_BINARY_INPUT)
+@MULTI_MATCH(channel_names=CHANNEL_BINARY_INPUT)
 class BinaryInput(BinarySensor):
     """ZHA BinarySensor."""
 
@@ -153,7 +154,7 @@ class Motion(BinarySensor):
     _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.MOTION
 
 
-@STRICT_MATCH(channel_names=CHANNEL_ZONE)
+@MULTI_MATCH(channel_names=CHANNEL_ZONE)
 class IASZone(BinarySensor):
     """ZHA IAS BinarySensor."""
 

--- a/homeassistant/components/zha/climate.py
+++ b/homeassistant/components/zha/climate.py
@@ -172,7 +172,11 @@ async def async_setup_entry(
     config_entry.async_on_unload(unsub)
 
 
-@MULTI_MATCH(channel_names=CHANNEL_THERMOSTAT, aux_channels=CHANNEL_FAN)
+@MULTI_MATCH(
+    channel_names=CHANNEL_THERMOSTAT,
+    aux_channels=CHANNEL_FAN,
+    stop_on_match_group=CHANNEL_THERMOSTAT,
+)
 class Thermostat(ZhaEntity, ClimateEntity):
     """Representation of a ZHA Thermostat device."""
 
@@ -526,7 +530,7 @@ class Thermostat(ZhaEntity, ClimateEntity):
 @MULTI_MATCH(
     channel_names={CHANNEL_THERMOSTAT, "sinope_manufacturer_specific"},
     manufacturers="Sinope Technologies",
-    stop_on_match=True,
+    stop_on_match_group=CHANNEL_THERMOSTAT,
 )
 class SinopeTechnologiesThermostat(Thermostat):
     """Sinope Technologies Thermostat."""
@@ -579,7 +583,7 @@ class SinopeTechnologiesThermostat(Thermostat):
     channel_names=CHANNEL_THERMOSTAT,
     aux_channels=CHANNEL_FAN,
     manufacturers="Zen Within",
-    stop_on_match=True,
+    stop_on_match_group=CHANNEL_THERMOSTAT,
 )
 class ZenWithinThermostat(Thermostat):
     """Zen Within Thermostat implementation."""
@@ -609,7 +613,7 @@ class ZenWithinThermostat(Thermostat):
     aux_channels=CHANNEL_FAN,
     manufacturers="Centralite",
     models={"3157100", "3157100-E"},
-    stop_on_match=True,
+    stop_on_match_group=CHANNEL_THERMOSTAT,
 )
 class CentralitePearl(ZenWithinThermostat):
     """Centralite Pearl Thermostat implementation."""

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -52,14 +52,10 @@ REMOTE_DEVICE_TYPES = collections.defaultdict(list, REMOTE_DEVICE_TYPES)
 SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {
     # this works for now but if we hit conflicts we can break it out to
     # a different dict that is keyed by manufacturer
-    SMARTTHINGS_ACCELERATION_CLUSTER: Platform.BINARY_SENSOR,
-    zcl.clusters.general.BinaryInput.cluster_id: Platform.BINARY_SENSOR,
     zcl.clusters.general.AnalogOutput.cluster_id: Platform.NUMBER,
     zcl.clusters.general.MultistateInput.cluster_id: Platform.SENSOR,
     zcl.clusters.general.OnOff.cluster_id: Platform.SWITCH,
     zcl.clusters.hvac.Fan.cluster_id: Platform.FAN,
-    zcl.clusters.measurement.OccupancySensing.cluster_id: Platform.BINARY_SENSOR,
-    zcl.clusters.security.IasZone.cluster_id: Platform.BINARY_SENSOR,
 }
 
 SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS = {

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import collections
 from collections.abc import Callable
 import dataclasses
-from typing import Dict, List, Tuple
 
 import attr
 from zigpy import zcl
@@ -54,8 +53,6 @@ SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {
     # this works for now but if we hit conflicts we can break it out to
     # a different dict that is keyed by manufacturer
     SMARTTHINGS_ACCELERATION_CLUSTER: Platform.BINARY_SENSOR,
-    SMARTTHINGS_HUMIDITY_CLUSTER: Platform.SENSOR,
-    VOC_LEVEL_CLUSTER: Platform.SENSOR,
     zcl.clusters.closures.DoorLock.cluster_id: Platform.LOCK,
     zcl.clusters.closures.WindowCovering.cluster_id: Platform.COVER,
     zcl.clusters.general.BinaryInput.cluster_id: Platform.BINARY_SENSOR,
@@ -63,16 +60,7 @@ SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {
     zcl.clusters.general.MultistateInput.cluster_id: Platform.SENSOR,
     zcl.clusters.general.OnOff.cluster_id: Platform.SWITCH,
     zcl.clusters.hvac.Fan.cluster_id: Platform.FAN,
-    zcl.clusters.measurement.CarbonDioxideConcentration.cluster_id: Platform.SENSOR,
-    zcl.clusters.measurement.CarbonMonoxideConcentration.cluster_id: Platform.SENSOR,
-    zcl.clusters.measurement.FormaldehydeConcentration.cluster_id: Platform.SENSOR,
-    zcl.clusters.measurement.IlluminanceMeasurement.cluster_id: Platform.SENSOR,
     zcl.clusters.measurement.OccupancySensing.cluster_id: Platform.BINARY_SENSOR,
-    zcl.clusters.measurement.PressureMeasurement.cluster_id: Platform.SENSOR,
-    zcl.clusters.measurement.RelativeHumidity.cluster_id: Platform.SENSOR,
-    zcl.clusters.measurement.SoilMoisture.cluster_id: Platform.SENSOR,
-    zcl.clusters.measurement.LeafWetness.cluster_id: Platform.SENSOR,
-    zcl.clusters.measurement.TemperatureMeasurement.cluster_id: Platform.SENSOR,
     zcl.clusters.security.IasZone.cluster_id: Platform.BINARY_SENSOR,
 }
 

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -261,10 +261,7 @@ class ZHAEntityRegistry:
                 for match in sorted_matches:
                     if match.strict_matched(manufacturer, model, channels):
                         claimed = match.claim_channels(channels)
-                        mtc_group = self._multi_entity_registry[component][
-                            stop_match_grp
-                        ]
-                        for ent_class in mtc_group[match]:
+                        for ent_class in stop_match_groups[stop_match_grp][match]:
                             ent_n_channels = EntityClassAndChannels(ent_class, claimed)
                             result[component].append(ent_n_channels)
                         all_claimed |= set(claimed)

--- a/homeassistant/components/zha/core/registries.py
+++ b/homeassistant/components/zha/core/registries.py
@@ -53,8 +53,6 @@ SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {
     # this works for now but if we hit conflicts we can break it out to
     # a different dict that is keyed by manufacturer
     SMARTTHINGS_ACCELERATION_CLUSTER: Platform.BINARY_SENSOR,
-    zcl.clusters.closures.DoorLock.cluster_id: Platform.LOCK,
-    zcl.clusters.closures.WindowCovering.cluster_id: Platform.COVER,
     zcl.clusters.general.BinaryInput.cluster_id: Platform.BINARY_SENSOR,
     zcl.clusters.general.AnalogOutput.cluster_id: Platform.NUMBER,
     zcl.clusters.general.MultistateInput.cluster_id: Platform.SENSOR,

--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -42,7 +42,7 @@ from .entity import ZhaEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.COVER)
+MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.COVER)
 
 
 async def async_setup_entry(
@@ -63,7 +63,7 @@ async def async_setup_entry(
     config_entry.async_on_unload(unsub)
 
 
-@STRICT_MATCH(channel_names=CHANNEL_COVER)
+@MULTI_MATCH(channel_names=CHANNEL_COVER)
 class ZhaCover(ZhaEntity, CoverEntity):
     """Representation of a ZHA cover."""
 
@@ -182,7 +182,7 @@ class ZhaCover(ZhaEntity, CoverEntity):
                 self._state = None
 
 
-@STRICT_MATCH(channel_names={CHANNEL_LEVEL, CHANNEL_ON_OFF, CHANNEL_SHADE})
+@MULTI_MATCH(channel_names={CHANNEL_LEVEL, CHANNEL_ON_OFF, CHANNEL_SHADE})
 class Shade(ZhaEntity, CoverEntity):
     """ZHA Shade."""
 
@@ -289,7 +289,7 @@ class Shade(ZhaEntity, CoverEntity):
             return
 
 
-@STRICT_MATCH(
+@MULTI_MATCH(
     channel_names={CHANNEL_LEVEL, CHANNEL_ON_OFF}, manufacturers="Keen Home Inc"
 )
 class KeenVent(Shade):

--- a/homeassistant/components/zha/lock.py
+++ b/homeassistant/components/zha/lock.py
@@ -23,7 +23,7 @@ from .entity import ZhaEntity
 
 # The first state is Zigbee 'Not fully locked'
 STATE_LIST = [STATE_UNLOCKED, STATE_LOCKED, STATE_UNLOCKED]
-STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.LOCK)
+MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.LOCK)
 
 VALUE_TO_STATE = dict(enumerate(STATE_LIST))
 
@@ -86,7 +86,7 @@ async def async_setup_entry(
     )
 
 
-@STRICT_MATCH(channel_names=CHANNEL_DOORLOCK)
+@MULTI_MATCH(channel_names=CHANNEL_DOORLOCK)
 class ZhaDoorLock(ZhaEntity, LockEntity):
     """Representation of a ZHA lock."""
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -186,19 +186,24 @@ class Sensor(ZhaEntity, SensorEntity):
         return round(float(value * self._multiplier) / self._divisor)
 
 
-@STRICT_MATCH(
+@MULTI_MATCH(
     channel_names=CHANNEL_ANALOG_INPUT,
     manufacturers="LUMI",
     models={"lumi.plug", "lumi.plug.maus01", "lumi.plug.mmeu01"},
+    stop_on_match_group=CHANNEL_ANALOG_INPUT,
 )
-@STRICT_MATCH(channel_names=CHANNEL_ANALOG_INPUT, manufacturers="Digi")
+@MULTI_MATCH(
+    channel_names=CHANNEL_ANALOG_INPUT,
+    manufacturers="Digi",
+    stop_on_match_group=CHANNEL_ANALOG_INPUT,
+)
 class AnalogInput(Sensor):
     """Sensor that displays analog input values."""
 
     SENSOR_ATTR = "present_value"
 
 
-@STRICT_MATCH(channel_names=CHANNEL_POWER_CONFIGURATION)
+@MULTI_MATCH(channel_names=CHANNEL_POWER_CONFIGURATION)
 class Battery(Sensor):
     """Battery sensor of power configuration cluster."""
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -547,7 +547,7 @@ class FormaldehydeConcentration(Sensor):
     _unit = CONCENTRATION_PARTS_PER_MILLION
 
 
-@MULTI_MATCH(channel_names=CHANNEL_THERMOSTAT)
+@MULTI_MATCH(channel_names=CHANNEL_THERMOSTAT, stop_on_match_group=CHANNEL_THERMOSTAT)
 class ThermostatHVACAction(Sensor, id_suffix="hvac_action"):
     """Thermostat HVAC action sensor."""
 
@@ -631,7 +631,7 @@ class ThermostatHVACAction(Sensor, id_suffix="hvac_action"):
 @MULTI_MATCH(
     channel_names=CHANNEL_THERMOSTAT,
     manufacturers="Zen Within",
-    stop_on_match=True,
+    stop_on_match_group=CHANNEL_THERMOSTAT,
 )
 class ZenHVACAction(ThermostatHVACAction):
     """Zen Within Thermostat HVAC Action."""

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -344,8 +344,10 @@ class ElectricalMeasurementRMSVoltage(ElectricalMeasurement, id_suffix="rms_volt
         return False
 
 
-@STRICT_MATCH(generic_ids=CHANNEL_ST_HUMIDITY_CLUSTER)
-@STRICT_MATCH(channel_names=CHANNEL_HUMIDITY)
+@MULTI_MATCH(
+    generic_ids=CHANNEL_ST_HUMIDITY_CLUSTER, stop_on_match_group=CHANNEL_HUMIDITY
+)
+@MULTI_MATCH(channel_names=CHANNEL_HUMIDITY, stop_on_match_group=CHANNEL_HUMIDITY)
 class Humidity(Sensor):
     """Humidity sensor."""
 
@@ -356,7 +358,7 @@ class Humidity(Sensor):
     _unit = PERCENTAGE
 
 
-@STRICT_MATCH(channel_names=CHANNEL_SOIL_MOISTURE)
+@MULTI_MATCH(channel_names=CHANNEL_SOIL_MOISTURE)
 class SoilMoisture(Sensor):
     """Soil Moisture sensor."""
 
@@ -367,7 +369,7 @@ class SoilMoisture(Sensor):
     _unit = PERCENTAGE
 
 
-@STRICT_MATCH(channel_names=CHANNEL_LEAF_WETNESS)
+@MULTI_MATCH(channel_names=CHANNEL_LEAF_WETNESS)
 class LeafWetness(Sensor):
     """Leaf Wetness sensor."""
 
@@ -378,7 +380,7 @@ class LeafWetness(Sensor):
     _unit = PERCENTAGE
 
 
-@STRICT_MATCH(channel_names=CHANNEL_ILLUMINANCE)
+@MULTI_MATCH(channel_names=CHANNEL_ILLUMINANCE)
 class Illuminance(Sensor):
     """Illuminance Sensor."""
 
@@ -470,7 +472,7 @@ class SmartEnergySummation(SmartEnergyMetering, id_suffix="summation_delivered")
         return round(cooked, 3)
 
 
-@STRICT_MATCH(channel_names=CHANNEL_PRESSURE)
+@MULTI_MATCH(channel_names=CHANNEL_PRESSURE)
 class Pressure(Sensor):
     """Pressure sensor."""
 
@@ -481,7 +483,7 @@ class Pressure(Sensor):
     _unit = PRESSURE_HPA
 
 
-@STRICT_MATCH(channel_names=CHANNEL_TEMPERATURE)
+@MULTI_MATCH(channel_names=CHANNEL_TEMPERATURE)
 class Temperature(Sensor):
     """Temperature Sensor."""
 
@@ -492,7 +494,7 @@ class Temperature(Sensor):
     _unit = TEMP_CELSIUS
 
 
-@STRICT_MATCH(channel_names="carbon_dioxide_concentration")
+@MULTI_MATCH(channel_names="carbon_dioxide_concentration")
 class CarbonDioxideConcentration(Sensor):
     """Carbon Dioxide Concentration sensor."""
 
@@ -504,7 +506,7 @@ class CarbonDioxideConcentration(Sensor):
     _unit = CONCENTRATION_PARTS_PER_MILLION
 
 
-@STRICT_MATCH(channel_names="carbon_monoxide_concentration")
+@MULTI_MATCH(channel_names="carbon_monoxide_concentration")
 class CarbonMonoxideConcentration(Sensor):
     """Carbon Monoxide Concentration sensor."""
 
@@ -516,8 +518,8 @@ class CarbonMonoxideConcentration(Sensor):
     _unit = CONCENTRATION_PARTS_PER_MILLION
 
 
-@STRICT_MATCH(generic_ids="channel_0x042e")
-@STRICT_MATCH(channel_names="voc_level")
+@MULTI_MATCH(generic_ids="channel_0x042e", stop_on_match_group="voc_level")
+@MULTI_MATCH(channel_names="voc_level", stop_on_match_group="voc_level")
 class VOCLevel(Sensor):
     """VOC Level sensor."""
 
@@ -529,7 +531,11 @@ class VOCLevel(Sensor):
     _unit = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
 
-@STRICT_MATCH(channel_names="voc_level", models="lumi.airmonitor.acn01")
+@MULTI_MATCH(
+    channel_names="voc_level",
+    models="lumi.airmonitor.acn01",
+    stop_on_match_group="voc_level",
+)
 class PPBVOCLevel(Sensor):
     """VOC Level sensor."""
 
@@ -541,7 +547,7 @@ class PPBVOCLevel(Sensor):
     _unit = CONCENTRATION_PARTS_PER_BILLION
 
 
-@STRICT_MATCH(channel_names="formaldehyde_concentration")
+@MULTI_MATCH(channel_names="formaldehyde_concentration")
 class FormaldehydeConcentration(Sensor):
     """Formaldehyde Concentration sensor."""
 
@@ -631,7 +637,7 @@ class ThermostatHVACAction(Sensor, id_suffix="hvac_action"):
     aux_channels=CHANNEL_FAN,
     manufacturers="Centralite",
     models={"3157100", "3157100-E"},
-    stop_on_match=True,
+    stop_on_match_group=CHANNEL_THERMOSTAT,
 )
 @MULTI_MATCH(
     channel_names=CHANNEL_THERMOSTAT,

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -367,7 +367,6 @@ def _test_single_input_cluster_device_class(probe_mock):
         cover_ch,
         multistate_ch,
         ias_ch,
-        analog_ch,
     ]
 
     disc.ProbeEndpoint().discover_by_cluster_id(ch_pool)

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -384,11 +384,6 @@ def _test_single_input_cluster_device_class(probe_mock):
         assert call[0][1] == ch
 
 
-def test_single_input_cluster_device_class():
-    """Test SINGLE_INPUT_CLUSTER_DEVICE_CLASS matching by cluster id or class."""
-    _test_single_input_cluster_device_class()
-
-
 def test_single_input_cluster_device_class_by_cluster_class():
     """Test SINGLE_INPUT_CLUSTER_DEVICE_CLASS matching by cluster id or class."""
     mock_reg = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve ZHA entity matching process for single cluster entities, by removing (partially) dependency on the `SINGLE_INPUT_CLUSTER_DEVICE_CLASS` registry. Now, the component just have to decorate an entity class with a  `MULTI_MATCH` and ZHA would automatically build the registry. 

The `stop_on_match` parameter of the matching rule was renamed to `stop_on_match_group_name` to allow grouping of the "multi-matches" into the same "logical" group. For example, a HVAC Zigbee cluster/channel may have multiple different "entity" implementations, depending on the manufacturer, model, etc -- in this case, multi-match must yield only a single entity and not an entity per different implementation. Grouping the multi-matches into "named group" achieves that, so for a "component", grouped multi-matched entities yield a single entity. This allows getting rid or reducing dependency on the single cluster device class registry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
