### PR TITLE
Fix Environment Canada server loading

### DIFF
--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -55,6 +55,7 @@ class ECCamera(CoordinatorEntity, Camera):
         self._attr_name = f"{coordinator.config_entry.title} Radar"
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}-radar"
         self._attr_attribution = self.radar_object.metadata["attribution"]
+        self._attr_entity_registry_enabled_default = False
 
         self.content_type = "image/gif"
         self.image = None

--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -2,7 +2,7 @@
   "domain": "environment_canada",
   "name": "Environment Canada",
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
-  "requirements": ["env_canada==0.5.14"],
+  "requirements": ["env_canada==0.5.17"],
   "codeowners": ["@gwww", "@michaeldavie"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -2,7 +2,7 @@
   "domain": "environment_canada",
   "name": "Environment Canada",
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
-  "requirements": ["env_canada==0.5.17"],
+  "requirements": ["env_canada==0.5.18"],
   "codeowners": ["@gwww", "@michaeldavie"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -600,7 +600,7 @@ enocean==0.50
 enturclient==0.2.2
 
 # homeassistant.components.environment_canada
-env_canada==0.5.17
+env_canada==0.5.18
 
 # homeassistant.components.envirophat
 # envirophat==0.0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -600,7 +600,7 @@ enocean==0.50
 enturclient==0.2.2
 
 # homeassistant.components.environment_canada
-env_canada==0.5.14
+env_canada==0.5.17
 
 # homeassistant.components.envirophat
 # envirophat==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -369,7 +369,7 @@ emulated_roku==0.2.1
 enocean==0.50
 
 # homeassistant.components.environment_canada
-env_canada==0.5.17
+env_canada==0.5.18
 
 # homeassistant.components.enphase_envoy
 envoy_reader==0.20.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -369,7 +369,7 @@ emulated_roku==0.2.1
 enocean==0.50
 
 # homeassistant.components.environment_canada
-env_canada==0.5.14
+env_canada==0.5.17
 
 # homeassistant.components.enphase_envoy
 envoy_reader==0.20.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**In order to respond to Environment Canada (EC) as quickly as possible we are asking for consideration to release this PR in the next dot release.**

The `config_flow` change to the EC integration did not change the way the underlying radar retrieval works, but did enable radar for everyone. As a result the EC servers are getting far too many requests. We (the codeowners) have been working with EC to diagnose this issue and understand their concerns. 

We are doing two things in this PR to address their concerns. Responses from the EC servers are cached. Work so far shows that through caching we can reduce the number of requests by 92%. This fix is in the integration dependency library.

Second, we are creating the radar (camera) entity with `_attr_entity_registry_enabled_default = False` so that new radar entities are disabled by default. Many people use the integration for forecast only.

Last, EC is putting a policy in place such that User Agent needs to be filled in to represent the calling library. This fix in the library helps with traceability.

Changelog for library: https://github.com/michaeldavie/env_canada/blob/master/CHANGELOG.md
Changes: https://github.com/michaeldavie/env_canada/compare/v0.5.14...v0.5.18

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/60067
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
