### PR TITLE
Cleanup Fronius config_flow and tests

### DIFF
--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -61,9 +61,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update a given config entry."""
-    return await hass.config_entries.async_reload(entry.entry_id)
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 class FroniusSolarNet:

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -86,20 +86,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
+            await self.async_set_unique_id(unique_id, raise_on_progress=False)
+            self._abort_if_unique_id_configured(
+                updates=dict(info), reload_on_update=False
+            )
             title = (
                 f"SolarNet {'Datalogger' if info['is_logger'] else 'Inverter'}"
                 f" at {info['host']}"
             )
-            if entry := await self.async_set_unique_id(
-                unique_id, raise_on_progress=False
-            ):
-                if info.items() <= entry.data.items():
-                    return self.async_abort(reason="already_configured")
-                self.hass.config_entries.async_update_entry(
-                    entry, title=title, data=info  # type: ignore[arg-type]
-                )
-                return self.async_abort(reason="entry_update_successful")
-
             return self.async_create_entry(title=title, data=info)
 
         return self.async_show_form(

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -14,8 +14,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "entry_update_successful": "Config entry updated"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   }
 }

--- a/homeassistant/components/fronius/translations/en.json
+++ b/homeassistant/components/fronius/translations/en.json
@@ -1,8 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured",
-            "entry_update_successful": "Config entry updated"
+            "already_configured": "Device is already configured"
         },
         "error": {
             "cannot_connect": "Failed to connect",

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -1,10 +1,10 @@
 """Tests for the Fronius integration."""
-
+from homeassistant.components.fronius.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_RESOURCE
 from homeassistant.setup import async_setup_component
 
-from .const import DOMAIN, MOCK_HOST
+from .const import MOCK_HOST
 
 from tests.common import load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -1,32 +1,33 @@
 """Tests for the Fronius integration."""
 from homeassistant.components.fronius.const import DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import CONF_RESOURCE
-from homeassistant.setup import async_setup_component
+from homeassistant.const import CONF_HOST
 
-from .const import MOCK_HOST
-
-from tests.common import load_fixture
+from tests.common import MockConfigEntry, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
+
+MOCK_HOST = "http://fronius"
+MOCK_UID = "123.4567890"  # has to match mocked logger unique_id
 
 
 async def setup_fronius_integration(hass):
     """Create the Fronius integration."""
-    assert await async_setup_component(
-        hass,
-        SENSOR_DOMAIN,
-        {
-            SENSOR_DOMAIN: {
-                "platform": DOMAIN,
-                CONF_RESOURCE: MOCK_HOST,
-            }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_UID,
+        data={
+            CONF_HOST: MOCK_HOST,
+            "is_logger": True,
         },
     )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
 
 def mock_responses(
-    aioclient_mock: AiohttpClientMocker, host: str = MOCK_HOST, night: bool = False
+    aioclient_mock: AiohttpClientMocker,
+    host: str = MOCK_HOST,
+    night: bool = False,
 ) -> None:
     """Mock responses for Fronius Symo inverter with meter."""
     aioclient_mock.clear_requests()

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -6,6 +6,9 @@ from homeassistant.setup import async_setup_component
 
 from .const import DOMAIN, MOCK_HOST
 
+from tests.common import load_fixture
+from tests.test_util.aiohttp import AiohttpClientMocker
+
 
 async def setup_fronius_integration(hass):
     """Create the Fronius integration."""
@@ -20,3 +23,49 @@ async def setup_fronius_integration(hass):
         },
     )
     await hass.async_block_till_done()
+
+
+def mock_responses(
+    aioclient_mock: AiohttpClientMocker, host: str = MOCK_HOST, night: bool = False
+) -> None:
+    """Mock responses for Fronius Symo inverter with meter."""
+    aioclient_mock.clear_requests()
+    _day_or_night = "night" if night else "day"
+
+    aioclient_mock.get(
+        f"{host}/solar_api/GetAPIVersion.cgi",
+        text=load_fixture("symo/GetAPIVersion.json", "fronius"),
+    )
+    aioclient_mock.get(
+        f"{host}/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&"
+        "DeviceId=1&DataCollection=CommonInverterData",
+        text=load_fixture(
+            f"symo/GetInverterRealtimeDate_Device_1_{_day_or_night}.json", "fronius"
+        ),
+    )
+    aioclient_mock.get(
+        f"{host}/solar_api/v1/GetInverterInfo.cgi",
+        text=load_fixture("symo/GetInverterInfo.json", "fronius"),
+    )
+    aioclient_mock.get(
+        f"{host}/solar_api/v1/GetLoggerInfo.cgi",
+        text=load_fixture("symo/GetLoggerInfo.json", "fronius"),
+    )
+    aioclient_mock.get(
+        f"{host}/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceId=0",
+        text=load_fixture("symo/GetMeterRealtimeData_Device_0.json", "fronius"),
+    )
+    aioclient_mock.get(
+        f"{host}/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System",
+        text=load_fixture("symo/GetMeterRealtimeData_System.json", "fronius"),
+    )
+    aioclient_mock.get(
+        f"{host}/solar_api/v1/GetPowerFlowRealtimeData.fcgi",
+        text=load_fixture(
+            f"symo/GetPowerFlowRealtimeData_{_day_or_night}.json", "fronius"
+        ),
+    )
+    aioclient_mock.get(
+        f"{host}/solar_api/v1/GetStorageRealtimeData.cgi?Scope=System",
+        text=load_fixture("symo/GetStorageRealtimeData_System.json", "fronius"),
+    )

--- a/tests/components/fronius/const.py
+++ b/tests/components/fronius/const.py
@@ -1,4 +1,3 @@
 """Constants for Fronius tests."""
 
-DOMAIN = "fronius"
 MOCK_HOST = "http://fronius"

--- a/tests/components/fronius/const.py
+++ b/tests/components/fronius/const.py
@@ -1,3 +1,0 @@
-"""Constants for Fronius tests."""
-
-MOCK_HOST = "http://fronius"

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -40,7 +40,7 @@ async def test_form_with_logger(hass: HomeAssistant) -> None:
     assert result["errors"] is None
 
     with patch(
-        "homeassistant.components.fronius.config_flow.Fronius.current_logger_info",
+        "pyfronius.Fronius.current_logger_info",
         return_value=LOGGER_INFO_RETURN_VALUE,
     ), patch(
         "homeassistant.components.fronius.async_setup_entry",
@@ -72,10 +72,10 @@ async def test_form_with_inverter(hass: HomeAssistant) -> None:
     assert result["errors"] is None
 
     with patch(
-        "homeassistant.components.fronius.config_flow.Fronius.current_logger_info",
+        "pyfronius.Fronius.current_logger_info",
         side_effect=FroniusError,
     ), patch(
-        "homeassistant.components.fronius.config_flow.Fronius.inverter_info",
+        "pyfronius.Fronius.inverter_info",
         return_value=INVERTER_INFO_RETURN_VALUE,
     ), patch(
         "homeassistant.components.fronius.async_setup_entry",
@@ -105,10 +105,10 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.fronius.config_flow.Fronius.current_logger_info",
+        "pyfronius.Fronius.current_logger_info",
         side_effect=FroniusError,
     ), patch(
-        "homeassistant.components.fronius.config_flow.Fronius.inverter_info",
+        "pyfronius.Fronius.inverter_info",
         side_effect=FroniusError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -129,10 +129,10 @@ async def test_form_no_device(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.fronius.config_flow.Fronius.current_logger_info",
+        "pyfronius.Fronius.current_logger_info",
         side_effect=FroniusError,
     ), patch(
-        "homeassistant.components.fronius.config_flow.Fronius.inverter_info",
+        "pyfronius.Fronius.inverter_info",
         return_value={"inverters": []},
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -153,7 +153,7 @@ async def test_form_unexpected(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.fronius.config_flow.Fronius.current_logger_info",
+        "pyfronius.Fronius.current_logger_info",
         side_effect=KeyError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -180,7 +180,7 @@ async def test_form_already_existing(hass):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     with patch(
-        "homeassistant.components.fronius.config_flow.Fronius.current_logger_info",
+        "pyfronius.Fronius.current_logger_info",
         return_value=LOGGER_INFO_RETURN_VALUE,
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -5,15 +5,18 @@ from pyfronius import FroniusError
 
 from homeassistant import config_entries
 from homeassistant.components.fronius.const import DOMAIN
-from homeassistant.const import CONF_HOST
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_HOST, CONF_RESOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
+from homeassistant.setup import async_setup_component
 
 from . import mock_responses
+from .const import MOCK_HOST
 
 from tests.common import MockConfigEntry
 
@@ -232,5 +235,31 @@ async def test_form_updates_host(hass, aioclient_mock):
     assert entries[0].title == f"SolarNet Datalogger at {new_host}"
     assert entries[0].data == {
         "host": new_host,
+        "is_logger": True,
+    }
+
+
+async def test_import(hass, aioclient_mock):
+    """Test import step."""
+    mock_responses(aioclient_mock)
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                CONF_RESOURCE: MOCK_HOST,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    fronius_entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(fronius_entries) == 1
+
+    test_entry = fronius_entries[0]
+    assert test_entry.unique_id == "123.4567890"  # has to match mocked logger unique_id
+    assert test_entry.data == {
+        "host": MOCK_HOST,
         "is_logger": True,
     }

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -15,8 +15,7 @@ from homeassistant.data_entry_flow import (
 )
 from homeassistant.setup import async_setup_component
 
-from . import mock_responses
-from .const import MOCK_HOST
+from . import MOCK_HOST, mock_responses
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -228,11 +228,10 @@ async def test_form_updates_host(hass, aioclient_mock):
     await hass.async_block_till_done()
 
     assert result2["type"] == RESULT_TYPE_ABORT
-    assert result2["reason"] == "entry_update_successful"
+    assert result2["reason"] == "already_configured"
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert entries[0].title == f"SolarNet Datalogger at {new_host}"
     assert entries[0].data == {
         "host": new_host,
         "is_logger": True,

--- a/tests/components/fronius/test_init.py
+++ b/tests/components/fronius/test_init.py
@@ -1,0 +1,23 @@
+"""Test the Fronius integration."""
+from homeassistant.components.fronius.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+
+from . import mock_responses, setup_fronius_integration
+
+
+async def test_unload_config_entry(hass, aioclient_mock):
+    """Test that configuration entry supports unloading."""
+    mock_responses(aioclient_mock)
+    await setup_fronius_integration(hass)
+
+    fronius_entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(fronius_entries) == 1
+
+    test_entry = fronius_entries[0]
+    assert test_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(test_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert test_entry.state is ConfigEntryState.NOT_LOADED
+    assert not hass.data.get(DOMAIN)

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -5,6 +5,7 @@ from homeassistant.components.fronius.const import (
     DEFAULT_UPDATE_INTERVAL,
     DEFAULT_UPDATE_INTERVAL_POWER_FLOW,
 )
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.util import dt
 
@@ -24,7 +25,7 @@ async def test_symo_inverter(hass, aioclient_mock):
     mock_responses(aioclient_mock, night=True)
     await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all()) == 55
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 55
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 0)
     assert_state("sensor.energy_day_fronius_inverter_1_http_fronius", 10828)
     assert_state("sensor.energy_total_fronius_inverter_1_http_fronius", 44186900)
@@ -38,7 +39,7 @@ async def test_symo_inverter(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 59
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 59
     # 4 additional AC entities
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 2.19)
     assert_state("sensor.energy_day_fronius_inverter_1_http_fronius", 1113)
@@ -62,7 +63,7 @@ async def test_symo_logger(hass, aioclient_mock):
     mock_responses(aioclient_mock)
     await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all()) == 59
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 59
     # ignored constant entities:
     # hardware_platform, hardware_version, product_type
     # software_version, time_zone, time_zone_location
@@ -94,7 +95,7 @@ async def test_symo_meter(hass, aioclient_mock):
     mock_responses(aioclient_mock)
     await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all()) == 59
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 59
     # ignored entities:
     # manufacturer, model, serial, enable, timestamp, visible, meter_location
     #
@@ -155,7 +156,7 @@ async def test_symo_power_flow(hass, aioclient_mock):
     mock_responses(aioclient_mock, night=True)
     await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all()) == 55
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 55
     # ignored: location, mode, timestamp
     #
     # states are rounded to 2 decimals
@@ -203,7 +204,7 @@ async def test_symo_power_flow(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
     # still 55 because power_flow update interval is shorter than others
-    assert len(hass.states.async_all()) == 55
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 55
     assert_state(
         "sensor.energy_day_fronius_power_flow_0_http_fronius",
         1101.7001,

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -24,7 +24,7 @@ async def test_symo_inverter(hass, aioclient_mock):
     mock_responses(aioclient_mock, night=True)
     await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all()) == 56
+    assert len(hass.states.async_all()) == 55
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 0)
     assert_state("sensor.energy_day_fronius_inverter_1_http_fronius", 10828)
     assert_state("sensor.energy_total_fronius_inverter_1_http_fronius", 44186900)
@@ -38,7 +38,7 @@ async def test_symo_inverter(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 60
+    assert len(hass.states.async_all()) == 59
     # 4 additional AC entities
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 2.19)
     assert_state("sensor.energy_day_fronius_inverter_1_http_fronius", 1113)
@@ -62,7 +62,7 @@ async def test_symo_logger(hass, aioclient_mock):
     mock_responses(aioclient_mock)
     await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all()) == 60
+    assert len(hass.states.async_all()) == 59
     # ignored constant entities:
     # hardware_platform, hardware_version, product_type
     # software_version, time_zone, time_zone_location
@@ -94,7 +94,7 @@ async def test_symo_meter(hass, aioclient_mock):
     mock_responses(aioclient_mock)
     await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all()) == 60
+    assert len(hass.states.async_all()) == 59
     # ignored entities:
     # manufacturer, model, serial, enable, timestamp, visible, meter_location
     #
@@ -155,7 +155,7 @@ async def test_symo_power_flow(hass, aioclient_mock):
     mock_responses(aioclient_mock, night=True)
     await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all()) == 56
+    assert len(hass.states.async_all()) == 55
     # ignored: location, mode, timestamp
     #
     # states are rounded to 2 decimals
@@ -203,7 +203,7 @@ async def test_symo_power_flow(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
     # still 55 because power_flow update interval is shorter than others
-    assert len(hass.states.async_all()) == 56
+    assert len(hass.states.async_all()) == 55
     assert_state(
         "sensor.energy_day_fronius_power_flow_0_http_fronius",
         1101.7001,

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -8,55 +8,9 @@ from homeassistant.components.fronius.const import (
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.util import dt
 
-from . import setup_fronius_integration
-from .const import MOCK_HOST
+from . import mock_responses, setup_fronius_integration
 
-from tests.common import async_fire_time_changed, load_fixture
-from tests.test_util.aiohttp import AiohttpClientMocker
-
-
-def mock_responses(aioclient_mock: AiohttpClientMocker, night: bool = False) -> None:
-    """Mock responses for Fronius Symo inverter with meter."""
-    aioclient_mock.clear_requests()
-    _day_or_night = "night" if night else "day"
-
-    aioclient_mock.get(
-        f"{MOCK_HOST}/solar_api/GetAPIVersion.cgi",
-        text=load_fixture("symo/GetAPIVersion.json", "fronius"),
-    )
-    aioclient_mock.get(
-        f"{MOCK_HOST}/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&"
-        "DeviceId=1&DataCollection=CommonInverterData",
-        text=load_fixture(
-            f"symo/GetInverterRealtimeDate_Device_1_{_day_or_night}.json", "fronius"
-        ),
-    )
-    aioclient_mock.get(
-        f"{MOCK_HOST}/solar_api/v1/GetInverterInfo.cgi",
-        text=load_fixture("symo/GetInverterInfo.json", "fronius"),
-    )
-    aioclient_mock.get(
-        f"{MOCK_HOST}/solar_api/v1/GetLoggerInfo.cgi",
-        text=load_fixture("symo/GetLoggerInfo.json", "fronius"),
-    )
-    aioclient_mock.get(
-        f"{MOCK_HOST}/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceId=0",
-        text=load_fixture("symo/GetMeterRealtimeData_Device_0.json", "fronius"),
-    )
-    aioclient_mock.get(
-        f"{MOCK_HOST}/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System",
-        text=load_fixture("symo/GetMeterRealtimeData_System.json", "fronius"),
-    )
-    aioclient_mock.get(
-        f"{MOCK_HOST}/solar_api/v1/GetPowerFlowRealtimeData.fcgi",
-        text=load_fixture(
-            f"symo/GetPowerFlowRealtimeData_{_day_or_night}.json", "fronius"
-        ),
-    )
-    aioclient_mock.get(
-        f"{MOCK_HOST}/solar_api/v1/GetStorageRealtimeData.cgi?Scope=System",
-        text=load_fixture("symo/GetStorageRealtimeData_System.json", "fronius"),
-    )
+from tests.common import async_fire_time_changed
 
 
 async def test_symo_inverter(hass, aioclient_mock):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- use _abort_if_unique_id_configured helper
- apply review suggestions from #59677

- use MockConfigEntry instead of yaml import for tests
- test yaml import
- test update and unload of config_entry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
