### PR TITLE
Use ZeroconfServiceInfo in sonos

### DIFF
--- a/homeassistant/components/sonos/config_flow.py
+++ b/homeassistant/components/sonos/config_flow.py
@@ -5,7 +5,6 @@ import soco
 
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
-from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.config_entry_flow import DiscoveryFlowHandler
@@ -31,13 +30,13 @@ class SonosDiscoveryFlowHandler(DiscoveryFlowHandler):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle a flow initialized by zeroconf."""
-        hostname = discovery_info["hostname"]
+        hostname = discovery_info[zeroconf.ATTR_HOSTNAME]
         if hostname is None or not hostname.lower().startswith("sonos"):
             return self.async_abort(reason="not_sonos_device")
         await self.async_set_unique_id(self._domain, raise_on_progress=False)
-        host = discovery_info[CONF_HOST]
-        mdns_name = discovery_info[CONF_NAME]
-        properties = discovery_info["properties"]
+        host = discovery_info[zeroconf.ATTR_HOST]
+        mdns_name = discovery_info[zeroconf.ATTR_NAME]
+        properties = discovery_info[zeroconf.ATTR_PROPERTIES]
         boot_seqnum = properties.get("bootseq")
         model = properties.get("model")
         uid = hostname_to_uid(hostname)

--- a/tests/components/sonos/test_config_flow.py
+++ b/tests/components/sonos/test_config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from homeassistant import config_entries, core
+from homeassistant.components import zeroconf
 from homeassistant.components.sonos.const import DATA_SONOS_DISCOVERY_MANAGER, DOMAIN
 
 
@@ -43,12 +44,12 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data={
-            "host": "192.168.4.2",
-            "name": "Sonos-aaa@Living Room._sonos._tcp.local.",
-            "hostname": "Sonos-aaa",
-            "properties": {"bootseq": "1234"},
-        },
+        data=zeroconf.ZeroconfServiceInfo(
+            host="192.168.4.2",
+            name="Sonos-aaa@Living Room._sonos._tcp.local.",
+            hostname="Sonos-aaa",
+            properties={"bootseq": "1234"},
+        ),
     )
     assert result["type"] == "form"
     assert result["errors"] is None
@@ -82,13 +83,13 @@ async def test_zeroconf_sonos_v1(hass: core.HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data={
-            "host": "192.168.1.107",
-            "port": 1443,
-            "hostname": "sonos5CAAFDE47AC8.local.",
-            "type": "_sonos._tcp.local.",
-            "name": "Sonos-5CAAFDE47AC8._sonos._tcp.local.",
-            "properties": {
+        data=zeroconf.ZeroconfServiceInfo(
+            host="192.168.1.107",
+            port=1443,
+            hostname="sonos5CAAFDE47AC8.local.",
+            type="_sonos._tcp.local.",
+            name="Sonos-5CAAFDE47AC8._sonos._tcp.local.",
+            properties={
                 "_raw": {
                     "info": b"/api/v1/players/RINCON_5CAAFDE47AC801400/info",
                     "vers": b"1",
@@ -98,7 +99,7 @@ async def test_zeroconf_sonos_v1(hass: core.HomeAssistant):
                 "vers": "1",
                 "protovers": "1.18.9",
             },
-        },
+        ),
     )
     assert result["type"] == "form"
     assert result["errors"] is None
@@ -132,11 +133,11 @@ async def test_zeroconf_form_not_sonos(hass: core.HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data={
-            "host": "192.168.4.2",
-            "hostname": "not-aaa",
-            "properties": {"bootseq": "1234"},
-        },
+        data=zeroconf.ZeroconfServiceInfo(
+            host="192.168.4.2",
+            hostname="not-aaa",
+            properties={"bootseq": "1234"},
+        ),
     )
     assert result["type"] == "abort"
     assert result["reason"] == "not_sonos_device"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and `zeroconf` constants) in `sonos`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
