### PR TITLE
Use ZeroconfServiceInfo in smappee

### DIFF
--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -3,8 +3,8 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow, setup
+from homeassistant.components import zeroconf
 from homeassistant.components.smappee.const import (
-    CONF_HOSTNAME,
     CONF_SERIALNUMBER,
     DOMAIN,
     ENV_CLOUD,
@@ -55,14 +55,14 @@ async def test_show_zeroconf_connection_error_form(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data={
-                "host": "1.2.3.4",
-                "port": 22,
-                CONF_HOSTNAME: "Smappee1006000212.local.",
-                "type": "_ssh._tcp.local.",
-                "name": "Smappee1006000212._ssh._tcp.local.",
-                "properties": {"_raw": {}},
-            },
+            data=zeroconf.ZeroconfServiceInfo(
+                host="1.2.3.4",
+                port=22,
+                hostname="Smappee1006000212.local.",
+                type="_ssh._tcp.local.",
+                name="Smappee1006000212._ssh._tcp.local.",
+                properties={"_raw": {}},
+            ),
         )
 
         assert result["description_placeholders"] == {CONF_SERIALNUMBER: "1006000212"}
@@ -84,14 +84,14 @@ async def test_show_zeroconf_connection_error_form_next_generation(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data={
-                "host": "1.2.3.4",
-                "port": 22,
-                CONF_HOSTNAME: "Smappee5001000212.local.",
-                "type": "_ssh._tcp.local.",
-                "name": "Smappee5001000212._ssh._tcp.local.",
-                "properties": {"_raw": {}},
-            },
+            data=zeroconf.ZeroconfServiceInfo(
+                host="1.2.3.4",
+                port=22,
+                hostname="Smappee5001000212.local.",
+                type="_ssh._tcp.local.",
+                name="Smappee5001000212._ssh._tcp.local.",
+                properties={"_raw": {}},
+            ),
         )
 
         assert result["description_placeholders"] == {CONF_SERIALNUMBER: "5001000212"}
@@ -166,14 +166,14 @@ async def test_zeroconf_wrong_mdns(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data={
-            "host": "1.2.3.4",
-            "port": 22,
-            CONF_HOSTNAME: "example.local.",
-            "type": "_ssh._tcp.local.",
-            "name": "example._ssh._tcp.local.",
-            "properties": {"_raw": {}},
-        },
+        data=zeroconf.ZeroconfServiceInfo(
+            host="1.2.3.4",
+            port=22,
+            hostname="example.local.",
+            type="_ssh._tcp.local.",
+            name="example._ssh._tcp.local.",
+            properties={"_raw": {}},
+        ),
     )
 
     assert result["reason"] == "invalid_mdns"
@@ -276,14 +276,14 @@ async def test_zeroconf_device_exists_abort(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data={
-                "host": "1.2.3.4",
-                "port": 22,
-                CONF_HOSTNAME: "Smappee1006000212.local.",
-                "type": "_ssh._tcp.local.",
-                "name": "Smappee1006000212._ssh._tcp.local.",
-                "properties": {"_raw": {}},
-            },
+            data=zeroconf.ZeroconfServiceInfo(
+                host="1.2.3.4",
+                port=22,
+                hostname="Smappee1006000212.local.",
+                type="_ssh._tcp.local.",
+                name="Smappee1006000212._ssh._tcp.local.",
+                properties={"_raw": {}},
+            ),
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "already_configured"
@@ -325,14 +325,14 @@ async def test_zeroconf_abort_if_cloud_device_exists(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data={
-            "host": "1.2.3.4",
-            "port": 22,
-            CONF_HOSTNAME: "Smappee1006000212.local.",
-            "type": "_ssh._tcp.local.",
-            "name": "Smappee1006000212._ssh._tcp.local.",
-            "properties": {"_raw": {}},
-        },
+        data=zeroconf.ZeroconfServiceInfo(
+            host="1.2.3.4",
+            port=22,
+            hostname="Smappee1006000212.local.",
+            type="_ssh._tcp.local.",
+            name="Smappee1006000212._ssh._tcp.local.",
+            properties={"_raw": {}},
+        ),
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured_device"
@@ -344,14 +344,14 @@ async def test_zeroconf_confirm_abort_if_cloud_device_exists(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data={
-            "host": "1.2.3.4",
-            "port": 22,
-            CONF_HOSTNAME: "Smappee1006000212.local.",
-            "type": "_ssh._tcp.local.",
-            "name": "Smappee1006000212._ssh._tcp.local.",
-            "properties": {"_raw": {}},
-        },
+        data=zeroconf.ZeroconfServiceInfo(
+            host="1.2.3.4",
+            port=22,
+            hostname="Smappee1006000212.local.",
+            type="_ssh._tcp.local.",
+            name="Smappee1006000212._ssh._tcp.local.",
+            properties={"_raw": {}},
+        ),
     )
 
     config_entry = MockConfigEntry(
@@ -463,14 +463,14 @@ async def test_full_zeroconf_flow(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data={
-                "host": "1.2.3.4",
-                "port": 22,
-                CONF_HOSTNAME: "Smappee1006000212.local.",
-                "type": "_ssh._tcp.local.",
-                "name": "Smappee1006000212._ssh._tcp.local.",
-                "properties": {"_raw": {}},
-            },
+            data=zeroconf.ZeroconfServiceInfo(
+                host="1.2.3.4",
+                port=22,
+                hostname="Smappee1006000212.local.",
+                type="_ssh._tcp.local.",
+                name="Smappee1006000212._ssh._tcp.local.",
+                properties={"_raw": {}},
+            ),
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "zeroconf_confirm"
@@ -538,14 +538,14 @@ async def test_full_zeroconf_flow_next_generation(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data={
-                "host": "1.2.3.4",
-                "port": 22,
-                CONF_HOSTNAME: "Smappee5001000212.local.",
-                "type": "_ssh._tcp.local.",
-                "name": "Smappee5001000212._ssh._tcp.local.",
-                "properties": {"_raw": {}},
-            },
+            data=zeroconf.ZeroconfServiceInfo(
+                host="1.2.3.4",
+                port=22,
+                hostname="Smappee5001000212.local.",
+                type="_ssh._tcp.local.",
+                name="Smappee5001000212._ssh._tcp.local.",
+                properties={"_raw": {}},
+            ),
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["step_id"] == "zeroconf_confirm"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and `zeroconf` constants) in `smappee`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
