### PR TITLE
Bumped version of wirelesstagpy to 0.8.0

### DIFF
--- a/homeassistant/components/wirelesstag/__init__.py
+++ b/homeassistant/components/wirelesstag/__init__.py
@@ -3,7 +3,8 @@ import logging
 
 from requests.exceptions import ConnectTimeout, HTTPError
 import voluptuous as vol
-from wirelesstagpy import WirelessTags, WirelessTagsException
+from wirelesstagpy import WirelessTags
+from wirelesstagpy.exceptions import WirelessTagsException
 
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,

--- a/homeassistant/components/wirelesstag/manifest.json
+++ b/homeassistant/components/wirelesstag/manifest.json
@@ -2,7 +2,7 @@
   "domain": "wirelesstag",
   "name": "Wireless Sensor Tags",
   "documentation": "https://www.home-assistant.io/integrations/wirelesstag",
-  "requirements": ["wirelesstagpy==0.5.0"],
+  "requirements": ["wirelesstagpy==0.8.0"],
   "codeowners": ["@sergeymaysak"],
   "iot_class": "cloud_push"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2418,7 +2418,7 @@ whirlpool-sixth-sense==0.15.1
 wiffi==1.0.1
 
 # homeassistant.components.wirelesstag
-wirelesstagpy==0.5.0
+wirelesstagpy==0.8.0
 
 # homeassistant.components.withings
 withings-api==2.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1418,6 +1418,9 @@ whirlpool-sixth-sense==0.15.1
 # homeassistant.components.wiffi
 wiffi==1.0.1
 
+# homeassistant.components.wirelesstag
+wirelesstagpy==0.8.0
+
 # homeassistant.components.withings
 withings-api==2.3.2
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Bumped version of wirelesstagpy to 0.8.0
git compare: https://github.com/sergeymaysak/wirelesstagpy/compare/0.5.0...0.8.0
release notes: https://github.com/sergeymaysak/wirelesstagpy/releases/


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
