### PR TITLE
Use ZeroconfServiceInfo in tradfri

### DIFF
--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -96,10 +96,14 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle homekit discovery."""
-        await self.async_set_unique_id(discovery_info["properties"]["id"])
-        self._abort_if_unique_id_configured({CONF_HOST: discovery_info["host"]})
+        await self.async_set_unique_id(
+            discovery_info[zeroconf.ATTR_PROPERTIES][zeroconf.ATTR_PROPERTIES_ID]
+        )
+        self._abort_if_unique_id_configured(
+            {CONF_HOST: discovery_info[zeroconf.ATTR_HOST]}
+        )
 
-        host = discovery_info["host"]
+        host = discovery_info[zeroconf.ATTR_HOST]
 
         for entry in self._async_current_entries():
             if entry.data.get(CONF_HOST) != host:
@@ -108,7 +112,10 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # Backwards compat, we update old entries
             if not entry.unique_id:
                 self.hass.config_entries.async_update_entry(
-                    entry, unique_id=discovery_info["properties"]["id"]
+                    entry,
+                    unique_id=discovery_info[zeroconf.ATTR_PROPERTIES][
+                        zeroconf.ATTR_PROPERTIES_ID
+                    ],
                 )
 
             return self.async_abort(reason="already_configured")

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
+from homeassistant.components import zeroconf
 from homeassistant.components.tradfri import config_flow
 
 from . import TRADFRI_PATH
@@ -103,7 +104,10 @@ async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
     flow = await hass.config_entries.flow.async_init(
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data={"host": "123.123.123.123", "properties": {"id": "homekit-id"}},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="123.123.123.123",
+            properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"},
+        ),
     )
 
     result = await hass.config_entries.flow.async_configure(
@@ -251,7 +255,9 @@ async def test_discovery_duplicate_aborted(hass):
     flow = await hass.config_entries.flow.async_init(
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data={"host": "new-host", "properties": {"id": "homekit-id"}},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="new-host", properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"}
+        ),
     )
 
     assert flow["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -279,7 +285,10 @@ async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
     result = await hass.config_entries.flow.async_init(
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data={"host": "123.123.123.123", "properties": {"id": "homekit-id"}},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="123.123.123.123",
+            properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"},
+        ),
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -287,7 +296,10 @@ async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
     result2 = await hass.config_entries.flow.async_init(
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data={"host": "123.123.123.123", "properties": {"id": "homekit-id"}},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="123.123.123.123",
+            properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"},
+        ),
     )
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -304,7 +316,9 @@ async def test_discovery_updates_unique_id(hass):
     flow = await hass.config_entries.flow.async_init(
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data={"host": "some-host", "properties": {"id": "homekit-id"}},
+        data=zeroconf.ZeroconfServiceInfo(
+            host="some-host", properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"}
+        ),
     )
 
     assert flow["type"] == data_entry_flow.RESULT_TYPE_ABORT


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and `zeroconf` constants) in `tradfri`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
