### PR TITLE
Use ZeroconfServiceInfo in vizio

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -11,6 +11,7 @@ from pyvizio.const import APP_HOME
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components import zeroconf
 from homeassistant.components.media_player import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV
 from homeassistant.config_entries import (
     SOURCE_IGNORE,
@@ -26,14 +27,11 @@ from homeassistant.const import (
     CONF_INCLUDE,
     CONF_NAME,
     CONF_PIN,
-    CONF_PORT,
-    CONF_TYPE,
 )
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.util.network import is_ip_address
 
 from .const import (
@@ -338,28 +336,25 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_user(user_input=import_config)
 
     async def async_step_zeroconf(
-        self, discovery_info: DiscoveryInfoType | None = None
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle zeroconf discovery."""
+        host = discovery_info[zeroconf.ATTR_HOST]
         # If host already has port, no need to add it again
-        if ":" not in discovery_info[CONF_HOST]:
-            discovery_info[
-                CONF_HOST
-            ] = f"{discovery_info[CONF_HOST]}:{discovery_info[CONF_PORT]}"
+        if ":" not in host:
+            host = f"{host}:{discovery_info[zeroconf.ATTR_PORT]}"
 
         # Set default name to discovered device name by stripping zeroconf service
         # (`type`) from `name`
-        num_chars_to_strip = len(discovery_info[CONF_TYPE]) + 1
-        discovery_info[CONF_NAME] = discovery_info[CONF_NAME][:-num_chars_to_strip]
+        num_chars_to_strip = len(discovery_info[zeroconf.ATTR_TYPE]) + 1
+        name = discovery_info[zeroconf.ATTR_NAME][:-num_chars_to_strip]
 
-        discovery_info[CONF_DEVICE_CLASS] = await async_guess_device_type(
-            discovery_info[CONF_HOST]
-        )
+        device_class = await async_guess_device_type(host)
 
         # Set unique ID early for discovery flow so we can abort if needed
         unique_id = await VizioAsync.get_unique_id(
-            discovery_info[CONF_HOST],
-            discovery_info[CONF_DEVICE_CLASS],
+            host,
+            device_class,
             session=async_get_clientsession(self.hass, False),
         )
 
@@ -372,7 +367,13 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Form must be shown after discovery so user can confirm/update configuration
         # before ConfigEntry creation.
         self._must_show_form = True
-        return await self.async_step_user(user_input=discovery_info)
+        return await self.async_step_user(
+            user_input={
+                CONF_HOST: host,
+                CONF_NAME: name,
+                CONF_DEVICE_CLASS: device_class,
+            }
+        )
 
     async def async_step_pair_tv(self, user_input: dict[str, Any] = None) -> FlowResult:
         """

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -339,15 +339,15 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle zeroconf discovery."""
-        host = discovery_info[zeroconf.ATTR_HOST]
+        host = discovery_info.host
         # If host already has port, no need to add it again
         if ":" not in host:
-            host = f"{host}:{discovery_info[zeroconf.ATTR_PORT]}"
+            host = f"{host}:{discovery_info.port}"
 
         # Set default name to discovered device name by stripping zeroconf service
         # (`type`) from `name`
-        num_chars_to_strip = len(discovery_info[zeroconf.ATTR_TYPE]) + 1
-        name = discovery_info[zeroconf.ATTR_NAME][:-num_chars_to_strip]
+        num_chars_to_strip = len(discovery_info.type) + 1
+        name = discovery_info.name[:-num_chars_to_strip]
 
         device_class = await async_guess_device_type(host)
 

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -1,4 +1,5 @@
 """Constants for the Vizio integration tests."""
+from homeassistant.components import zeroconf
 from homeassistant.components.media_player import (
     DEVICE_CLASS_SPEAKER,
     DEVICE_CLASS_TV,
@@ -23,8 +24,6 @@ from homeassistant.const import (
     CONF_INCLUDE,
     CONF_NAME,
     CONF_PIN,
-    CONF_PORT,
-    CONF_TYPE,
 )
 from homeassistant.util import slugify
 
@@ -198,10 +197,10 @@ ZEROCONF_NAME = f"{NAME}.{VIZIO_ZEROCONF_SERVICE_TYPE}"
 ZEROCONF_HOST = HOST.split(":")[0]
 ZEROCONF_PORT = HOST.split(":")[1]
 
-MOCK_ZEROCONF_SERVICE_INFO = {
-    CONF_TYPE: VIZIO_ZEROCONF_SERVICE_TYPE,
-    CONF_NAME: ZEROCONF_NAME,
-    CONF_HOST: ZEROCONF_HOST,
-    CONF_PORT: ZEROCONF_PORT,
-    "properties": {"name": "SB4031-D5"},
-}
+MOCK_ZEROCONF_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
+    type=VIZIO_ZEROCONF_SERVICE_TYPE,
+    name=ZEROCONF_NAME,
+    host=ZEROCONF_HOST,
+    port=ZEROCONF_PORT,
+    properties={"name": "SB4031-D5"},
+)

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -198,9 +198,10 @@ ZEROCONF_HOST = HOST.split(":")[0]
 ZEROCONF_PORT = HOST.split(":")[1]
 
 MOCK_ZEROCONF_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
-    type=VIZIO_ZEROCONF_SERVICE_TYPE,
-    name=ZEROCONF_NAME,
     host=ZEROCONF_HOST,
+    hostname="mock_hostname",
+    name=ZEROCONF_NAME,
     port=ZEROCONF_PORT,
     properties={"name": "SB4031-D5"},
+    type=VIZIO_ZEROCONF_SERVICE_TYPE,
 )

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -3,6 +3,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
+from homeassistant.components import zeroconf
 from homeassistant.components.media_player import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV
 from homeassistant.components.vizio.config_flow import _get_config_schema
 from homeassistant.components.vizio.const import (
@@ -27,7 +28,6 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     CONF_PIN,
-    CONF_PORT,
 )
 from homeassistant.core import HomeAssistant
 
@@ -796,8 +796,8 @@ async def test_zeroconf_flow_with_port_in_host(
     # Try rediscovering same device, this time with port already in host
     discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
     discovery_info[
-        CONF_HOST
-    ] = f"{discovery_info[CONF_HOST]}:{discovery_info[CONF_PORT]}"
+        zeroconf.ATTR_HOST
+    ] = f"{discovery_info[zeroconf.ATTR_HOST]}:{discovery_info[zeroconf.ATTR_PORT]}"
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -739,7 +739,15 @@ async def test_zeroconf_flow(
 
     # Apply discovery updates to entry to mimic when user hits submit without changing
     # defaults which were set from discovery parameters
-    user_input = result["data_schema"](discovery_info)
+    user_input = result["data_schema"](
+        {
+            CONF_HOST: f"{discovery_info[zeroconf.ATTR_HOST]}:{discovery_info[zeroconf.ATTR_PORT]}",
+            CONF_NAME: discovery_info[zeroconf.ATTR_NAME][
+                : -(len(discovery_info[zeroconf.ATTR_TYPE]) + 1)
+            ],
+            CONF_DEVICE_CLASS: "speaker",
+        }
+    )
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=user_input

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -1,4 +1,6 @@
 """Tests for Vizio config flow."""
+import dataclasses
+
 import pytest
 import voluptuous as vol
 
@@ -728,7 +730,7 @@ async def test_zeroconf_flow(
     vizio_guess_device_type: pytest.fixture,
 ) -> None:
     """Test zeroconf config flow."""
-    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
@@ -776,7 +778,7 @@ async def test_zeroconf_flow_already_configured(
     entry.add_to_hass(hass)
 
     # Try rediscovering same device
-    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
@@ -802,10 +804,8 @@ async def test_zeroconf_flow_with_port_in_host(
     entry.add_to_hass(hass)
 
     # Try rediscovering same device, this time with port already in host
-    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
-    discovery_info[
-        zeroconf.ATTR_HOST
-    ] = f"{discovery_info[zeroconf.ATTR_HOST]}:{discovery_info[zeroconf.ATTR_PORT]}"
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
+    discovery_info.host = f"{discovery_info.host}:{discovery_info.port}"
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
@@ -822,7 +822,7 @@ async def test_zeroconf_dupe_fail(
     vizio_guess_device_type: pytest.fixture,
 ) -> None:
     """Test zeroconf config flow when device gets discovered multiple times."""
-    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
@@ -831,7 +831,7 @@ async def test_zeroconf_dupe_fail(
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
-    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
@@ -856,7 +856,7 @@ async def test_zeroconf_ignore(
     )
     entry.add_to_hass(hass)
 
-    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
@@ -871,7 +871,7 @@ async def test_zeroconf_no_unique_id(
 ) -> None:
     """Test zeroconf discovery aborts when unique_id is None."""
 
-    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
@@ -896,7 +896,7 @@ async def test_zeroconf_abort_when_ignored(
     )
     entry.add_to_hass(hass)
 
-    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
@@ -924,7 +924,7 @@ async def test_zeroconf_flow_already_configured_hostname(
     entry.add_to_hass(hass)
 
     # Try rediscovering same device
-    discovery_info = MOCK_ZEROCONF_SERVICE_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ZeroconfServiceInfo` (and `zeroconf` constants) in `vizio`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
