### PR TITLE
Bump openwrt-luci-rpc from 1.1.8 to 1.1.11

### DIFF
--- a/homeassistant/components/luci/manifest.json
+++ b/homeassistant/components/luci/manifest.json
@@ -2,7 +2,7 @@
   "domain": "luci",
   "name": "OpenWRT (luci)",
   "documentation": "https://www.home-assistant.io/integrations/luci",
-  "requirements": ["openwrt-luci-rpc==1.1.8"],
+  "requirements": ["openwrt-luci-rpc==1.1.11"],
   "codeowners": ["@mzdrale"],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1150,7 +1150,7 @@ opensensemap-api==0.1.5
 openwebifpy==3.2.7
 
 # homeassistant.components.luci
-openwrt-luci-rpc==1.1.8
+openwrt-luci-rpc==1.1.11
 
 # homeassistant.components.ubus
 openwrt-ubus-rpc==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -696,9 +696,6 @@ onvif-zeep-async==1.2.0
 # homeassistant.components.opengarage
 open-garage==0.2.0
 
-# homeassistant.components.luci
-openwrt-luci-rpc==1.1.11
-
 # homeassistant.components.openerz
 openerz-api==0.1.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -696,6 +696,9 @@ onvif-zeep-async==1.2.0
 # homeassistant.components.opengarage
 open-garage==0.2.0
 
+# homeassistant.components.luci
+openwrt-luci-rpc==1.1.11
+
 # homeassistant.components.openerz
 openerz-api==0.1.0
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps openwrt-luci-rpc to the latest version 1.1.11

Changelog from the openwrt-luc-rpc dev: https://github.com/fbradyirl/openwrt-luci-rpc/blob/master/HISTORY.rst
1.1.9 (2021-03-21)
Publish to pypi only once in github actions (fbradyirl/openwrt-luci-rpc#47)
1.1.10 (2021-03-21)
Also trigger the Github Actions on push of tags (fbradyirl/openwrt-luci-rpc#49)
1.1.11 (2021-03-21)
Add rst-linter pre-commit hook to prevent committing errors to HISTORY.rst fbradyirl/openwrt-luci-rpc#50

https://github.com/fbradyirl/openwrt-luci-rpc/compare/v1.1.8...v1.1.11

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
