### PR TITLE
Add UNIX timestamp detection to `as_datetime` template filter

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1496,13 +1496,14 @@ def forgiving_as_timestamp(value, default=_SENTINEL):
         return default
 
 
-def as_datetime(value, from_timestamp=False):
+def as_datetime(value):
     """Filter and to convert a time string or UNIX timestamp to datetime object."""
-    return (
-        dt_util.utc_from_timestamp(value)
-        if from_timestamp
-        else dt_util.parse_datetime(value)
-    )
+    try:
+        # Check for a valid UNIX timestamp string, int or float
+        timestamp = float(value)
+        return dt_util.utc_from_timestamp(timestamp)
+    except ValueError:
+        return dt_util.parse_datetime(value)
 
 
 def strptime(string, fmt, default=_SENTINEL):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1496,6 +1496,15 @@ def forgiving_as_timestamp(value, default=_SENTINEL):
         return default
 
 
+def as_datetime(value, from_timestamp=False):
+    """Filter and to convert a time string or UNIX timestamp to datetime object."""
+    return (
+        dt_util.utc_from_timestamp(value)
+        if from_timestamp
+        else dt_util.parse_datetime(value)
+    )
+
+
 def strptime(string, fmt, default=_SENTINEL):
     """Parse a time string to datetime."""
     try:
@@ -1791,7 +1800,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["atan"] = arc_tangent
         self.filters["atan2"] = arc_tangent2
         self.filters["sqrt"] = square_root
-        self.filters["as_datetime"] = dt_util.parse_datetime
+        self.filters["as_datetime"] = as_datetime
         self.filters["as_timestamp"] = forgiving_as_timestamp
         self.filters["today_at"] = today_at
         self.filters["as_local"] = dt_util.as_local
@@ -1832,7 +1841,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["atan"] = arc_tangent
         self.globals["atan2"] = arc_tangent2
         self.globals["float"] = forgiving_float
-        self.globals["as_datetime"] = dt_util.parse_datetime
+        self.globals["as_datetime"] = as_datetime
         self.globals["as_local"] = dt_util.as_local
         self.globals["as_timestamp"] = forgiving_as_timestamp
         self.globals["today_at"] = today_at

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -737,6 +737,7 @@ def test_as_datetime_from_timestamp(hass):
     tests = [
         (1469119144, "2016-07-21 16:39:04+00:00"),
         (1469119144.0, "2016-07-21 16:39:04+00:00"),
+        (-1, "1969-12-31 23:59:59+00:00"),
     ]
     for input, output in tests:
         # expected = dt_util.parse_datetime(input)
@@ -744,15 +745,19 @@ def test_as_datetime_from_timestamp(hass):
             output = str(output)
 
         assert (
-            template.Template(
-                f"{{{{ as_datetime({input}, from_timestamp=True) }}}}", hass
-            ).async_render()
+            template.Template(f"{{{{ as_datetime({input}) }}}}", hass).async_render()
             == output
         )
         assert (
-            template.Template(
-                f"{{{{ {input} | as_datetime(from_timestamp=True) }}}}", hass
-            ).async_render()
+            template.Template(f"{{{{ {input} | as_datetime }}}}", hass).async_render()
+            == output
+        )
+        assert (
+            template.Template(f"{{{{ as_datetime('{input}') }}}}", hass).async_render()
+            == output
+        )
+        assert (
+            template.Template(f"{{{{ '{input}' | as_datetime }}}}", hass).async_render()
             == output
         )
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -732,6 +732,31 @@ def test_as_datetime(hass, input):
     )
 
 
+def test_as_datetime_from_timestamp(hass):
+    """Test converting a UNIX timestamp to a date object."""
+    tests = [
+        (1469119144, "2016-07-21 16:39:04+00:00"),
+        (1469119144.0, "2016-07-21 16:39:04+00:00"),
+    ]
+    for input, output in tests:
+        # expected = dt_util.parse_datetime(input)
+        if output is not None:
+            output = str(output)
+
+        assert (
+            template.Template(
+                f"{{{{ as_datetime({input}, from_timestamp=True) }}}}", hass
+            ).async_render()
+            == output
+        )
+        assert (
+            template.Template(
+                f"{{{{ {input} | as_datetime(from_timestamp=True) }}}}", hass
+            ).async_render()
+            == output
+        )
+
+
 def test_as_local(hass):
     """Test converting time to local."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With PR https://github.com/home-assistant/core/pull/52671 a sensor state with a `device_class` == `timestamp` should be assigned a state with a `datetime` type value. For MQTT this can be an ISO formatted datetime string with timezone info as well. In the past a string assignment was parsed and accepted. If no timezone was added the time was treated as a local time. With pull https://github.com/home-assistant/core/pull/59923 this is also no longer valid.

MQTT sensor completely relies on text or json payloads that will be needed translate using templates.

The current template filters support converting timestamps to a date string:
- `timestamp_local`
- `timestamp_utc`
- `timestamp_custom`
And there is a filter to convert a date string to `datetime`:
- `as_datetime`

To convert a `float` to a `datetime` value currently two filters are needed:
- `timestamp_local | as_date_time`

The disadvantage here is that the float number is converted to text first, which is time consuming.

This PR adds UNIX timestamp detection to the `as_datetime` template filter.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #60029
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20394

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
