### PR TITLE
Use ServiceInfo in zha

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -8,9 +8,9 @@ import voluptuous as vol
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 
 from homeassistant import config_entries
-from homeassistant.components import usb
-from homeassistant.const import CONF_HOST, CONF_NAME
-from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.components import usb, zeroconf
+from homeassistant.const import CONF_NAME
+from homeassistant.data_entry_flow import FlowResult
 
 from .core.const import (
     CONF_BAUDRATE,
@@ -94,14 +94,14 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(schema),
         )
 
-    async def async_step_usb(self, discovery_info: DiscoveryInfoType):
+    async def async_step_usb(self, discovery_info: usb.UsbServiceInfo) -> FlowResult:
         """Handle usb discovery."""
-        vid = discovery_info["vid"]
-        pid = discovery_info["pid"]
-        serial_number = discovery_info["serial_number"]
-        device = discovery_info["device"]
-        manufacturer = discovery_info["manufacturer"]
-        description = discovery_info["description"]
+        vid = discovery_info[usb.ATTR_VID]
+        pid = discovery_info[usb.ATTR_PID]
+        serial_number = discovery_info[usb.ATTR_SERIAL_NUMBER]
+        device = discovery_info[usb.ATTR_DEVICE]
+        manufacturer = discovery_info[usb.ATTR_MANUFACTURER]
+        description = discovery_info[usb.ATTR_DESCRIPTION]
         dev_path = await self.hass.async_add_executor_job(usb.get_serial_by_id, device)
         unique_id = f"{vid}:{pid}_{serial_number}_{manufacturer}_{description}"
         if current_entry := await self.async_set_unique_id(unique_id):
@@ -159,12 +159,14 @@ class ZhaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({}),
         )
 
-    async def async_step_zeroconf(self, discovery_info: DiscoveryInfoType):
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
         """Handle zeroconf discovery."""
         # Hostname is format: livingroom.local.
-        local_name = discovery_info["hostname"][:-1]
+        local_name = discovery_info[zeroconf.ATTR_HOSTNAME][:-1]
         node_name = local_name[: -len(".local")]
-        host = discovery_info[CONF_HOST]
+        host = discovery_info[zeroconf.ATTR_HOST]
         device_path = f"socket://{host}:6638"
 
         if current_entry := await self.async_set_unique_id(node_name):

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -8,6 +8,7 @@ import zigpy.config
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 
 from homeassistant import config_entries
+from homeassistant.components import usb, zeroconf
 from homeassistant.components.ssdp import (
     ATTR_SSDP_LOCATION,
     ATTR_UPNP_MANUFACTURER_URL,
@@ -52,12 +53,12 @@ def com_port():
 @patch("zigpy_znp.zigbee.application.ControllerApplication.probe", return_value=True)
 async def test_discovery(detect_mock, hass):
     """Test zeroconf flow -- radio detected."""
-    service_info = {
-        "host": "192.168.1.200",
-        "port": 6053,
-        "hostname": "_tube_zb_gw._tcp.local.",
-        "properties": {"name": "tube_123456"},
-    }
+    service_info = zeroconf.ZeroconfServiceInfo(
+        host="192.168.1.200",
+        port=6053,
+        hostname="_tube_zb_gw._tcp.local.",
+        properties={"name": "tube_123456"},
+    )
     flow = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_ZEROCONF}, data=service_info
     )
@@ -94,12 +95,12 @@ async def test_discovery_via_zeroconf_ip_change(detect_mock, hass):
     )
     entry.add_to_hass(hass)
 
-    service_info = {
-        "host": "192.168.1.22",
-        "port": 6053,
-        "hostname": "tube_zb_gw_cc2652p2_poe.local.",
-        "properties": {"address": "tube_zb_gw_cc2652p2_poe.local"},
-    }
+    service_info = zeroconf.ZeroconfServiceInfo(
+        host="192.168.1.22",
+        port=6053,
+        hostname="tube_zb_gw_cc2652p2_poe.local.",
+        properties={"address": "tube_zb_gw_cc2652p2_poe.local"},
+    )
     result = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_ZEROCONF}, data=service_info
     )
@@ -124,12 +125,12 @@ async def test_discovery_via_zeroconf_ip_change_ignored(detect_mock, hass):
     )
     entry.add_to_hass(hass)
 
-    service_info = {
-        "host": "192.168.1.22",
-        "port": 6053,
-        "hostname": "tube_zb_gw_cc2652p2_poe.local.",
-        "properties": {"address": "tube_zb_gw_cc2652p2_poe.local"},
-    }
+    service_info = zeroconf.ZeroconfServiceInfo(
+        host="192.168.1.22",
+        port=6053,
+        hostname="tube_zb_gw_cc2652p2_poe.local.",
+        properties={"address": "tube_zb_gw_cc2652p2_poe.local"},
+    )
     result = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_ZEROCONF}, data=service_info
     )
@@ -144,14 +145,14 @@ async def test_discovery_via_zeroconf_ip_change_ignored(detect_mock, hass):
 @patch("zigpy_znp.zigbee.application.ControllerApplication.probe", return_value=True)
 async def test_discovery_via_usb(detect_mock, hass):
     """Test usb flow -- radio detected."""
-    discovery_info = {
-        "device": "/dev/ttyZIGBEE",
-        "pid": "AAAA",
-        "vid": "AAAA",
-        "serial_number": "1234",
-        "description": "zigbee radio",
-        "manufacturer": "test",
-    }
+    discovery_info = usb.UsbServiceInfo(
+        device="/dev/ttyZIGBEE",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="zigbee radio",
+        manufacturer="test",
+    )
     result = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_USB}, data=discovery_info
     )
@@ -180,14 +181,14 @@ async def test_discovery_via_usb(detect_mock, hass):
 @patch("zigpy_znp.zigbee.application.ControllerApplication.probe", return_value=False)
 async def test_discovery_via_usb_no_radio(detect_mock, hass):
     """Test usb flow -- no radio detected."""
-    discovery_info = {
-        "device": "/dev/null",
-        "pid": "AAAA",
-        "vid": "AAAA",
-        "serial_number": "1234",
-        "description": "zigbee radio",
-        "manufacturer": "test",
-    }
+    discovery_info = usb.UsbServiceInfo(
+        device="/dev/null",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="zigbee radio",
+        manufacturer="test",
+    )
     result = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_USB}, data=discovery_info
     )
@@ -213,14 +214,14 @@ async def test_discovery_via_usb_already_setup(detect_mock, hass):
         domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE_PATH: "/dev/ttyUSB1"}}
     ).add_to_hass(hass)
 
-    discovery_info = {
-        "device": "/dev/ttyZIGBEE",
-        "pid": "AAAA",
-        "vid": "AAAA",
-        "serial_number": "1234",
-        "description": "zigbee radio",
-        "manufacturer": "test",
-    }
+    discovery_info = usb.UsbServiceInfo(
+        device="/dev/ttyZIGBEE",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="zigbee radio",
+        manufacturer="test",
+    )
     result = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_USB}, data=discovery_info
     )
@@ -247,14 +248,14 @@ async def test_discovery_via_usb_path_changes(hass):
     )
     entry.add_to_hass(hass)
 
-    discovery_info = {
-        "device": "/dev/ttyZIGBEE",
-        "pid": "AAAA",
-        "vid": "AAAA",
-        "serial_number": "1234",
-        "description": "zigbee radio",
-        "manufacturer": "test",
-    }
+    discovery_info = usb.UsbServiceInfo(
+        device="/dev/ttyZIGBEE",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="zigbee radio",
+        manufacturer="test",
+    )
     result = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_USB}, data=discovery_info
     )
@@ -282,14 +283,14 @@ async def test_discovery_via_usb_deconz_already_discovered(detect_mock, hass):
         context={"source": SOURCE_SSDP},
     )
     await hass.async_block_till_done()
-    discovery_info = {
-        "device": "/dev/ttyZIGBEE",
-        "pid": "AAAA",
-        "vid": "AAAA",
-        "serial_number": "1234",
-        "description": "zigbee radio",
-        "manufacturer": "test",
-    }
+    discovery_info = usb.UsbServiceInfo(
+        device="/dev/ttyZIGBEE",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="zigbee radio",
+        manufacturer="test",
+    )
     result = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_USB}, data=discovery_info
     )
@@ -304,14 +305,14 @@ async def test_discovery_via_usb_deconz_already_setup(detect_mock, hass):
     """Test usb flow -- deconz setup."""
     MockConfigEntry(domain="deconz", data={}).add_to_hass(hass)
     await hass.async_block_till_done()
-    discovery_info = {
-        "device": "/dev/ttyZIGBEE",
-        "pid": "AAAA",
-        "vid": "AAAA",
-        "serial_number": "1234",
-        "description": "zigbee radio",
-        "manufacturer": "test",
-    }
+    discovery_info = usb.UsbServiceInfo(
+        device="/dev/ttyZIGBEE",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="zigbee radio",
+        manufacturer="test",
+    )
     result = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_USB}, data=discovery_info
     )
@@ -328,14 +329,14 @@ async def test_discovery_via_usb_deconz_ignored(detect_mock, hass):
         domain="deconz", source=config_entries.SOURCE_IGNORE, data={}
     ).add_to_hass(hass)
     await hass.async_block_till_done()
-    discovery_info = {
-        "device": "/dev/ttyZIGBEE",
-        "pid": "AAAA",
-        "vid": "AAAA",
-        "serial_number": "1234",
-        "description": "zigbee radio",
-        "manufacturer": "test",
-    }
+    discovery_info = usb.UsbServiceInfo(
+        device="/dev/ttyZIGBEE",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="zigbee radio",
+        manufacturer="test",
+    )
     result = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_USB}, data=discovery_info
     )
@@ -356,14 +357,14 @@ async def test_discovery_via_usb_zha_ignored_updates(detect_mock, hass):
     )
     entry.add_to_hass(hass)
     await hass.async_block_till_done()
-    discovery_info = {
-        "device": "/dev/ttyZIGBEE",
-        "pid": "AAAA",
-        "vid": "AAAA",
-        "serial_number": "1234",
-        "description": "zigbee radio",
-        "manufacturer": "test",
-    }
+    discovery_info = usb.UsbServiceInfo(
+        device="/dev/ttyZIGBEE",
+        pid="AAAA",
+        vid="AAAA",
+        serial_number="1234",
+        description="zigbee radio",
+        manufacturer="test",
+    )
     result = await hass.config_entries.flow.async_init(
         "zha", context={"source": SOURCE_USB}, data=discovery_info
     )
@@ -380,12 +381,12 @@ async def test_discovery_via_usb_zha_ignored_updates(detect_mock, hass):
 @patch("zigpy_znp.zigbee.application.ControllerApplication.probe", return_value=True)
 async def test_discovery_already_setup(detect_mock, hass):
     """Test zeroconf flow -- radio detected."""
-    service_info = {
-        "host": "192.168.1.200",
-        "port": 6053,
-        "hostname": "_tube_zb_gw._tcp.local.",
-        "properties": {"name": "tube_123456"},
-    }
+    service_info = zeroconf.ZeroconfServiceInfo(
+        host="192.168.1.200",
+        port=6053,
+        hostname="_tube_zb_gw._tcp.local.",
+        properties={"name": "tube_123456"},
+    )
 
     MockConfigEntry(
         domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE_PATH: "/dev/ttyUSB1"}}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `UsbServiceInfo` and `ZeroconfServiceInfo` (and corresponding constants) in `zha`.

See home-assistant/architecture#662


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
