### PR TITLE
Use dataclass for DhcpServiceInfo

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -7,7 +7,7 @@ from ipaddress import ip_address as make_ip_address
 import logging
 import os
 import threading
-from typing import Final
+from typing import Any, Final
 
 from aiodiscover import DiscoverHosts
 from aiodiscover.discovery import (
@@ -63,6 +63,17 @@ class DhcpServiceInfo(config_entries.BaseServiceInfo):
     ip: str
     hostname: str
     macaddress: str
+
+    def __getitem__(self, name: str) -> Any:
+        """
+        Allow property access by name for compatibility reason.
+
+        Deprecated, and will be removed in a future release.
+        """
+        _LOGGER.warning(
+            "__getitem__ will fail in version 2022.6. Please use <cls>.<name> instead."
+        )
+        return getattr(self, name)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -57,7 +57,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class DhcpServiceInfo(config_entries.BaseServiceInfo):
+class DhcpServiceInfo:
     """Prepared info from dhcp entries."""
 
     ip: str

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -65,7 +65,16 @@ class DhcpServiceInfo:
     macaddress: str
 
     def __getitem__(self, name: str) -> Any:
-        """Allow property access by name for compatibility reason."""
+        """
+        Allow property access by name for compatibility reason.
+
+        Deprecated, and will be removed in version 2022.6.
+        """
+        _LOGGER.debug(
+            "Accessing discovery_info['%s'] will fail in version 2022.6. Please use discovery_info.%s instead",
+            name,
+            name,
+        )
         return getattr(self, name)
 
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -64,17 +64,23 @@ class DhcpServiceInfo:
     hostname: str
     macaddress: str
 
+    # Used to prevent log flooding. To be removed in 2022.6
+    _warning_logged: bool = False
+
     def __getitem__(self, name: str) -> Any:
         """
         Allow property access by name for compatibility reason.
 
         Deprecated, and will be removed in version 2022.6.
         """
-        _LOGGER.debug(
-            "Accessing discovery_info['%s'] will fail in version 2022.6. Please use discovery_info.%s instead",
-            name,
-            name,
-        )
+        if not self._warning_logged:
+            _LOGGER.debug(
+                "Accessing discovery_info['%s'] will fail in version 2022.6, "
+                "please use discovery_info.%s instead",
+                name,
+                name,
+            )
+            self._warning_logged = True
         return getattr(self, name)
 
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -65,11 +65,7 @@ class DhcpServiceInfo:
     macaddress: str
 
     def __getitem__(self, name: str) -> Any:
-        """
-        Allow property access by name for compatibility reason.
-
-        Deprecated, and will be removed in version 2022.6.
-        """
+        """Allow property access by name for compatibility reason."""
         return getattr(self, name)
 
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -60,7 +60,7 @@ _LOGGER = logging.getLogger(__name__)
 class DhcpServiceInfo:
     """Prepared info from dhcp entries."""
 
-    ip: str
+    ip: str  # pylint: disable=[C0103]
     hostname: str
     macaddress: str
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -60,7 +60,7 @@ _LOGGER = logging.getLogger(__name__)
 class DhcpServiceInfo:
     """Prepared info from dhcp entries."""
 
-    ip: str  # pylint: disable=[C0103]
+    ip: str  # pylint: disable=invalid-name
     hostname: str
     macaddress: str
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -39,6 +39,7 @@ from homeassistant.helpers.event import (
     async_track_state_added_domain,
     async_track_time_interval,
 )
+from homeassistant.helpers.frame import report
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_dhcp
 from homeassistant.util.async_ import run_callback_threadsafe
@@ -74,11 +75,11 @@ class DhcpServiceInfo:
         Deprecated, and will be removed in version 2022.6.
         """
         if not self._warning_logged:
-            _LOGGER.debug(
-                "Accessing discovery_info['%s'] will fail in version 2022.6, "
-                "please use discovery_info.%s instead",
-                name,
-                name,
+            report(
+                f"accessed discovery_info['{name}'] instead of discovery_info.{name}; this will fail in version 2022.6",
+                exclude_integrations={"dhcp"},
+                error_if_core=False,
+                level=logging.DEBUG,
             )
             self._warning_logged = True
         return getattr(self, name)

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -68,7 +68,7 @@ class DhcpServiceInfo:
         """
         Allow property access by name for compatibility reason.
 
-        Deprecated, and will be removed in a future release.
+        Deprecated, and will be removed in version 2022.6.
         """
         _LOGGER.warning(
             "__getitem__ will fail in version 2022.6. Please use <cls>.<name> instead."

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
     STATE_HOME,
 )
 from homeassistant.core import Event, HomeAssistant, State, callback
+from homeassistant.data_entry_flow import BaseServiceInfo
 from homeassistant.helpers import discovery_flow
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.event import (
@@ -58,7 +59,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class DhcpServiceInfo:
+class DhcpServiceInfo(BaseServiceInfo):
     """Prepared info from dhcp entries."""
 
     ip: str  # pylint: disable=invalid-name

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -71,7 +71,10 @@ class DhcpServiceInfo:
         Deprecated, and will be removed in version 2022.6.
         """
         _LOGGER.warning(
-            "__getitem__ will fail in version 2022.6. Please use <cls>.<name> instead."
+            "Accessing ['%s'] will fail in version 2022.6. Please use %s.%s instead.",
+            name,
+            self,
+            name,
         )
         return getattr(self, name)
 

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -1,12 +1,13 @@
 """The dhcp integration."""
 
+from dataclasses import dataclass
 from datetime import timedelta
 import fnmatch
 from ipaddress import ip_address as make_ip_address
 import logging
 import os
 import threading
-from typing import Final, TypedDict
+from typing import Final
 
 from aiodiscover import DiscoverHosts
 from aiodiscover.discovery import (
@@ -55,7 +56,8 @@ SCAN_INTERVAL = timedelta(minutes=60)
 _LOGGER = logging.getLogger(__name__)
 
 
-class DhcpServiceInfo(TypedDict):
+@dataclass
+class DhcpServiceInfo(config_entries.BaseServiceInfo):
     """Prepared info from dhcp entries."""
 
     ip: str

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -70,12 +70,6 @@ class DhcpServiceInfo:
 
         Deprecated, and will be removed in version 2022.6.
         """
-        _LOGGER.warning(
-            "Accessing ['%s'] will fail in version 2022.6. Please use %s.%s instead.",
-            name,
-            self,
-            name,
-        )
         return getattr(self, name)
 
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -79,7 +79,14 @@ class BaseServiceInfo:
     """Base ServiceInfo type for discovery."""
 
     def __getitem__(self, name: str) -> Any:
-        """Allow property access by name."""
+        """
+        Allow property access by name for compatibility reason.
+
+        Deprecated, and will be removed in a future release.
+        """
+        _LOGGER.warning(
+            "__getitem__ is deprecated and will be removed in a future release."
+        )
         return getattr(self, name)
 
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -75,21 +75,6 @@ PATH_CONFIG = ".config_entries.json"
 SAVE_DELAY = 1
 
 
-class BaseServiceInfo:
-    """Base ServiceInfo type for discovery."""
-
-    def __getitem__(self, name: str) -> Any:
-        """
-        Allow property access by name for compatibility reason.
-
-        Deprecated, and will be removed in a future release.
-        """
-        _LOGGER.warning(
-            "__getitem__ is deprecated and will be removed in a future release."
-        )
-        return getattr(self, name)
-
-
 class ConfigEntryState(Enum):
     """Config entry state."""
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -75,6 +75,14 @@ PATH_CONFIG = ".config_entries.json"
 SAVE_DELAY = 1
 
 
+class BaseServiceInfo:
+    """Base ServiceInfo type for discovery."""
+
+    def __getitem__(self, name: str) -> Any:
+        """Allow property access by name."""
+        return getattr(self, name)
+
+
 class ConfigEntryState(Enum):
     """Config entry state."""
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -25,6 +25,10 @@ RESULT_TYPE_SHOW_PROGRESS_DONE = "progress_done"
 EVENT_DATA_ENTRY_FLOW_PROGRESSED = "data_entry_flow_progressed"
 
 
+class BaseServiceInfo:
+    """Base class for discovery ServiceInfo."""
+
+
 class FlowError(HomeAssistantError):
     """Error while configuring an account."""
 
@@ -301,7 +305,7 @@ class FlowManager(abc.ABC):
         self,
         flow: Any,
         step_id: str,
-        user_input: dict | None,
+        user_input: dict | BaseServiceInfo | None,
         step_done: asyncio.Future | None = None,
     ) -> FlowResult:
         """Handle a step of a flow."""

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import abc
 import asyncio
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, TypedDict
 import uuid
@@ -25,6 +26,7 @@ RESULT_TYPE_SHOW_PROGRESS_DONE = "progress_done"
 EVENT_DATA_ENTRY_FLOW_PROGRESSED = "data_entry_flow_progressed"
 
 
+@dataclass
 class BaseServiceInfo:
     """Base class for discovery ServiceInfo."""
 

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -51,7 +51,10 @@ class MissingIntegrationFrame(HomeAssistantError):
 
 
 def report(
-    what: str, exclude_integrations: set | None = None, error_if_core: bool = True
+    what: str,
+    exclude_integrations: set | None = None,
+    error_if_core: bool = True,
+    level: int = logging.WARNING,
 ) -> None:
     """Report incorrect usage.
 
@@ -68,11 +71,13 @@ def report(
         _LOGGER.warning(msg, stack_info=True)
         return
 
-    report_integration(what, integration_frame)
+    report_integration(what, integration_frame, level)
 
 
 def report_integration(
-    what: str, integration_frame: tuple[FrameSummary, str, str]
+    what: str,
+    integration_frame: tuple[FrameSummary, str, str],
+    level: int = logging.WARNING,
 ) -> None:
     """Report incorrect usage in an integration.
 
@@ -86,7 +91,8 @@ def report_integration(
     else:
         extra = ""
 
-    _LOGGER.warning(
+    _LOGGER.log(
+        level,
         "Detected integration that %s. "
         "Please report issue%s for %s using this method at %s, line %s: %s",
         what,

--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -191,7 +191,9 @@ async def test_discovered_dhcp(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(ip="1.2.3.4", macaddress=MOCK_MAC_ADDR),
+        data=dhcp.DhcpServiceInfo(
+            ip="1.2.3.4", macaddress=MOCK_MAC_ADDR, hostname="mock_hostname"
+        ),
     )
     assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] == {}
@@ -246,7 +248,9 @@ async def test_discovered_by_homekit_and_dhcp(hass):
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(ip="1.2.3.4", macaddress=MOCK_MAC_ADDR),
+        data=dhcp.DhcpServiceInfo(
+            ip="1.2.3.4", macaddress=MOCK_MAC_ADDR, hostname="mock_hostname"
+        ),
     )
     assert result2["type"] == RESULT_TYPE_ABORT
     assert result2["reason"] == "already_in_progress"
@@ -254,7 +258,9 @@ async def test_discovered_by_homekit_and_dhcp(hass):
     result3 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(ip="1.2.3.4", macaddress="00:00:00:00:00:00"),
+        data=dhcp.DhcpServiceInfo(
+            ip="1.2.3.4", macaddress="00:00:00:00:00:00", hostname="mock_hostname"
+        ),
     )
     assert result3["type"] == RESULT_TYPE_ABORT
     assert result3["reason"] == "already_in_progress"

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -23,7 +23,9 @@ ZEROCONF_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
 )
 
 DHCP_DISCOVERY_INFO = dhcp.DhcpServiceInfo(
-    hostname="Hunter Douglas Powerview Hub", ip="1.2.3.4", macaddress=""
+    hostname="Hunter Douglas Powerview Hub",
+    ip="1.2.3.4",
+    macaddress="AA:BB:CC:DD:EE:FF",
 )
 
 DISCOVERY_DATA = [

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -23,7 +23,7 @@ ZEROCONF_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
 )
 
 DHCP_DISCOVERY_INFO = dhcp.DhcpServiceInfo(
-    hostname="Hunter Douglas Powerview Hub", ip="1.2.3.4"
+    hostname="Hunter Douglas Powerview Hub", ip="1.2.3.4", macaddress=None
 )
 
 DISCOVERY_DATA = [

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -23,7 +23,7 @@ ZEROCONF_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
 )
 
 DHCP_DISCOVERY_INFO = dhcp.DhcpServiceInfo(
-    hostname="Hunter Douglas Powerview Hub", ip="1.2.3.4", macaddress=None
+    hostname="Hunter Douglas Powerview Hub", ip="1.2.3.4", macaddress=""
 )
 
 DISCOVERY_DATA = [

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -85,7 +85,7 @@ MOCK_SSDP_DATA_WRONGMODEL = {
     ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172df",
 }
 MOCK_DHCP_DATA = dhcp.DhcpServiceInfo(
-    ip="fake_host", macaddress="aa:bb:cc:dd:ee:ff", hostname=""
+    ip="fake_ip", macaddress="aa:bb:cc:dd:ee:ff", hostname="fake_host"
 )
 EXISTING_IP = "192.168.40.221"
 MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -84,7 +84,9 @@ MOCK_SSDP_DATA_WRONGMODEL = {
     ATTR_UPNP_MODEL_NAME: "HW-Qfake",
     ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172df",
 }
-MOCK_DHCP_DATA = dhcp.DhcpServiceInfo(ip="fake_host", macaddress="aa:bb:cc:dd:ee:ff")
+MOCK_DHCP_DATA = dhcp.DhcpServiceInfo(
+    ip="fake_host", macaddress="aa:bb:cc:dd:ee:ff", hostname=None
+)
 EXISTING_IP = "192.168.40.221"
 MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
     host="fake_host",

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -85,7 +85,7 @@ MOCK_SSDP_DATA_WRONGMODEL = {
     ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172df",
 }
 MOCK_DHCP_DATA = dhcp.DhcpServiceInfo(
-    ip="fake_ip", macaddress="aa:bb:cc:dd:ee:ff", hostname="fake_host"
+    ip="fake_host", macaddress="aa:bb:cc:dd:ee:ff", hostname="fake_hostname"
 )
 EXISTING_IP = "192.168.40.221"
 MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
@@ -1098,7 +1098,9 @@ async def test_update_legacy_missing_mac_from_dhcp(hass, remote: Mock):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(ip=EXISTING_IP, macaddress="aa:bb:cc:dd:ee:ff"),
+            data=dhcp.DhcpServiceInfo(
+                ip=EXISTING_IP, macaddress="aa:bb:cc:dd:ee:ff", hostname="fake_hostname"
+            ),
         )
         await hass.async_block_till_done()
         assert len(mock_setup.mock_calls) == 1
@@ -1132,7 +1134,9 @@ async def test_update_legacy_missing_mac_from_dhcp_no_unique_id(hass, remote: Mo
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(ip=EXISTING_IP, macaddress="aa:bb:cc:dd:ee:ff"),
+            data=dhcp.DhcpServiceInfo(
+                ip=EXISTING_IP, macaddress="aa:bb:cc:dd:ee:ff", hostname="fake_hostname"
+            ),
         )
         await hass.async_block_till_done()
         assert len(mock_setup.mock_calls) == 1

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -85,7 +85,7 @@ MOCK_SSDP_DATA_WRONGMODEL = {
     ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172df",
 }
 MOCK_DHCP_DATA = dhcp.DhcpServiceInfo(
-    ip="fake_host", macaddress="aa:bb:cc:dd:ee:ff", hostname=None
+    ip="fake_host", macaddress="aa:bb:cc:dd:ee:ff", hostname=""
 )
 EXISTING_IP = "192.168.40.221"
 MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(

--- a/tests/components/screenlogic/test_config_flow.py
+++ b/tests/components/screenlogic/test_config_flow.py
@@ -141,6 +141,7 @@ async def test_dhcp(hass):
         data=dhcp.DhcpServiceInfo(
             hostname="Pentair: 01-01-01",
             ip="1.1.1.1",
+            macaddress="AA:BB:CC:DD:EE:FF",
         ),
     )
 

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -321,7 +321,9 @@ async def test_discovered_by_discovery_and_dhcp(hass):
         result3 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(ip=IP_ADDRESS, macaddress="00:00:00:00:00:00"),
+            data=dhcp.DhcpServiceInfo(
+                ip=IP_ADDRESS, macaddress="00:00:00:00:00:00", hostname="mock_hostname"
+            ),
         )
         await hass.async_block_till_done()
     assert result3["type"] == RESULT_TYPE_ABORT
@@ -331,7 +333,9 @@ async def test_discovered_by_discovery_and_dhcp(hass):
         result3 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(ip="1.2.3.5", macaddress="00:00:00:00:00:01"),
+            data=dhcp.DhcpServiceInfo(
+                ip="1.2.3.5", macaddress="00:00:00:00:00:01", hostname="mock_hostname"
+            ),
         )
         await hass.async_block_till_done()
     assert result3["type"] == RESULT_TYPE_ABORT

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -176,7 +176,9 @@ async def test_dhcp(hass: HomeAssistant) -> None:
     """Test that DHCP discovery works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data=dhcp.DhcpServiceInfo(macaddress="01:23:45:67:89:ab"),
+        data=dhcp.DhcpServiceInfo(
+            ip="1.2.3.4", macaddress="01:23:45:67:89:ab", hostname="mock_hostname"
+        ),
         context={"source": config_entries.SOURCE_DHCP},
     )
 

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -485,7 +485,9 @@ async def test_discovered_by_homekit_and_dhcp(hass):
         result3 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(ip=IP_ADDRESS, macaddress="00:00:00:00:00:00"),
+            data=dhcp.DhcpServiceInfo(
+                ip=IP_ADDRESS, macaddress="00:00:00:00:00:00", hostname="mock_hostname"
+            ),
         )
         await hass.async_block_till_done()
     assert result3["type"] == RESULT_TYPE_ABORT
@@ -499,7 +501,9 @@ async def test_discovered_by_homekit_and_dhcp(hass):
         result3 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(ip="1.2.3.5", macaddress="00:00:00:00:00:01"),
+            data=dhcp.DhcpServiceInfo(
+                ip="1.2.3.5", macaddress="00:00:00:00:00:01", hostname="mock_hostname"
+            ),
         )
         await hass.async_block_till_done()
     assert result3["type"] == RESULT_TYPE_ABORT

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -471,7 +471,9 @@ async def test_discovered_by_homekit_and_dhcp(hass):
         result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(ip=IP_ADDRESS, macaddress="aa:bb:cc:dd:ee:ff"),
+            data=dhcp.DhcpServiceInfo(
+                ip=IP_ADDRESS, macaddress="aa:bb:cc:dd:ee:ff", hostname="mock_hostname"
+            ),
         )
         await hass.async_block_till_done()
     assert result2["type"] == RESULT_TYPE_ABORT
@@ -509,7 +511,9 @@ async def test_discovered_by_homekit_and_dhcp(hass):
     [
         (
             config_entries.SOURCE_DHCP,
-            dhcp.DhcpServiceInfo(ip=IP_ADDRESS, macaddress="aa:bb:cc:dd:ee:ff"),
+            dhcp.DhcpServiceInfo(
+                ip=IP_ADDRESS, macaddress="aa:bb:cc:dd:ee:ff", hostname="mock_hostname"
+            ),
         ),
         (
             config_entries.SOURCE_HOMEKIT,
@@ -570,7 +574,9 @@ async def test_discovered_by_dhcp_or_homekit(hass, source, data):
     [
         (
             config_entries.SOURCE_DHCP,
-            dhcp.DhcpServiceInfo(ip=IP_ADDRESS, macaddress="aa:bb:cc:dd:ee:ff"),
+            dhcp.DhcpServiceInfo(
+                ip=IP_ADDRESS, macaddress="aa:bb:cc:dd:ee:ff", hostname="mock_hostname"
+            ),
         ),
         (
             config_entries.SOURCE_HOMEKIT,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Dhcp discovery now uses a dataclass instead of a dictionary object.
Access using `__getitem__` will fail in version 2022.6.
Please use `<cls>.<name>` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Dhcp discovery now uses a dataclass instead of a dictionary object.
Access using `__getitem__` will fail in version 2022.6.
Please use `<cls>.<name>` instead.

Linked to this comment in the architecture discussion https://github.com/home-assistant/architecture/discussions/662#discussioncomment-1674270

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
