### PR TITLE
Use dataclass for UsbServiceInfo

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -49,7 +49,10 @@ class UsbServiceInfo:
         Deprecated, and will be removed in version 2022.6.
         """
         _LOGGER.warning(
-            "__getitem__ will fail in version 2022.6. Please use <cls>.<name> instead."
+            "Accessing ['%s'] will fail in version 2022.6. Please use %s.%s instead.",
+            name,
+            self,
+            name,
         )
         return getattr(self, name)
 

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -6,7 +6,6 @@ import fnmatch
 import logging
 import os
 import sys
-from typing import TypedDict
 
 from serial.tools.list_ports import comports
 from serial.tools.list_ports_common import ListPortInfo
@@ -31,7 +30,8 @@ _LOGGER = logging.getLogger(__name__)
 REQUEST_SCAN_COOLDOWN = 60  # 1 minute cooldown
 
 
-class UsbServiceInfo(TypedDict):
+@dataclasses.dataclass
+class UsbServiceInfo:
     """Prepared info from usb entries."""
 
     device: str

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.data_entry_flow import BaseServiceInfo
 from homeassistant.helpers import discovery_flow, system_info
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.frame import report
@@ -33,7 +34,7 @@ REQUEST_SCAN_COOLDOWN = 60  # 1 minute cooldown
 
 
 @dataclasses.dataclass
-class UsbServiceInfo:
+class UsbServiceInfo(BaseServiceInfo):
     """Prepared info from usb entries."""
 
     device: str

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -6,6 +6,7 @@ import fnmatch
 import logging
 import os
 import sys
+from typing import Any
 
 from serial.tools.list_ports import comports
 from serial.tools.list_ports_common import ListPortInfo
@@ -40,6 +41,17 @@ class UsbServiceInfo:
     serial_number: str | None
     manufacturer: str | None
     description: str | None
+
+    def __getitem__(self, name: str) -> Any:
+        """
+        Allow property access by name for compatibility reason.
+
+        Deprecated, and will be removed in version 2022.6.
+        """
+        _LOGGER.warning(
+            "__getitem__ will fail in version 2022.6. Please use <cls>.<name> instead."
+        )
+        return getattr(self, name)
 
 
 def human_readable_device_name(

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -48,12 +48,6 @@ class UsbServiceInfo:
 
         Deprecated, and will be removed in version 2022.6.
         """
-        _LOGGER.warning(
-            "Accessing ['%s'] will fail in version 2022.6. Please use %s.%s instead.",
-            name,
-            self,
-            name,
-        )
         return getattr(self, name)
 
 

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import discovery_flow, system_info
 from homeassistant.helpers.debounce import Debouncer
+from homeassistant.helpers.frame import report
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_usb
 
@@ -42,12 +43,22 @@ class UsbServiceInfo:
     manufacturer: str | None
     description: str | None
 
+    # Used to prevent log flooding. To be removed in 2022.6
+    _warning_logged: bool = False
+
     def __getitem__(self, name: str) -> Any:
         """
         Allow property access by name for compatibility reason.
 
         Deprecated, and will be removed in version 2022.6.
         """
+        if not self._warning_logged:
+            report(
+                f"accessed discovery_info['{name}'] instead of discovery_info.{name}; this will fail in version 2022.6",
+                exclude_integrations={"usb"},
+                error_if_core=False,
+            )
+            self._warning_logged = True
         return getattr(self, name)
 
 

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -58,6 +58,7 @@ class UsbServiceInfo(BaseServiceInfo):
                 f"accessed discovery_info['{name}'] instead of discovery_info.{name}; this will fail in version 2022.6",
                 exclude_integrations={"usb"},
                 error_if_core=False,
+                level=logging.DEBUG,
             )
             self._warning_logged = True
         return getattr(self, name)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Usb discovery now uses a dataclass instead of a dictionary object.
Access using `__getitem__` will fail in version 2022.6.
Please use `<cls>.<name>` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Usb discovery now uses a dataclass instead of a dictionary object.
Access using `__getitem__` will fail in version 2022.6.
Please use `<cls>.<name>` instead.

Linked to this comment in the architecture discussion https://github.com/home-assistant/architecture/discussions/662#discussioncomment-1674270

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
