### PR TITLE
Remove legacy executor usage from HomeKit tests

### DIFF
--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -92,7 +92,7 @@ async def test_garage_door_open_close(hass, hk_driver, events):
     call_close_cover = async_mock_service(hass, DOMAIN, "close_cover")
     call_open_cover = async_mock_service(hass, DOMAIN, "open_cover")
 
-    await hass.async_add_executor_job(acc.char_target_state.client_update_value, 1)
+    acc.char_target_state.client_update_value(1)
     await hass.async_block_till_done()
     assert call_close_cover
     assert call_close_cover[0].data[ATTR_ENTITY_ID] == entity_id
@@ -104,14 +104,14 @@ async def test_garage_door_open_close(hass, hk_driver, events):
     hass.states.async_set(entity_id, STATE_CLOSED)
     await hass.async_block_till_done()
 
-    await hass.async_add_executor_job(acc.char_target_state.client_update_value, 1)
+    acc.char_target_state.client_update_value(1)
     await hass.async_block_till_done()
     assert acc.char_current_state.value == HK_DOOR_CLOSED
     assert acc.char_target_state.value == HK_DOOR_CLOSED
     assert len(events) == 2
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_target_state.client_update_value, 0)
+    acc.char_target_state.client_update_value(0)
     await hass.async_block_till_done()
     assert call_open_cover
     assert call_open_cover[0].data[ATTR_ENTITY_ID] == entity_id
@@ -123,7 +123,7 @@ async def test_garage_door_open_close(hass, hk_driver, events):
     hass.states.async_set(entity_id, STATE_OPEN)
     await hass.async_block_till_done()
 
-    await hass.async_add_executor_job(acc.char_target_state.client_update_value, 0)
+    acc.char_target_state.client_update_value(0)
     await hass.async_block_till_done()
     assert acc.char_current_state.value == HK_DOOR_OPEN
     assert acc.char_target_state.value == HK_DOOR_OPEN
@@ -202,7 +202,7 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     # Set from HomeKit
     call_set_cover_position = async_mock_service(hass, DOMAIN, "set_cover_position")
 
-    await hass.async_add_executor_job(acc.char_target_position.client_update_value, 25)
+    acc.char_target_position.client_update_value(25)
     await hass.async_block_till_done()
     assert call_set_cover_position[0]
     assert call_set_cover_position[0].data[ATTR_ENTITY_ID] == entity_id
@@ -212,7 +212,7 @@ async def test_windowcovering_set_cover_position(hass, hk_driver, events):
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] == 25
 
-    await hass.async_add_executor_job(acc.char_target_position.client_update_value, 75)
+    acc.char_target_position.client_update_value(75)
     await hass.async_block_till_done()
     assert call_set_cover_position[1]
     assert call_set_cover_position[1].data[ATTR_ENTITY_ID] == entity_id
@@ -286,7 +286,7 @@ async def test_windowcovering_cover_set_tilt(hass, hk_driver, events):
     # HomeKit sets tilts between -90 and 90 (degrees), whereas
     # Homeassistant expects a % between 0 and 100. Keep that in mind
     # when comparing
-    await hass.async_add_executor_job(acc.char_target_tilt.client_update_value, 90)
+    acc.char_target_tilt.client_update_value(90)
     await hass.async_block_till_done()
     assert call_set_tilt_position[0]
     assert call_set_tilt_position[0].data[ATTR_ENTITY_ID] == entity_id
@@ -296,7 +296,7 @@ async def test_windowcovering_cover_set_tilt(hass, hk_driver, events):
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] == 100
 
-    await hass.async_add_executor_job(acc.char_target_tilt.client_update_value, 45)
+    acc.char_target_tilt.client_update_value(45)
     await hass.async_block_till_done()
     assert call_set_tilt_position[1]
     assert call_set_tilt_position[1].data[ATTR_ENTITY_ID] == entity_id
@@ -378,7 +378,7 @@ async def test_windowcovering_open_close(hass, hk_driver, events):
     call_close_cover = async_mock_service(hass, DOMAIN, "close_cover")
     call_open_cover = async_mock_service(hass, DOMAIN, "open_cover")
 
-    await hass.async_add_executor_job(acc.char_target_position.client_update_value, 25)
+    acc.char_target_position.client_update_value(25)
     await hass.async_block_till_done()
     assert call_close_cover
     assert call_close_cover[0].data[ATTR_ENTITY_ID] == entity_id
@@ -388,7 +388,7 @@ async def test_windowcovering_open_close(hass, hk_driver, events):
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_target_position.client_update_value, 90)
+    acc.char_target_position.client_update_value(90)
     await hass.async_block_till_done()
     assert call_open_cover[0]
     assert call_open_cover[0].data[ATTR_ENTITY_ID] == entity_id
@@ -398,7 +398,7 @@ async def test_windowcovering_open_close(hass, hk_driver, events):
     assert len(events) == 2
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_target_position.client_update_value, 55)
+    acc.char_target_position.client_update_value(55)
     await hass.async_block_till_done()
     assert call_open_cover[1]
     assert call_open_cover[1].data[ATTR_ENTITY_ID] == entity_id
@@ -425,7 +425,7 @@ async def test_windowcovering_open_close_stop(hass, hk_driver, events):
     call_open_cover = async_mock_service(hass, DOMAIN, "open_cover")
     call_stop_cover = async_mock_service(hass, DOMAIN, "stop_cover")
 
-    await hass.async_add_executor_job(acc.char_target_position.client_update_value, 25)
+    acc.char_target_position.client_update_value(25)
     await hass.async_block_till_done()
     assert call_close_cover
     assert call_close_cover[0].data[ATTR_ENTITY_ID] == entity_id
@@ -435,7 +435,7 @@ async def test_windowcovering_open_close_stop(hass, hk_driver, events):
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_target_position.client_update_value, 90)
+    acc.char_target_position.client_update_value(90)
     await hass.async_block_till_done()
     assert call_open_cover
     assert call_open_cover[0].data[ATTR_ENTITY_ID] == entity_id
@@ -445,7 +445,7 @@ async def test_windowcovering_open_close_stop(hass, hk_driver, events):
     assert len(events) == 2
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_target_position.client_update_value, 55)
+    acc.char_target_position.client_update_value(55)
     await hass.async_block_till_done()
     assert call_stop_cover
     assert call_stop_cover[0].data[ATTR_ENTITY_ID] == entity_id
@@ -474,11 +474,11 @@ async def test_windowcovering_open_close_with_position_and_stop(
     # Set from HomeKit
     call_stop_cover = async_mock_service(hass, DOMAIN, "stop_cover")
 
-    await hass.async_add_executor_job(acc.char_hold_position.client_update_value, 0)
+    acc.char_hold_position.client_update_value(0)
     await hass.async_block_till_done()
     assert not call_stop_cover
 
-    await hass.async_add_executor_job(acc.char_hold_position.client_update_value, 1)
+    acc.char_hold_position.client_update_value(1)
     await hass.async_block_till_done()
     assert call_stop_cover
     assert call_stop_cover[0].data[ATTR_ENTITY_ID] == entity_id

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -170,7 +170,7 @@ async def test_fan_direction(hass, hk_driver, events):
         },
         "mock_addr",
     )
-    await hass.async_add_executor_job(acc.char_direction.client_update_value, 1)
+    acc.char_direction.client_update_value(1)
     await hass.async_block_till_done()
     assert call_set_direction[1]
     assert call_set_direction[1].data[ATTR_ENTITY_ID] == entity_id
@@ -219,7 +219,7 @@ async def test_fan_oscillate(hass, hk_driver, events):
         },
         "mock_addr",
     )
-    await hass.async_add_executor_job(acc.char_swing.client_update_value, 0)
+    acc.char_swing.client_update_value(0)
     await hass.async_block_till_done()
     assert call_oscillate[0]
     assert call_oscillate[0].data[ATTR_ENTITY_ID] == entity_id
@@ -239,7 +239,7 @@ async def test_fan_oscillate(hass, hk_driver, events):
         },
         "mock_addr",
     )
-    await hass.async_add_executor_job(acc.char_swing.client_update_value, 1)
+    acc.char_swing.client_update_value(1)
     await hass.async_block_till_done()
     assert call_oscillate[1]
     assert call_oscillate[1].data[ATTR_ENTITY_ID] == entity_id
@@ -295,7 +295,7 @@ async def test_fan_speed(hass, hk_driver, events):
         },
         "mock_addr",
     )
-    await hass.async_add_executor_job(acc.char_speed.client_update_value, 42)
+    acc.char_speed.client_update_value(42)
     await hass.async_block_till_done()
     assert acc.char_speed.value == 50
     assert acc.char_active.value == 1

--- a/tests/components/homekit/test_type_locks.py
+++ b/tests/components/homekit/test_type_locks.py
@@ -76,7 +76,7 @@ async def test_lock_unlock(hass, hk_driver, events):
     call_lock = async_mock_service(hass, DOMAIN, "lock")
     call_unlock = async_mock_service(hass, DOMAIN, "unlock")
 
-    await hass.async_add_executor_job(acc.char_target_state.client_update_value, 1)
+    acc.char_target_state.client_update_value(1)
     await hass.async_block_till_done()
     assert call_lock
     assert call_lock[0].data[ATTR_ENTITY_ID] == entity_id
@@ -85,7 +85,7 @@ async def test_lock_unlock(hass, hk_driver, events):
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_target_state.client_update_value, 0)
+    acc.char_target_state.client_update_value(0)
     await hass.async_block_till_done()
     assert call_unlock
     assert call_unlock[0].data[ATTR_ENTITY_ID] == entity_id
@@ -107,7 +107,7 @@ async def test_no_code(hass, hk_driver, config, events):
     # Set from HomeKit
     call_lock = async_mock_service(hass, DOMAIN, "lock")
 
-    await hass.async_add_executor_job(acc.char_target_state.client_update_value, 1)
+    acc.char_target_state.client_update_value(1)
     await hass.async_block_till_done()
     assert call_lock
     assert call_lock[0].data[ATTR_ENTITY_ID] == entity_id

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -71,14 +71,14 @@ async def test_outlet_set_state(hass, hk_driver, events):
     call_turn_on = async_mock_service(hass, "switch", "turn_on")
     call_turn_off = async_mock_service(hass, "switch", "turn_off")
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, True)
+    acc.char_on.client_update_value(True)
     await hass.async_block_till_done()
     assert call_turn_on
     assert call_turn_on[0].data[ATTR_ENTITY_ID] == entity_id
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, False)
+    acc.char_on.client_update_value(False)
     await hass.async_block_till_done()
     assert call_turn_off
     assert call_turn_off[0].data[ATTR_ENTITY_ID] == entity_id
@@ -123,14 +123,14 @@ async def test_switch_set_state(hass, hk_driver, entity_id, attrs, events):
     call_turn_on = async_mock_service(hass, domain, "turn_on")
     call_turn_off = async_mock_service(hass, domain, "turn_off")
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, True)
+    acc.char_on.client_update_value(True)
     await hass.async_block_till_done()
     assert call_turn_on
     assert call_turn_on[0].data[ATTR_ENTITY_ID] == entity_id
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, False)
+    acc.char_on.client_update_value(False)
     await hass.async_block_till_done()
     assert call_turn_off
     assert call_turn_off[0].data[ATTR_ENTITY_ID] == entity_id
@@ -188,7 +188,7 @@ async def test_valve_set_state(hass, hk_driver, events):
     call_turn_on = async_mock_service(hass, "switch", "turn_on")
     call_turn_off = async_mock_service(hass, "switch", "turn_off")
 
-    await hass.async_add_executor_job(acc.char_active.client_update_value, 1)
+    acc.char_active.client_update_value(1)
     await hass.async_block_till_done()
     assert acc.char_in_use.value == 1
     assert call_turn_on
@@ -196,7 +196,7 @@ async def test_valve_set_state(hass, hk_driver, events):
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_active.client_update_value, 0)
+    acc.char_active.client_update_value(0)
     await hass.async_block_till_done()
     assert acc.char_in_use.value == 0
     assert call_turn_off
@@ -246,7 +246,7 @@ async def test_vacuum_set_state_with_returnhome_and_start_support(
         hass, VACUUM_DOMAIN, SERVICE_RETURN_TO_BASE
     )
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, 1)
+    acc.char_on.client_update_value(1)
     await hass.async_block_till_done()
     assert acc.char_on.value == 1
     assert call_start
@@ -254,7 +254,7 @@ async def test_vacuum_set_state_with_returnhome_and_start_support(
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, 0)
+    acc.char_on.client_update_value(0)
     await hass.async_block_till_done()
     assert acc.char_on.value == 0
     assert call_return_to_base
@@ -292,7 +292,7 @@ async def test_vacuum_set_state_without_returnhome_and_start_support(
     call_turn_on = async_mock_service(hass, VACUUM_DOMAIN, SERVICE_TURN_ON)
     call_turn_off = async_mock_service(hass, VACUUM_DOMAIN, SERVICE_TURN_OFF)
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, 1)
+    acc.char_on.client_update_value(1)
     await hass.async_block_till_done()
     assert acc.char_on.value == 1
     assert call_turn_on
@@ -300,7 +300,7 @@ async def test_vacuum_set_state_without_returnhome_and_start_support(
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] is None
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, 0)
+    acc.char_on.client_update_value(0)
     await hass.async_block_till_done()
     assert acc.char_on.value == 0
     assert call_turn_off
@@ -326,7 +326,7 @@ async def test_reset_switch(hass, hk_driver, events):
     call_turn_on = async_mock_service(hass, domain, "turn_on")
     call_turn_off = async_mock_service(hass, domain, "turn_off")
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, True)
+    acc.char_on.client_update_value(True)
     await hass.async_block_till_done()
     assert acc.char_on.value is True
     assert call_turn_on
@@ -347,7 +347,7 @@ async def test_reset_switch(hass, hk_driver, events):
     assert len(events) == 1
     assert not call_turn_off
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, False)
+    acc.char_on.client_update_value(False)
     await hass.async_block_till_done()
     assert acc.char_on.value is False
     assert len(events) == 1
@@ -370,7 +370,7 @@ async def test_script_switch(hass, hk_driver, events):
     call_turn_on = async_mock_service(hass, domain, "test")
     call_turn_off = async_mock_service(hass, domain, "turn_off")
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, True)
+    acc.char_on.client_update_value(True)
     await hass.async_block_till_done()
     assert acc.char_on.value is True
     assert call_turn_on
@@ -391,7 +391,7 @@ async def test_script_switch(hass, hk_driver, events):
     assert len(events) == 1
     assert not call_turn_off
 
-    await hass.async_add_executor_job(acc.char_on.client_update_value, False)
+    acc.char_on.client_update_value(False)
     await hass.async_block_till_done()
     assert acc.char_on.value is False
     assert len(events) == 1

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -1062,16 +1062,16 @@ async def test_thermostat_hvac_modes(hass, hk_driver):
     assert acc.char_target_heat_cool.value == 0
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 3)
+        acc.char_target_heat_cool.set_value(3)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 0
 
-    await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 1)
+    acc.char_target_heat_cool.set_value(1)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 2)
+        acc.char_target_heat_cool.set_value(2)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
@@ -1104,16 +1104,16 @@ async def test_thermostat_hvac_modes_with_auto_heat_cool(hass, hk_driver):
     assert hap["valid-values"] == [0, 1, 3]
     assert acc.char_target_heat_cool.value == 0
 
-    await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 3)
+    acc.char_target_heat_cool.set_value(3)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 3
 
-    await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 1)
+    acc.char_target_heat_cool.set_value(1)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 2)
+        acc.char_target_heat_cool.set_value(2)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
@@ -1160,16 +1160,16 @@ async def test_thermostat_hvac_modes_with_auto_no_heat_cool(hass, hk_driver):
     assert hap["valid-values"] == [0, 1, 3]
     assert acc.char_target_heat_cool.value == 1
 
-    await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 3)
+    acc.char_target_heat_cool.set_value(3)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 3
 
-    await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 1)
+    acc.char_target_heat_cool.set_value(1)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 2)
+        acc.char_target_heat_cool.set_value(2)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
@@ -1214,17 +1214,17 @@ async def test_thermostat_hvac_modes_with_auto_only(hass, hk_driver):
     assert hap["valid-values"] == [0, 3]
     assert acc.char_target_heat_cool.value == 3
 
-    await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 3)
+    acc.char_target_heat_cool.set_value(3)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 3
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 1)
+        acc.char_target_heat_cool.set_value(1)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 3
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 2)
+        acc.char_target_heat_cool.set_value(2)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 3
 
@@ -1268,23 +1268,17 @@ async def test_thermostat_hvac_modes_with_heat_only(hass, hk_driver):
     assert hap["valid-values"] == [HC_HEAT_COOL_OFF, HC_HEAT_COOL_HEAT]
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_HEAT
 
-    await hass.async_add_executor_job(
-        acc.char_target_heat_cool.set_value, HC_HEAT_COOL_HEAT
-    )
+    acc.char_target_heat_cool.set_value(HC_HEAT_COOL_HEAT)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_HEAT
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(
-            acc.char_target_heat_cool.set_value, HC_HEAT_COOL_COOL
-        )
+        acc.char_target_heat_cool.set_value(HC_HEAT_COOL_COOL)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_HEAT
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(
-            acc.char_target_heat_cool.set_value, HC_HEAT_COOL_AUTO
-        )
+        acc.char_target_heat_cool.set_value(HC_HEAT_COOL_AUTO)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_HEAT
 
@@ -1328,23 +1322,17 @@ async def test_thermostat_hvac_modes_with_cool_only(hass, hk_driver):
     assert hap["valid-values"] == [HC_HEAT_COOL_OFF, HC_HEAT_COOL_COOL]
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_COOL
 
-    await hass.async_add_executor_job(
-        acc.char_target_heat_cool.set_value, HC_HEAT_COOL_COOL
-    )
+    acc.char_target_heat_cool.set_value(HC_HEAT_COOL_COOL)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_COOL
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(
-            acc.char_target_heat_cool.set_value, HC_HEAT_COOL_AUTO
-        )
+        acc.char_target_heat_cool.set_value(HC_HEAT_COOL_AUTO)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_COOL
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(
-            acc.char_target_heat_cool.set_value, HC_HEAT_COOL_HEAT
-        )
+        acc.char_target_heat_cool.set_value(HC_HEAT_COOL_HEAT)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_COOL
 
@@ -1396,22 +1384,16 @@ async def test_thermostat_hvac_modes_with_heat_cool_only(hass, hk_driver):
     ]
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_COOL
 
-    await hass.async_add_executor_job(
-        acc.char_target_heat_cool.set_value, HC_HEAT_COOL_COOL
-    )
+    acc.char_target_heat_cool.set_value(HC_HEAT_COOL_COOL)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_COOL
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(
-            acc.char_target_heat_cool.set_value, HC_HEAT_COOL_AUTO
-        )
+        acc.char_target_heat_cool.set_value(HC_HEAT_COOL_AUTO)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_COOL
 
-    await hass.async_add_executor_job(
-        acc.char_target_heat_cool.set_value, HC_HEAT_COOL_HEAT
-    )
+    acc.char_target_heat_cool.set_value(HC_HEAT_COOL_HEAT)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == HC_HEAT_COOL_HEAT
     char_target_temp_iid = acc.char_target_temp.to_HAP()[HAP_REPR_IID]
@@ -1481,21 +1463,21 @@ async def test_thermostat_hvac_modes_without_off(hass, hk_driver):
     assert hap["valid-values"] == [1, 3]
     assert acc.char_target_heat_cool.value == 3
 
-    await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 3)
+    acc.char_target_heat_cool.set_value(3)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 3
 
-    await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 1)
+    acc.char_target_heat_cool.set_value(1)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 2)
+        acc.char_target_heat_cool.set_value(2)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 0)
+        acc.char_target_heat_cool.set_value(0)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
@@ -1737,7 +1719,7 @@ async def test_water_heater(hass, hk_driver, events):
         hass, DOMAIN_WATER_HEATER, "set_temperature"
     )
 
-    await hass.async_add_executor_job(acc.char_target_temp.client_update_value, 52.0)
+    acc.char_target_temp.client_update_value(52.0)
     await hass.async_block_till_done()
     assert call_set_temperature
     assert call_set_temperature[0].data[ATTR_ENTITY_ID] == entity_id
@@ -1746,12 +1728,12 @@ async def test_water_heater(hass, hk_driver, events):
     assert len(events) == 1
     assert events[-1].data[ATTR_VALUE] == f"52.0{TEMP_CELSIUS}"
 
-    await hass.async_add_executor_job(acc.char_target_heat_cool.client_update_value, 1)
+    acc.char_target_heat_cool.client_update_value(1)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
     with pytest.raises(ValueError):
-        await hass.async_add_executor_job(acc.char_target_heat_cool.set_value, 3)
+        acc.char_target_heat_cool.set_value(3)
     await hass.async_block_till_done()
     assert acc.char_target_heat_cool.value == 1
 
@@ -1778,7 +1760,7 @@ async def test_water_heater_fahrenheit(hass, hk_driver, events):
         hass, DOMAIN_WATER_HEATER, "set_temperature"
     )
 
-    await hass.async_add_executor_job(acc.char_target_temp.client_update_value, 60)
+    acc.char_target_temp.client_update_value(60)
     await hass.async_block_till_done()
     assert call_set_temperature
     assert call_set_temperature[0].data[ATTR_ENTITY_ID] == entity_id


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove legacy executor usage from HomeKit tests

- HomeKit is fully async. No need to do these anymore

- Followup to #60165

- The media player ones will come out in #59743

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
