### PR TITLE
Adaptive update interval for Fronius coordinators

### DIFF
--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
 import logging
 from typing import Callable, TypeVar
 
@@ -17,9 +16,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import (
-    DEFAULT_UPDATE_INTERVAL,
-    DEFAULT_UPDATE_INTERVAL_LOGGER,
-    DEFAULT_UPDATE_INTERVAL_POWER_FLOW,
     DOMAIN,
     SOLAR_NET_ID_SYSTEM,
     FroniusDeviceInfo,
@@ -101,7 +97,6 @@ class FroniusSolarNet:
                 solar_net=self,
                 logger=_LOGGER,
                 name=f"{DOMAIN}_logger_{self.host}",
-                update_interval=timedelta(seconds=DEFAULT_UPDATE_INTERVAL_LOGGER),
             )
             await self.logger_coordinator.async_config_entry_first_refresh()
 
@@ -115,7 +110,6 @@ class FroniusSolarNet:
                 solar_net=self,
                 logger=_LOGGER,
                 name=f"{DOMAIN}_inverter_{inverter_info.solar_net_id}_{self.host}",
-                update_interval=timedelta(seconds=DEFAULT_UPDATE_INTERVAL),
                 inverter_info=inverter_info,
             )
             await coordinator.async_config_entry_first_refresh()
@@ -127,7 +121,6 @@ class FroniusSolarNet:
                 solar_net=self,
                 logger=_LOGGER,
                 name=f"{DOMAIN}_meters_{self.host}",
-                update_interval=timedelta(seconds=DEFAULT_UPDATE_INTERVAL),
             )
         )
 
@@ -137,7 +130,6 @@ class FroniusSolarNet:
                 solar_net=self,
                 logger=_LOGGER,
                 name=f"{DOMAIN}_power_flow_{self.host}",
-                update_interval=timedelta(seconds=DEFAULT_UPDATE_INTERVAL_POWER_FLOW),
             )
         )
 
@@ -147,7 +139,6 @@ class FroniusSolarNet:
                 solar_net=self,
                 logger=_LOGGER,
                 name=f"{DOMAIN}_storages_{self.host}",
-                update_interval=timedelta(seconds=DEFAULT_UPDATE_INTERVAL),
             )
         )
 

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -15,11 +15,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 
-from .const import (
-    DOMAIN,
-    SOLAR_NET_ID_SYSTEM,
-    FroniusDeviceInfo,
-)
+from .const import DOMAIN, SOLAR_NET_ID_SYSTEM, FroniusDeviceInfo
 from .coordinator import (
     FroniusCoordinatorBase,
     FroniusInverterUpdateCoordinator,

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -3,9 +3,6 @@ from typing import Final, NamedTuple, TypedDict
 
 from homeassistant.helpers.entity import DeviceInfo
 
-DEFAULT_UPDATE_INTERVAL = 60
-DEFAULT_UPDATE_INTERVAL_LOGGER = 60 * 60
-DEFAULT_UPDATE_INTERVAL_POWER_FLOW = 10
 DOMAIN: Final = "fronius"
 
 SolarNetId = str

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -59,14 +59,15 @@ class FroniusCoordinatorBase(
         async with self.solar_net.coordinator_lock:
             try:
                 data = await self._update_method()
-                if self._failed_update_count != 0:
-                    self._failed_update_count = 0
-                    self.update_interval = self.default_interval
             except FroniusError as err:
                 self._failed_update_count += 1
                 if self._failed_update_count == 3:
                     self.update_interval = self.error_interval
                 raise UpdateFailed(err) from err
+
+            if self._failed_update_count != 0:
+                self._failed_update_count = 0
+                self.update_interval = self.default_interval
 
             for solar_net_id in data:
                 if solar_net_id not in self.unregistered_keys:

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Dict, TypeVar
 
 from pyfronius import FroniusError
@@ -37,14 +38,17 @@ class FroniusCoordinatorBase(
 ):
     """Query Fronius endpoint and keep track of seen conditions."""
 
+    default_interval: timedelta
+    error_interval: timedelta
     valid_descriptions: list[SensorEntityDescription]
 
     def __init__(self, *args: Any, solar_net: FroniusSolarNet, **kwargs: Any) -> None:
         """Set up the FroniusCoordinatorBase class."""
+        self._failed_update_count = 0
         self.solar_net = solar_net
         # unregistered_keys are used to create entities in platform module
         self.unregistered_keys: dict[SolarNetId, set[str]] = {}
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, update_interval=self.default_interval, **kwargs)
 
     @abstractmethod
     async def _update_method(self) -> dict[SolarNetId, Any]:
@@ -55,7 +59,13 @@ class FroniusCoordinatorBase(
         async with self.solar_net.coordinator_lock:
             try:
                 data = await self._update_method()
+                if self._failed_update_count != 0:
+                    self._failed_update_count = 0
+                    self.update_interval = self.default_interval
             except FroniusError as err:
+                self._failed_update_count += 1
+                if self._failed_update_count == 3:
+                    self.update_interval = self.error_interval
                 raise UpdateFailed(err) from err
 
             for solar_net_id in data:
@@ -100,6 +110,8 @@ class FroniusCoordinatorBase(
 class FroniusInverterUpdateCoordinator(FroniusCoordinatorBase):
     """Query Fronius device inverter endpoint and keep track of seen conditions."""
 
+    default_interval = timedelta(minutes=1)
+    error_interval = timedelta(minutes=10)
     valid_descriptions = INVERTER_ENTITY_DESCRIPTIONS
 
     def __init__(
@@ -122,6 +134,8 @@ class FroniusInverterUpdateCoordinator(FroniusCoordinatorBase):
 class FroniusLoggerUpdateCoordinator(FroniusCoordinatorBase):
     """Query Fronius logger info endpoint and keep track of seen conditions."""
 
+    default_interval = timedelta(hours=1)
+    error_interval = timedelta(hours=1)
     valid_descriptions = LOGGER_ENTITY_DESCRIPTIONS
 
     async def _update_method(self) -> dict[SolarNetId, Any]:
@@ -133,6 +147,8 @@ class FroniusLoggerUpdateCoordinator(FroniusCoordinatorBase):
 class FroniusMeterUpdateCoordinator(FroniusCoordinatorBase):
     """Query Fronius system meter endpoint and keep track of seen conditions."""
 
+    default_interval = timedelta(minutes=1)
+    error_interval = timedelta(minutes=10)
     valid_descriptions = METER_ENTITY_DESCRIPTIONS
 
     async def _update_method(self) -> dict[SolarNetId, Any]:
@@ -144,6 +160,8 @@ class FroniusMeterUpdateCoordinator(FroniusCoordinatorBase):
 class FroniusPowerFlowUpdateCoordinator(FroniusCoordinatorBase):
     """Query Fronius power flow endpoint and keep track of seen conditions."""
 
+    default_interval = timedelta(seconds=10)
+    error_interval = timedelta(minutes=3)
     valid_descriptions = POWER_FLOW_ENTITY_DESCRIPTIONS
 
     async def _update_method(self) -> dict[SolarNetId, Any]:
@@ -155,6 +173,8 @@ class FroniusPowerFlowUpdateCoordinator(FroniusCoordinatorBase):
 class FroniusStorageUpdateCoordinator(FroniusCoordinatorBase):
     """Query Fronius system storage endpoint and keep track of seen conditions."""
 
+    default_interval = timedelta(minutes=1)
+    error_interval = timedelta(minutes=10)
     valid_descriptions = STORAGE_ENTITY_DESCRIPTIONS
 
     async def _update_method(self) -> dict[SolarNetId, Any]:

--- a/tests/components/fronius/test_coordinator.py
+++ b/tests/components/fronius/test_coordinator.py
@@ -1,0 +1,55 @@
+"""Test the Fronius update coordinators."""
+from unittest.mock import patch
+
+from pyfronius import FroniusError
+
+from homeassistant.components.fronius.coordinator import (
+    FroniusInverterUpdateCoordinator,
+)
+from homeassistant.util import dt
+
+from . import mock_responses, setup_fronius_integration
+
+from tests.common import async_fire_time_changed
+
+
+async def test_adaptive_update_interval(hass, aioclient_mock):
+    """Test conordinators changing their update interval when inverter not available."""
+    with patch("pyfronius.Fronius.current_inverter_data") as mock_inverter_data:
+        mock_responses(aioclient_mock)
+        await setup_fronius_integration(hass)
+        assert mock_inverter_data.call_count == 1
+
+        async_fire_time_changed(
+            hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
+        )
+        await hass.async_block_till_done()
+        assert mock_inverter_data.call_count == 2
+
+        mock_inverter_data.side_effect = FroniusError
+        # first 3 requests at default interval - 4th has different interval
+        for _ in range(4):
+            async_fire_time_changed(
+                hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
+            )
+            await hass.async_block_till_done()
+        assert mock_inverter_data.call_count == 5
+        async_fire_time_changed(
+            hass, dt.utcnow() + FroniusInverterUpdateCoordinator.error_interval
+        )
+        await hass.async_block_till_done()
+        assert mock_inverter_data.call_count == 6
+
+        mock_inverter_data.side_effect = None
+        # next successful request resets to default interval
+        async_fire_time_changed(
+            hass, dt.utcnow() + FroniusInverterUpdateCoordinator.error_interval
+        )
+        await hass.async_block_till_done()
+        assert mock_inverter_data.call_count == 7
+
+        async_fire_time_changed(
+            hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
+        )
+        await hass.async_block_till_done()
+        assert mock_inverter_data.call_count == 8

--- a/tests/components/fronius/test_coordinator.py
+++ b/tests/components/fronius/test_coordinator.py
@@ -14,7 +14,7 @@ from tests.common import async_fire_time_changed
 
 
 async def test_adaptive_update_interval(hass, aioclient_mock):
-    """Test conordinators changing their update interval when inverter not available."""
+    """Test coordinators changing their update interval when inverter not available."""
     with patch("pyfronius.Fronius.current_inverter_data") as mock_inverter_data:
         mock_responses(aioclient_mock)
         await setup_fronius_integration(hass)

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -1,9 +1,7 @@
 """Tests for the Fronius sensor platform."""
-from datetime import timedelta
-
-from homeassistant.components.fronius.const import (
-    DEFAULT_UPDATE_INTERVAL,
-    DEFAULT_UPDATE_INTERVAL_POWER_FLOW,
+from homeassistant.components.fronius.coordinator import (
+    FroniusInverterUpdateCoordinator,
+    FroniusPowerFlowUpdateCoordinator,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import STATE_UNKNOWN
@@ -35,7 +33,7 @@ async def test_symo_inverter(hass, aioclient_mock):
     # Second test at daytime when inverter is producing
     mock_responses(aioclient_mock, night=False)
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=DEFAULT_UPDATE_INTERVAL)
+        hass, dt.utcnow() + FroniusInverterUpdateCoordinator.default_interval
     )
     await hass.async_block_till_done()
 
@@ -200,7 +198,7 @@ async def test_symo_power_flow(hass, aioclient_mock):
     # Second test at daytime when inverter is producing
     mock_responses(aioclient_mock, night=False)
     async_fire_time_changed(
-        hass, dt.utcnow() + timedelta(seconds=DEFAULT_UPDATE_INTERVAL_POWER_FLOW)
+        hass, dt.utcnow() + FroniusPowerFlowUpdateCoordinator.default_interval
     )
     await hass.async_block_till_done()
     # still 55 because power_flow update interval is shorter than others


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adaptive update interval for Fronius coordinators

Some inverters shut down over night. This PR increases the update interval of the coordinators after 3 failed queries until a valid response was received again.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
