### PR TITLE
Add twitch states to helper state_as_number

### DIFF
--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -10,6 +10,7 @@ from types import ModuleType, TracebackType
 from typing import Any
 
 from homeassistant.components.sun import STATE_ABOVE_HORIZON, STATE_BELOW_HORIZON
+from homeassistant.components.twitch.sensor import STATE_OFFLINE, STATE_STREAMING
 from homeassistant.const import (
     STATE_CLOSED,
     STATE_HOME,
@@ -130,6 +131,7 @@ def state_as_number(state: State) -> float:
         STATE_ABOVE_HORIZON,
         STATE_OPEN,
         STATE_HOME,
+        STATE_STREAMING,
     ):
         return 1
     if state.state in (
@@ -139,6 +141,7 @@ def state_as_number(state: State) -> float:
         STATE_BELOW_HORIZON,
         STATE_CLOSED,
         STATE_NOT_HOME,
+        STATE_OFFLINE,
     ):
         return 0
 

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.sun import STATE_ABOVE_HORIZON, STATE_BELOW_HORIZON
+from homeassistant.components.twitch.sensor import STATE_OFFLINE, STATE_STREAMING
 from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
@@ -192,8 +193,16 @@ async def test_as_number_states(hass):
         STATE_UNLOCKED,
         STATE_BELOW_HORIZON,
         STATE_NOT_HOME,
+        STATE_OFFLINE,
     )
-    one_states = (STATE_ON, STATE_OPEN, STATE_LOCKED, STATE_ABOVE_HORIZON, STATE_HOME)
+    one_states = (
+        STATE_ON,
+        STATE_OPEN,
+        STATE_LOCKED,
+        STATE_ABOVE_HORIZON,
+        STATE_HOME,
+        STATE_STREAMING,
+    )
     for _state in zero_states:
         assert state.state_as_number(ha.State("domain.test", _state, {})) == 0
     for _state in one_states:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Add sensor states `STATE_STREAMING` and `STATE_OFFLINE` of the `twitch` integration to the state helper function `state_as_number(state: State) -> float`.

I hope this is an intended addition to the helper function. I also saw states of the `sun` integration being parsed in this function.
This would also allow `twitch` sensors to be exported to `prometheus` if pull request #60157 is merged.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
