### PR TITLE
Add bytes support for bitwise template operations

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -52,7 +52,12 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.loader import bind_hass
-from homeassistant.util import convert, dt as dt_util, location as loc_util
+from homeassistant.util import (
+    convert,
+    convert_to_int,
+    dt as dt_util,
+    location as loc_util,
+)
 from homeassistant.util.async_ import run_callback_threadsafe
 from homeassistant.util.thread import ThreadWithException
 
@@ -1621,14 +1626,18 @@ def regex_findall(value, find="", ignorecase=False):
     return re.findall(find, value, flags)
 
 
-def bitwise_and(first_value, second_value):
+def bitwise_and(first_value, second_value, little_endian=False):
     """Perform a bitwise and operation."""
-    return first_value & second_value
+    return convert_to_int(first_value, little_endian=little_endian) & convert_to_int(
+        second_value, little_endian=little_endian
+    )
 
 
-def bitwise_or(first_value, second_value):
+def bitwise_or(first_value, second_value, little_endian=False):
     """Perform a bitwise or operation."""
-    return first_value | second_value
+    return convert_to_int(first_value, little_endian=little_endian) | convert_to_int(
+        second_value, little_endian=little_endian
+    )
 
 
 def base64_encode(value):

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -120,7 +120,7 @@ def convert_to_int(
     """
     if isinstance(value, int):
         return value
-    if isinstance(value, bytes):
+    if isinstance(value, bytes) and value:
         bytes_value = bytearray(value)
         return_value = 0
         while len(bytes_value):

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -109,6 +109,35 @@ def convert(
         return default
 
 
+def convert_to_int(
+    value: Any, default: int | None = None, little_endian: bool = False
+) -> int | None:
+    """Convert value or bytes to int, returns default if fails.
+
+    This supports bitwise integer operations on `bytes` objects.
+    By default the conversion is in Big-endian style (The last byte contains the least significant bit).
+    In Little-endian style the first byte contains the least significat bit.
+    """
+    try:
+        if isinstance(value, int):
+            return value
+        if isinstance(value, bytes):
+            bytes_value = bytearray(value)
+            return_value = 0
+            while len(bytes_value):
+                return_value <<= 8
+                if little_endian:
+                    return_value |= bytes_value.pop(len(bytes_value) - 1)
+                else:
+                    return_value |= bytes_value.pop(0)
+
+            return return_value
+        return convert(value, int, default)
+    except (ValueError, TypeError):
+        # If value could not be converted
+        return default
+
+
 def ensure_unique_string(
     preferred_string: str, current_strings: Iterable[str] | KeysView[str]
 ) -> str:

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -116,7 +116,7 @@ def convert_to_int(
 
     This supports bitwise integer operations on `bytes` objects.
     By default the conversion is in Big-endian style (The last byte contains the least significant bit).
-    In Little-endian style the first byte contains the least significat bit.
+    In Little-endian style the first byte contains the least significant bit.
     """
     try:
         if isinstance(value, int):

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -118,24 +118,20 @@ def convert_to_int(
     By default the conversion is in Big-endian style (The last byte contains the least significant bit).
     In Little-endian style the first byte contains the least significant bit.
     """
-    try:
-        if isinstance(value, int):
-            return value
-        if isinstance(value, bytes):
-            bytes_value = bytearray(value)
-            return_value = 0
-            while len(bytes_value):
-                return_value <<= 8
-                if little_endian:
-                    return_value |= bytes_value.pop(len(bytes_value) - 1)
-                else:
-                    return_value |= bytes_value.pop(0)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, bytes):
+        bytes_value = bytearray(value)
+        return_value = 0
+        while len(bytes_value):
+            return_value <<= 8
+            if little_endian:
+                return_value |= bytes_value.pop(len(bytes_value) - 1)
+            else:
+                return_value |= bytes_value.pop(0)
 
-            return return_value
-        return convert(value, int, default)
-    except (ValueError, TypeError):
-        # If value could not be converted
-        return default
+        return return_value
+    return convert(value, int, default=default)
 
 
 def ensure_unique_string(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1424,25 +1424,21 @@ def test_bitwise_and(hass):
 
     tpl = template.Template(
         """
-{{ ( value_a ) | bitwise_and(0xFFFF, little_endian=True) }}
+{{ ( value_a ) | bitwise_and(value_b) }}
             """,
         hass,
     )
-    variables = {
-        "value_a": b"\xc2\x9b",
-    }
-    assert tpl.async_render(variables=variables) == 39874
+    variables = {"value_a": b"\x9b\xc2", "value_b": 0xFF00}
+    assert tpl.async_render(variables=variables) == 0x9B00
 
     tpl = template.Template(
         """
-{{ ( value_a ) | bitwise_and(0xFFFF, little_endian=True) }}
+{{ ( value_a ) | bitwise_and(value_b, little_endian=True) }}
             """,
         hass,
     )
-    variables = {
-        "value_a": b"\xc2\x9b",
-    }
-    assert tpl.async_render(variables=variables) == 39874
+    variables = {"value_a": b"\xc2\x9b", "value_b": 0xFFFF}
+    assert tpl.async_render(variables=variables) == 0x9BC2
 
 
 def test_bitwise_or(hass):
@@ -1469,10 +1465,6 @@ def test_bitwise_or(hass):
     )
     assert tpl.async_render() == 8 | 2
 
-
-def test_bitwise_or_with_bytes(hass):
-    """Test bitwise or operations with bytes."""
-
     tpl = template.Template(
         """
 {{ value_a | bitwise_or(value_b) }}
@@ -1481,31 +1473,45 @@ def test_bitwise_or_with_bytes(hass):
     )
     variables = {
         "value_a": b"\xc2\x9b",
-        "value_b": 65535,
+        "value_b": 0xFFFF,
     }
     assert tpl.async_render(variables=variables) == 65535  # 39874
 
     tpl = template.Template(
         """
-{{ ( value_a[0] ) * 256 + (value_a[1] ) | bitwise_and(0xFFFF) }}
+{{ ( value_a ) | bitwise_or(value_b) }}
             """,
         hass,
     )
     variables = {
-        "value_a": b"\xc2\x9b",
+        "value_a": 0xFF00,
+        "value_b": b"\xc2\x9b",
     }
-    assert tpl.async_render(variables=variables) == 49819
+    assert tpl.async_render(variables=variables) == 0xFF9B
 
     tpl = template.Template(
         """
-{{ ( value_a ) | bitwise_and(0xFFFF, little_endian=True) }}
+{{ ( value_a ) | bitwise_or(value_b) }}
             """,
         hass,
     )
     variables = {
         "value_a": b"\xc2\x9b",
+        "value_b": 0x0000,
     }
-    assert tpl.async_render(variables=variables) == 39874
+    assert tpl.async_render(variables=variables) == 0xC29B
+
+    tpl = template.Template(
+        """
+{{ ( value_a ) | bitwise_or(value_b, little_endian=True) }}
+            """,
+        hass,
+    )
+    variables = {
+        "value_a": b"\xc2\x9b",
+        "value_b": 0,
+    }
+    assert tpl.async_render(variables=variables) == 0x9BC2
 
 
 def test_distance_function_with_1_state(hass):

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1422,6 +1422,28 @@ def test_bitwise_and(hass):
     )
     assert tpl.async_render() == 8 & 2
 
+    tpl = template.Template(
+        """
+{{ ( value_a ) | bitwise_and(0xFFFF, little_endian=True) }}
+            """,
+        hass,
+    )
+    variables = {
+        "value_a": b"\xc2\x9b",
+    }
+    assert tpl.async_render(variables=variables) == 39874
+
+    tpl = template.Template(
+        """
+{{ ( value_a ) | bitwise_and(0xFFFF, little_endian=True) }}
+            """,
+        hass,
+    )
+    variables = {
+        "value_a": b"\xc2\x9b",
+    }
+    assert tpl.async_render(variables=variables) == 39874
+
 
 def test_bitwise_or(hass):
     """Test bitwise_or method."""
@@ -1446,6 +1468,44 @@ def test_bitwise_or(hass):
         hass,
     )
     assert tpl.async_render() == 8 | 2
+
+
+def test_bitwise_or_with_bytes(hass):
+    """Test bitwise or operations with bytes."""
+
+    tpl = template.Template(
+        """
+{{ value_a | bitwise_or(value_b) }}
+            """,
+        hass,
+    )
+    variables = {
+        "value_a": b"\xc2\x9b",
+        "value_b": 65535,
+    }
+    assert tpl.async_render(variables=variables) == 65535  # 39874
+
+    tpl = template.Template(
+        """
+{{ ( value_a[0] ) * 256 + (value_a[1] ) | bitwise_and(0xFFFF) }}
+            """,
+        hass,
+    )
+    variables = {
+        "value_a": b"\xc2\x9b",
+    }
+    assert tpl.async_render(variables=variables) == 49819
+
+    tpl = template.Template(
+        """
+{{ ( value_a ) | bitwise_and(0xFFFF, little_endian=True) }}
+            """,
+        hass,
+    )
+    variables = {
+        "value_a": b"\xc2\x9b",
+    }
+    assert tpl.async_render(variables=variables) == 39874
 
 
 def test_distance_function_with_1_state(hass):

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -111,6 +111,7 @@ def test_convert_to_int():
     assert util.convert_to_int("\xc2\x9b", 10) == 10
     assert util.convert_to_int(None, 10) == 10
     assert util.convert_to_int(None) is None
+    assert util.convert_to_int("NOT A NUMBER", 1) == 1
 
 
 def test_ensure_unique_string():

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -101,7 +101,7 @@ def test_convert():
 def test_convert_to_int():
     """Test convert of bytes and numbers to int."""
     assert util.convert_to_int(b"\x9b\xc2") == 39874
-    assert util.convert_to_int(b"") == 0
+    assert util.convert_to_int(b"") is None
     assert util.convert_to_int(b"\x9b\xc2", 10) == 39874
     assert util.convert_to_int(b"\xc2\x9b", little_endian=True) == 39874
     assert util.convert_to_int(b"\xc2\x9b", 10, little_endian=True) == 39874

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -98,6 +98,21 @@ def test_convert():
     assert util.convert(object, int, 1) == 1
 
 
+def test_convert_to_int():
+    """Test convert of bytes and numbers to int."""
+    assert util.convert_to_int(b"\x9b\xc2") == 39874
+    assert util.convert_to_int(b"") == 0
+    assert util.convert_to_int(b"\x9b\xc2", 10) == 39874
+    assert util.convert_to_int(b"\xc2\x9b", little_endian=True) == 39874
+    assert util.convert_to_int(b"\xc2\x9b", 10, little_endian=True) == 39874
+    assert util.convert_to_int("abc", 10) == 10
+    assert util.convert_to_int("11.0", 10) == 10
+    assert util.convert_to_int("12", 10) == 12
+    assert util.convert_to_int("\xc2\x9b", 10) == 10
+    assert util.convert_to_int(None, 10) == 10
+    assert util.convert_to_int(None) is None
+
+
 def test_ensure_unique_string():
     """Test ensure_unique_string."""
     assert util.ensure_unique_string("Beer", ["Beer", "Beer_2"]) == "Beer_3"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current template filters `bitwise_or` and `bitwise_and` only support integers. MQTT based devices rely heavily on templates to convert raw data to entities states and attributes.

This PR adds support to translate a raw `bytes` object to an integer.

E.g. if the received `value` is `b"\x9b\xc2"` it will be translated as `0x9bc2` or if the `little_endian` parameter is set to `True` as `0xc29b`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  https://github.com/home-assistant/core/issues/60085
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20412

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
