### PR TITLE
New entity names for Fronius entities

### DIFF
--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
+    DOMAIN as SENSOR_DOMAIN,
     PLATFORM_SCHEMA,
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
@@ -610,7 +611,7 @@ class _FroniusSensorEntity(CoordinatorEntity, SensorEntity):
 
     coordinator: FroniusCoordinatorBase
     entity_descriptions: list[SensorEntityDescription]
-    _name_extension: str
+    _entity_id_prefix: str
 
     def __init__(
         self,
@@ -623,8 +624,8 @@ class _FroniusSensorEntity(CoordinatorEntity, SensorEntity):
         self.entity_description = next(
             desc for desc in self.entity_descriptions if desc.key == key
         )
+        self.entity_id = f"{SENSOR_DOMAIN}.{key}_{DOMAIN}_{self._entity_id_prefix}_{coordinator.solar_net.host}"
         self.solar_net_id = solar_net_id
-        self._attr_name = f"{key.replace('_', ' ').capitalize()} {DOMAIN.capitalize()} {self._name_extension} {coordinator.solar_net.host}"
         self._attr_native_value = self._get_entity_value()
 
     def _device_data(self) -> dict[str, Any]:
@@ -660,7 +661,7 @@ class InverterSensor(_FroniusSensorEntity):
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius inverter sensor."""
-        self._name_extension = f"Inverter {solar_net_id}"
+        self._entity_id_prefix = f"inverter_{solar_net_id}"
         super().__init__(coordinator, key, solar_net_id)
         self._attr_unique_id = f"{coordinator.inverter_info.unique_id}-{key}"
 
@@ -669,7 +670,7 @@ class LoggerSensor(_FroniusSensorEntity):
     """Defines a Fronius logger device sensor entity."""
 
     entity_descriptions = LOGGER_ENTITY_DESCRIPTIONS
-    _name_extension = "Logger info 0"
+    _entity_id_prefix = "logger_info_0"
 
     def __init__(
         self,
@@ -697,7 +698,7 @@ class MeterSensor(_FroniusSensorEntity):
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius meter sensor."""
-        self._name_extension = f"Meter {solar_net_id}"
+        self._entity_id_prefix = f"meter_{solar_net_id}"
         super().__init__(coordinator, key, solar_net_id)
 
         self._attr_unique_id = f'{self._device_data()["serial"]["value"]}-{key}'
@@ -707,7 +708,7 @@ class PowerFlowSensor(_FroniusSensorEntity):
     """Defines a Fronius power flow sensor entity."""
 
     entity_descriptions = POWER_FLOW_ENTITY_DESCRIPTIONS
-    _name_extension = "Power flow 0"
+    _entity_id_prefix = "power_flow_0"
 
     def __init__(
         self,
@@ -734,7 +735,7 @@ class StorageSensor(_FroniusSensorEntity):
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius storage sensor."""
-        self._name_extension = f"Storage {solar_net_id}"
+        self._entity_id_prefix = f"storage_{solar_net_id}"
         super().__init__(coordinator, key, solar_net_id)
 
         self._attr_unique_id = f'{self._device_data()["serial"]["value"]}-{key}'

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -624,6 +624,9 @@ class _FroniusSensorEntity(CoordinatorEntity, SensorEntity):
         self.entity_description = next(
             desc for desc in self.entity_descriptions if desc.key == key
         )
+        # default entity_id added 2021.12
+        # used for migration from non-unique_id entities of previous integration implementation
+        # when removed after migration period `_entity_id_prefix` will also no longer be needed
         self.entity_id = f"{SENSOR_DOMAIN}.{key}_{DOMAIN}_{self._entity_id_prefix}_{coordinator.solar_net.host}"
         self.solar_net_id = solar_net_id
         self._attr_native_value = self._get_entity_value()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- entity names defined in the EntityDescriptions are used
- the entity_id schema of the previous (non-unique_id) implementation is still used for migration
after a migration period of some releases this can be removed as the entity_id will be stored in the entity_registry then so the default entity_ids will only hit new users of the integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
