### PR TITLE
Update ZeroconfServiceInfo in tests (g-m)

### DIFF
--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -108,7 +108,12 @@ async def test_form_homekit_unique_id_already_setup(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4", properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR}
+            host="1.2.3.4",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
+            properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
+            type="mock_type",
         ),
     )
     assert result["type"] == RESULT_TYPE_FORM
@@ -130,7 +135,12 @@ async def test_form_homekit_unique_id_already_setup(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4", properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR}
+            host="1.2.3.4",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
+            properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
+            type="mock_type",
         ),
     )
     assert result["type"] == RESULT_TYPE_ABORT
@@ -149,7 +159,12 @@ async def test_form_homekit_ip_address_already_setup(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4", properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR}
+            host="1.2.3.4",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
+            properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
+            type="mock_type",
         ),
     )
     assert result["type"] == RESULT_TYPE_ABORT
@@ -162,7 +177,12 @@ async def test_form_homekit_ip_address(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4", properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR}
+            host="1.2.3.4",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
+            properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
+            type="mock_type",
         ),
     )
     assert result["type"] == RESULT_TYPE_FORM
@@ -237,7 +257,12 @@ async def test_discovered_by_homekit_and_dhcp(hass):
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="1.2.3.4", properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR}
+            host="1.2.3.4",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
+            properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
+            type="mock_type",
         ),
     )
     assert result["type"] == RESULT_TYPE_FORM

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -141,10 +141,9 @@ def get_device_discovery_info(
     record = device.info
     result = zeroconf.ZeroconfServiceInfo(
         host=record["address"],
-        port=record["port"],
         hostname=record["name"],
-        type="_hap._tcp.local.",
         name=record["name"],
+        port=record["port"],
         properties={
             "md": record["md"],
             "pv": record["pv"],
@@ -156,6 +155,7 @@ def get_device_discovery_info(
             "sf": 0x01,  # record["sf"],
             "sh": "",
         },
+        type="_hap._tcp.local.",
     )
 
     if missing_csharp:

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -517,7 +517,11 @@ async def test_bridge_homekit(hass, aioclient_mock):
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
             host="0.0.0.0",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
             properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
+            type="mock_type",
         ),
     )
 
@@ -560,7 +564,11 @@ async def test_bridge_homekit_already_configured(hass, aioclient_mock):
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
             host="0.0.0.0",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
             properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
+            type="mock_type",
         ),
     )
 

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -12,14 +12,21 @@ from homeassistant.components.hunterdouglas_powerview.const import DOMAIN
 from tests.common import MockConfigEntry, load_fixture
 
 HOMEKIT_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    name="Hunter Douglas Powerview Hub._hap._tcp.local.",
     host="1.2.3.4",
-    properties={"id": "AA::BB::CC::DD::EE::FF"},
+    hostname="mock_hostname",
+    name="Hunter Douglas Powerview Hub._hap._tcp.local.",
+    port=None,
+    properties={zeroconf.ATTR_PROPERTIES_ID: "AA::BB::CC::DD::EE::FF"},
+    type="mock_type",
 )
 
 ZEROCONF_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    name="Hunter Douglas Powerview Hub._powerview._tcp.local.",
     host="1.2.3.4",
+    hostname="mock_hostname",
+    name="Hunter Douglas Powerview Hub._powerview._tcp.local.",
+    port=None,
+    properties={},
+    type="mock_type",
 )
 
 DHCP_DISCOVERY_INFO = dhcp.DhcpServiceInfo(

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -428,6 +428,10 @@ async def test_zeroconf_host_already_configured(hass, tmpdir):
         data=zeroconf.ZeroconfServiceInfo(
             host="1.1.1.1",
             hostname="lutron-abc.local.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
     await hass.async_block_till_done()
@@ -451,6 +455,10 @@ async def test_zeroconf_lutron_id_already_configured(hass):
         data=zeroconf.ZeroconfServiceInfo(
             host="1.1.1.1",
             hostname="lutron-abc.local.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
     await hass.async_block_till_done()
@@ -469,6 +477,10 @@ async def test_zeroconf_not_lutron_device(hass):
         data=zeroconf.ZeroconfServiceInfo(
             host="1.1.1.1",
             hostname="notlutron-abc.local.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
     await hass.async_block_till_done()
@@ -493,6 +505,10 @@ async def test_zeroconf(hass, source, tmpdir):
         data=zeroconf.ZeroconfServiceInfo(
             host="1.1.1.1",
             hostname="lutron-abc.local.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
     await hass.async_block_till_done()

--- a/tests/components/modern_forms/test_config_flow.py
+++ b/tests/components/modern_forms/test_config_flow.py
@@ -70,7 +70,12 @@ async def test_full_zeroconf_flow_implementation(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123", hostname="example.local.", properties={}
+            host="192.168.1.123",
+            hostname="example.local.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
 
@@ -134,7 +139,12 @@ async def test_zeroconf_connection_error(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123", hostname="example.local.", properties={}
+            host="192.168.1.123",
+            hostname="example.local.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
 
@@ -160,7 +170,12 @@ async def test_zeroconf_confirm_connection_error(
             CONF_NAME: "test",
         },
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123", hostname="example.com.", properties={}
+            host="192.168.1.123",
+            hostname="example.com.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
 
@@ -226,7 +241,10 @@ async def test_zeroconf_with_mac_device_exists_abort(
         data=zeroconf.ZeroconfServiceInfo(
             host="192.168.1.123",
             hostname="example.local.",
+            name="mock_name",
+            port=None,
             properties={CONF_MAC: "AA:BB:CC:DD:EE:FF"},
+            type="mock_type",
         ),
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As preliminary work for #60206, ensure that all properties in `ZeroconfServiceInfo` are initialised in tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
