### PR TITLE
Update ZeroconfServiceInfo in tests (t-z)

### DIFF
--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -106,7 +106,11 @@ async def test_discovery_connection(hass, mock_auth, mock_entry_setup):
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
             host="123.123.123.123",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
             properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"},
+            type="mock_type",
         ),
     )
 
@@ -256,7 +260,12 @@ async def test_discovery_duplicate_aborted(hass):
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="new-host", properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"}
+            host="new-host",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
+            properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"},
+            type="mock_type",
         ),
     )
 
@@ -287,7 +296,11 @@ async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
             host="123.123.123.123",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
             properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"},
+            type="mock_type",
         ),
     )
 
@@ -298,7 +311,11 @@ async def test_duplicate_discovery(hass, mock_auth, mock_entry_setup):
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
             host="123.123.123.123",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
             properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"},
+            type="mock_type",
         ),
     )
 
@@ -317,7 +334,12 @@ async def test_discovery_updates_unique_id(hass):
         "tradfri",
         context={"source": config_entries.SOURCE_HOMEKIT},
         data=zeroconf.ZeroconfServiceInfo(
-            host="some-host", properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"}
+            host="some-host",
+            hostname="mock_hostname",
+            name="mock_name",
+            port=None,
+            properties={zeroconf.ATTR_PROPERTIES_ID: "homekit-id"},
+            type="mock_type",
         ),
     )
 

--- a/tests/components/volumio/test_config_flow.py
+++ b/tests/components/volumio/test_config_flow.py
@@ -19,8 +19,11 @@ TEST_CONNECTION = {
 
 TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
     host="1.1.1.1",
+    hostname="mock_hostname",
+    name="mock_name",
     port=3000,
     properties={"volumioName": "discovered", "UUID": "2222-2222-2222-2222"},
+    type="mock_type",
 )
 
 TEST_DISCOVERY_RESULT = {

--- a/tests/components/wled/test_config_flow.py
+++ b/tests/components/wled/test_config_flow.py
@@ -49,7 +49,12 @@ async def test_full_zeroconf_flow_implementation(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123", hostname="example.local.", properties={}
+            host="192.168.1.123",
+            hostname="example.local.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
 
@@ -104,7 +109,12 @@ async def test_zeroconf_connection_error(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123", hostname="example.local.", properties={}
+            host="192.168.1.123",
+            hostname="example.local.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
 
@@ -126,7 +136,12 @@ async def test_zeroconf_confirm_connection_error(
             CONF_NAME: "test",
         },
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123", hostname="example.com.", properties={}
+            host="192.168.1.123",
+            hostname="example.com.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
 
@@ -160,7 +175,12 @@ async def test_zeroconf_device_exists_abort(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host="192.168.1.123", hostname="example.local.", properties={}
+            host="192.168.1.123",
+            hostname="example.local.",
+            name="mock_name",
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
 
@@ -180,7 +200,10 @@ async def test_zeroconf_with_mac_device_exists_abort(
         data=zeroconf.ZeroconfServiceInfo(
             host="192.168.1.123",
             hostname="example.local.",
+            name="mock_name",
+            port=None,
             properties={CONF_MAC: "aabbccddeeff"},
+            type="mock_type",
         ),
     )
 

--- a/tests/components/xiaomi_aqara/test_config_flow.py
+++ b/tests/components/xiaomi_aqara/test_config_flow.py
@@ -403,8 +403,11 @@ async def test_zeroconf_success(hass):
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
             host=TEST_HOST,
+            hostname="mock_hostname",
             name=TEST_ZEROCONF_NAME,
+            port=None,
             properties={ZEROCONF_MAC: TEST_MAC},
+            type="mock_type",
         ),
     )
 
@@ -445,7 +448,12 @@ async def test_zeroconf_missing_data(hass):
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=TEST_HOST, name=TEST_ZEROCONF_NAME, properties={}
+            host=TEST_HOST,
+            hostname="mock_hostname",
+            name=TEST_ZEROCONF_NAME,
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
 
@@ -460,8 +468,11 @@ async def test_zeroconf_unknown_device(hass):
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
             host=TEST_HOST,
+            hostname="mock_hostname",
             name="not-a-xiaomi-aqara-gateway",
+            port=None,
             properties={ZEROCONF_MAC: TEST_MAC},
+            type="mock_type",
         ),
     )
 

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -394,8 +394,11 @@ async def test_zeroconf_gateway_success(hass):
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
             host=TEST_HOST,
+            hostname="mock_hostname",
             name=TEST_ZEROCONF_NAME,
+            port=None,
             properties={ZEROCONF_MAC: TEST_MAC},
+            type="mock_type",
         ),
     )
 
@@ -433,8 +436,11 @@ async def test_zeroconf_unknown_device(hass):
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
             host=TEST_HOST,
+            hostname="mock_hostname",
             name="not-a-xiaomi-miio-device",
+            port=None,
             properties={ZEROCONF_MAC: TEST_MAC},
+            type="mock_type",
         ),
     )
 
@@ -447,7 +453,14 @@ async def test_zeroconf_no_data(hass):
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(host=None, name=None, properties={}),
+        data=zeroconf.ZeroconfServiceInfo(
+            host=None,
+            hostname="mock_hostname",
+            name=None,
+            port=None,
+            properties={},
+            type="mock_type",
+        ),
     )
 
     assert result["type"] == "abort"
@@ -460,7 +473,12 @@ async def test_zeroconf_missing_data(hass):
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
-            host=TEST_HOST, name=TEST_ZEROCONF_NAME, properties={}
+            host=TEST_HOST,
+            hostname="mock_hostname",
+            name=TEST_ZEROCONF_NAME,
+            port=None,
+            properties={},
+            type="mock_type",
         ),
     )
 
@@ -753,8 +771,11 @@ async def zeroconf_device_success(hass, zeroconf_name_to_test, model_to_test):
         context={"source": config_entries.SOURCE_ZEROCONF},
         data=zeroconf.ZeroconfServiceInfo(
             host=TEST_HOST,
+            hostname="mock_hostname",
             name=zeroconf_name_to_test,
+            port=None,
             properties={"poch": f"0:mac={TEST_MAC_DEVICE}\x00"},
+            type="mock_type",
         ),
     )
 

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -458,7 +458,11 @@ async def test_discovered_by_homekit_and_dhcp(hass):
             context={"source": config_entries.SOURCE_HOMEKIT},
             data=zeroconf.ZeroconfServiceInfo(
                 host=IP_ADDRESS,
+                hostname="mock_hostname",
+                name="mock_name",
+                port=None,
                 properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
+                type="mock_type",
             ),
         )
         await hass.async_block_till_done()
@@ -515,7 +519,11 @@ async def test_discovered_by_homekit_and_dhcp(hass):
             config_entries.SOURCE_HOMEKIT,
             zeroconf.ZeroconfServiceInfo(
                 host=IP_ADDRESS,
+                hostname="mock_hostname",
+                name="mock_name",
+                port=None,
                 properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
+                type="mock_type",
             ),
         ),
     ],
@@ -576,7 +584,11 @@ async def test_discovered_by_dhcp_or_homekit(hass, source, data):
             config_entries.SOURCE_HOMEKIT,
             zeroconf.ZeroconfServiceInfo(
                 host=IP_ADDRESS,
+                hostname="mock_hostname",
+                name="mock_name",
+                port=None,
                 properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
+                type="mock_type",
             ),
         ),
     ],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As preliminary work for #60206, ensure that all properties in `ZeroconfServiceInfo` are initialised in tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
