### PR TITLE
Ensure homekit setup messages run in event loop

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -102,11 +102,11 @@ from .const import (
 from .type_triggers import DeviceTriggerAccessory
 from .util import (
     accessory_friendly_name,
+    async_dismiss_setup_message,
     async_port_is_available,
-    dismiss_setup_message,
+    async_show_setup_message,
     get_persist_fullpath_for_entry_id,
     remove_state_files_for_entry_id,
-    show_setup_message,
     state_needs_accessory_mode,
     validate_entity_config,
 )
@@ -321,7 +321,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    dismiss_setup_message(hass, entry.entry_id)
+    async_dismiss_setup_message(hass, entry.entry_id)
     homekit = hass.data[DOMAIN][entry.entry_id][HOMEKIT]
 
     if homekit.status == STATUS_RUNNING:
@@ -719,7 +719,7 @@ class HomeKit:
     @callback
     def _async_show_setup_message(self):
         """Show the pairing setup message."""
-        show_setup_message(
+        async_show_setup_message(
             self.hass,
             self._entry_id,
             accessory_friendly_name(self._entry_title, self.driver.accessory),

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -4,6 +4,7 @@ import logging
 from pyhap.accessory import Accessory, Bridge
 from pyhap.accessory_driver import AccessoryDriver
 from pyhap.const import CATEGORY_OTHER
+from pyhap.util import callback as pyhap_callback
 
 from homeassistant.components import cover
 from homeassistant.components.cover import (
@@ -80,10 +81,10 @@ from .const import (
 )
 from .util import (
     accessory_friendly_name,
+    async_dismiss_setup_message,
+    async_show_setup_message,
     convert_to_float,
-    dismiss_setup_message,
     format_sw_version,
-    show_setup_message,
     validate_media_player_features,
 )
 
@@ -550,13 +551,15 @@ class HomeDriver(AccessoryDriver):
         self._bridge_name = bridge_name
         self._entry_title = entry_title
 
+    @pyhap_callback
     def pair(self, client_uuid, client_public, client_permissions):
         """Override super function to dismiss setup message if paired."""
         success = super().pair(client_uuid, client_public, client_permissions)
         if success:
-            dismiss_setup_message(self.hass, self._entry_id)
+            async_dismiss_setup_message(self.hass, self._entry_id)
         return success
 
+    @pyhap_callback
     def unpair(self, client_uuid):
         """Override super function to show setup message if unpaired."""
         super().unpair(client_uuid)
@@ -564,7 +567,7 @@ class HomeDriver(AccessoryDriver):
         if self.state.paired:
             return
 
-        show_setup_message(
+        async_show_setup_message(
             self.hass,
             self._entry_id,
             accessory_friendly_name(self._entry_title, self.accessory),

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -315,7 +315,7 @@ def validate_media_player_features(state, feature_list):
     return True
 
 
-def show_setup_message(hass, entry_id, bridge_name, pincode, uri):
+def async_show_setup_message(hass, entry_id, bridge_name, pincode, uri):
     """Display persistent notification with setup information."""
     pin = pincode.decode()
     _LOGGER.info("Pincode: %s", pin)
@@ -334,12 +334,14 @@ def show_setup_message(hass, entry_id, bridge_name, pincode, uri):
         f"### {pin}\n"
         f"![image](/api/homekit/pairingqr?{entry_id}-{pairing_secret})"
     )
-    hass.components.persistent_notification.create(message, "HomeKit Pairing", entry_id)
+    hass.components.persistent_notification.async_create(
+        message, "HomeKit Pairing", entry_id
+    )
 
 
-def dismiss_setup_message(hass, entry_id):
+def async_dismiss_setup_message(hass, entry_id):
     """Dismiss persistent notification and remove QR code."""
-    hass.components.persistent_notification.dismiss(entry_id)
+    hass.components.persistent_notification.async_dismiss(entry_id)
 
 
 def convert_to_float(state):

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -694,7 +694,7 @@ def test_home_driver():
 
     # pair
     with patch("pyhap.accessory_driver.AccessoryDriver.pair") as mock_pair, patch(
-        "homeassistant.components.homekit.accessories.dismiss_setup_message"
+        "homeassistant.components.homekit.accessories.async_dismiss_setup_message"
     ) as mock_dissmiss_msg:
         driver.pair("client_uuid", "client_public", b"1")
 
@@ -703,7 +703,7 @@ def test_home_driver():
 
     # unpair
     with patch("pyhap.accessory_driver.AccessoryDriver.unpair") as mock_unpair, patch(
-        "homeassistant.components.homekit.accessories.show_setup_message"
+        "homeassistant.components.homekit.accessories.async_show_setup_message"
     ) as mock_show_msg:
         driver.unpair("client_uuid")
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -459,7 +459,7 @@ async def test_homekit_start(hass, hk_driver, mock_async_zeroconf, device_reg):
     state = hass.states.async_all()[0]
 
     with patch(f"{PATH_HOMEKIT}.HomeKit.add_bridge_accessory") as mock_add_acc, patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
     ) as hk_driver_start:
@@ -491,7 +491,7 @@ async def test_homekit_start(hass, hk_driver, mock_async_zeroconf, device_reg):
     # Start again to make sure the registry entry is kept
     homekit.status = STATUS_READY
     with patch(f"{PATH_HOMEKIT}.HomeKit.add_bridge_accessory") as mock_add_acc, patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
     ) as hk_driver_start:
@@ -529,7 +529,7 @@ async def test_homekit_start_with_a_broken_accessory(
     hass.states.async_set("light.broken", "on")
 
     with patch(f"{PATH_HOMEKIT}.get_accessory", side_effect=Exception), patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
     ) as hk_driver_start:
@@ -568,7 +568,7 @@ async def test_homekit_start_with_a_device(
     homekit.driver = hk_driver
 
     with patch(f"{PATH_HOMEKIT}.get_accessory", side_effect=Exception), patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ) as mock_setup_msg:
         await homekit.async_start()
 
@@ -1085,7 +1085,7 @@ async def test_homekit_too_many_accessories(
     hass.states.async_set("light.demo3", "on")
 
     with patch("pyhap.accessory_driver.AccessoryDriver.async_start"), patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ), patch(f"{PATH_HOMEKIT}.HomeBridge", _mock_bridge):
         await homekit.async_start()
         await hass.async_block_till_done()
@@ -1141,7 +1141,7 @@ async def test_homekit_finds_linked_batteries(
     )
     hass.states.async_set(light.entity_id, STATE_ON)
 
-    with patch(f"{PATH_HOMEKIT}.show_setup_message"), patch(
+    with patch(f"{PATH_HOMEKIT}.async_show_setup_message"), patch(
         f"{PATH_HOMEKIT}.get_accessory"
     ) as mock_get_acc, patch("pyhap.accessory_driver.AccessoryDriver.async_start"):
         await homekit.async_start()
@@ -1211,7 +1211,7 @@ async def test_homekit_async_get_integration_fails(
     hass.states.async_set(light.entity_id, STATE_ON)
 
     with patch.object(homekit.bridge, "add_accessory"), patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ), patch(f"{PATH_HOMEKIT}.get_accessory") as mock_get_acc, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
     ):
@@ -1418,7 +1418,7 @@ async def test_homekit_finds_linked_motion_sensors(
     hass.states.async_set(camera.entity_id, STATE_ON)
 
     with patch.object(homekit.bridge, "add_accessory"), patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ), patch(f"{PATH_HOMEKIT}.get_accessory") as mock_get_acc, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
     ):
@@ -1483,7 +1483,7 @@ async def test_homekit_finds_linked_humidity_sensors(
     hass.states.async_set(humidifier.entity_id, STATE_ON)
 
     with patch.object(homekit.bridge, "add_accessory"), patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ), patch(f"{PATH_HOMEKIT}.get_accessory") as mock_get_acc, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
     ):
@@ -1543,7 +1543,7 @@ async def test_reload(hass, mock_async_zeroconf):
     with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path), patch(
         f"{PATH_HOMEKIT}.HomeKit"
     ) as mock_homekit2, patch.object(homekit.bridge, "add_accessory"), patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ), patch(
         f"{PATH_HOMEKIT}.get_accessory"
     ), patch(
@@ -1592,7 +1592,7 @@ async def test_homekit_start_in_accessory_mode(
     hass.states.async_set("light.demo", "on")
 
     with patch(f"{PATH_HOMEKIT}.HomeKit.add_bridge_accessory") as mock_add_acc, patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
     ) as hk_driver_start:
@@ -1623,7 +1623,7 @@ async def test_homekit_start_in_accessory_mode_unsupported_entity(
     hass.states.async_set("notsupported.demo", "on")
 
     with patch(f"{PATH_HOMEKIT}.HomeKit.add_bridge_accessory") as mock_add_acc, patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start"
     ) as hk_driver_start:
@@ -1651,7 +1651,7 @@ async def test_homekit_start_in_accessory_mode_missing_entity(
     homekit.driver.accessory = Accessory(hk_driver, "any")
 
     with patch(f"{PATH_HOMEKIT}.HomeKit.add_bridge_accessory") as mock_add_acc, patch(
-        f"{PATH_HOMEKIT}.show_setup_message"
+        f"{PATH_HOMEKIT}.async_show_setup_message"
     ), patch("pyhap.accessory_driver.AccessoryDriver.async_start"):
         await homekit.async_start()
 

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -25,21 +25,21 @@ from homeassistant.components.homekit.const import (
 )
 from homeassistant.components.homekit.util import (
     accessory_friendly_name,
+    async_dismiss_setup_message,
     async_find_next_available_port,
     async_port_is_available,
+    async_show_setup_message,
     cleanup_name_for_homekit,
     convert_to_float,
     density_to_air_quality,
-    dismiss_setup_message,
     format_sw_version,
-    show_setup_message,
     state_needs_accessory_mode,
     temperature_to_homekit,
     temperature_to_states,
     validate_entity_config as vec,
     validate_media_player_features,
 )
-from homeassistant.components.persistent_notification import create, dismiss
+from homeassistant.components.persistent_notification import async_create, async_dismiss
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_SUPPORTED_FEATURES,
@@ -231,7 +231,7 @@ def test_density_to_air_quality():
     assert density_to_air_quality(300) == 5
 
 
-async def test_show_setup_msg(hass, hk_driver, mock_get_source_ip):
+async def test_async_show_setup_msg(hass, hk_driver, mock_get_source_ip):
     """Test show setup message as persistence notification."""
     pincode = b"123-45-678"
 
@@ -239,10 +239,11 @@ async def test_show_setup_msg(hass, hk_driver, mock_get_source_ip):
     assert entry
 
     with patch(
-        "homeassistant.components.persistent_notification.create", side_effect=create
+        "homeassistant.components.persistent_notification.async_create",
+        side_effect=async_create,
     ) as mock_create:
-        await hass.async_add_executor_job(
-            show_setup_message, hass, entry.entry_id, "bridge_name", pincode, "X-HM://0"
+        async_show_setup_message(
+            hass, entry.entry_id, "bridge_name", pincode, "X-HM://0"
         )
         await hass.async_block_till_done()
     assert hass.data[DOMAIN][entry.entry_id][HOMEKIT_PAIRING_QR_SECRET]
@@ -253,12 +254,13 @@ async def test_show_setup_msg(hass, hk_driver, mock_get_source_ip):
     assert pincode.decode() in mock_create.mock_calls[0][1][1]
 
 
-async def test_dismiss_setup_msg(hass):
+async def test_async_dismiss_setup_msg(hass):
     """Test dismiss setup message."""
     with patch(
-        "homeassistant.components.persistent_notification.dismiss", side_effect=dismiss
+        "homeassistant.components.persistent_notification.async_dismiss",
+        side_effect=async_dismiss,
     ) as mock_dismiss:
-        await hass.async_add_executor_job(dismiss_setup_message, hass, "entry_id")
+        async_dismiss_setup_message(hass, "entry_id")
         await hass.async_block_till_done()
 
     assert len(mock_dismiss.mock_calls) == 1


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- HomeKit is fully async now. These should not run in the executor

- Fixes failed CI run seen in https://github.com/home-assistant/core/pull/60140

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
