### PR TITLE
Run partial test suite in CI if core untouched

### DIFF
--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -53,7 +53,6 @@ components: &components
   - homeassistant/components/demo/*
   - homeassistant/components/device_automation/*
   - homeassistant/components/dhcp/*
-  - homeassistant/components/dhcp/*
   - homeassistant/components/discovery/*
   - homeassistant/components/energy/*
   - homeassistant/components/ffmpeg/*

--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -16,6 +16,7 @@ base_platforms: &base_platforms
   - homeassistant/components/alarm_control_panel/*
   - homeassistant/components/binary_sensor/*
   - homeassistant/components/button/*
+  - homeassistant/components/calendar/*
   - homeassistant/components/camera/*
   - homeassistant/components/climate/*
   - homeassistant/components/cover/*

--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -22,6 +22,7 @@ base_platforms: &base_platforms
   - homeassistant/components/cover/*
   - homeassistant/components/device_tracker/*
   - homeassistant/components/fan/*
+  - homeassistant/components/geo_location/*
   - homeassistant/components/humidifier/*
   - homeassistant/components/image_processing/*
   - homeassistant/components/light/*

--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -61,7 +61,6 @@ components: &components
   - homeassistant/components/group/*
   - homeassistant/components/hassio/*
   - homeassistant/components/homeassistant/**
-  - homeassistant/components/homekit/*
   - homeassistant/components/image/*
   - homeassistant/components/input_boolean/*
   - homeassistant/components/input_datetime/*

--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -1,0 +1,120 @@
+# Defines a list of files that are part of main core of Home Assistant.
+# Changes to these files/filters define how our CI test suite is ran.
+core: &core
+  - homeassistant/*.py
+  - homeassistant/auth/**
+  - homeassistant/helpers/*
+  - homeassistant/package_constraints.txt
+  - homeassistant/util/*
+  - pyproject.yaml
+  - requirements.txt
+  - setup.cfg
+
+# Our base platforms, that are used by other integrations
+base_platforms: &base_platforms
+  - homeassistant/components/air_quality/*
+  - homeassistant/components/alarm_control_panel/*
+  - homeassistant/components/binary_sensor/*
+  - homeassistant/components/button/*
+  - homeassistant/components/camera/*
+  - homeassistant/components/climate/*
+  - homeassistant/components/cover/*
+  - homeassistant/components/device_tracker/*
+  - homeassistant/components/fan/*
+  - homeassistant/components/humidifier/*
+  - homeassistant/components/image_processing/*
+  - homeassistant/components/light/*
+  - homeassistant/components/lock/*
+  - homeassistant/components/media_player/*
+  - homeassistant/components/notify/*
+  - homeassistant/components/number/*
+  - homeassistant/components/remote/*
+  - homeassistant/components/scene/*
+  - homeassistant/components/select/*
+  - homeassistant/components/sensor/*
+  - homeassistant/components/siren/*
+  - homeassistant/components/stt/*
+  - homeassistant/components/switch/*
+  - homeassistant/components/tts/*
+  - homeassistant/components/vacuum/*
+  - homeassistant/components/water_heater/*
+  - homeassistant/components/weather/*
+
+# Extra components that trigger the full suite
+components: &components
+  - homeassistant/components/alert/*
+  - homeassistant/components/alexa/*
+  - homeassistant/components/auth/*
+  - homeassistant/components/automation/*
+  - homeassistant/components/cloud/*
+  - homeassistant/components/config/*
+  - homeassistant/components/configurator/*
+  - homeassistant/components/conversation/*
+  - homeassistant/components/demo/*
+  - homeassistant/components/device_automation/*
+  - homeassistant/components/dhcp/*
+  - homeassistant/components/dhcp/*
+  - homeassistant/components/discovery/*
+  - homeassistant/components/energy/*
+  - homeassistant/components/ffmpeg/*
+  - homeassistant/components/frontend/*
+  - homeassistant/components/google_assistant/*
+  - homeassistant/components/group/*
+  - homeassistant/components/hassio/*
+  - homeassistant/components/homeassistant/**
+  - homeassistant/components/homekit/*
+  - homeassistant/components/image/*
+  - homeassistant/components/input_boolean/*
+  - homeassistant/components/input_datetime/*
+  - homeassistant/components/input_number/*
+  - homeassistant/components/input_select/*
+  - homeassistant/components/input_text/*
+  - homeassistant/components/logbook/*
+  - homeassistant/components/logger/*
+  - homeassistant/components/lovelace/*
+  - homeassistant/components/media_source/*
+  - homeassistant/components/mqtt/*
+  - homeassistant/components/network/*
+  - homeassistant/components/onboarding/*
+  - homeassistant/components/otp/*
+  - homeassistant/components/persistent_notification/*
+  - homeassistant/components/person/*
+  - homeassistant/components/recorder/*
+  - homeassistant/components/safe_mode/*
+  - homeassistant/components/script/*
+  - homeassistant/components/shopping_list/*
+  - homeassistant/components/ssdp/*
+  - homeassistant/components/stream/*
+  - homeassistant/components/sun/*
+  - homeassistant/components/system_health/*
+  - homeassistant/components/tag/*
+  - homeassistant/components/template/*
+  - homeassistant/components/timer/*
+  - homeassistant/components/usb/*
+  - homeassistant/components/webhook/*
+  - homeassistant/components/websocket_api/*
+  - homeassistant/components/zeroconf/*
+  - homeassistant/components/zone/*
+
+# Testing related files that affect the whole test/linting suite
+tests: &tests
+  - codecov.yaml
+  - requirements_test_pre_commit.txt
+  - requirements_test.txt
+  - tests/common.py
+  - tests/conftest.py
+  - tests/ignore_uncaught_exceptions.py
+  - tests/mock/*
+  - tests/test_util/*
+  - tests/testing_config/**
+
+other: &other
+  - .github/workflows/*
+  - homeassistant/scripts/**
+
+any:
+  - *base_platforms
+  - *components
+  - *core
+  - *other
+  - *tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -654,7 +654,7 @@ jobs:
   changes:
     name: Determine what has changed
     outputs:
-      core: ${{ steps.core.outputs.changes }}
+      core: ${{ steps.core.outputs.any }}
       integrations: ${{ steps.integrations.outputs.changes }}
       tests: ${{ steps.tests.outputs.integrations }}
     runs-on: ubuntu-latest
@@ -698,7 +698,7 @@ jobs:
           echo "::set-output name=integrations::${integrations}"
 
   pytest-full:
-    if: ${{ needs.changes.outputs.core.any == 'true' }}
+    if: ${{ needs.changes.outputs.core == 'true' }}
     runs-on: ubuntu-latest
     needs:
       - changes
@@ -774,7 +774,7 @@ jobs:
           ./script/check_dirty
 
   pytest-partial:
-    if: ${{ needs.changes.outputs.core.any == 'false' }}
+    if: ${{ needs.changes.outputs.core == 'false' }}
     runs-on: ubuntu-latest
     needs:
       - changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -651,9 +651,57 @@ jobs:
           . venv/bin/activate
           mypy homeassistant
 
-  pytest:
+  changes:
+    name: Determine what has changed
+    outputs:
+      core: ${{ steps.core.outputs.changes }}
+      integrations: ${{ steps.integrations.outputs.changes }}
+      tests: ${{ steps.tests.outputs.integrations }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.4.0
+      - name: Filter for core changes
+        uses: dorny/paths-filter@v2.10.2
+        id: core
+        with:
+          filters: .core_files.yaml
+      - name: Create a list of integrations to filter for changes
+        id: integration-filters
+        run: |
+          integrations=$(ls -Ad ./homeassistant/components/[!_]*  | xargs -n 1 basename)
+          touch .integration_paths.yaml
+          for integration in $integrations; do
+            echo "${integration}: [homeassistant/components/${integration}/*, tests/components/${integration}/*]" \
+              >> .integration_paths.yaml;
+          done
+          echo "Result:"
+          cat .integration_paths.yaml
+      - name: Filter for integration changes
+        uses: dorny/paths-filter@v2.10.2
+        id: integrations
+        with:
+          filters: .integration_paths.yaml
+      - name: Determine integration tests to run
+        if: ${{ steps.integrations.outputs.changes }}
+        id: tests
+        run: |
+          possible_integrations=$(echo '${{ steps.integrations.outputs.changes }}' | jq -cSr '. | join(" ")')
+          integrations=$(for integration in $possible_integrations; do [[ -d "tests/components/${integration}" ]] && echo -n "${integration},"; done)
+          integrations="${integrations::-1}"
+
+          # If more than one, add brackets to it
+          if [[ "${integrations}" == *","* ]]; then
+            integrations="{${integrations}}"
+          fi
+
+          echo "::set-output name=integrations::${integrations}"
+
+  pytest-full:
+    if: ${{ needs.changes.outputs.core.any == 'true' }}
     runs-on: ubuntu-latest
     needs:
+      - changes
       - gen-requirements-all
       - hassfest
       - lint-bandit
@@ -725,10 +773,83 @@ jobs:
         run: |
           ./script/check_dirty
 
-  coverage:
+  pytest-partial:
+    if: ${{ needs.changes.outputs.core.any == 'false' }}
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - gen-requirements-all
+      - hassfest
+      - lint-bandit
+      - lint-black
+      - lint-codespell
+      - lint-dockerfile
+      - lint-executable-shebangs
+      - lint-isort
+      - lint-json
+      - lint-pyupgrade
+      - lint-yaml
+      - mypy
+      - prepare-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9]
+    name: >-
+      Run partial tests Python ${{ matrix.python-version }}
+    container: homeassistant/ci-azure:${{ matrix.python-version }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.4.0
+      - name: Restore full Python ${{ matrix.python-version }} virtual environment
+        id: cache-venv
+        uses: actions/cache@v2.1.7
+        with:
+          path: venv
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{
+            needs.prepare-tests.outputs.python-key }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python virtual environment from cache"
+          exit 1
+      - name: Register Python problem matcher
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/python.json"
+      - name: Install Pytest Annotation plugin
+        run: |
+          . venv/bin/activate
+          # Ideally this should be part of our dependencies
+          # However this plugin is fairly new and doesn't run correctly
+          # on a non-GitHub environment.
+          pip install pytest-github-actions-annotate-failures==0.1.3
+      - name: Run pytest
+        run: |
+          . venv/bin/activate
+          python3 -X dev -m pytest \
+            -qq \
+            --timeout=9 \
+            --durations=10 \
+            -n auto \
+            --dist=loadfile \
+            --cov homeassistant \
+            --cov-report= \
+            -o console_output_style=count \
+            -p no:sugar \
+            tests/components/${{ needs.changes.outputs.tests }}
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: coverage-${{ matrix.python-version }}
+          path: .coverage
+      - name: Check dirty
+        run: |
+          ./script/check_dirty
+
+  coverage-full:
     name: Process test coverage
     runs-on: ubuntu-latest
-    needs: ["prepare-tests", "pytest"]
+    needs: ["prepare-tests", "pytest-full"]
     strategy:
       matrix:
         python-version: [3.8]
@@ -755,6 +876,39 @@ jobs:
           . venv/bin/activate
           coverage combine coverage*/.coverage*
           coverage report --fail-under=94
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2.1.0
+
+  coverage-partial:
+    name: Process partial test coverage
+    runs-on: ubuntu-latest
+    needs: ["prepare-tests", "pytest-partial"]
+    strategy:
+      matrix:
+        python-version: [3.8]
+    container: homeassistant/ci-azure:${{ matrix.python-version }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.4.0
+      - name: Restore full Python ${{ matrix.python-version }} virtual environment
+        id: cache-venv
+        uses: actions/cache@v2.1.7
+        with:
+          path: venv
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{
+            needs.prepare-tests.outputs.python-key }}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python virtual environment from cache"
+          exit 1
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v2
+      - name: Combine coverage results
+        run: |
+          . venv/bin/activate
+          coverage combine coverage*/.coverage*
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2.1.0

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,9 @@ coverage:
         target: 90
         threshold: 0.09
 comment: false
+
+# To make partial tests possible,
+# we need to carry forward.
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is an attempt to make the CI/GitHub Actions running in a minimal form as possible to speed up our CI massively.

- If only an integration(s) is/are touched, only the tests for those specific integration(s) 
  is/are run (if it has a test suite).
- If any of the files matches any of the definitions from the `.core_files.yaml` file in our project root, it means a significant part of the core has been touched and the full test suite will run.

To make codecov work, I've configured codecov to carry forward previous coverage when partial coverage is brought in.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
