### PR TITLE
Avoid errors when AirNow API does not return all expected pollutants

### DIFF
--- a/homeassistant/components/airnow/sensor.py
+++ b/homeassistant/components/airnow/sensor.py
@@ -86,10 +86,7 @@ class AirNowSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state."""
-        if self.entity_description.key in self.coordinator.data:
-            self._state = self.coordinator.data[self.entity_description.key]
-        else:
-            self._state = None
+        self._state = self.coordinator.data.get(self.entity_description.key)
 
         return self._state
 

--- a/homeassistant/components/airnow/sensor.py
+++ b/homeassistant/components/airnow/sensor.py
@@ -86,7 +86,11 @@ class AirNowSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state."""
-        self._state = self.coordinator.data[self.entity_description.key]
+        if self.entity_description.key in self.coordinator.data:
+            self._state = self.coordinator.data[self.entity_description.key]
+        else:
+            self._state = None
+
         return self._state
 
     @property


### PR DESCRIPTION
## Proposed change
Add check so that the AirNow integration does not throw exceptions when the AirNow API does not return both PM2.5 and O3 data.  The API seems to occasionally and inconsistently not report all pollutants.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #60173 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone
