### PR TITLE
Disable less popular Fronius entities by default

### DIFF
--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -148,6 +148,7 @@ INVERTER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=FREQUENCY_HERTZ,
         device_class=DEVICE_CLASS_FREQUENCY,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="current_ac",
@@ -185,6 +186,7 @@ INVERTER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         device_class=DEVICE_CLASS_VOLTAGE,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="voltage_dc",
@@ -222,11 +224,13 @@ INVERTER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="led_state",
         name="LED state",
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="led_color",
         name="LED color",
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
 ]
 
@@ -258,6 +262,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
         device_class=DEVICE_CLASS_CURRENT,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="current_ac_phase_2",
@@ -265,6 +270,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
         device_class=DEVICE_CLASS_CURRENT,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="current_ac_phase_3",
@@ -272,6 +278,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
         device_class=DEVICE_CLASS_CURRENT,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="energy_reactive_ac_consumed",
@@ -279,6 +286,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ENERGY_VOLT_AMPERE_REACTIVE_HOUR,
         state_class=STATE_CLASS_TOTAL_INCREASING,
         icon="mdi:lightning-bolt-outline",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="energy_reactive_ac_produced",
@@ -286,6 +294,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ENERGY_VOLT_AMPERE_REACTIVE_HOUR,
         state_class=STATE_CLASS_TOTAL_INCREASING,
         icon="mdi:lightning-bolt-outline",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="energy_real_ac_minus",
@@ -293,6 +302,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ENERGY_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="energy_real_ac_plus",
@@ -300,6 +310,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ENERGY_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="energy_real_consumed",
@@ -333,6 +344,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_VOLT_AMPERE,
         state_class=STATE_CLASS_MEASUREMENT,
         icon="mdi:flash-outline",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_apparent_phase_2",
@@ -340,6 +352,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_VOLT_AMPERE,
         state_class=STATE_CLASS_MEASUREMENT,
         icon="mdi:flash-outline",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_apparent_phase_3",
@@ -347,6 +360,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_VOLT_AMPERE,
         state_class=STATE_CLASS_MEASUREMENT,
         icon="mdi:flash-outline",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_apparent",
@@ -354,24 +368,28 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_VOLT_AMPERE,
         state_class=STATE_CLASS_MEASUREMENT,
         icon="mdi:flash-outline",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_factor_phase_1",
         name="Power factor phase 1",
         device_class=DEVICE_CLASS_POWER_FACTOR,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_factor_phase_2",
         name="Power factor phase 2",
         device_class=DEVICE_CLASS_POWER_FACTOR,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_factor_phase_3",
         name="Power factor phase 3",
         device_class=DEVICE_CLASS_POWER_FACTOR,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_factor",
@@ -385,6 +403,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
         state_class=STATE_CLASS_MEASUREMENT,
         icon="mdi:flash-outline",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_reactive_phase_2",
@@ -392,6 +411,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
         state_class=STATE_CLASS_MEASUREMENT,
         icon="mdi:flash-outline",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_reactive_phase_3",
@@ -399,6 +419,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
         state_class=STATE_CLASS_MEASUREMENT,
         icon="mdi:flash-outline",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_reactive",
@@ -406,6 +427,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
         state_class=STATE_CLASS_MEASUREMENT,
         icon="mdi:flash-outline",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_real_phase_1",
@@ -413,6 +435,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_real_phase_2",
@@ -420,6 +443,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_real_phase_3",
@@ -427,6 +451,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="power_real",
@@ -441,6 +466,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         device_class=DEVICE_CLASS_VOLTAGE,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="voltage_ac_phase_2",
@@ -448,6 +474,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         device_class=DEVICE_CLASS_VOLTAGE,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="voltage_ac_phase_3",
@@ -455,6 +482,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         device_class=DEVICE_CLASS_VOLTAGE,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="voltage_ac_phase_to_phase_12",
@@ -462,6 +490,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         device_class=DEVICE_CLASS_VOLTAGE,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="voltage_ac_phase_to_phase_23",
@@ -469,6 +498,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         device_class=DEVICE_CLASS_VOLTAGE,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="voltage_ac_phase_to_phase_31",
@@ -476,6 +506,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         device_class=DEVICE_CLASS_VOLTAGE,
         state_class=STATE_CLASS_MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
 ]
 
@@ -486,6 +517,7 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ENERGY_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="energy_year",
@@ -493,6 +525,7 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ENERGY_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="energy_total",
@@ -500,6 +533,7 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=ENERGY_WATT_HOUR,
         device_class=DEVICE_CLASS_ENERGY,
         state_class=STATE_CLASS_TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="meter_mode",
@@ -555,11 +589,13 @@ STORAGE_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="capacity_maximum",
         name="Capacity maximum",
         native_unit_of_measurement=ELECTRIC_CHARGE_AMPERE_HOURS,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="capacity_designed",
         name="Capacity designed",
         native_unit_of_measurement=ELECTRIC_CHARGE_AMPERE_HOURS,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="current_dc",
@@ -584,6 +620,7 @@ STORAGE_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         device_class=DEVICE_CLASS_VOLTAGE,
         state_class=STATE_CLASS_MEASUREMENT,
         icon="mdi:current-dc",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="voltage_dc_minimum_cell",
@@ -592,6 +629,7 @@ STORAGE_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         device_class=DEVICE_CLASS_VOLTAGE,
         state_class=STATE_CLASS_MEASUREMENT,
         icon="mdi:current-dc",
+        entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
         key="state_of_charge",

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_FREQUENCY,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_POWER_FACTOR,
     DEVICE_CLASS_TEMPERATURE,
@@ -145,6 +146,7 @@ INVERTER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="frequency_ac",
         name="Frequency AC",
         native_unit_of_measurement=FREQUENCY_HERTZ,
+        device_class=DEVICE_CLASS_FREQUENCY,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     SensorEntityDescription(
@@ -317,6 +319,7 @@ METER_ENTITY_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="frequency_phase_average",
         name="Frequency phase average",
         native_unit_of_measurement=FREQUENCY_HERTZ,
+        device_class=DEVICE_CLASS_FREQUENCY,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     SensorEntityDescription(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- disable less popular Fronius entities by default
- use new device class Frequency

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #59686
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
