### PR TITLE
Use UsbServiceInfo in zwave-js

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -345,12 +345,12 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_in_progress():
             return self.async_abort(reason="already_in_progress")
 
-        vid = discovery_info["vid"]
-        pid = discovery_info["pid"]
-        serial_number = discovery_info["serial_number"]
-        device = discovery_info["device"]
-        manufacturer = discovery_info["manufacturer"]
-        description = discovery_info["description"]
+        vid = discovery_info.vid
+        pid = discovery_info.pid
+        serial_number = discovery_info.serial_number
+        device = discovery_info.device
+        manufacturer = discovery_info.manufacturer
+        description = discovery_info.description
         # Zooz uses this vid/pid, but so do 2652 sticks
         if vid == "10C4" and pid == "EA60" and description and "2652" in description:
             return self.async_abort(reason="not_zwave_device")

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -345,12 +345,12 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_in_progress():
             return self.async_abort(reason="already_in_progress")
 
-        vid = discovery_info["vid"]
-        pid = discovery_info["pid"]
-        serial_number = discovery_info["serial_number"]
-        device = discovery_info["device"]
-        manufacturer = discovery_info["manufacturer"]
-        description = discovery_info["description"]
+        vid = discovery_info[usb.ATTR_VID]
+        pid = discovery_info[usb.ATTR_PID]
+        serial_number = discovery_info[usb.ATTR_SERIAL_NUMBER]
+        device = discovery_info[usb.ATTR_DEVICE]
+        manufacturer = discovery_info[usb.ATTR_MANUFACTURER]
+        description = discovery_info[usb.ATTR_DESCRIPTION]
         # Zooz uses this vid/pid, but so do 2652 sticks
         if vid == "10C4" and pid == "EA60" and description and "2652" in description:
             return self.async_abort(reason="not_zwave_device")

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -345,12 +345,12 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_in_progress():
             return self.async_abort(reason="already_in_progress")
 
-        vid = discovery_info[usb.ATTR_VID]
-        pid = discovery_info[usb.ATTR_PID]
-        serial_number = discovery_info[usb.ATTR_SERIAL_NUMBER]
-        device = discovery_info[usb.ATTR_DEVICE]
-        manufacturer = discovery_info[usb.ATTR_MANUFACTURER]
-        description = discovery_info[usb.ATTR_DESCRIPTION]
+        vid = discovery_info["vid"]
+        pid = discovery_info["pid"]
+        serial_number = discovery_info["serial_number"]
+        device = discovery_info["device"]
+        manufacturer = discovery_info["manufacturer"]
+        description = discovery_info["description"]
         # Zooz uses this vid/pid, but so do 2652 sticks
         if vid == "10C4" and pid == "EA60" and description and "2652" in description:
             return self.async_abort(reason="not_zwave_device")

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -7,6 +7,7 @@ import pytest
 from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries
+from homeassistant.components import usb
 from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.zwave_js.config_flow import SERVER_VERSION_TIMEOUT, TITLE
 from homeassistant.components.zwave_js.const import DOMAIN
@@ -20,32 +21,32 @@ ADDON_DISCOVERY_INFO = {
 }
 
 
-USB_DISCOVERY_INFO = {
-    "device": "/dev/zwave",
-    "pid": "AAAA",
-    "vid": "AAAA",
-    "serial_number": "1234",
-    "description": "zwave radio",
-    "manufacturer": "test",
-}
+USB_DISCOVERY_INFO = usb.UsbServiceInfo(
+    device="/dev/zwave",
+    pid="AAAA",
+    vid="AAAA",
+    serial_number="1234",
+    description="zwave radio",
+    manufacturer="test",
+)
 
-NORTEK_ZIGBEE_DISCOVERY_INFO = {
-    "device": "/dev/zigbee",
-    "pid": "8A2A",
-    "vid": "10C4",
-    "serial_number": "1234",
-    "description": "nortek zigbee radio",
-    "manufacturer": "nortek",
-}
+NORTEK_ZIGBEE_DISCOVERY_INFO = usb.UsbServiceInfo(
+    device="/dev/zigbee",
+    pid="8A2A",
+    vid="10C4",
+    serial_number="1234",
+    description="nortek zigbee radio",
+    manufacturer="nortek",
+)
 
-CP2652_ZIGBEE_DISCOVERY_INFO = {
-    "device": "/dev/zigbee",
-    "pid": "EA60",
-    "vid": "10C4",
-    "serial_number": "",
-    "description": "cp2652",
-    "manufacturer": "generic",
-}
+CP2652_ZIGBEE_DISCOVERY_INFO = usb.UsbServiceInfo(
+    device="/dev/zigbee",
+    pid="EA60",
+    vid="10C4",
+    serial_number="",
+    description="cp2652",
+    manufacturer="generic",
+)
 
 
 @pytest.fixture(name="setup_entry")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `UsbServiceInfo` in `zwave-js`.

See home-assistant/architecture#662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
