### PR TITLE
Adjust async_step_discovery methods for BaseServiceInfo

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Iterable, Mapping
 from contextvars import ContextVar
+import dataclasses
 from enum import Enum
 import functools
 import logging
@@ -1378,7 +1379,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         self, discovery_info: ZeroconfServiceInfo
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by Zeroconf discovery."""
-        return await self.async_step_discovery(cast(dict, discovery_info))
+        return await self.async_step_discovery(dataclasses.asdict(discovery_info))
 
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1367,7 +1367,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         self, discovery_info: MqttServiceInfo
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by MQTT discovery."""
-        return await self.async_step_discovery(cast(dict, discovery_info))
+        return await self.async_step_discovery(dataclasses.asdict(discovery_info))
 
     async def async_step_ssdp(
         self, discovery_info: DiscoveryInfoType

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1385,7 +1385,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         self, discovery_info: DhcpServiceInfo
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by DHCP discovery."""
-        return await self.async_step_discovery(cast(dict, discovery_info))
+        return await self.async_step_discovery(dataclasses.asdict(discovery_info))
 
     async def async_step_usb(
         self, discovery_info: UsbServiceInfo

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1361,7 +1361,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         self, discovery_info: ZeroconfServiceInfo
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by Homekit discovery."""
-        return await self.async_step_discovery(cast(dict, discovery_info))
+        return await self.async_step_discovery(dataclasses.asdict(discovery_info))
 
     async def async_step_mqtt(
         self, discovery_info: MqttServiceInfo

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1391,7 +1391,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         self, discovery_info: UsbServiceInfo
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by USB discovery."""
-        return await self.async_step_discovery(cast(dict, discovery_info))
+        return await self.async_step_discovery(dataclasses.asdict(discovery_info))
 
     @callback
     def async_create_entry(  # pylint: disable=arguments-differ

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -5,12 +5,22 @@ from unittest.mock import patch
 from spotipy import SpotifyException
 
 from homeassistant import data_entry_flow, setup
+from homeassistant.components import zeroconf
 from homeassistant.components.spotify.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from tests.common import MockConfigEntry
+
+BLANK_ZEROCONF_INFO = zeroconf.ZeroconfServiceInfo(
+    host="1.2.3.4",
+    hostname="mock_hostname",
+    name="mock_name",
+    port=None,
+    properties={},
+    type="mock_type",
+)
 
 
 async def test_abort_if_no_configuration(hass):
@@ -23,7 +33,7 @@ async def test_abort_if_no_configuration(hass):
     assert result["reason"] == "missing_configuration"
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_ZEROCONF}
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=BLANK_ZEROCONF_INFO
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -35,7 +45,7 @@ async def test_zeroconf_abort_if_existing_entry(hass):
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_ZEROCONF}
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=BLANK_ZEROCONF_INFO
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -220,7 +220,9 @@ async def test_step_discovery(hass, flow_handler, local_impl):
     )
 
     result = await hass.config_entries.flow.async_init(
-        TEST_DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}
+        TEST_DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=data_entry_flow.BaseServiceInfo(),
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -242,7 +244,9 @@ async def test_abort_discovered_multiple(hass, flow_handler, local_impl):
     assert result["step_id"] == "pick_implementation"
 
     result = await hass.config_entries.flow.async_init(
-        TEST_DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}
+        TEST_DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=data_entry_flow.BaseServiceInfo(),
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow, loader
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CoreState, callback
-from homeassistant.data_entry_flow import RESULT_TYPE_ABORT
+from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, BaseServiceInfo
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
     ConfigEntryNotReady,
@@ -2350,13 +2350,13 @@ async def test_async_setup_update_entry(hass):
 @pytest.mark.parametrize(
     "discovery_source",
     (
-        config_entries.SOURCE_DISCOVERY,
-        config_entries.SOURCE_SSDP,
-        config_entries.SOURCE_USB,
-        config_entries.SOURCE_HOMEKIT,
-        config_entries.SOURCE_DHCP,
-        config_entries.SOURCE_ZEROCONF,
-        config_entries.SOURCE_HASSIO,
+        (config_entries.SOURCE_DISCOVERY, {}),
+        (config_entries.SOURCE_SSDP, {}),
+        (config_entries.SOURCE_USB, BaseServiceInfo()),
+        (config_entries.SOURCE_HOMEKIT, BaseServiceInfo()),
+        (config_entries.SOURCE_DHCP, BaseServiceInfo()),
+        (config_entries.SOURCE_ZEROCONF, BaseServiceInfo()),
+        (config_entries.SOURCE_HASSIO, {}),
     ),
 )
 async def test_flow_with_default_discovery(hass, manager, discovery_source):
@@ -2382,7 +2382,7 @@ async def test_flow_with_default_discovery(hass, manager, discovery_source):
     with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
         # Create one to be in progress
         result = await manager.flow.async_init(
-            "comp", context={"source": discovery_source}
+            "comp", context={"source": discovery_source[0]}, data=discovery_source[1]
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
@@ -2403,7 +2403,7 @@ async def test_flow_with_default_discovery(hass, manager, discovery_source):
 
     entry = hass.config_entries.async_entries("comp")[0]
     assert entry.title == "yo"
-    assert entry.source == discovery_source
+    assert entry.source == discovery_source[0]
     assert entry.unique_id is None
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I think this was missed following the `TypedDict` > `dataclass` migration of https://github.com/home-assistant/architecture/discussions/662

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
