### PR TITLE
Use SsdpServiceInfo for ssdp tests (part 2)

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -101,7 +101,7 @@ class _SsdpServiceDescription:
 
     ssdp_usn: str
     ssdp_st: str
-    ssdp_location: str
+    ssdp_location: str | None = None
     ssdp_nt: str | None = None
     ssdp_udn: str | None = None
     ssdp_ext: str | None = None

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -5,7 +5,7 @@ import pytest
 import respx
 
 from homeassistant import data_entry_flow
-from homeassistant.components import dhcp, zeroconf
+from homeassistant.components import dhcp, ssdp, zeroconf
 from homeassistant.components.axis import config_flow
 from homeassistant.components.axis.const import (
     CONF_EVENTS,
@@ -263,32 +263,36 @@ async def test_reauth_flow_update_configuration(hass):
         ),
         (
             SOURCE_SSDP,
-            {
-                "st": "urn:axis-com:service:BasicService:1",
-                "usn": f"uuid:Upnp-BasicDevice-1_0-{MAC}::urn:axis-com:service:BasicService:1",
-                "ext": "",
-                "server": "Linux/4.14.173-axis8, UPnP/1.0, Portable SDK for UPnP devices/1.8.7",
-                "deviceType": "urn:schemas-upnp-org:device:Basic:1",
-                "friendlyName": f"AXIS M1065-LW - {MAC}",
-                "manufacturer": "AXIS",
-                "manufacturerURL": "http://www.axis.com/",
-                "modelDescription": "AXIS M1065-LW Network Camera",
-                "modelName": "AXIS M1065-LW",
-                "modelNumber": "M1065-LW",
-                "modelURL": "http://www.axis.com/",
-                "serialNumber": MAC,
-                "UDN": f"uuid:Upnp-BasicDevice-1_0-{MAC}",
-                "serviceList": {
-                    "service": {
-                        "serviceType": "urn:axis-com:service:BasicService:1",
-                        "serviceId": "urn:axis-com:serviceId:BasicServiceId",
-                        "controlURL": "/upnp/control/BasicServiceId",
-                        "eventSubURL": "/upnp/event/BasicServiceId",
-                        "SCPDURL": "/scpd_basic.xml",
-                    }
+            ssdp.SsdpServiceInfo(
+                ssdp_usn="mock_usn",
+                ssdp_st="mock_st",
+                upnp={
+                    "st": "urn:axis-com:service:BasicService:1",
+                    "usn": f"uuid:Upnp-BasicDevice-1_0-{MAC}::urn:axis-com:service:BasicService:1",
+                    "ext": "",
+                    "server": "Linux/4.14.173-axis8, UPnP/1.0, Portable SDK for UPnP devices/1.8.7",
+                    "deviceType": "urn:schemas-upnp-org:device:Basic:1",
+                    "friendlyName": f"AXIS M1065-LW - {MAC}",
+                    "manufacturer": "AXIS",
+                    "manufacturerURL": "http://www.axis.com/",
+                    "modelDescription": "AXIS M1065-LW Network Camera",
+                    "modelName": "AXIS M1065-LW",
+                    "modelNumber": "M1065-LW",
+                    "modelURL": "http://www.axis.com/",
+                    "serialNumber": MAC,
+                    "UDN": f"uuid:Upnp-BasicDevice-1_0-{MAC}",
+                    "serviceList": {
+                        "service": {
+                            "serviceType": "urn:axis-com:service:BasicService:1",
+                            "serviceId": "urn:axis-com:serviceId:BasicServiceId",
+                            "controlURL": "/upnp/control/BasicServiceId",
+                            "eventSubURL": "/upnp/event/BasicServiceId",
+                            "SCPDURL": "/scpd_basic.xml",
+                        }
+                    },
+                    "presentationURL": f"http://{DEFAULT_HOST}:80/",
                 },
-                "presentationURL": f"http://{DEFAULT_HOST}:80/",
-            },
+            ),
         ),
         (
             SOURCE_ZEROCONF,
@@ -354,11 +358,15 @@ async def test_discovery_flow(hass, source: str, discovery_info: dict):
         ),
         (
             SOURCE_SSDP,
-            {
-                "friendlyName": f"AXIS M1065-LW - {MAC}",
-                "serialNumber": MAC,
-                "presentationURL": f"http://{DEFAULT_HOST}:80/",
-            },
+            ssdp.SsdpServiceInfo(
+                ssdp_usn="mock_usn",
+                ssdp_st="mock_st",
+                upnp={
+                    "friendlyName": f"AXIS M1065-LW - {MAC}",
+                    "serialNumber": MAC,
+                    "presentationURL": f"http://{DEFAULT_HOST}:80/",
+                },
+            ),
         ),
         (
             SOURCE_ZEROCONF,
@@ -403,11 +411,15 @@ async def test_discovered_device_already_configured(
         ),
         (
             SOURCE_SSDP,
-            {
-                "friendlyName": f"AXIS M1065-LW - {MAC}",
-                "serialNumber": MAC,
-                "presentationURL": "http://2.3.4.5:8080/",
-            },
+            ssdp.SsdpServiceInfo(
+                ssdp_usn="mock_usn",
+                ssdp_st="mock_st",
+                upnp={
+                    "friendlyName": f"AXIS M1065-LW - {MAC}",
+                    "serialNumber": MAC,
+                    "presentationURL": "http://2.3.4.5:8080/",
+                },
+            ),
             8080,
         ),
         (
@@ -474,11 +486,15 @@ async def test_discovery_flow_updated_configuration(
         ),
         (
             SOURCE_SSDP,
-            {
-                "friendlyName": "",
-                "serialNumber": "01234567890",
-                "presentationURL": "",
-            },
+            ssdp.SsdpServiceInfo(
+                ssdp_usn="mock_usn",
+                ssdp_st="mock_st",
+                upnp={
+                    "friendlyName": "",
+                    "serialNumber": "01234567890",
+                    "presentationURL": "",
+                },
+            ),
         ),
         (
             SOURCE_ZEROCONF,
@@ -518,11 +534,15 @@ async def test_discovery_flow_ignore_non_axis_device(
         ),
         (
             SOURCE_SSDP,
-            {
-                "friendlyName": f"AXIS M1065-LW - {MAC}",
-                "serialNumber": MAC,
-                "presentationURL": "http://169.254.3.4:80/",
-            },
+            ssdp.SsdpServiceInfo(
+                ssdp_usn="mock_usn",
+                ssdp_st="mock_st",
+                upnp={
+                    "friendlyName": f"AXIS M1065-LW - {MAC}",
+                    "serialNumber": MAC,
+                    "presentationURL": "http://169.254.3.4:80/",
+                },
+            ),
         ),
         (
             SOURCE_ZEROCONF,

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -7,7 +7,7 @@ from aionanoleaf import InvalidToken, NanoleafException, Unauthorized, Unavailab
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
+from homeassistant.components import ssdp, zeroconf
 from homeassistant.components.nanoleaf.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
@@ -462,11 +462,15 @@ async def test_ssdp_discovery(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
-            data={
-                "_host": TEST_HOST,
-                "nl-devicename": TEST_NAME,
-                "nl-deviceid": TEST_DEVICE_ID,
-            },
+            data=ssdp.SsdpServiceInfo(
+                ssdp_usn="mock_usn",
+                ssdp_st="mock_st",
+                upnp={
+                    "_host": TEST_HOST,
+                    "nl-devicename": TEST_NAME,
+                    "nl-deviceid": TEST_DEVICE_ID,
+                },
+            ),
         )
 
         assert result["type"] == "form"

--- a/tests/components/octoprint/test_config_flow.py
+++ b/tests/components/octoprint/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from pyoctoprintapi import ApiError, DiscoverySettings
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components import zeroconf
+from homeassistant.components import ssdp, zeroconf
 from homeassistant.components.octoprint.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
@@ -235,11 +235,15 @@ async def test_show_ssdp_form(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data={
-            "presentationURL": "http://192.168.1.123:80/discovery/device.xml",
-            "port": 80,
-            "UDN": "uuid:83747482",
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            upnp={
+                "presentationURL": "http://192.168.1.123:80/discovery/device.xml",
+                "port": 80,
+                "UDN": "uuid:83747482",
+            },
+        ),
     )
     assert result["type"] == "form"
     assert not result["errors"]
@@ -512,11 +516,15 @@ async def test_duplicate_ssdp_ignored(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data={
-            "presentationURL": "http://192.168.1.123:80/discovery/device.xml",
-            "port": 80,
-            "UDN": "uuid:83747482",
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            upnp={
+                "presentationURL": "http://192.168.1.123:80/discovery/device.xml",
+                "port": 80,
+                "UDN": "uuid:83747482",
+            },
+        ),
     )
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
+from homeassistant.components import dhcp, ssdp, zeroconf
 from homeassistant.components.yeelight.config_flow import MODEL_UNKNOWN, CannotConnect
 from homeassistant.components.yeelight.const import (
     CONF_DETECTED_MODEL,
@@ -51,6 +51,12 @@ DEFAULT_CONFIG = {
     CONF_SAVE_ON_CHANGE: DEFAULT_SAVE_ON_CHANGE,
     CONF_NIGHTLIGHT_SWITCH: DEFAULT_NIGHTLIGHT_SWITCH,
 }
+
+SSDP_INFO = ssdp.SsdpServiceInfo(
+    ssdp_usn="mock_usn",
+    ssdp_st="mock_st",
+    upnp=CAPABILITIES,
+)
 
 
 async def test_discovery(hass: HomeAssistant):
@@ -627,7 +633,7 @@ async def test_discovered_ssdp(hass):
         f"{MODULE_CONFIG_FLOW}.AsyncBulb", return_value=mocked_bulb
     ):
         result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=CAPABILITIES
+            DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=SSDP_INFO
         )
         await hass.async_block_till_done()
 
@@ -656,7 +662,7 @@ async def test_discovered_ssdp(hass):
         f"{MODULE_CONFIG_FLOW}.AsyncBulb", return_value=mocked_bulb
     ):
         result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=CAPABILITIES
+            DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=SSDP_INFO
         )
         await hass.async_block_till_done()
 
@@ -719,7 +725,7 @@ async def test_discovered_zeroconf(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
-            data=CAPABILITIES,
+            data=SSDP_INFO,
         )
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `SsdpServiceInfo` for `SOURCE_SSDP` tests (part 2) as preliminary work for #59931.

They are split out from part 1 because the `ssdp_location` needs to be made optional (or we update the tests with a default value `ssdp_location="mock_location"`) 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
