### PR TITLE
Adjust/Fix CI coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -711,19 +711,22 @@ jobs:
             --timeout=9 \
             --durations=10 \
             -n auto \
-            --dist=loadfile \
             --cov homeassistant.components.${{ matrix.group }} \
             --cov-report= \
+            --cov-report=term-missing \
             -o console_output_style=count \
             -p no:sugar \
             tests/components/${{ matrix.group }}
       - name: Upload coverage to Codecov (full coverage)
         if: needs.changes.outputs.test_full_suite == 'true'
         uses: codecov/codecov-action@v2.1.0
+        with:
+          files: .coverage
       - name: Upload coverage to Codecov (partial coverage)
         if: needs.changes.outputs.test_full_suite == 'false'
         uses: codecov/codecov-action@v2.1.0
         with:
+          files: .coverage
           flags: ${{ matrix.group }}
       - name: Check dirty
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -698,7 +698,7 @@ jobs:
             --test-group-count ${{ needs.changes.outputs.test_group_count }} \
             --test-group=${{ matrix.group }} \
             --cov homeassistant \
-            --cov-report= \
+            --cov-report=xml \
             -o console_output_style=count \
             -p no:sugar \
             tests
@@ -712,7 +712,7 @@ jobs:
             --durations=10 \
             -n auto \
             --cov homeassistant.components.${{ matrix.group }} \
-            --cov-report= \
+            --cov-report=xml \
             --cov-report=term-missing \
             -o console_output_style=count \
             -p no:sugar \
@@ -721,12 +721,12 @@ jobs:
         if: needs.changes.outputs.test_full_suite == 'true'
         uses: codecov/codecov-action@v2.1.0
         with:
-          files: .coverage
+          files: coverage.xml
       - name: Upload coverage to Codecov (partial coverage)
         if: needs.changes.outputs.test_full_suite == 'false'
         uses: codecov/codecov-action@v2.1.0
         with:
-          files: .coverage
+          files: coverage.xml
           flags: ${{ matrix.group }}
       - name: Check dirty
         run: |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We are currently experiencing issues with coverage reporting on Codecov.

However, this might not be fully related to Codecov, but the new CI.

This PR adjust:

- Remove useless `dist` flag from partial tests
- Adds term missing report in partial tests, so results of these smaller suites can be viewed in the build log
- Explicitly tell codecov the file to pick up.
 
The uploaded results to codecov contain anything but coverage results, looking the build logs, it seems to find a lot of file, but not the coverage file:

```txt
[2021-11-25T12:19:10.248Z] ['info'] 
     _____          _
    / ____|        | |
   | |     ___   __| | ___  ___ _____   __
   | |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
   | |___| (_) | (_| |  __/ (_| (_) \ V /
    \_____\___/ \__,_|\___|\___\___/ \_/

  Codecov report uploader 0.1.13
[2021-11-25T12:19:10.253Z] ['info'] => Project root located at: /__w/core/core
[2021-11-25T12:19:10.256Z] ['info'] -> No token specified or token is empty
[2021-11-25T12:19:11.567Z] ['info'] Searching for coverage files...
[2021-11-25T12:19:13.099Z] ['info'] => Found 16 possible coverage files:
  script/hassfest/coverage.py
  venv/bin/coverage-3.9
  venv/lib/python3.9/site-packages/coverage/htmlfiles/coverage_html.js
  venv/lib/python3.9/site-packages/sphinx/ext/coverage.py
  venv/lib64/python3.9/site-packages/coverage/htmlfiles/coverage_html.js
  venv/lib64/python3.9/site-packages/sphinx/ext/coverage.py
  venv/lib/python3.9/site-packages/debugpy/_vendored/pydevd/pydev_coverage.py
  venv/lib/python3.9/site-packages/sphinx/ext/__pycache__/coverage.cpython-39.pyc
  venv/lib64/python3.9/site-packages/debugpy/_vendored/pydevd/pydev_coverage.py
  venv/lib64/python3.9/site-packages/sphinx/ext/__pycache__/coverage.cpython-39.pyc
  venv/lib/python3.9/site-packages/debugpy/_vendored/pydevd/__pycache__/pydev_coverage.cpython-39.pyc
  venv/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydev_runfiles/pydev_runfiles_coverage.py
  venv/lib64/python3.9/site-packages/debugpy/_vendored/pydevd/__pycache__/pydev_coverage.cpython-39.pyc
  venv/lib64/python3.9/site-packages/debugpy/_vendored/pydevd/_pydev_runfiles/pydev_runfiles_coverage.py
  venv/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydev_runfiles/__pycache__/pydev_runfiles_coverage.cpython-39.pyc
  venv/lib64/python3.9/site-packages/debugpy/_vendored/pydevd/_pydev_runfiles/__pycache__/pydev_runfiles_coverage.cpython-39.pyc
[2021-11-25T12:19:13.099Z] ['info'] Processing /__w/core/core/script/hassfest/coverage.py...
[2021-11-25T12:19:13.102Z] ['info'] Processing /__w/core/core/venv/bin/coverage-3.9...
[2021-11-25T12:19:13.103Z] ['info'] Processing /__w/core/core/venv/lib/python3.9/site-packages/coverage/htmlfiles/coverage_html.js...
[2021-11-25T12:19:13.103Z] ['info'] Processing /__w/core/core/venv/lib/python3.9/site-packages/sphinx/ext/coverage.py...
[2021-11-25T12:19:13.104Z] ['info'] Processing /__w/core/core/venv/lib64/python3.9/site-packages/coverage/htmlfiles/coverage_html.js...
[2021-11-25T12:19:13.105Z] ['info'] Processing /__w/core/core/venv/lib64/python3.9/site-packages/sphinx/ext/coverage.py...
[2021-11-25T12:19:13.105Z] ['info'] Processing /__w/core/core/venv/lib/python3.9/site-packages/debugpy/_vendored/pydevd/pydev_coverage.py...
[2021-11-25T12:19:13.106Z] ['info'] Processing /__w/core/core/venv/lib/python3.9/site-packages/sphinx/ext/__pycache__/coverage.cpython-39.pyc...
[2021-11-25T12:19:13.107Z] ['info'] Processing /__w/core/core/venv/lib64/python3.9/site-packages/debugpy/_vendored/pydevd/pydev_coverage.py...
[2021-11-25T12:19:13.107Z] ['info'] Processing /__w/core/core/venv/lib64/python3.9/site-packages/sphinx/ext/__pycache__/coverage.cpython-39.pyc...
[2021-11-25T12:19:13.108Z] ['info'] Processing /__w/core/core/venv/lib/python3.9/site-packages/debugpy/_vendored/pydevd/__pycache__/pydev_coverage.cpython-39.pyc...
[2021-11-25T12:19:13.109Z] ['info'] Processing /__w/core/core/venv/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydev_runfiles/pydev_runfiles_coverage.py...
[2021-11-25T12:19:13.110Z] ['info'] Processing /__w/core/core/venv/lib64/python3.9/site-packages/debugpy/_vendored/pydevd/__pycache__/pydev_coverage.cpython-39.pyc...
[2021-11-25T12:19:13.110Z] ['info'] Processing /__w/core/core/venv/lib64/python3.9/site-packages/debugpy/_vendored/pydevd/_pydev_runfiles/pydev_runfiles_coverage.py...
[2021-11-25T12:19:13.111Z] ['info'] Processing /__w/core/core/venv/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydev_runfiles/__pycache__/pydev_runfiles_coverage.cpython-39.pyc...
[2021-11-25T12:19:13.112Z] ['info'] Processing /__w/core/core/venv/lib64/python3.9/site-packages/debugpy/_vendored/pydevd/_pydev_runfiles/__pycache__/pydev_runfiles_coverage.cpython-39.pyc...
[2021-11-25T12:19:13.291Z] ['info'] Detected GitHub Actions as the CI provider.
[2021-11-25T12:19:13.293Z] ['info'] Pinging Codecov: codecov.io/upload/v4?package=github-action-2.1.0-uploader-0.1.13&token=*******&branch=tolo-select&build=1503638895&build_url=https%3A%2F%2Fgithub.com%2Fhome-assistant%2Fcore%2Factions%2Fruns%2F1503638895&commit=62b577a6b936e6b284e3be731a86cce6977336af&job=CI&pr=60326&service=github-actions&slug=home-assistant%2Fcore&name=&tag=&flags=tolo&parent=
[2021-11-25T12:19:13.747Z] ['info'] Uploading...
[2021-11-25T12:19:14.002Z] ['info'] {"status":"success","resultURL":"codecov.io/github/home-assistant/core/commit/62b577a6b936e6b284e3be731a86cce6977336af"}
```

By pointing to the specific file, this should be resolved.

Results:

![image](https://user-images.githubusercontent.com/195327/143453736-8277d4b7-a074-41f7-b030-9fa80b97211e.png)

![image](https://user-images.githubusercontent.com/195327/143453766-a5b541d1-5363-405a-b590-c361f03061e6.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
