### PR TITLE
Use SsdpServiceInfo for ssdp tests (part 3)

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -146,6 +146,24 @@ class SsdpServiceInfo(
             return getattr(self, name)
         return self.upnp.get(name)
 
+    def get(self, name: str, default: Any = None) -> Any:
+        """
+        Allow property access by name for compatibility reason.
+
+        Deprecated, and will be removed in version 2022.6.
+        """
+        if not self._warning_logged:
+            report(
+                f"accessed discovery_info.get('{name}') instead of discovery_info.{name}; this will fail in version 2022.6",
+                exclude_integrations={"ssdp"},
+                error_if_core=False,
+                level=logging.DEBUG,
+            )
+            self._warning_logged = True
+        if hasattr(self, name):
+            return getattr(self, name)
+        return self.upnp.get(name, default)
+
 
 @bind_hass
 async def async_register_callback(

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -450,7 +450,6 @@ async def test_flow_ssdp_bad_discovery(hass, aioclient_mock):
         data=ssdp.SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
-            ssdp_location="mock_location",
             upnp={ATTR_UPNP_MANUFACTURER_URL: "other"},
         ),
         context={"source": SOURCE_SSDP},

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pydeconz
 
+from homeassistant.components import ssdp
 from homeassistant.components.deconz.config_flow import (
     CONF_MANUAL_INPUT,
     CONF_SERIAL,
@@ -17,11 +18,7 @@ from homeassistant.components.deconz.const import (
     CONF_MASTER_GATEWAY,
     DOMAIN as DECONZ_DOMAIN,
 )
-from homeassistant.components.ssdp import (
-    ATTR_SSDP_LOCATION,
-    ATTR_UPNP_MANUFACTURER_URL,
-    ATTR_UPNP_SERIAL,
-)
+from homeassistant.components.ssdp import ATTR_UPNP_MANUFACTURER_URL, ATTR_UPNP_SERIAL
 from homeassistant.config_entries import (
     SOURCE_HASSIO,
     SOURCE_REAUTH,
@@ -412,11 +409,15 @@ async def test_flow_ssdp_discovery(hass, aioclient_mock):
     """Test that config flow for one discovered bridge works."""
     result = await hass.config_entries.flow.async_init(
         DECONZ_DOMAIN,
-        data={
-            ATTR_SSDP_LOCATION: "http://1.2.3.4:80/",
-            ATTR_UPNP_MANUFACTURER_URL: DECONZ_MANUFACTURERURL,
-            ATTR_UPNP_SERIAL: BRIDGEID,
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location="http://1.2.3.4:80/",
+            upnp={
+                ATTR_UPNP_MANUFACTURER_URL: DECONZ_MANUFACTURERURL,
+                ATTR_UPNP_SERIAL: BRIDGEID,
+            },
+        ),
         context={"source": SOURCE_SSDP},
     )
 
@@ -446,7 +447,12 @@ async def test_flow_ssdp_bad_discovery(hass, aioclient_mock):
     """Test that SSDP discovery aborts if manufacturer URL is wrong."""
     result = await hass.config_entries.flow.async_init(
         DECONZ_DOMAIN,
-        data={ATTR_UPNP_MANUFACTURER_URL: "other"},
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location="mock_location",
+            upnp={ATTR_UPNP_MANUFACTURER_URL: "other"},
+        ),
         context={"source": SOURCE_SSDP},
     )
 
@@ -464,11 +470,15 @@ async def test_ssdp_discovery_update_configuration(hass, aioclient_mock):
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
             DECONZ_DOMAIN,
-            data={
-                ATTR_SSDP_LOCATION: "http://2.3.4.5:80/",
-                ATTR_UPNP_MANUFACTURER_URL: DECONZ_MANUFACTURERURL,
-                ATTR_UPNP_SERIAL: BRIDGEID,
-            },
+            data=ssdp.SsdpServiceInfo(
+                ssdp_usn="mock_usn",
+                ssdp_st="mock_st",
+                ssdp_location="http://2.3.4.5:80/",
+                upnp={
+                    ATTR_UPNP_MANUFACTURER_URL: DECONZ_MANUFACTURERURL,
+                    ATTR_UPNP_SERIAL: BRIDGEID,
+                },
+            ),
             context={"source": SOURCE_SSDP},
         )
         await hass.async_block_till_done()
@@ -485,11 +495,15 @@ async def test_ssdp_discovery_dont_update_configuration(hass, aioclient_mock):
 
     result = await hass.config_entries.flow.async_init(
         DECONZ_DOMAIN,
-        data={
-            ATTR_SSDP_LOCATION: "http://1.2.3.4:80/",
-            ATTR_UPNP_MANUFACTURER_URL: DECONZ_MANUFACTURERURL,
-            ATTR_UPNP_SERIAL: BRIDGEID,
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location="http://1.2.3.4:80/",
+            upnp={
+                ATTR_UPNP_MANUFACTURER_URL: DECONZ_MANUFACTURERURL,
+                ATTR_UPNP_SERIAL: BRIDGEID,
+            },
+        ),
         context={"source": SOURCE_SSDP},
     )
 
@@ -508,11 +522,15 @@ async def test_ssdp_discovery_dont_update_existing_hassio_configuration(
 
     result = await hass.config_entries.flow.async_init(
         DECONZ_DOMAIN,
-        data={
-            ATTR_SSDP_LOCATION: "http://1.2.3.4:80/",
-            ATTR_UPNP_MANUFACTURER_URL: DECONZ_MANUFACTURERURL,
-            ATTR_UPNP_SERIAL: BRIDGEID,
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location="http://1.2.3.4:80/",
+            upnp={
+                ATTR_UPNP_MANUFACTURER_URL: DECONZ_MANUFACTURERURL,
+                ATTR_UPNP_SERIAL: BRIDGEID,
+            },
+        ),
         context={"source": SOURCE_SSDP},
     )
 

--- a/tests/components/directv/__init__.py
+++ b/tests/components/directv/__init__.py
@@ -1,8 +1,8 @@
 """Tests for the DirecTV component."""
 from http import HTTPStatus
 
+from homeassistant.components import ssdp
 from homeassistant.components.directv.const import CONF_RECEIVER_ID, DOMAIN
-from homeassistant.components.ssdp import ATTR_SSDP_LOCATION
 from homeassistant.const import CONF_HOST, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
 
@@ -15,7 +15,12 @@ SSDP_LOCATION = "http://127.0.0.1/"
 UPNP_SERIAL = "RID-028877455858"
 
 MOCK_CONFIG = {DOMAIN: [{CONF_HOST: HOST}]}
-MOCK_SSDP_DISCOVERY_INFO = {ATTR_SSDP_LOCATION: SSDP_LOCATION}
+MOCK_SSDP_DISCOVERY_INFO = ssdp.SsdpServiceInfo(
+    ssdp_usn="mock_usn",
+    ssdp_st="mock_st",
+    ssdp_location=SSDP_LOCATION,
+    upnp={},
+)
 MOCK_USER_INPUT = {CONF_HOST: HOST}
 
 

--- a/tests/components/directv/test_config_flow.py
+++ b/tests/components/directv/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the DirecTV config flow."""
+import dataclasses
 from unittest.mock import patch
 
 from aiohttp import ClientError as HTTPClientError
@@ -43,7 +44,7 @@ async def test_show_ssdp_form(
     """Test that the ssdp confirmation form is served."""
     mock_connection(aioclient_mock)
 
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_SSDP}, data=discovery_info
     )
@@ -77,7 +78,7 @@ async def test_ssdp_cannot_connect(
     """Test we abort SSDP flow on connection error."""
     aioclient_mock.get("http://127.0.0.1:8080/info/getVersion", exc=HTTPClientError)
 
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_SSDP},
@@ -94,7 +95,7 @@ async def test_ssdp_confirm_cannot_connect(
     """Test we abort SSDP flow on connection error."""
     aioclient_mock.get("http://127.0.0.1:8080/info/getVersion", exc=HTTPClientError)
 
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_SSDP, CONF_HOST: HOST, CONF_NAME: HOST},
@@ -128,7 +129,7 @@ async def test_ssdp_device_exists_abort(
     """Test we abort SSDP flow if DirecTV receiver already configured."""
     await setup_integration(hass, aioclient_mock, skip_entry_setup=True)
 
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_SSDP},
@@ -145,8 +146,8 @@ async def test_ssdp_with_receiver_id_device_exists_abort(
     """Test we abort SSDP flow if DirecTV receiver already configured."""
     await setup_integration(hass, aioclient_mock, skip_entry_setup=True)
 
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
-    discovery_info[ATTR_UPNP_SERIAL] = UPNP_SERIAL
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
+    discovery_info.upnp[ATTR_UPNP_SERIAL] = UPNP_SERIAL
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_SSDP},
@@ -180,7 +181,7 @@ async def test_ssdp_unknown_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort SSDP flow on unknown error."""
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     with patch(
         "homeassistant.components.directv.config_flow.DIRECTV.update",
         side_effect=Exception,
@@ -199,7 +200,7 @@ async def test_ssdp_confirm_unknown_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort SSDP flow on unknown error."""
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     with patch(
         "homeassistant.components.directv.config_flow.DIRECTV.update",
         side_effect=Exception,
@@ -249,7 +250,7 @@ async def test_full_ssdp_flow_implementation(
     """Test the full SSDP flow from start to finish."""
     mock_connection(aioclient_mock)
 
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_SSDP}, data=discovery_info
     )

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for AVM Fritz!Box config flow."""
+import dataclasses
 from unittest import mock
 from unittest.mock import Mock, patch
 
@@ -6,12 +7,9 @@ from pyfritzhome import LoginError
 import pytest
 from requests.exceptions import HTTPError
 
+from homeassistant.components import ssdp
 from homeassistant.components.fritzbox.const import DOMAIN
-from homeassistant.components.ssdp import (
-    ATTR_SSDP_LOCATION,
-    ATTR_UPNP_FRIENDLY_NAME,
-    ATTR_UPNP_UDN,
-)
+from homeassistant.components.ssdp import ATTR_UPNP_FRIENDLY_NAME, ATTR_UPNP_UDN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -26,11 +24,15 @@ from .const import CONF_FAKE_NAME, MOCK_CONFIG
 from tests.common import MockConfigEntry
 
 MOCK_USER_DATA = MOCK_CONFIG[DOMAIN][CONF_DEVICES][0]
-MOCK_SSDP_DATA = {
-    ATTR_SSDP_LOCATION: "https://fake_host:12345/test",
-    ATTR_UPNP_FRIENDLY_NAME: CONF_FAKE_NAME,
-    ATTR_UPNP_UDN: "uuid:only-a-test",
-}
+MOCK_SSDP_DATA = ssdp.SsdpServiceInfo(
+    ssdp_usn="mock_usn",
+    ssdp_st="mock_st",
+    ssdp_location="https://fake_host:12345/test",
+    upnp={
+        ATTR_UPNP_FRIENDLY_NAME: CONF_FAKE_NAME,
+        ATTR_UPNP_UDN: "uuid:only-a-test",
+    },
+)
 
 
 @pytest.fixture(name="fritz")
@@ -201,8 +203,9 @@ async def test_ssdp(hass: HomeAssistant, fritz: Mock):
 
 async def test_ssdp_no_friendly_name(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow from discovery without friendly name."""
-    MOCK_NO_NAME = MOCK_SSDP_DATA.copy()
-    del MOCK_NO_NAME[ATTR_UPNP_FRIENDLY_NAME]
+    MOCK_NO_NAME = dataclasses.replace(MOCK_SSDP_DATA)
+    MOCK_NO_NAME.upnp = MOCK_NO_NAME.upnp.copy()
+    del MOCK_NO_NAME.upnp[ATTR_UPNP_FRIENDLY_NAME]
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_NO_NAME
     )
@@ -300,8 +303,9 @@ async def test_ssdp_already_in_progress_host(hass: HomeAssistant, fritz: Mock):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["step_id"] == "confirm"
 
-    MOCK_NO_UNIQUE_ID = MOCK_SSDP_DATA.copy()
-    del MOCK_NO_UNIQUE_ID[ATTR_UPNP_UDN]
+    MOCK_NO_UNIQUE_ID = dataclasses.replace(MOCK_SSDP_DATA)
+    MOCK_NO_UNIQUE_ID.upnp = MOCK_NO_UNIQUE_ID.upnp.copy()
+    del MOCK_NO_UNIQUE_ID.upnp[ATTR_UPNP_UDN]
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_NO_UNIQUE_ID
     )

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -177,19 +177,22 @@ async def test_ssdp(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context=context,
-        data={
-            ssdp.ATTR_SSDP_LOCATION: "http://192.168.100.1:60957/rootDesc.xml",
-            ssdp.ATTR_SSDP_ST: "upnp:rootdevice",
-            ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:InternetGatewayDevice:1",
-            ssdp.ATTR_UPNP_FRIENDLY_NAME: "Mobile Wi-Fi",
-            ssdp.ATTR_UPNP_MANUFACTURER: "Huawei",
-            ssdp.ATTR_UPNP_MANUFACTURER_URL: "http://www.huawei.com/",
-            ssdp.ATTR_UPNP_MODEL_NAME: "Huawei router",
-            ssdp.ATTR_UPNP_MODEL_NUMBER: "12345678",
-            ssdp.ATTR_UPNP_PRESENTATION_URL: url,
-            ssdp.ATTR_UPNP_SERIAL: "00000000",
-            ssdp.ATTR_UPNP_UDN: "uuid:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="upnp:rootdevice",
+            ssdp_location="http://192.168.100.1:60957/rootDesc.xml",
+            upnp={
+                ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+                ssdp.ATTR_UPNP_FRIENDLY_NAME: "Mobile Wi-Fi",
+                ssdp.ATTR_UPNP_MANUFACTURER: "Huawei",
+                ssdp.ATTR_UPNP_MANUFACTURER_URL: "http://www.huawei.com/",
+                ssdp.ATTR_UPNP_MODEL_NAME: "Huawei router",
+                ssdp.ATTR_UPNP_MODEL_NUMBER: "12345678",
+                ssdp.ATTR_UPNP_PRESENTATION_URL: url,
+                ssdp.ATTR_UPNP_SERIAL: "00000000",
+                ssdp.ATTR_UPNP_UDN: "uuid:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+            },
+        ),
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/components/keenetic_ndms2/__init__.py
+++ b/tests/components/keenetic_ndms2/__init__.py
@@ -29,8 +29,12 @@ MOCK_OPTIONS = {
     const.CONF_INTERFACES: ["Home", "VPS0"],
 }
 
-MOCK_SSDP_DISCOVERY_INFO = {
-    ssdp.ATTR_SSDP_LOCATION: SSDP_LOCATION,
-    ssdp.ATTR_UPNP_UDN: "uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    ssdp.ATTR_UPNP_FRIENDLY_NAME: MOCK_NAME,
-}
+MOCK_SSDP_DISCOVERY_INFO = ssdp.SsdpServiceInfo(
+    ssdp_usn="mock_usn",
+    ssdp_st="mock_st",
+    ssdp_location=SSDP_LOCATION,
+    upnp={
+        ssdp.ATTR_UPNP_UDN: "uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        ssdp.ATTR_UPNP_FRIENDLY_NAME: MOCK_NAME,
+    },
+)

--- a/tests/components/keenetic_ndms2/test_config_flow.py
+++ b/tests/components/keenetic_ndms2/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test Keenetic NDMS2 setup process."""
 
+import dataclasses
 from unittest.mock import Mock, patch
 
 from ndms2_client import ConnectionException
@@ -164,7 +165,7 @@ async def test_connection_error(hass: HomeAssistant, connect_error) -> None:
 async def test_ssdp_works(hass: HomeAssistant, connect) -> None:
     """Test host already configured and discovered."""
 
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
         keenetic.DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},
@@ -200,7 +201,7 @@ async def test_ssdp_already_configured(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
         keenetic.DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},
@@ -221,7 +222,7 @@ async def test_ssdp_ignored(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
         keenetic.DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},
@@ -245,10 +246,8 @@ async def test_ssdp_update_host(hass: HomeAssistant) -> None:
 
     new_ip = "10.10.10.10"
 
-    discovery_info = {
-        **MOCK_SSDP_DISCOVERY_INFO,
-        ssdp.ATTR_SSDP_LOCATION: f"http://{new_ip}/",
-    }
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
+    discovery_info.ssdp_location = f"http://{new_ip}/"
 
     result = await hass.config_entries.flow.async_init(
         keenetic.DOMAIN,
@@ -264,10 +263,9 @@ async def test_ssdp_update_host(hass: HomeAssistant) -> None:
 async def test_ssdp_reject_no_udn(hass: HomeAssistant) -> None:
     """Discovered device has no UDN."""
 
-    discovery_info = {
-        **MOCK_SSDP_DISCOVERY_INFO,
-    }
-    discovery_info.pop(ssdp.ATTR_UPNP_UDN)
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
+    discovery_info.upnp = {**discovery_info.upnp}
+    discovery_info.upnp.pop(ssdp.ATTR_UPNP_UDN)
 
     result = await hass.config_entries.flow.async_init(
         keenetic.DOMAIN,
@@ -282,10 +280,9 @@ async def test_ssdp_reject_no_udn(hass: HomeAssistant) -> None:
 async def test_ssdp_reject_non_keenetic(hass: HomeAssistant) -> None:
     """Discovered device does not look like a keenetic router."""
 
-    discovery_info = {
-        **MOCK_SSDP_DISCOVERY_INFO,
-        ssdp.ATTR_UPNP_FRIENDLY_NAME: "Suspicious device",
-    }
+    discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
+    discovery_info.upnp = {**discovery_info.upnp}
+    discovery_info.upnp[ssdp.ATTR_UPNP_FRIENDLY_NAME] = "Suspicious device"
     result = await hass.config_entries.flow.async_init(
         keenetic.DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -211,12 +211,16 @@ async def test_ssdp_already_configured(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
-        data={
-            ssdp.ATTR_SSDP_LOCATION: SSDP_URL_SLL,
-            ssdp.ATTR_UPNP_MODEL_NUMBER: "RBR20",
-            ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
-            ssdp.ATTR_UPNP_SERIAL: SERIAL,
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location=SSDP_URL_SLL,
+            upnp={
+                ssdp.ATTR_UPNP_MODEL_NUMBER: "RBR20",
+                ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
+                ssdp.ATTR_UPNP_SERIAL: SERIAL,
+            },
+        ),
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
@@ -227,12 +231,16 @@ async def test_ssdp(hass, service):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
-        data={
-            ssdp.ATTR_SSDP_LOCATION: SSDP_URL,
-            ssdp.ATTR_UPNP_MODEL_NUMBER: "RBR20",
-            ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
-            ssdp.ATTR_UPNP_SERIAL: SERIAL,
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location=SSDP_URL,
+            upnp={
+                ssdp.ATTR_UPNP_MODEL_NUMBER: "RBR20",
+                ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
+                ssdp.ATTR_UPNP_SERIAL: SERIAL,
+            },
+        ),
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -7,7 +7,7 @@ from samsungtvws.exceptions import ConnectionFailure, HttpApiError
 from websocket import WebSocketException, WebSocketProtocolException
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
+from homeassistant.components import dhcp, ssdp, zeroconf
 from homeassistant.components.samsungtv.const import (
     CONF_MANUFACTURER,
     CONF_MODEL,
@@ -24,7 +24,6 @@ from homeassistant.components.samsungtv.const import (
     TIMEOUT_WEBSOCKET,
 )
 from homeassistant.components.ssdp import (
-    ATTR_SSDP_LOCATION,
     ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_MANUFACTURER,
     ATTR_UPNP_MODEL_NAME,
@@ -63,27 +62,39 @@ MOCK_IMPORT_WSDATA = {
     CONF_PORT: 8002,
 }
 MOCK_USER_DATA = {CONF_HOST: "fake_host", CONF_NAME: "fake_name"}
-MOCK_SSDP_DATA = {
-    ATTR_SSDP_LOCATION: "https://fake_host:12345/test",
-    ATTR_UPNP_FRIENDLY_NAME: "[TV] fake_name",
-    ATTR_UPNP_MANUFACTURER: "Samsung fake_manufacturer",
-    ATTR_UPNP_MODEL_NAME: "fake_model",
-    ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172de",
-}
-MOCK_SSDP_DATA_NOPREFIX = {
-    ATTR_SSDP_LOCATION: "http://fake2_host:12345/test",
-    ATTR_UPNP_FRIENDLY_NAME: "fake2_name",
-    ATTR_UPNP_MANUFACTURER: "Samsung fake2_manufacturer",
-    ATTR_UPNP_MODEL_NAME: "fake2_model",
-    ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172df",
-}
-MOCK_SSDP_DATA_WRONGMODEL = {
-    ATTR_SSDP_LOCATION: "http://fake2_host:12345/test",
-    ATTR_UPNP_FRIENDLY_NAME: "fake2_name",
-    ATTR_UPNP_MANUFACTURER: "fake2_manufacturer",
-    ATTR_UPNP_MODEL_NAME: "HW-Qfake",
-    ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172df",
-}
+MOCK_SSDP_DATA = ssdp.SsdpServiceInfo(
+    ssdp_usn="mock_usn",
+    ssdp_st="mock_st",
+    ssdp_location="https://fake_host:12345/test",
+    upnp={
+        ATTR_UPNP_FRIENDLY_NAME: "[TV] fake_name",
+        ATTR_UPNP_MANUFACTURER: "Samsung fake_manufacturer",
+        ATTR_UPNP_MODEL_NAME: "fake_model",
+        ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172de",
+    },
+)
+MOCK_SSDP_DATA_NOPREFIX = ssdp.SsdpServiceInfo(
+    ssdp_usn="mock_usn",
+    ssdp_st="mock_st",
+    ssdp_location="http://fake2_host:12345/test",
+    upnp={
+        ATTR_UPNP_FRIENDLY_NAME: "fake2_name",
+        ATTR_UPNP_MANUFACTURER: "Samsung fake2_manufacturer",
+        ATTR_UPNP_MODEL_NAME: "fake2_model",
+        ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172df",
+    },
+)
+MOCK_SSDP_DATA_WRONGMODEL = ssdp.SsdpServiceInfo(
+    ssdp_usn="mock_usn",
+    ssdp_st="mock_st",
+    ssdp_location="http://fake2_host:12345/test",
+    upnp={
+        ATTR_UPNP_FRIENDLY_NAME: "fake2_name",
+        ATTR_UPNP_MANUFACTURER: "fake2_manufacturer",
+        ATTR_UPNP_MODEL_NAME: "HW-Qfake",
+        ATTR_UPNP_UDN: "uuid:0d1cef00-00dc-1000-9c80-4844f7b172df",
+    },
+)
 MOCK_DHCP_DATA = dhcp.DhcpServiceInfo(
     ip="fake_host", macaddress="aa:bb:cc:dd:ee:ff", hostname="fake_hostname"
 )

--- a/tests/components/syncthru/test_config_flow.py
+++ b/tests/components/syncthru/test_config_flow.py
@@ -130,14 +130,18 @@ async def test_ssdp(hass, aioclient_mock):
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data={
-            ssdp.ATTR_SSDP_LOCATION: "http://192.168.1.2:5200/Printer.xml",
-            ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:Printer:1",
-            ssdp.ATTR_UPNP_MANUFACTURER: "Samsung Electronics",
-            ssdp.ATTR_UPNP_PRESENTATION_URL: url,
-            ssdp.ATTR_UPNP_SERIAL: "00000000",
-            ssdp.ATTR_UPNP_UDN: "uuid:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location="http://192.168.1.2:5200/Printer.xml",
+            upnp={
+                ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:Printer:1",
+                ssdp.ATTR_UPNP_MANUFACTURER: "Samsung Electronics",
+                ssdp.ATTR_UPNP_PRESENTATION_URL: url,
+                ssdp.ATTR_UPNP_SERIAL: "00000000",
+                ssdp.ATTR_UPNP_UDN: "uuid:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+            },
+        ),
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/components/yamaha_musiccast/test_config_flow.py
+++ b/tests/components/yamaha_musiccast/test_config_flow.py
@@ -308,11 +308,15 @@ async def test_ssdp_discovery_failed(hass, mock_ssdp_no_yamaha, mock_get_source_
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data={
-            ssdp.ATTR_SSDP_LOCATION: "http://127.0.0.1/desc.xml",
-            ssdp.ATTR_UPNP_MODEL_NAME: "MC20",
-            ssdp.ATTR_UPNP_SERIAL: "123456789",
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location="http://127.0.0.1/desc.xml",
+            upnp={
+                ssdp.ATTR_UPNP_MODEL_NAME: "MC20",
+                ssdp.ATTR_UPNP_SERIAL: "123456789",
+            },
+        ),
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -326,11 +330,15 @@ async def test_ssdp_discovery_successful_add_device(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data={
-            ssdp.ATTR_SSDP_LOCATION: "http://127.0.0.1/desc.xml",
-            ssdp.ATTR_UPNP_MODEL_NAME: "MC20",
-            ssdp.ATTR_UPNP_SERIAL: "1234567890",
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location="http://127.0.0.1/desc.xml",
+            upnp={
+                ssdp.ATTR_UPNP_MODEL_NAME: "MC20",
+                ssdp.ATTR_UPNP_SERIAL: "1234567890",
+            },
+        ),
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
@@ -364,11 +372,15 @@ async def test_ssdp_discovery_existing_device_update(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data={
-            ssdp.ATTR_SSDP_LOCATION: "http://127.0.0.1/desc.xml",
-            ssdp.ATTR_UPNP_MODEL_NAME: "MC20",
-            ssdp.ATTR_UPNP_SERIAL: "1234567890",
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location="http://127.0.0.1/desc.xml",
+            upnp={
+                ssdp.ATTR_UPNP_MODEL_NAME: "MC20",
+                ssdp.ATTR_UPNP_SERIAL: "1234567890",
+            },
+        ),
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -8,12 +8,8 @@ import zigpy.config
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 
 from homeassistant import config_entries
-from homeassistant.components import usb, zeroconf
-from homeassistant.components.ssdp import (
-    ATTR_SSDP_LOCATION,
-    ATTR_UPNP_MANUFACTURER_URL,
-    ATTR_UPNP_SERIAL,
-)
+from homeassistant.components import ssdp, usb, zeroconf
+from homeassistant.components.ssdp import ATTR_UPNP_MANUFACTURER_URL, ATTR_UPNP_SERIAL
 from homeassistant.components.zha import config_flow
 from homeassistant.components.zha.core.const import (
     CONF_BAUDRATE,
@@ -281,11 +277,15 @@ async def test_discovery_via_usb_deconz_already_discovered(detect_mock, hass):
     """Test usb flow -- deconz discovered."""
     result = await hass.config_entries.flow.async_init(
         "deconz",
-        data={
-            ATTR_SSDP_LOCATION: "http://1.2.3.4:80/",
-            ATTR_UPNP_MANUFACTURER_URL: "http://www.dresden-elektronik.de",
-            ATTR_UPNP_SERIAL: "0000000000000000",
-        },
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location="http://1.2.3.4:80/",
+            upnp={
+                ATTR_UPNP_MANUFACTURER_URL: "http://www.dresden-elektronik.de",
+                ATTR_UPNP_SERIAL: "0000000000000000",
+            },
+        ),
         context={"source": SOURCE_SSDP},
     )
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `SsdpServiceInfo` for `SOURCE_SSDP` tests (part 3) as preliminary work for #59931.

They are split out from part 1/2 because the `get` method needs to be implemented in `SsdpServiceInfo` (at least temporarily) 

~Requires part 2 to be merged: #60322~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
