### PR TITLE
Add tolo button platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1094,6 +1094,7 @@ omit =
     homeassistant/components/todoist/const.py
     homeassistant/components/tof/sensor.py
     homeassistant/components/tolo/__init__.py
+    homeassistant/components/tolo/button.py
     homeassistant/components/tolo/climate.py
     homeassistant/components/tolo/light.py
     homeassistant/components/tolo/select.py

--- a/homeassistant/components/tolo/__init__.py
+++ b/homeassistant/components/tolo/__init__.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DEFAULT_RETRY_COUNT, DEFAULT_RETRY_TIMEOUT, DOMAIN
 
-PLATFORMS = ["climate", "light", "select", "sensor"]
+PLATFORMS = ["button", "climate", "light", "select", "sensor"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tolo/button.py
+++ b/homeassistant/components/tolo/button.py
@@ -1,0 +1,54 @@
+"""TOLO Sauna Button controls."""
+
+from tololib.const import LampMode
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import ToloSaunaCoordinatorEntity, ToloSaunaUpdateCoordinator
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up buttons for TOLO Sauna."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [
+            ToloLampNextColorButton(coordinator, entry),
+        ]
+    )
+
+
+class ToloLampNextColorButton(ToloSaunaCoordinatorEntity, ButtonEntity):
+    """Button for switching to the next lamp color."""
+
+    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_icon = "mdi:palette"
+    _attr_name = "Next Color"
+
+    def __init__(
+        self, coordinator: ToloSaunaUpdateCoordinator, entry: ConfigEntry
+    ) -> None:
+        """Initialize lamp next color button entity."""
+        super().__init__(coordinator, entry)
+
+        self._attr_unique_id = f"{entry.entry_id}_lamp_next_color"
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.data.status.lamp_on
+            and self.coordinator.data.settings.lamp_mode == LampMode.MANUAL
+        )
+
+    def press(self) -> None:
+        """Execute action when lamp change color button was pressed."""
+        self.coordinator.client.lamp_change_color()


### PR DESCRIPTION
## Proposed change
This pull request adds the `button` platform to the `tolo` component. A button is used to manually switch to the next lamp color when the lamp is in manual mode.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20447

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (see https://github.com/home-assistant/home-assistant.io/pull/20447)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
