### PR TITLE
Use native datetime value in Brother uptime sensor

### DIFF
--- a/homeassistant/components/brother/sensor.py
+++ b/homeassistant/components/brother/sensor.py
@@ -1,6 +1,8 @@
 """Support for the Brother service."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, cast
 
 from homeassistant.components.sensor import (
@@ -84,198 +86,6 @@ ATTRS_MAP: dict[str, tuple[str, str]] = {
     ),
 }
 
-SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
-    SensorEntityDescription(
-        key=ATTR_STATUS,
-        icon="mdi:printer",
-        name=ATTR_STATUS.title(),
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_PAGE_COUNTER,
-        icon="mdi:file-document-outline",
-        name=ATTR_PAGE_COUNTER.replace("_", " ").title(),
-        native_unit_of_measurement=UNIT_PAGES,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_BW_COUNTER,
-        icon="mdi:file-document-outline",
-        name=ATTR_BW_COUNTER.replace("_", " ").title(),
-        native_unit_of_measurement=UNIT_PAGES,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_COLOR_COUNTER,
-        icon="mdi:file-document-outline",
-        name=ATTR_COLOR_COUNTER.replace("_", " ").title(),
-        native_unit_of_measurement=UNIT_PAGES,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_DUPLEX_COUNTER,
-        icon="mdi:file-document-outline",
-        name=ATTR_DUPLEX_COUNTER.replace("_", " ").title(),
-        native_unit_of_measurement=UNIT_PAGES,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_DRUM_REMAINING_LIFE,
-        icon="mdi:chart-donut",
-        name=ATTR_DRUM_REMAINING_LIFE.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_BLACK_DRUM_REMAINING_LIFE,
-        icon="mdi:chart-donut",
-        name=ATTR_BLACK_DRUM_REMAINING_LIFE.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_CYAN_DRUM_REMAINING_LIFE,
-        icon="mdi:chart-donut",
-        name=ATTR_CYAN_DRUM_REMAINING_LIFE.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_MAGENTA_DRUM_REMAINING_LIFE,
-        icon="mdi:chart-donut",
-        name=ATTR_MAGENTA_DRUM_REMAINING_LIFE.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_YELLOW_DRUM_REMAINING_LIFE,
-        icon="mdi:chart-donut",
-        name=ATTR_YELLOW_DRUM_REMAINING_LIFE.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_BELT_UNIT_REMAINING_LIFE,
-        icon="mdi:current-ac",
-        name=ATTR_BELT_UNIT_REMAINING_LIFE.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_FUSER_REMAINING_LIFE,
-        icon="mdi:water-outline",
-        name=ATTR_FUSER_REMAINING_LIFE.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_LASER_REMAINING_LIFE,
-        icon="mdi:spotlight-beam",
-        name=ATTR_LASER_REMAINING_LIFE.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_PF_KIT_1_REMAINING_LIFE,
-        icon="mdi:printer-3d",
-        name=ATTR_PF_KIT_1_REMAINING_LIFE.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_PF_KIT_MP_REMAINING_LIFE,
-        icon="mdi:printer-3d",
-        name=ATTR_PF_KIT_MP_REMAINING_LIFE.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_BLACK_TONER_REMAINING,
-        icon="mdi:printer-3d-nozzle",
-        name=ATTR_BLACK_TONER_REMAINING.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_CYAN_TONER_REMAINING,
-        icon="mdi:printer-3d-nozzle",
-        name=ATTR_CYAN_TONER_REMAINING.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_MAGENTA_TONER_REMAINING,
-        icon="mdi:printer-3d-nozzle",
-        name=ATTR_MAGENTA_TONER_REMAINING.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_YELLOW_TONER_REMAINING,
-        icon="mdi:printer-3d-nozzle",
-        name=ATTR_YELLOW_TONER_REMAINING.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_BLACK_INK_REMAINING,
-        icon="mdi:printer-3d-nozzle",
-        name=ATTR_BLACK_INK_REMAINING.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_CYAN_INK_REMAINING,
-        icon="mdi:printer-3d-nozzle",
-        name=ATTR_CYAN_INK_REMAINING.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_MAGENTA_INK_REMAINING,
-        icon="mdi:printer-3d-nozzle",
-        name=ATTR_MAGENTA_INK_REMAINING.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_YELLOW_INK_REMAINING,
-        icon="mdi:printer-3d-nozzle",
-        name=ATTR_YELLOW_INK_REMAINING.replace("_", " ").title(),
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    SensorEntityDescription(
-        key=ATTR_UPTIME,
-        name=ATTR_UPTIME.title(),
-        entity_registry_enabled_default=False,
-        device_class=DEVICE_CLASS_TIMESTAMP,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-)
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -296,7 +106,9 @@ async def async_setup_entry(
 
     for description in SENSOR_TYPES:
         if description.key in coordinator.data:
-            sensors.append(BrotherPrinterSensor(coordinator, description, device_info))
+            sensors.append(
+                description.entity_class(coordinator, description, device_info)
+            )
     async_add_entities(sensors, False)
 
 
@@ -306,7 +118,7 @@ class BrotherPrinterSensor(CoordinatorEntity, SensorEntity):
     def __init__(
         self,
         coordinator: BrotherDataUpdateCoordinator,
-        description: SensorEntityDescription,
+        description: BrotherSensorEntityDescription,
         device_info: DeviceInfo,
     ) -> None:
         """Initialize."""
@@ -318,13 +130,8 @@ class BrotherPrinterSensor(CoordinatorEntity, SensorEntity):
         self.entity_description = description
 
     @property
-    def native_value(self) -> StateType:
+    def native_value(self) -> StateType | datetime:
         """Return the state."""
-        if self.entity_description.key == ATTR_UPTIME:
-            return cast(
-                StateType,
-                getattr(self.coordinator.data, self.entity_description.key).isoformat(),
-            )
         return cast(
             StateType, getattr(self.coordinator.data, self.entity_description.key)
         )
@@ -341,3 +148,215 @@ class BrotherPrinterSensor(CoordinatorEntity, SensorEntity):
             )
             self._attrs[ATTR_COUNTER] = getattr(self.coordinator.data, drum_counter)
         return self._attrs
+
+
+class BrotherPrinterUptimeSensor(BrotherPrinterSensor):
+    """Define an Brother Printer Uptime sensor."""
+
+    @property
+    def native_value(self) -> datetime:
+        """Return the state."""
+        return cast(
+            datetime, getattr(self.coordinator.data, self.entity_description.key)
+        )
+
+
+@dataclass
+class BrotherSensorEntityDescription(SensorEntityDescription):
+    """A class that describes sensor entities."""
+
+    entity_class: type[BrotherPrinterSensor] = BrotherPrinterSensor
+
+
+SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
+    BrotherSensorEntityDescription(
+        key=ATTR_STATUS,
+        icon="mdi:printer",
+        name=ATTR_STATUS.title(),
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_PAGE_COUNTER,
+        icon="mdi:file-document-outline",
+        name=ATTR_PAGE_COUNTER.replace("_", " ").title(),
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_BW_COUNTER,
+        icon="mdi:file-document-outline",
+        name=ATTR_BW_COUNTER.replace("_", " ").title(),
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_COLOR_COUNTER,
+        icon="mdi:file-document-outline",
+        name=ATTR_COLOR_COUNTER.replace("_", " ").title(),
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_DUPLEX_COUNTER,
+        icon="mdi:file-document-outline",
+        name=ATTR_DUPLEX_COUNTER.replace("_", " ").title(),
+        native_unit_of_measurement=UNIT_PAGES,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_DRUM_REMAINING_LIFE,
+        icon="mdi:chart-donut",
+        name=ATTR_DRUM_REMAINING_LIFE.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_BLACK_DRUM_REMAINING_LIFE,
+        icon="mdi:chart-donut",
+        name=ATTR_BLACK_DRUM_REMAINING_LIFE.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_CYAN_DRUM_REMAINING_LIFE,
+        icon="mdi:chart-donut",
+        name=ATTR_CYAN_DRUM_REMAINING_LIFE.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_MAGENTA_DRUM_REMAINING_LIFE,
+        icon="mdi:chart-donut",
+        name=ATTR_MAGENTA_DRUM_REMAINING_LIFE.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_YELLOW_DRUM_REMAINING_LIFE,
+        icon="mdi:chart-donut",
+        name=ATTR_YELLOW_DRUM_REMAINING_LIFE.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_BELT_UNIT_REMAINING_LIFE,
+        icon="mdi:current-ac",
+        name=ATTR_BELT_UNIT_REMAINING_LIFE.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_FUSER_REMAINING_LIFE,
+        icon="mdi:water-outline",
+        name=ATTR_FUSER_REMAINING_LIFE.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_LASER_REMAINING_LIFE,
+        icon="mdi:spotlight-beam",
+        name=ATTR_LASER_REMAINING_LIFE.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_PF_KIT_1_REMAINING_LIFE,
+        icon="mdi:printer-3d",
+        name=ATTR_PF_KIT_1_REMAINING_LIFE.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_PF_KIT_MP_REMAINING_LIFE,
+        icon="mdi:printer-3d",
+        name=ATTR_PF_KIT_MP_REMAINING_LIFE.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_BLACK_TONER_REMAINING,
+        icon="mdi:printer-3d-nozzle",
+        name=ATTR_BLACK_TONER_REMAINING.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_CYAN_TONER_REMAINING,
+        icon="mdi:printer-3d-nozzle",
+        name=ATTR_CYAN_TONER_REMAINING.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_MAGENTA_TONER_REMAINING,
+        icon="mdi:printer-3d-nozzle",
+        name=ATTR_MAGENTA_TONER_REMAINING.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_YELLOW_TONER_REMAINING,
+        icon="mdi:printer-3d-nozzle",
+        name=ATTR_YELLOW_TONER_REMAINING.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_BLACK_INK_REMAINING,
+        icon="mdi:printer-3d-nozzle",
+        name=ATTR_BLACK_INK_REMAINING.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_CYAN_INK_REMAINING,
+        icon="mdi:printer-3d-nozzle",
+        name=ATTR_CYAN_INK_REMAINING.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_MAGENTA_INK_REMAINING,
+        icon="mdi:printer-3d-nozzle",
+        name=ATTR_MAGENTA_INK_REMAINING.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_YELLOW_INK_REMAINING,
+        icon="mdi:printer-3d-nozzle",
+        name=ATTR_YELLOW_INK_REMAINING.replace("_", " ").title(),
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    BrotherSensorEntityDescription(
+        key=ATTR_UPTIME,
+        name=ATTR_UPTIME.title(),
+        entity_registry_enabled_default=False,
+        device_class=DEVICE_CLASS_TIMESTAMP,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        entity_class=BrotherPrinterUptimeSensor,
+    ),
+)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use datetime as native state of Brother uptime sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
