### PR TITLE
CI: Always run full testsuite for components with issues

### DIFF
--- a/.core_files.yaml
+++ b/.core_files.yaml
@@ -108,6 +108,11 @@ tests: &tests
   - tests/test_util/*
   - tests/testing_config/**
 
+# Components which tests only pass if the whole testsuite is run
+# Don't add anything here, unless absolutely necessary!
+broken_tests: &broken_tests
+  - homeassistant/components/xiaomi_miio/*
+
 other: &other
   - .github/workflows/*
   - homeassistant/scripts/**
@@ -118,3 +123,4 @@ any:
   - *core
   - *other
   - *tests
+  - *broken_tests

--- a/homeassistant/components/xiaomi_miio/binary_sensor.py
+++ b/homeassistant/components/xiaomi_miio/binary_sensor.py
@@ -1,9 +1,9 @@
 """Support for Xiaomi Miio binary sensors."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Callable
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,

--- a/homeassistant/components/xiaomi_miio/binary_sensor.py
+++ b/homeassistant/components/xiaomi_miio/binary_sensor.py
@@ -33,7 +33,7 @@ from .const import (
 )
 from .device import XiaomiCoordinatedMiioEntity
 
-_LOGGER = logging.getLogger(__name__)  # some comment
+_LOGGER = logging.getLogger(__name__)
 
 ATTR_NO_WATER = "no_water"
 ATTR_POWERSUPPLY_ATTACHED = "powersupply_attached"

--- a/homeassistant/components/xiaomi_miio/binary_sensor.py
+++ b/homeassistant/components/xiaomi_miio/binary_sensor.py
@@ -33,7 +33,7 @@ from .const import (
 )
 from .device import XiaomiCoordinatedMiioEntity
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)  # some comment
 
 ATTR_NO_WATER = "no_water"
 ATTR_POWERSUPPLY_ATTACHED = "powersupply_attached"


### PR DESCRIPTION
## Proposed change
Followup from #60354

I noticed that the `xiamoi_miio` tests for `3.8` were always failing if run individually. I suspect this needs more attention before it could be resolved. (Maybe related to #60336)

To still be able to commit changes, I propose to add a new section in `.core_files.yaml` for components with issues. These should always trigger a full CI run.

_I'll push the remaining commits after the initial CI run is complete to show the issue._


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
