### PR TITLE
Upgrade pylint to 2.12.1

### DIFF
--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -211,7 +211,7 @@ class Alert(ToggleEntity):
         )
 
     @property
-    def state(self):
+    def state(self):  # pylint: disable=overridden-final-method
         """Return the alert status."""
         if self._firing:
             if self._ack:

--- a/homeassistant/components/bloomsky/binary_sensor.py
+++ b/homeassistant/components/bloomsky/binary_sensor.py
@@ -39,7 +39,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class BloomSkySensor(BinarySensorEntity):
     """Representation of a single binary sensor in a BloomSky device."""
 
-    def __init__(self, bs, device, sensor_name):
+    def __init__(self, bs, device, sensor_name):  # pylint: disable=invalid-name
         """Initialize a BloomSky binary sensor."""
         self._bloomsky = bs
         self._device_id = device["DeviceID"]

--- a/homeassistant/components/bloomsky/sensor.py
+++ b/homeassistant/components/bloomsky/sensor.py
@@ -79,7 +79,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class BloomSkySensor(SensorEntity):
     """Representation of a single sensor in a BloomSky device."""
 
-    def __init__(self, bs, device, sensor_name):
+    def __init__(self, bs, device, sensor_name):  # pylint: disable=invalid-name
         """Initialize a BloomSky sensor."""
         self._bloomsky = bs
         self._device_id = device["DeviceID"]

--- a/homeassistant/components/demo/light.py
+++ b/homeassistant/components/demo/light.py
@@ -103,7 +103,7 @@ class DemoLight(LightEntity):
         state,
         available=False,
         brightness=180,
-        ct=None,
+        ct=None,  # pylint: disable=invalid-name
         effect_list=None,
         effect=None,
         hs_color=None,

--- a/homeassistant/components/devolo_home_network/config_flow.py
+++ b/homeassistant/components/devolo_home_network/config_flow.py
@@ -83,7 +83,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(discovery_info[zeroconf.ATTR_PROPERTIES]["SN"])
         self._abort_if_unique_id_configured()
 
-        # pylint: disable=no-member # https://github.com/PyCQA/pylint/issues/3167
         self.context[CONF_HOST] = discovery_info[zeroconf.ATTR_HOST]
         self.context["title_placeholders"] = {
             PRODUCT: discovery_info[zeroconf.ATTR_PROPERTIES]["Product"],

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -62,7 +62,7 @@ _LOGGER = logging.getLogger(__name__)
 class DhcpServiceInfo(BaseServiceInfo):
     """Prepared info from dhcp entries."""
 
-    ip: str  # pylint: disable=invalid-name
+    ip: str
     hostname: str
     macaddress: str
 

--- a/homeassistant/components/digital_ocean/binary_sensor.py
+++ b/homeassistant/components/digital_ocean/binary_sensor.py
@@ -54,7 +54,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class DigitalOceanBinarySensor(BinarySensorEntity):
     """Representation of a Digital Ocean droplet sensor."""
 
-    def __init__(self, do, droplet_id):
+    def __init__(self, do, droplet_id):  # pylint: disable=invalid-name
         """Initialize a new Digital Ocean sensor."""
         self._digital_ocean = do
         self._droplet_id = droplet_id

--- a/homeassistant/components/digital_ocean/switch.py
+++ b/homeassistant/components/digital_ocean/switch.py
@@ -51,7 +51,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class DigitalOceanSwitch(SwitchEntity):
     """Representation of a Digital Ocean droplet switch."""
 
-    def __init__(self, do, droplet_id):
+    def __init__(self, do, droplet_id):  # pylint: disable=invalid-name
         """Initialize a new Digital Ocean sensor."""
         self._digital_ocean = do
         self._droplet_id = droplet_id

--- a/homeassistant/components/linode/binary_sensor.py
+++ b/homeassistant/components/linode/binary_sensor.py
@@ -51,7 +51,7 @@ class LinodeBinarySensor(BinarySensorEntity):
 
     _attr_device_class = DEVICE_CLASS_MOVING
 
-    def __init__(self, li, node_id):
+    def __init__(self, li, node_id):  # pylint: disable=invalid-name
         """Initialize a new Linode sensor."""
         self._linode = li
         self._node_id = node_id

--- a/homeassistant/components/linode/switch.py
+++ b/homeassistant/components/linode/switch.py
@@ -46,7 +46,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class LinodeSwitch(SwitchEntity):
     """Representation of a Linode Node switch."""
 
-    def __init__(self, li, node_id):
+    def __init__(self, li, node_id):  # pylint: disable=invalid-name
         """Initialize a new Linode sensor."""
         self._linode = li
         self._node_id = node_id

--- a/homeassistant/components/litejet/light.py
+++ b/homeassistant/components/litejet/light.py
@@ -34,7 +34,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class LiteJetLight(LightEntity):
     """Representation of a single LiteJet light."""
 
-    def __init__(self, config_entry, lj, i, name):
+    def __init__(self, config_entry, lj, i, name):  # pylint: disable=invalid-name
         """Initialize a LiteJet light."""
         self._config_entry = config_entry
         self._lj = lj

--- a/homeassistant/components/litejet/scene.py
+++ b/homeassistant/components/litejet/scene.py
@@ -26,7 +26,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class LiteJetScene(Scene):
     """Representation of a single LiteJet scene."""
 
-    def __init__(self, entry_id, lj, i, name):
+    def __init__(self, entry_id, lj, i, name):  # pylint: disable=invalid-name
         """Initialize the scene."""
         self._entry_id = entry_id
         self._lj = lj

--- a/homeassistant/components/litejet/switch.py
+++ b/homeassistant/components/litejet/switch.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class LiteJetSwitch(SwitchEntity):
     """Representation of a single LiteJet switch."""
 
-    def __init__(self, entry_id, lj, i, name):
+    def __init__(self, entry_id, lj, i, name):  # pylint: disable=invalid-name
         """Initialize a LiteJet switch."""
         self._entry_id = entry_id
         self._lj = lj

--- a/homeassistant/components/london_air/sensor.py
+++ b/homeassistant/components/london_air/sensor.py
@@ -94,10 +94,10 @@ class AirSensor(SensorEntity):
 
     ICON = "mdi:cloud-outline"
 
-    def __init__(self, name, APIdata):
+    def __init__(self, name, api_data):
         """Initialize the sensor."""
         self._name = name
-        self._api_data = APIdata
+        self._api_data = api_data
         self._site_data = None
         self._state = None
         self._updated = None

--- a/homeassistant/components/pushbullet/notify.py
+++ b/homeassistant/components/pushbullet/notify.py
@@ -41,7 +41,7 @@ def get_service(hass, config, discovery_info=None):
 class PushBulletNotificationService(BaseNotificationService):
     """Implement the notification service for Pushbullet."""
 
-    def __init__(self, pb):
+    def __init__(self, pb):  # pylint: disable=invalid-name
         """Initialize the service."""
         self.pushbullet = pb
         self.pbtargets = {}

--- a/homeassistant/components/pushbullet/sensor.py
+++ b/homeassistant/components/pushbullet/sensor.py
@@ -95,7 +95,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class PushBulletNotificationSensor(SensorEntity):
     """Representation of a Pushbullet Sensor."""
 
-    def __init__(self, pb, description: SensorEntityDescription):
+    def __init__(
+        self,
+        pb,  # pylint: disable=invalid-name
+        description: SensorEntityDescription,
+    ):
         """Initialize the Pushbullet sensor."""
         self.entity_description = description
         self.pushbullet = pb
@@ -118,10 +122,10 @@ class PushBulletNotificationSensor(SensorEntity):
 class PushBulletNotificationProvider:
     """Provider for an account, leading to one or more sensors."""
 
-    def __init__(self, pb):
+    def __init__(self, pushbullet):
         """Start to retrieve pushes from the given Pushbullet instance."""
 
-        self.pushbullet = pb
+        self.pushbullet = pushbullet
         self._data = None
         self.listener = None
         self.thread = threading.Thread(target=self.retrieve_pushes)

--- a/homeassistant/components/serial_pm/sensor.py
+++ b/homeassistant/components/serial_pm/sensor.py
@@ -58,12 +58,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ParticulateMatterSensor(SensorEntity):
     """Representation of an Particulate matter sensor."""
 
-    def __init__(self, pmDataCollector, name, pmname):
+    def __init__(self, pm_data_collector, name, pmname):
         """Initialize a new PM sensor."""
         self._name = name
         self._pmname = pmname
         self._state = None
-        self._collector = pmDataCollector
+        self._collector = pm_data_collector
 
     @property
     def name(self):

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -234,7 +234,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         self,
         session: OAuth2Session,
         spotify: Spotify,
-        me: dict,
+        me: dict,  # pylint: disable=invalid-name
         user_id: str,
         name: str,
     ) -> None:

--- a/homeassistant/components/xiaomi_miio/binary_sensor.py
+++ b/homeassistant/components/xiaomi_miio/binary_sensor.py
@@ -1,9 +1,9 @@
 """Support for Xiaomi Miio binary sensors."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Callable
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,

--- a/homeassistant/components/zabbix/sensor.py
+++ b/homeassistant/components/zabbix/sensor.py
@@ -79,10 +79,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ZabbixTriggerCountSensor(SensorEntity):
     """Get the active trigger count for all Zabbix monitored hosts."""
 
-    def __init__(self, zApi, name="Zabbix"):
+    def __init__(self, zapi, name="Zabbix"):
         """Initialize Zabbix sensor."""
         self._name = name
-        self._zapi = zApi
+        self._zapi = zapi
         self._state = None
         self._attributes = {}
 
@@ -121,9 +121,9 @@ class ZabbixTriggerCountSensor(SensorEntity):
 class ZabbixSingleHostTriggerCountSensor(ZabbixTriggerCountSensor):
     """Get the active trigger count for a single Zabbix monitored host."""
 
-    def __init__(self, zApi, hostid, name=None):
+    def __init__(self, zapi, hostid, name=None):
         """Initialize Zabbix sensor."""
-        super().__init__(zApi, name)
+        super().__init__(zapi, name)
         self._hostid = hostid
         if not name:
             self._name = self._zapi.host.get(hostids=self._hostid, output="extend")[0][
@@ -145,9 +145,9 @@ class ZabbixSingleHostTriggerCountSensor(ZabbixTriggerCountSensor):
 class ZabbixMultipleHostTriggerCountSensor(ZabbixTriggerCountSensor):
     """Get the active trigger count for specified Zabbix monitored hosts."""
 
-    def __init__(self, zApi, hostids, name=None):
+    def __init__(self, zapi, hostids, name=None):
         """Initialize Zabbix sensor."""
-        super().__init__(zApi, name)
+        super().__init__(zapi, name)
         self._hostids = hostids
         if not name:
             host_names = self._zapi.host.get(hostids=self._hostids, output="extend")

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -56,7 +56,7 @@ from .const import (
     DOMAIN,
 )
 from .discovery_schemas import DISCOVERY_SCHEMAS
-from .migration import (  # noqa: F401 pylint: disable=unused-import
+from .migration import (  # noqa: F401
     async_add_migration_entity_value,
     async_get_migration_data,
     async_is_ozw_migrated,

--- a/homeassistant/components/zwave_js/discovery_data_template.py
+++ b/homeassistant/components/zwave_js/discovery_data_template.py
@@ -444,7 +444,6 @@ class FanSpeedDataTemplate:
 
         Empty lists are not permissible.
         """
-        # pylint: disable=no-self-use
         raise NotImplementedError
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ good-names = [
     "k",
     "Run",
     "T",
+    "ip",
 ]
 
 [tool.pylint."MESSAGES CONTROL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ score = false
 ignored-classes = [
     "_CountingAttr",  # for attrs
 ]
+mixin-class-rgx = ".*[Mm]ix[Ii]n"
 
 [tool.pylint.FORMAT]
 expected-line-ending-format = "LF"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -14,7 +14,7 @@ jsonpickle==1.4.1
 mock-open==1.4.0
 mypy==0.910
 pre-commit==2.15.0
-pylint==2.11.1
+pylint==2.12.1
 pipdeptree==2.2.0
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
## Proposed change
Upgrade pylint to `2.12.1`.

Release notes: https://pylint.pycqa.org/en/latest/whatsnew/2.12.html
Full changelog: https://pylint.pycqa.org/en/latest/whatsnew/changelog.html#what-s-new-in-pylint-2-12-0
Full diff: https://github.com/PyCQA/pylint/compare/v2.11.1...v2.12.1

#### Noteworthy changes
* The `py-version` setting is now officially supported. I already added it with
#56364
* New `overridden-final-method` check. This has already been useful to detect some issues:
#57477
#60352
* Fixed bug with `typing.Callable` that caused `consider-using-alias` not to be emitted although `Callable` could already be imported from `collections.abc`.
#60354
#56778
... and others.
* `invalid-name` now correctly checks `__init__` methods.
* Support for mixin class name patterns via `mixin-class-rgx`.
* Added optional `end_line` and `end_column` information for reports. _That doesn't change anything for HA, but expect error highlighting in VS Code (maybe also other IDEs) to improve soon._
* A lot of bug fixes


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
