### PR TITLE
Fix brightness support for Tuya dimmers that use the Light ("dj") category

### DIFF
--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -330,6 +330,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
     _brightness_type: IntegerTypeData | None = None
     _color_data_dpcode: DPCode | None = None
     _color_data_type: ColorTypeData | None = None
+    _color_mode_dpcode: DPCode | None = None
     _color_temp_dpcode: DPCode | None = None
     _color_temp_type: IntegerTypeData | None = None
 
@@ -360,6 +361,13 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
                 ),
                 None,
             )
+
+        # Determine color mode DPCode
+        if (
+            isinstance(description.color_mode, DPCode)
+            and description.color_mode in device.function
+        ):
+            self._color_mode_dpcode = description.color_mode
 
         # Determine DPCodes for color temperature
         if (
@@ -451,10 +459,10 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         commands = [{"code": self.entity_description.key, "value": True}]
 
         if self._color_temp_type and ATTR_COLOR_TEMP in kwargs:
-            if color_mode_dpcode := self.entity_description.color_mode:
+            if self._color_mode_dpcode:
                 commands += [
                     {
-                        "code": color_mode_dpcode,
+                        "code": self._color_mode_dpcode,
                         "value": WorkMode.WHITE,
                     },
                 ]
@@ -476,10 +484,10 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
             ATTR_HS_COLOR in kwargs
             or (ATTR_BRIGHTNESS in kwargs and self.color_mode == COLOR_MODE_HS)
         ):
-            if color_mode_dpcode := self.entity_description.color_mode:
+            if self._color_mode_dpcode:
                 commands += [
                     {
-                        "code": color_mode_dpcode,
+                        "code": self._color_mode_dpcode,
                         "value": WorkMode.COLOUR,
                     },
                 ]
@@ -651,9 +659,8 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         # We consider it to be in HS color mode, when work mode is anything
         # else than "white".
         if (
-            self.entity_description.color_mode
-            and self.entity_description.color_mode in self.device.function
-            and self.device.status.get(self.entity_description.color_mode)
+            self._color_mode_dpcode
+            and self.device.status.get(self._color_mode_dpcode)
             != WorkMode.WHITE
         ):
             return COLOR_MODE_HS

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -652,6 +652,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         # else than "white".
         if (
             self.entity_description.color_mode
+            and self.entity_description.color_mode in self.device.function
             and self.device.status.get(self.entity_description.color_mode)
             != WorkMode.WHITE
         ):

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -660,8 +660,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         # else than "white".
         if (
             self._color_mode_dpcode
-            and self.device.status.get(self._color_mode_dpcode)
-            != WorkMode.WHITE
+            and self.device.status.get(self._color_mode_dpcode) != WorkMode.WHITE
         ):
             return COLOR_MODE_HS
         if self._color_temp_dpcode:

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -364,7 +364,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
 
         # Determine color mode DPCode
         if (
-            isinstance(description.color_mode, DPCode)
+            description.color_mode is not None
             and description.color_mode in device.function
         ):
             self._color_mode_dpcode = description.color_mode


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix brightness support for Tuya dimmer switches (and light bulbs that only support dimming) that use the Light ("dj") category. For these devices, the color mode should be "brightness" but it was being set to "hs" and, subsequently, setting brightness wouldn't work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #59031
  - fixes #59167
  - fixes #59757
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
