### PR TITLE
Add `button` platform to NAM integration

### DIFF
--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -42,7 +42,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["sensor"]
+PLATFORMS = ["button", "sensor"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/nam/button.py
+++ b/homeassistant/components/nam/button.py
@@ -1,7 +1,6 @@
 """Support for the Nettigo Air Monitor service."""
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from aiohttp.client_exceptions import ClientError
@@ -12,10 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import (
-    ConfigEntryAuthFailed,
-    CoordinatorEntity,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import NAMDataUpdateCoordinator
 from .const import DEFAULT_NAME, DOMAIN
@@ -64,11 +60,9 @@ class NAMButton(CoordinatorEntity, ButtonEntity):
         """Triggers the restart."""
         try:
             await self.coordinator.nam.async_restart()
-        except AuthFailed as err:
-            raise ConfigEntryAuthFailed from err
         except (
+            AuthFailed,
             ApiError,
             ClientError,
-            asyncio.TimeoutError,
         ) as err:
             _LOGGER.error("Failed to restart the device: %s", err)

--- a/homeassistant/components/nam/button.py
+++ b/homeassistant/components/nam/button.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 
 import logging
 
-from aiohttp.client_exceptions import ClientError
-from nettigo_air_monitor import ApiError, AuthFailed
-
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ENTITY_CATEGORY_CONFIG
@@ -58,11 +55,4 @@ class NAMButton(CoordinatorEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Triggers the restart."""
-        try:
-            await self.coordinator.nam.async_restart()
-        except (
-            AuthFailed,
-            ApiError,
-            ClientError,
-        ) as err:
-            _LOGGER.error("Failed to restart the device: %s", err)
+        await self.coordinator.nam.async_restart()

--- a/homeassistant/components/nam/button.py
+++ b/homeassistant/components/nam/button.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from aiohttp.client_exceptions import ClientConnectorError, ClientError
+from aiohttp.client_exceptions import ClientError
 from nettigo_air_monitor import ApiError, AuthFailed
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
@@ -69,7 +69,6 @@ class NAMButton(CoordinatorEntity, ButtonEntity):
         except (
             ApiError,
             ClientError,
-            ClientConnectorError,
             asyncio.TimeoutError,
         ) as err:
             _LOGGER.error("Failed to restart the device: %s", err)

--- a/homeassistant/components/nam/button.py
+++ b/homeassistant/components/nam/button.py
@@ -1,0 +1,75 @@
+"""Support for the Nettigo Air Monitor service."""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiohttp.client_exceptions import ClientConnectorError, ClientError
+from nettigo_air_monitor import ApiError, AuthFailed
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    ConfigEntryAuthFailed,
+    CoordinatorEntity,
+)
+
+from . import NAMDataUpdateCoordinator
+from .const import DEFAULT_NAME, DOMAIN
+
+PARALLEL_UPDATES = 1
+
+_LOGGER = logging.getLogger(__name__)
+
+RESTART_BUTTON: ButtonEntityDescription = ButtonEntityDescription(
+    key="restart",
+    name=f"{DEFAULT_NAME} Restart",
+    icon="mdi:restart",
+    entity_category=ENTITY_CATEGORY_CONFIG,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Add a Nettigo Air Monitor entities from a config_entry."""
+    coordinator: NAMDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    buttons: list[NAMButton] = []
+    buttons.append(NAMButton(coordinator, RESTART_BUTTON))
+
+    async_add_entities(buttons, False)
+
+
+class NAMButton(CoordinatorEntity, ButtonEntity):
+    """Define an Nettigo Air Monitor button."""
+
+    coordinator: NAMDataUpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: NAMDataUpdateCoordinator,
+        description: ButtonEntityDescription,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
+        self.entity_description = description
+
+    async def async_press(self) -> None:
+        """Triggers the restart."""
+        try:
+            await self.coordinator.nam.async_restart()
+        except AuthFailed as err:
+            raise ConfigEntryAuthFailed from err
+        except (
+            ApiError,
+            ClientError,
+            ClientConnectorError,
+            asyncio.TimeoutError,
+        ) as err:
+            _LOGGER.error("Failed to restart the device: %s", err)

--- a/tests/components/nam/test_button.py
+++ b/tests/components/nam/test_button.py
@@ -43,12 +43,13 @@ async def test_button_press(hass):
             {ATTR_ENTITY_ID: "button.nettigo_air_monitor_restart"},
             blocking=True,
         )
+        await hass.async_block_till_done()
 
-        mock_restart.assert_called_once()
+    mock_restart.assert_called_once()
 
-        state = hass.states.get("button.nettigo_air_monitor_restart")
-        assert state
-        assert state.state == now.isoformat()
+    state = hass.states.get("button.nettigo_air_monitor_restart")
+    assert state
+    assert state.state == now.isoformat()
 
 
 @pytest.mark.parametrize(
@@ -74,7 +75,8 @@ async def test_button_press_with_error(hass, error, caplog):
             {ATTR_ENTITY_ID: "button.nettigo_air_monitor_restart"},
             blocking=True,
         )
+        await hass.async_block_till_done()
 
-        mock_restart.assert_called_once()
+    mock_restart.assert_called_once()
 
-        assert status in caplog.text
+    assert status in caplog.text

--- a/tests/components/nam/test_button.py
+++ b/tests/components/nam/test_button.py
@@ -2,7 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, STATE_UNKNOWN
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
@@ -17,7 +17,7 @@ async def test_button(hass):
 
     state = hass.states.get("button.nettigo_air_monitor_restart")
     assert state
-    assert state.state == "unknown"
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_ICON) == "mdi:restart"
 
     entry = registry.async_get("button.nettigo_air_monitor_restart")

--- a/tests/components/nam/test_button.py
+++ b/tests/components/nam/test_button.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from tests.components.nam import init_integration
 
@@ -28,9 +29,10 @@ async def test_button_press(hass):
     """Test button press."""
     await init_integration(hass)
 
+    now = dt_util.utcnow()
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_restart"
-    ) as mock_restart:
+    ) as mock_restart, patch("homeassistant.core.dt_util.utcnow", return_value=now):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             "press",
@@ -39,3 +41,7 @@ async def test_button_press(hass):
         )
 
         mock_restart.assert_called_once()
+
+        state = hass.states.get("button.nettigo_air_monitor_restart")
+        assert state
+        assert state.state == now.isoformat()

--- a/tests/components/nam/test_button.py
+++ b/tests/components/nam/test_button.py
@@ -1,6 +1,10 @@
 """Test button of Nettigo Air Monitor integration."""
 from unittest.mock import patch
 
+from aiohttp.client_exceptions import ClientError
+from nettigo_air_monitor import ApiError, AuthFailed
+import pytest
+
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON, STATE_UNKNOWN
 from homeassistant.helpers import entity_registry as er
@@ -45,3 +49,32 @@ async def test_button_press(hass):
         state = hass.states.get("button.nettigo_air_monitor_restart")
         assert state
         assert state.state == now.isoformat()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        (ApiError, "API Error"),
+        (AuthFailed, "Auth Error"),
+        (ClientError, "Client Error"),
+    ],
+)
+async def test_button_press_with_error(hass, error, caplog):
+    """Test button press with error."""
+    exc, status = error
+    await init_integration(hass)
+
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_restart",
+        side_effect=exc(status),
+    ) as mock_restart:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            "press",
+            {ATTR_ENTITY_ID: "button.nettigo_air_monitor_restart"},
+            blocking=True,
+        )
+
+        mock_restart.assert_called_once()
+
+        assert status in caplog.text

--- a/tests/components/nam/test_button.py
+++ b/tests/components/nam/test_button.py
@@ -1,0 +1,41 @@
+"""Test button of Nettigo Air Monitor integration."""
+from unittest.mock import patch
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_ICON
+from homeassistant.helpers import entity_registry as er
+
+from tests.components.nam import init_integration
+
+
+async def test_button(hass):
+    """Test states of the button."""
+    registry = er.async_get(hass)
+
+    await init_integration(hass)
+
+    state = hass.states.get("button.nettigo_air_monitor_restart")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes.get(ATTR_ICON) == "mdi:restart"
+
+    entry = registry.async_get("button.nettigo_air_monitor_restart")
+    assert entry
+    assert entry.unique_id == "aa:bb:cc:dd:ee:ff-restart"
+
+
+async def test_button_press(hass):
+    """Test button press."""
+    await init_integration(hass)
+
+    with patch(
+        "homeassistant.components.nam.NettigoAirMonitor.async_restart"
+    ) as mock_restart:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            "press",
+            {ATTR_ENTITY_ID: "button.nettigo_air_monitor_restart"},
+            blocking=True,
+        )
+
+        mock_restart.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds `button` platform to NAM integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20486

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
