### PR TITLE
Add reboot button to Shelly devices

### DIFF
--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -47,6 +47,14 @@ BUTTONS: Final = [
         entity_category=ENTITY_CATEGORY_CONFIG,
         press_action=lambda wrapper: wrapper.async_trigger_ota_update(beta=True),
     ),
+    ShellyButtonDescription(
+        key="reboot",
+        name="Reboot",
+        icon="mdi:restart",
+        entity_registry_enabled_default=False,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        press_action=lambda wrapper: wrapper.device.trigger_reboot(),
+    ),
 ]
 
 

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -1,9 +1,11 @@
 """Button for Shelly."""
 from __future__ import annotations
 
-from typing import cast
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Final, cast
 
-from homeassistant.components.button import ButtonEntity
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
@@ -15,6 +17,37 @@ from homeassistant.util import slugify
 from . import BlockDeviceWrapper, RpcDeviceWrapper
 from .const import BLOCK, DATA_CONFIG_ENTRY, DOMAIN, RPC
 from .utils import get_block_device_name, get_device_entry_gen, get_rpc_device_name
+
+
+@dataclass
+class ShellyButtonDescriptionMixin:
+    """Mixin to describe a Button entity."""
+
+    press_action: Callable
+
+
+@dataclass
+class ShellyButtonDescription(ButtonEntityDescription, ShellyButtonDescriptionMixin):
+    """Class to describe a Button entity."""
+
+
+BUTTONS: Final = [
+    ShellyButtonDescription(
+        key="ota_update",
+        name="OTA Update",
+        icon="mdi:package-up",
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        press_action=lambda wrapper: wrapper.async_trigger_ota_update(),
+    ),
+    ShellyButtonDescription(
+        key="ota_update_beta",
+        name="OTA Update Beta",
+        icon="mdi:flask-outline",
+        entity_registry_enabled_default=False,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        press_action=lambda wrapper: wrapper.async_trigger_ota_update(beta=True),
+    ),
+]
 
 
 async def async_setup_entry(
@@ -36,66 +69,34 @@ async def async_setup_entry(
             wrapper = cast(BlockDeviceWrapper, block_wrapper)
 
     if wrapper is not None:
-        async_add_entities(
-            [
-                ShellyOtaUpdateStableButton(wrapper, config_entry),
-                ShellyOtaUpdateBetaButton(wrapper, config_entry),
-            ]
-        )
+        async_add_entities([ShellyButton(wrapper, button) for button in BUTTONS])
 
 
-class ShellyOtaUpdateBaseButton(ButtonEntity):
+class ShellyButton(ButtonEntity):
     """Defines a Shelly OTA update base button."""
 
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    entity_description: ShellyButtonDescription
 
     def __init__(
         self,
         wrapper: RpcDeviceWrapper | BlockDeviceWrapper,
-        entry: ConfigEntry,
-        name: str,
-        beta_channel: bool,
-        icon: str,
+        description: ShellyButtonDescription,
     ) -> None:
         """Initialize Shelly OTA update button."""
-        self._attr_device_info = DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, wrapper.mac)}
-        )
+        self.entity_description = description
+        self.wrapper = wrapper
 
         if isinstance(wrapper, RpcDeviceWrapper):
             device_name = get_rpc_device_name(wrapper.device)
         else:
             device_name = get_block_device_name(wrapper.device)
 
-        self._attr_name = f"{device_name} {name}"
+        self._attr_name = f"{device_name} {description.name}"
         self._attr_unique_id = slugify(self._attr_name)
-        self._attr_icon = icon
-
-        self.beta_channel = beta_channel
-        self.entry = entry
-        self.wrapper = wrapper
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, wrapper.mac)}
+        )
 
     async def async_press(self) -> None:
         """Triggers the OTA update service."""
-        await self.wrapper.async_trigger_ota_update(beta=self.beta_channel)
-
-
-class ShellyOtaUpdateStableButton(ShellyOtaUpdateBaseButton):
-    """Defines a Shelly OTA update stable channel button."""
-
-    def __init__(
-        self, wrapper: RpcDeviceWrapper | BlockDeviceWrapper, entry: ConfigEntry
-    ) -> None:
-        """Initialize Shelly OTA update button."""
-        super().__init__(wrapper, entry, "OTA Update", False, "mdi:package-up")
-
-
-class ShellyOtaUpdateBetaButton(ShellyOtaUpdateBaseButton):
-    """Defines a Shelly OTA update beta channel button."""
-
-    def __init__(
-        self, wrapper: RpcDeviceWrapper | BlockDeviceWrapper, entry: ConfigEntry
-    ) -> None:
-        """Initialize Shelly OTA update button."""
-        super().__init__(wrapper, entry, "OTA Update Beta", True, "mdi:flask-outline")
-        self._attr_entity_registry_enabled_default = False
+        await self.entity_description.press_action(self.wrapper)

--- a/homeassistant/components/shelly/button.py
+++ b/homeassistant/components/shelly/button.py
@@ -51,7 +51,6 @@ BUTTONS: Final = [
         key="reboot",
         name="Reboot",
         icon="mdi:restart",
-        entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_CONFIG,
         press_action=lambda wrapper: wrapper.device.trigger_reboot(),
     ),

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -138,6 +138,7 @@ async def coap_wrapper(hass):
         firmware_version="some fw string",
         update=AsyncMock(),
         trigger_ota_update=AsyncMock(),
+        trigger_reboot=AsyncMock(),
         initialized=True,
     )
 
@@ -173,6 +174,7 @@ async def rpc_wrapper(hass):
         firmware_version="some fw string",
         update=AsyncMock(),
         trigger_ota_update=AsyncMock(),
+        trigger_reboot=AsyncMock(),
         initialized=True,
         shutdown=AsyncMock(),
     )

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -1,6 +1,7 @@
 """Tests for Shelly button platform."""
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.button.const import SERVICE_PRESS
+from homeassistant.components.shelly.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
@@ -10,6 +11,21 @@ async def test_block_button(hass: HomeAssistant, coap_wrapper):
     """Test block device OTA button."""
     assert coap_wrapper
 
+    entity_registry = async_get(hass)
+    entity_registry.async_get_or_create(
+        BUTTON_DOMAIN,
+        DOMAIN,
+        "test_name_ota_update_beta",
+        suggested_object_id="test_name_ota_update_beta",
+        disabled_by=None,
+    )
+    entity_registry.async_get_or_create(
+        BUTTON_DOMAIN,
+        DOMAIN,
+        "test_name_reboot",
+        suggested_object_id="test_name_reboot",
+        disabled_by=None,
+    )
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(coap_wrapper.entry, BUTTON_DOMAIN)
     )
@@ -27,20 +43,60 @@ async def test_block_button(hass: HomeAssistant, coap_wrapper):
         blocking=True,
     )
     await hass.async_block_till_done()
-    coap_wrapper.device.trigger_ota_update.assert_called_once_with(beta=False)
+    assert coap_wrapper.device.trigger_ota_update.call_count == 1
+    coap_wrapper.device.trigger_ota_update.assert_called_with(beta=False)
 
     # beta channel button
-    entity_registry = async_get(hass)
-    entry = entity_registry.async_get("button.test_name_ota_update_beta")
     state = hass.states.get("button.test_name_ota_update_beta")
 
-    assert entry
-    assert state is None
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_name_ota_update_beta"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert coap_wrapper.device.trigger_ota_update.call_count == 2
+    coap_wrapper.device.trigger_ota_update.assert_called_with(beta=True)
+
+    # reboot button
+    state = hass.states.get("button.test_name_reboot")
+
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_name_reboot"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert coap_wrapper.device.trigger_reboot.call_count == 1
 
 
 async def test_rpc_button(hass: HomeAssistant, rpc_wrapper):
     """Test rpc device OTA button."""
     assert rpc_wrapper
+
+    entity_registry = async_get(hass)
+    entity_registry.async_get_or_create(
+        BUTTON_DOMAIN,
+        DOMAIN,
+        "test_name_ota_update_beta",
+        suggested_object_id="test_name_ota_update_beta",
+        disabled_by=None,
+    )
+    entity_registry.async_get_or_create(
+        BUTTON_DOMAIN,
+        DOMAIN,
+        "test_name_reboot",
+        suggested_object_id="test_name_reboot",
+        disabled_by=None,
+    )
 
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(rpc_wrapper.entry, BUTTON_DOMAIN)
@@ -59,12 +115,36 @@ async def test_rpc_button(hass: HomeAssistant, rpc_wrapper):
         blocking=True,
     )
     await hass.async_block_till_done()
-    rpc_wrapper.device.trigger_ota_update.assert_called_once_with(beta=False)
+    assert rpc_wrapper.device.trigger_ota_update.call_count == 1
+    rpc_wrapper.device.trigger_ota_update.assert_called_with(beta=False)
 
     # beta channel button
-    entity_registry = async_get(hass)
-    entry = entity_registry.async_get("button.test_name_ota_update_beta")
     state = hass.states.get("button.test_name_ota_update_beta")
 
-    assert entry
-    assert state is None
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_name_ota_update_beta"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert rpc_wrapper.device.trigger_ota_update.call_count == 2
+    rpc_wrapper.device.trigger_ota_update.assert_called_with(beta=True)
+
+    # reboot button
+    state = hass.states.get("button.test_name_reboot")
+
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.test_name_reboot"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert rpc_wrapper.device.trigger_reboot.call_count == 1

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -19,13 +19,6 @@ async def test_block_button(hass: HomeAssistant, coap_wrapper):
         suggested_object_id="test_name_ota_update_beta",
         disabled_by=None,
     )
-    entity_registry.async_get_or_create(
-        BUTTON_DOMAIN,
-        DOMAIN,
-        "test_name_reboot",
-        suggested_object_id="test_name_reboot",
-        disabled_by=None,
-    )
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(coap_wrapper.entry, BUTTON_DOMAIN)
     )
@@ -88,13 +81,6 @@ async def test_rpc_button(hass: HomeAssistant, rpc_wrapper):
         DOMAIN,
         "test_name_ota_update_beta",
         suggested_object_id="test_name_ota_update_beta",
-        disabled_by=None,
-    )
-    entity_registry.async_get_or_create(
-        BUTTON_DOMAIN,
-        DOMAIN,
-        "test_name_reboot",
-        suggested_object_id="test_name_reboot",
         disabled_by=None,
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reworks the recent implemented buttons to use entity descriptors and adds the new button to trigger a reboot of the Shelly device.
Since this feature is fairly not common to be used, the button is disabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io/pull/20460

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
