### PR TITLE
Adds ability to set icon for light group

### DIFF
--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -115,7 +115,9 @@ class LightGroup(GroupEntity, light.LightEntity):
     _attr_min_mireds = 154
     _attr_should_poll = False
 
-    def __init__(self, unique_id: str | None, name: str, entity_ids: list[str], icon: str) -> None:
+    def __init__(
+        self, unique_id: str | None, name: str, entity_ids: list[str], icon: str
+    ) -> None:
         """Initialize a light group."""
         self._entity_ids = entity_ids
         self._white_value: int | None = None

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -39,6 +39,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
+    CONF_ICON,
     CONF_NAME,
     CONF_UNIQUE_ID,
     STATE_ON,
@@ -59,6 +60,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_ICON, default="mdi:lightbulb-group"): cv.icon,
         vol.Required(CONF_ENTITIES): cv.entities_domain(light.DOMAIN),
     }
 )
@@ -80,7 +82,7 @@ async def async_setup_platform(
     async_add_entities(
         [
             LightGroup(
-                config.get(CONF_UNIQUE_ID), config[CONF_NAME], config[CONF_ENTITIES]
+                config.get(CONF_UNIQUE_ID), config[CONF_NAME], config[CONF_ENTITIES], config[CONF_ICON]
             )
         ]
     )
@@ -108,13 +110,12 @@ class LightGroup(GroupEntity, light.LightEntity):
     """Representation of a light group."""
 
     _attr_available = False
-    _attr_icon = "mdi:lightbulb-group"
     _attr_is_on = False
     _attr_max_mireds = 500
     _attr_min_mireds = 154
     _attr_should_poll = False
 
-    def __init__(self, unique_id: str | None, name: str, entity_ids: list[str]) -> None:
+    def __init__(self, unique_id: str | None, name: str, entity_ids: list[str], icon: str) -> None:
         """Initialize a light group."""
         self._entity_ids = entity_ids
         self._white_value: int | None = None
@@ -122,6 +123,7 @@ class LightGroup(GroupEntity, light.LightEntity):
         self._attr_name = name
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
         self._attr_unique_id = unique_id
+        self._attr_icon = icon
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -85,7 +85,7 @@ async def async_setup_platform(
                 config.get(CONF_UNIQUE_ID),
                 config[CONF_NAME],
                 config[CONF_ENTITIES],
-                config[CONF_ICON],
+                config.get(CONF_ICON),
             )
         ]
     )
@@ -119,7 +119,7 @@ class LightGroup(GroupEntity, light.LightEntity):
     _attr_should_poll = False
 
     def __init__(
-        self, unique_id: str | None, name: str, entity_ids: list[str], icon: str
+        self, unique_id: str | None, name: str, entity_ids: list[str], icon: str | None
     ) -> None:
         """Initialize a light group."""
         self._entity_ids = entity_ids

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -82,7 +82,10 @@ async def async_setup_platform(
     async_add_entities(
         [
             LightGroup(
-                config.get(CONF_UNIQUE_ID), config[CONF_NAME], config[CONF_ENTITIES], config[CONF_ICON]
+                config.get(CONF_UNIQUE_ID),
+                config[CONF_NAME],
+                config[CONF_ENTITIES],
+                config[CONF_ICON],
             )
         ]
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After #22530 being opened in 2019 and this issue being one that I've come across, I've added support to optionally specify the icon type in the light group YAML, rather than having to use the entity customize workaround.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #22530

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

See home-assistant/home-assistant.io#20464

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
