### PR TITLE
Use entity_registry.RegistryEntryDisabler instead of deprecated DISABLED_*

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1554,12 +1554,13 @@ def _handle_entry_updated_filter(event: Event) -> bool:
     """Handle entity registry entry update filter.
 
     Only handle changes to "disabled_by".
-    If "disabled_by" was DISABLED_CONFIG_ENTRY, reload is not needed.
+    If "disabled_by" was CONFIG_ENTRY, reload is not needed.
     """
     if (
         event.data["action"] != "update"
         or "disabled_by" not in event.data["changes"]
-        or event.data["changes"]["disabled_by"] == entity_registry.DISABLED_CONFIG_ENTRY
+        or event.data["changes"]["disabled_by"]
+        is entity_registry.RegistryEntryDisabler.CONFIG_ENTRY
     ):
         return False
     return True

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -190,7 +190,7 @@ async def test_sensor_disabled(hass):
     assert entry
     assert entry.unique_id == "0123456-apparenttemperature"
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # Test enabling entity
     updated_entry = registry.async_update_entity(

--- a/tests/components/ambee/test_sensor.py
+++ b/tests/components/ambee/test_sensor.py
@@ -280,7 +280,7 @@ async def test_pollen_disabled_by_default(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.parametrize(

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -273,7 +273,7 @@ async def test_disabled_by_default_sensors(hass):
     assert entry
     assert entry.unique_id == "0123456789_uptime"
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_availability(hass):

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -4,7 +4,7 @@ import pytest
 from homeassistant.components.config import entity_registry
 from homeassistant.const import ATTR_ICON
 from homeassistant.helpers.device_registry import DeviceEntryDisabler
-from homeassistant.helpers.entity_registry import DISABLED_USER, RegistryEntry
+from homeassistant.helpers.entity_registry import RegistryEntry, RegistryEntryDisabler
 
 from tests.common import (
     MockConfigEntry,
@@ -215,14 +215,16 @@ async def test_update_entity(hass, client):
             "id": 7,
             "type": "config/entity_registry/update",
             "entity_id": "test_domain.world",
-            "disabled_by": DISABLED_USER,
+            "disabled_by": RegistryEntryDisabler.USER,
         }
     )
 
     msg = await client.receive_json()
 
     assert hass.states.get("test_domain.world") is None
-    assert registry.entities["test_domain.world"].disabled_by == DISABLED_USER
+    assert (
+        registry.entities["test_domain.world"].disabled_by is RegistryEntryDisabler.USER
+    )
 
     # UPDATE DISABLED_BY TO NONE
     await client.send_json(

--- a/tests/components/efergy/test_sensor.py
+++ b/tests/components/efergy/test_sensor.py
@@ -89,7 +89,7 @@ async def test_sensor_readings(
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "EUR"
     assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_TOTAL_INCREASING
     entity = ent_reg.async_get("sensor.power_usage_728386")
-    assert entity.disabled_by == er.DISABLED_INTEGRATION
+    assert entity.disabled_by is er.RegistryEntryDisabler.INTEGRATION
     ent_reg.async_update_entity(entity.entity_id, **{"disabled_by": None})
     await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/forecast_solar/test_sensor.py
+++ b/tests/components/forecast_solar/test_sensor.py
@@ -166,7 +166,7 @@ async def test_disabled_by_default(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.parametrize(

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -90,7 +90,9 @@ async def enable_all_entities(hass, config_entry_id, time_till_next_update):
     registry = er.async_get(hass)
     entities = er.async_entries_for_config_entry(registry, config_entry_id)
     for entry in [
-        entry for entry in entities if entry.disabled_by == er.DISABLED_INTEGRATION
+        entry
+        for entry in entities
+        if entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
     ]:
         registry.async_update_entity(entry.entity_id, **{"disabled_by": None})
     await hass.async_block_till_done()

--- a/tests/components/greeneye_monitor/test_sensor.py
+++ b/tests/components/greeneye_monitor/test_sensor.py
@@ -7,7 +7,10 @@ from homeassistant.components.greeneye_monitor.sensor import (
 )
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_registry import async_get as get_entity_registry
+from homeassistant.helpers.entity_registry import (
+    RegistryEntryDisabler,
+    async_get as get_entity_registry,
+)
 
 from .common import (
     SINGLE_MONITOR_CONFIG_POWER_SENSORS,
@@ -161,5 +164,7 @@ def connect_monitor(monitors: AsyncMock, serial_number: int) -> MagicMock:
 async def disable_entity(hass: HomeAssistant, entity_id: str) -> None:
     """Disable the given entity."""
     entity_registry = get_entity_registry(hass)
-    entity_registry.async_update_entity(entity_id, disabled_by="user")
+    entity_registry.async_update_entity(
+        entity_id, disabled_by=RegistryEntryDisabler.USER
+    )
     await hass.async_block_till_done()

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -232,7 +232,7 @@ async def test_grouped_lights(hass, mock_bridge_v2, v2_resources_test_data):
 
         assert entity_entry
         assert entity_entry.disabled
-        assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
+        assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
         # entity should not have a device assigned
         assert entity_entry.device_id is None
 

--- a/tests/components/hue/test_sensor_v2.py
+++ b/tests/components/hue/test_sensor_v2.py
@@ -56,7 +56,7 @@ async def test_sensors(hass, mock_bridge_v2, v2_resources_test_data):
 
     assert entity_entry
     assert entity_entry.disabled
-    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_enable_sensor(
@@ -76,7 +76,7 @@ async def test_enable_sensor(
 
     assert entity_entry
     assert entity_entry.disabled
-    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # enable the entity
     updated_entry = ent_reg.async_update_entity(

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -1345,7 +1345,7 @@ async def test_lights_can_be_enabled(hass: HomeAssistant) -> None:
     entry = entity_registry.async_get(TEST_PRIORITY_LIGHT_ENTITY_ID_1)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
     entity_state = hass.states.get(TEST_PRIORITY_LIGHT_ENTITY_ID_1)
     assert not entity_state
 

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -199,7 +199,7 @@ async def test_switches_can_be_enabled(hass: HomeAssistant) -> None:
         entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.disabled
-        assert entry.disabled_by == er.DISABLED_INTEGRATION
+        assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
         entity_state = hass.states.get(entity_id)
         assert not entity_state
 

--- a/tests/components/ipp/test_sensor.py
+++ b/tests/components/ipp/test_sensor.py
@@ -95,7 +95,7 @@ async def test_disabled_by_default_sensors(
     entry = registry.async_get("sensor.epson_xp_6000_series_uptime")
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_missing_entry_unique_id(

--- a/tests/components/litejet/test_scene.py
+++ b/tests/components/litejet/test_scene.py
@@ -23,7 +23,7 @@ async def test_disabled_by_default(hass, mock_litejet):
     entry = registry.async_get(ENTITY_SCENE)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_activate(hass, mock_litejet):

--- a/tests/components/met/test_weather.py
+++ b/tests/components/met/test_weather.py
@@ -22,7 +22,7 @@ async def test_tracking_home(hass, mock_weather):
     entry = registry.async_get("weather.test_home_hourly")
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # Test we track config
     await hass.config.async_update(latitude=10, longitude=20)

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -518,7 +518,7 @@ async def test_first_run_with_failing_zones(hass):
 
     entry = registry.async_get(ZONE_7_ID)
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_not_first_run_with_failing_zone(hass):

--- a/tests/components/motioneye/test_sensor.py
+++ b/tests/components/motioneye/test_sensor.py
@@ -108,7 +108,7 @@ async def test_sensor_actions_can_be_enabled(hass: HomeAssistant) -> None:
     entry = entity_registry.async_get(TEST_SENSOR_ACTION_ENTITY_ID)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
     entity_state = hass.states.get(TEST_SENSOR_ACTION_ENTITY_ID)
     assert not entity_state
 

--- a/tests/components/motioneye/test_switch.py
+++ b/tests/components/motioneye/test_switch.py
@@ -160,7 +160,7 @@ async def test_disabled_switches_can_be_enabled(hass: HomeAssistant) -> None:
         entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.disabled
-        assert entry.disabled_by == er.DISABLED_INTEGRATION
+        assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
         entity_state = hass.states.get(entity_id)
         assert not entity_state
 

--- a/tests/components/nam/test_sensor.py
+++ b/tests/components/nam/test_sensor.py
@@ -351,7 +351,7 @@ async def test_sensor_disabled(hass):
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-signal"
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # Test enabling entity
     updated_entry = registry.async_update_entity(

--- a/tests/components/onewire/__init__.py
+++ b/tests/components/onewire/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceRegistry
-from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntryDisabler
 
 from .const import (
     ATTR_DEFAULT_DISABLED,
@@ -42,7 +42,7 @@ def check_and_enable_disabled_entities(
             entity_id = expected_entity[ATTR_ENTITY_ID]
             registry_entry = entity_registry.entities.get(entity_id)
             assert registry_entry.disabled
-            assert registry_entry.disabled_by == "integration"
+            assert registry_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
             entity_registry.async_update_entity(entity_id, **{"disabled_by": None})
 
 

--- a/tests/components/ozw/test_binary_sensor.py
+++ b/tests/components/ozw/test_binary_sensor.py
@@ -22,7 +22,7 @@ async def test_binary_sensor(hass, generic_data, binary_sensor_msg):
     entry = registry.async_get(entity_id)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # Test enabling legacy entity
     updated_entry = registry.async_update_entity(

--- a/tests/components/ozw/test_sensor.py
+++ b/tests/components/ozw/test_sensor.py
@@ -43,7 +43,7 @@ async def test_sensor(hass, generic_data):
     entry = registry.async_get(entity_id)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # Test enabling entity
     updated_entry = registry.async_update_entity(

--- a/tests/components/p1_monitor/test_sensor.py
+++ b/tests/components/p1_monitor/test_sensor.py
@@ -203,4 +203,4 @@ async def test_smartmeter_disabled_by_default(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION

--- a/tests/components/plex/test_sensor.py
+++ b/tests/components/plex/test_sensor.py
@@ -179,7 +179,8 @@ async def test_library_sensor_values(
 
     # Test movie library sensor
     entity_registry.async_update_entity(
-        entity_id="sensor.plex_server_1_library_tv_shows", disabled_by="user"
+        entity_id="sensor.plex_server_1_library_tv_shows",
+        disabled_by=er.RegistryEntryDisabler.USER,
     )
     entity_registry.async_update_entity(
         entity_id="sensor.plex_server_1_library_movies", disabled_by=None
@@ -214,7 +215,8 @@ async def test_library_sensor_values(
 
     # Test music library sensor
     entity_registry.async_update_entity(
-        entity_id="sensor.plex_server_1_library_movies", disabled_by="user"
+        entity_id="sensor.plex_server_1_library_movies",
+        disabled_by=er.RegistryEntryDisabler.USER,
     )
     entity_registry.async_update_entity(
         entity_id="sensor.plex_server_1_library_music", disabled_by=None

--- a/tests/components/renault/test_sensor.py
+++ b/tests/components/renault/test_sensor.py
@@ -7,7 +7,7 @@ import pytest
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntryDisabler
 
 from . import (
     check_device_registry,
@@ -38,7 +38,7 @@ def _check_and_enable_disabled_entities(
             entity_id = expected_entity[ATTR_ENTITY_ID]
             registry_entry = entity_registry.entities.get(entity_id)
             assert registry_entry.disabled
-            assert registry_entry.disabled_by == "integration"
+            assert registry_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
             entity_registry.async_update_entity(entity_id, **{"disabled_by": None})
 
 

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -116,7 +116,7 @@ async def test_disabled_by_default_sensors(
     entry = registry.async_get(entity_id)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_availability(

--- a/tests/components/switcher_kis/test_sensor.py
+++ b/tests/components/switcher_kis/test_sensor.py
@@ -61,7 +61,7 @@ async def test_sensor_disabled(hass, mock_bridge):
     assert entry
     assert entry.unique_id == unique_id
     assert entry.disabled is True
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # Test enabling entity
     updated_entry = registry.async_update_entity(

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -788,12 +788,12 @@ async def test_indexed_sensor_attributes(hass, mqtt_mock, setup_tasmota):
 @pytest.mark.parametrize(
     "sensor_name, disabled, disabled_by",
     [
-        ("tasmota_firmware_version", True, er.DISABLED_INTEGRATION),
-        ("tasmota_ip", True, er.DISABLED_INTEGRATION),
+        ("tasmota_firmware_version", True, er.RegistryEntryDisabler.INTEGRATION),
+        ("tasmota_ip", True, er.RegistryEntryDisabler.INTEGRATION),
         ("tasmota_last_restart_time", False, None),
         ("tasmota_mqtt_connect_count", False, None),
-        ("tasmota_rssi", True, er.DISABLED_INTEGRATION),
-        ("tasmota_signal", True, er.DISABLED_INTEGRATION),
+        ("tasmota_rssi", True, er.RegistryEntryDisabler.INTEGRATION),
+        ("tasmota_signal", True, er.RegistryEntryDisabler.INTEGRATION),
         ("tasmota_ssid", False, None),
         ("tasmota_wifi_connect_count", False, None),
     ],
@@ -819,7 +819,7 @@ async def test_diagnostic_sensors(
     assert bool(state) != disabled
     entry = entity_reg.async_get(f"sensor.{sensor_name}")
     assert entry.disabled == disabled
-    assert entry.disabled_by == disabled_by
+    assert entry.disabled_by is disabled_by
     assert entry.entity_category == "diagnostic"
 
 
@@ -843,7 +843,7 @@ async def test_enable_status_sensor(hass, mqtt_mock, setup_tasmota):
     assert state is None
     entry = entity_reg.async_get("sensor.tasmota_signal")
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # Enable the signal level status sensor
     updated_entry = entity_reg.async_update_entity(

--- a/tests/components/wled/test_sensor.py
+++ b/tests/components/wled/test_sensor.py
@@ -196,7 +196,7 @@ async def test_disabled_by_default_sensors(
     entry = registry.async_get(entity_id)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.parametrize(

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -89,7 +89,7 @@ async def test_disabled_legacy_sensor(hass, multisensor_6, integration):
     entry = registry.async_get(entity_id)
     assert entry
     assert entry.disabled
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # Test enabling legacy entity
     updated_entry = registry.async_update_entity(

--- a/tests/components/zwave_js/test_number.py
+++ b/tests/components/zwave_js/test_number.py
@@ -174,4 +174,4 @@ async def test_disabled_basic_number(hass, ge_in_wall_dimmer_switch, integration
 
     assert entity_entry
     assert entity_entry.disabled
-    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -122,7 +122,7 @@ async def test_disabled_notification_sensor(hass, multisensor_6, integration):
 
     assert entity_entry
     assert entity_entry.disabled
-    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     # Test enabling entity
     updated_entry = ent_reg.async_update_entity(
@@ -149,7 +149,7 @@ async def test_disabled_indcator_sensor(
 
     assert entity_entry
     assert entity_entry.disabled
-    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_config_parameter_sensor(hass, lock_id_lock_as_id150, integration):

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -580,7 +580,7 @@ async def test_warn_disabled(hass, caplog):
         entity_id="hello.world",
         unique_id="test-unique-id",
         platform="test-platform",
-        disabled_by=entity_registry.DISABLED_USER,
+        disabled_by=entity_registry.RegistryEntryDisabler.USER,
     )
     mock_registry(hass, {"hello.world": entry})
 
@@ -622,7 +622,7 @@ async def test_disabled_in_entity_registry(hass):
     assert hass.states.get("hello.world") is not None
 
     entry2 = registry.async_update_entity(
-        "hello.world", disabled_by=entity_registry.DISABLED_USER
+        "hello.world", disabled_by=entity_registry.RegistryEntryDisabler.USER
     )
     await hass.async_block_till_done()
     assert entry2 != entry

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -519,7 +519,7 @@ async def test_registry_respect_entity_disabled(hass):
                 unique_id="1234",
                 # Using component.async_add_entities is equal to platform "domain"
                 platform="test_platform",
-                disabled_by=er.DISABLED_USER,
+                disabled_by=er.RegistryEntryDisabler.USER,
             )
         },
     )
@@ -1077,7 +1077,7 @@ async def test_entity_disabled_by_integration(hass):
     entry_default = registry.async_get_or_create(DOMAIN, DOMAIN, "default")
     assert entry_default.disabled_by is None
     entry_disabled = registry.async_get_or_create(DOMAIN, DOMAIN, "disabled")
-    assert entry_disabled.disabled_by == er.DISABLED_INTEGRATION
+    assert entry_disabled.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_entity_disabled_by_device(hass: HomeAssistant):
@@ -1115,7 +1115,7 @@ async def test_entity_disabled_by_device(hass: HomeAssistant):
     registry = er.async_get(hass)
 
     entry_disabled = registry.async_get_or_create(DOMAIN, DOMAIN, "disabled")
-    assert entry_disabled.disabled_by == er.DISABLED_DEVICE
+    assert entry_disabled.disabled_by is er.RegistryEntryDisabler.DEVICE
 
 
 async def test_entity_info_added_to_entity_registry(hass):

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -76,7 +76,7 @@ def test_get_or_create_updates_data(registry):
         capabilities={"max": 100},
         config_entry=orig_config_entry,
         device_id="mock-dev-id",
-        disabled_by=er.DISABLED_HASS,
+        disabled_by=er.RegistryEntryDisabler.HASS,
         entity_category="config",
         original_device_class="mock-device-class",
         original_icon="initial-original_icon",
@@ -94,7 +94,7 @@ def test_get_or_create_updates_data(registry):
         config_entry_id=orig_config_entry.entry_id,
         device_class=None,
         device_id="mock-dev-id",
-        disabled_by=er.DISABLED_HASS,
+        disabled_by=er.RegistryEntryDisabler.HASS,
         entity_category="config",
         icon=None,
         id=orig_entry.id,
@@ -116,7 +116,7 @@ def test_get_or_create_updates_data(registry):
         capabilities={"new-max": 100},
         config_entry=new_config_entry,
         device_id="new-mock-dev-id",
-        disabled_by=er.DISABLED_USER,
+        disabled_by=er.RegistryEntryDisabler.USER,
         entity_category=None,
         original_device_class="new-mock-device-class",
         original_icon="updated-original_icon",
@@ -134,7 +134,7 @@ def test_get_or_create_updates_data(registry):
         config_entry_id=new_config_entry.entry_id,
         device_class=None,
         device_id="new-mock-dev-id",
-        disabled_by=er.DISABLED_HASS,  # Should not be updated
+        disabled_by=er.RegistryEntryDisabler.HASS,  # Should not be updated
         entity_category="config",
         icon=None,
         id=orig_entry.id,
@@ -188,7 +188,7 @@ async def test_loading_saving_data(hass, registry):
         capabilities={"max": 100},
         config_entry=mock_config,
         device_id="mock-dev-id",
-        disabled_by=er.DISABLED_HASS,
+        disabled_by=er.RegistryEntryDisabler.HASS,
         entity_category="config",
         original_device_class="mock-device-class",
         original_icon="hass:original-icon",
@@ -223,7 +223,7 @@ async def test_loading_saving_data(hass, registry):
     assert new_entry2.config_entry_id == mock_config.entry_id
     assert new_entry2.device_class == "user-class"
     assert new_entry2.device_id == "mock-dev-id"
-    assert new_entry2.disabled_by == er.DISABLED_HASS
+    assert new_entry2.disabled_by is er.RegistryEntryDisabler.HASS
     assert new_entry2.entity_category == "config"
     assert new_entry2.icon == "hass:user-icon"
     assert new_entry2.name == "User Name"
@@ -277,19 +277,19 @@ async def test_loading_extra_values(hass, hass_storage):
                     "entity_id": "test.disabled_user",
                     "platform": "super_platform",
                     "unique_id": "disabled-user",
-                    "disabled_by": er.DISABLED_USER,
+                    "disabled_by": er.RegistryEntryDisabler.USER,
                 },
                 {
                     "entity_id": "test.disabled_hass",
                     "platform": "super_platform",
                     "unique_id": "disabled-hass",
-                    "disabled_by": er.DISABLED_HASS,
+                    "disabled_by": er.RegistryEntryDisabler.HASS,
                 },
                 {
                     "entity_id": "test.invalid__entity",
                     "platform": "super_platform",
                     "unique_id": "invalid-hass",
-                    "disabled_by": er.DISABLED_HASS,
+                    "disabled_by": er.RegistryEntryDisabler.HASS,
                 },
             ]
         },
@@ -317,9 +317,9 @@ async def test_loading_extra_values(hass, hass_storage):
         "test", "super_platform", "disabled-user"
     )
     assert entry_disabled_hass.disabled
-    assert entry_disabled_hass.disabled_by == er.DISABLED_HASS
+    assert entry_disabled_hass.disabled_by is er.RegistryEntryDisabler.HASS
     assert entry_disabled_user.disabled
-    assert entry_disabled_user.disabled_by == er.DISABLED_USER
+    assert entry_disabled_user.disabled_by is er.RegistryEntryDisabler.USER
 
 
 def test_async_get_entity_id(registry):
@@ -399,7 +399,7 @@ async def test_migration_yaml_to_json(hass):
             "unique_id": "test-unique",
             "platform": "test-platform",
             "name": "Test Name",
-            "disabled_by": er.DISABLED_HASS,
+            "disabled_by": er.RegistryEntryDisabler.HASS,
         }
     }
     with patch("os.path.isfile", return_value=True), patch("os.remove"), patch(
@@ -416,7 +416,7 @@ async def test_migration_yaml_to_json(hass):
         config_entry=mock_config,
     )
     assert entry.name == "Test Name"
-    assert entry.disabled_by == er.DISABLED_HASS
+    assert entry.disabled_by is er.RegistryEntryDisabler.HASS
     assert entry.config_entry_id == "test-config-id"
 
 
@@ -554,7 +554,7 @@ async def test_update_entity(registry):
     for attr_name, new_value in (
         ("name", "new name"),
         ("icon", "new icon"),
-        ("disabled_by", er.DISABLED_USER),
+        ("disabled_by", er.RegistryEntryDisabler.USER),
     ):
         changes = {attr_name: new_value}
         updated_entry = registry.async_update_entity(entry.entity_id, **changes)
@@ -573,14 +573,14 @@ async def test_update_entity(registry):
 async def test_disabled_by(registry):
     """Test that we can disable an entry when we create it."""
     entry = registry.async_get_or_create(
-        "light", "hue", "5678", disabled_by=er.DISABLED_HASS
+        "light", "hue", "5678", disabled_by=er.RegistryEntryDisabler.HASS
     )
-    assert entry.disabled_by == er.DISABLED_HASS
+    assert entry.disabled_by is er.RegistryEntryDisabler.HASS
 
     entry = registry.async_get_or_create(
-        "light", "hue", "5678", disabled_by=er.DISABLED_INTEGRATION
+        "light", "hue", "5678", disabled_by=er.RegistryEntryDisabler.INTEGRATION
     )
-    assert entry.disabled_by == er.DISABLED_HASS
+    assert entry.disabled_by is er.RegistryEntryDisabler.HASS
 
     entry2 = registry.async_get_or_create("light", "hue", "1234")
     assert entry2.disabled_by is None
@@ -596,16 +596,16 @@ async def test_disabled_by_config_entry_pref(registry):
     entry = registry.async_get_or_create(
         "light", "hue", "AAAA", config_entry=mock_config
     )
-    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
     entry2 = registry.async_get_or_create(
         "light",
         "hue",
         "BBBB",
         config_entry=mock_config,
-        disabled_by=er.DISABLED_USER,
+        disabled_by=er.RegistryEntryDisabler.USER,
     )
-    assert entry2.disabled_by == er.DISABLED_USER
+    assert entry2.disabled_by is er.RegistryEntryDisabler.USER
 
 
 async def test_restore_states(hass):
@@ -626,7 +626,7 @@ async def test_restore_states(hass):
         "hue",
         "5678",
         suggested_object_id="disabled",
-        disabled_by=er.DISABLED_HASS,
+        disabled_by=er.RegistryEntryDisabler.HASS,
     )
     registry.async_get_or_create(
         "light",
@@ -836,7 +836,7 @@ async def test_disable_device_disables_entities(hass, registry):
         "ABCD",
         config_entry=config_entry,
         device_id=device_entry.id,
-        disabled_by=er.DISABLED_USER,
+        disabled_by=er.RegistryEntryDisabler.USER,
     )
     entry3 = registry.async_get_or_create(
         "light",
@@ -844,7 +844,7 @@ async def test_disable_device_disables_entities(hass, registry):
         "EFGH",
         config_entry=config_entry,
         device_id=device_entry.id,
-        disabled_by=er.DISABLED_CONFIG_ENTRY,
+        disabled_by=er.RegistryEntryDisabler.CONFIG_ENTRY,
     )
 
     assert not entry1.disabled
@@ -858,13 +858,13 @@ async def test_disable_device_disables_entities(hass, registry):
 
     entry1 = registry.async_get(entry1.entity_id)
     assert entry1.disabled
-    assert entry1.disabled_by == er.DISABLED_DEVICE
+    assert entry1.disabled_by is er.RegistryEntryDisabler.DEVICE
     entry2 = registry.async_get(entry2.entity_id)
     assert entry2.disabled
-    assert entry2.disabled_by == er.DISABLED_USER
+    assert entry2.disabled_by is er.RegistryEntryDisabler.USER
     entry3 = registry.async_get(entry3.entity_id)
     assert entry3.disabled
-    assert entry3.disabled_by == er.DISABLED_CONFIG_ENTRY
+    assert entry3.disabled_by is er.RegistryEntryDisabler.CONFIG_ENTRY
 
     device_registry.async_update_device(device_entry.id, disabled_by=None)
     await hass.async_block_till_done()
@@ -873,10 +873,10 @@ async def test_disable_device_disables_entities(hass, registry):
     assert not entry1.disabled
     entry2 = registry.async_get(entry2.entity_id)
     assert entry2.disabled
-    assert entry2.disabled_by == er.DISABLED_USER
+    assert entry2.disabled_by is er.RegistryEntryDisabler.USER
     entry3 = registry.async_get(entry3.entity_id)
     assert entry3.disabled
-    assert entry3.disabled_by == er.DISABLED_CONFIG_ENTRY
+    assert entry3.disabled_by is er.RegistryEntryDisabler.CONFIG_ENTRY
 
 
 async def test_disable_config_entry_disables_entities(hass, registry):
@@ -903,7 +903,7 @@ async def test_disable_config_entry_disables_entities(hass, registry):
         "ABCD",
         config_entry=config_entry,
         device_id=device_entry.id,
-        disabled_by=er.DISABLED_USER,
+        disabled_by=er.RegistryEntryDisabler.USER,
     )
     entry3 = registry.async_get_or_create(
         "light",
@@ -911,7 +911,7 @@ async def test_disable_config_entry_disables_entities(hass, registry):
         "EFGH",
         config_entry=config_entry,
         device_id=device_entry.id,
-        disabled_by=er.DISABLED_DEVICE,
+        disabled_by=er.RegistryEntryDisabler.DEVICE,
     )
 
     assert not entry1.disabled
@@ -925,13 +925,13 @@ async def test_disable_config_entry_disables_entities(hass, registry):
 
     entry1 = registry.async_get(entry1.entity_id)
     assert entry1.disabled
-    assert entry1.disabled_by == er.DISABLED_CONFIG_ENTRY
+    assert entry1.disabled_by is er.RegistryEntryDisabler.CONFIG_ENTRY
     entry2 = registry.async_get(entry2.entity_id)
     assert entry2.disabled
-    assert entry2.disabled_by == er.DISABLED_USER
+    assert entry2.disabled_by is er.RegistryEntryDisabler.USER
     entry3 = registry.async_get(entry3.entity_id)
     assert entry3.disabled
-    assert entry3.disabled_by == er.DISABLED_DEVICE
+    assert entry3.disabled_by is er.RegistryEntryDisabler.DEVICE
 
     await hass.config_entries.async_set_disabled_by(config_entry.entry_id, None)
     await hass.async_block_till_done()
@@ -940,7 +940,7 @@ async def test_disable_config_entry_disables_entities(hass, registry):
     assert not entry1.disabled
     entry2 = registry.async_get(entry2.entity_id)
     assert entry2.disabled
-    assert entry2.disabled_by == er.DISABLED_USER
+    assert entry2.disabled_by is er.RegistryEntryDisabler.USER
     # The device was re-enabled, so entity disabled by the device will be re-enabled too
     entry3 = registry.async_get(entry3.entity_id)
     assert not entry3.disabled_by
@@ -970,7 +970,7 @@ async def test_disabled_entities_excluded_from_entity_list(hass, registry):
         "ABCD",
         config_entry=config_entry,
         device_id=device_entry.id,
-        disabled_by=er.DISABLED_USER,
+        disabled_by=er.RegistryEntryDisabler.USER,
     )
 
     entries = er.async_entries_for_device(registry, device_entry.id)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1433,7 +1433,9 @@ async def test_reload_entry_entity_registry_ignores_no_entry(hass):
 
     # Test we ignore entities without config entry
     entry = registry.async_get_or_create("light", "hue", "123")
-    registry.async_update_entity(entry.entity_id, disabled_by=er.DISABLED_USER)
+    registry.async_update_entity(
+        entry.entity_id, disabled_by=er.RegistryEntryDisabler.USER
+    )
     await hass.async_block_till_done()
     assert not handler.changed
     assert handler._remove_call_later is None
@@ -1472,7 +1474,9 @@ async def test_reload_entry_entity_registry_works(hass):
     assert handler._remove_call_later is None
 
     # Disable entity, we should not do anything, only act when enabled.
-    registry.async_update_entity(entity_entry.entity_id, disabled_by=er.DISABLED_USER)
+    registry.async_update_entity(
+        entity_entry.entity_id, disabled_by=er.RegistryEntryDisabler.USER
+    )
     await hass.async_block_till_done()
     assert not handler.changed
     assert handler._remove_call_later is None


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

~This is an alternative/add-on to https://github.com/home-assistant/core/pull/60424. We can choose to apply this instead of that if we have someone comfortable with reviewing a PR this size; otherwise, if that ones is applied first, I'll rebase and possibly chop up this to smaller chunks.~

Use the new enum instead of deprecated string constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/60424
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
