### PR TITLE
Allow template int filter to render from a bytes based integer

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1567,8 +1567,10 @@ def forgiving_float_filter(value, default=_SENTINEL):
         return default
 
 
-def forgiving_int(value, default=_SENTINEL, base=10):
+def forgiving_int(value, default=_SENTINEL, base=10, little_endian=False):
     """Try to convert value to an int, and warn if it fails."""
+    if isinstance(value, bytes) and value:
+        return convert_to_int(value, little_endian=little_endian)
     result = jinja2.filters.do_int(value, default=default, base=base)
     if result is _SENTINEL:
         warn_no_default("int", value, value)
@@ -1576,8 +1578,10 @@ def forgiving_int(value, default=_SENTINEL, base=10):
     return result
 
 
-def forgiving_int_filter(value, default=_SENTINEL, base=10):
+def forgiving_int_filter(value, default=_SENTINEL, base=10, little_endian=False):
     """Try to convert value to an int, and warn if it fails."""
+    if isinstance(value, bytes) and value:
+        return convert_to_int(value, little_endian=little_endian)
     result = jinja2.filters.do_int(value, default=default, base=base)
     if result is _SENTINEL:
         warn_no_default("int", value, 0)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1570,6 +1570,13 @@ def forgiving_float_filter(value, default=_SENTINEL):
 def forgiving_int(value, default=_SENTINEL, base=10, little_endian=False):
     """Try to convert value to an int, and warn if it fails."""
     if isinstance(value, bytes) and value:
+        if base != 10:
+            _LOGGER.warning(
+                (
+                    "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter."
+                ),
+                base,
+            )
         return convert_to_int(value, little_endian=little_endian)
     result = jinja2.filters.do_int(value, default=default, base=base)
     if result is _SENTINEL:
@@ -1581,6 +1588,13 @@ def forgiving_int(value, default=_SENTINEL, base=10, little_endian=False):
 def forgiving_int_filter(value, default=_SENTINEL, base=10, little_endian=False):
     """Try to convert value to an int, and warn if it fails."""
     if isinstance(value, bytes) and value:
+        if base != 10:
+            _LOGGER.warning(
+                (
+                    "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter."
+                ),
+                base,
+            )
         return convert_to_int(value, little_endian=little_endian)
     result = jinja2.filters.do_int(value, default=default, base=base)
     if result is _SENTINEL:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1572,9 +1572,7 @@ def forgiving_int(value, default=_SENTINEL, base=10, little_endian=False):
     if isinstance(value, bytes) and value:
         if base != 10:
             _LOGGER.warning(
-                (
-                    "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter"
-                ),
+                "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter",
                 base,
             )
         return convert_to_int(value, little_endian=little_endian)
@@ -1590,9 +1588,7 @@ def forgiving_int_filter(value, default=_SENTINEL, base=10, little_endian=False)
     if isinstance(value, bytes) and value:
         if base != 10:
             _LOGGER.warning(
-                (
-                    "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter"
-                ),
+                "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter",
                 base,
             )
         return convert_to_int(value, little_endian=little_endian)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1573,7 +1573,7 @@ def forgiving_int(value, default=_SENTINEL, base=10, little_endian=False):
         if base != 10:
             _LOGGER.warning(
                 (
-                    "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter."
+                    "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter"
                 ),
                 base,
             )
@@ -1591,7 +1591,7 @@ def forgiving_int_filter(value, default=_SENTINEL, base=10, little_endian=False)
         if base != 10:
             _LOGGER.warning(
                 (
-                    "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter."
+                    "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter"
                 ),
                 base,
             )

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1572,7 +1572,9 @@ def forgiving_int(value, default=_SENTINEL, base=10, little_endian=False):
     if isinstance(value, bytes) and value:
         if base != 10:
             _LOGGER.warning(
-                "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter"
+                (
+                    "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter"
+                ),
                 base,
             )
         return convert_to_int(value, little_endian=little_endian)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1572,9 +1572,7 @@ def forgiving_int(value, default=_SENTINEL, base=10, little_endian=False):
     if isinstance(value, bytes) and value:
         if base != 10:
             _LOGGER.warning(
-                (
-                    "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter"
-                ),
+                "Template warning: 'int' got 'bytes' type input, ignoring base=%s parameter"
                 base,
             )
         return convert_to_int(value, little_endian=little_endian)

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -252,7 +252,7 @@ def test_float_filter(hass):
     assert render(hass, "{{ 'bad' | float(default=1) }}") == 1
 
 
-def test_int_filter(hass):
+def test_int_filter(hass, caplog):
     """Test int filter."""
     hass.states.async_set("sensor.temperature", "12.2")
     assert render(hass, "{{ states.sensor.temperature.state | int }}") == 12
@@ -273,8 +273,17 @@ def test_int_filter(hass):
         == 0xEFBEADDE
     )
 
+    # Test with base and base parameter set
+    assert (
+        render(hass, "{{ value | int(base=16) }}", variables=variables)
+    ) == 0xDEADBEEF
+    assert (
+        "Template warning: 'int' got 'bytes' type input, ignoring base=16 parameter."
+        in caplog.text
+    )
 
-def test_int_function(hass):
+
+def test_int_function(hass, caplog):
     """Test int filter."""
     hass.states.async_set("sensor.temperature", "12.2")
     assert render(hass, "{{ int(states.sensor.temperature.state) }}") == 12
@@ -287,12 +296,20 @@ def test_int_function(hass):
     assert render(hass, "{{ int('bad', 1) }}") == 1
     assert render(hass, "{{ int('bad', default=1) }}") == 1
 
-    # Test with bytes based integer
+    # Test with base and base parameter set
     variables = {"value": b"\xde\xad\xbe\xef"}
     assert (render(hass, "{{ int(value) }}", variables=variables)) == 0xDEADBEEF
     assert (
         render(hass, "{{ int(value, little_endian=True) }}", variables=variables)
         == 0xEFBEADDE
+    )
+
+    assert (
+        render(hass, "{{ int(value, base=16) }}", variables=variables)
+    ) == 0xDEADBEEF
+    assert (
+        "Template warning: 'int' got 'bytes' type input, ignoring base=16 parameter."
+        in caplog.text
     )
 
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -265,6 +265,14 @@ def test_int_filter(hass):
     assert render(hass, "{{ 'bad' | int(1) }}") == 1
     assert render(hass, "{{ 'bad' | int(default=1) }}") == 1
 
+    # Test with bytes based integer
+    variables = {"value": b"\xde\xad\xbe\xef"}
+    assert (render(hass, "{{ value | int }}", variables=variables)) == 0xDEADBEEF
+    assert (
+        render(hass, "{{ value | int(little_endian=True) }}", variables=variables)
+        == 0xEFBEADDE
+    )
+
 
 def test_int_function(hass):
     """Test int filter."""
@@ -278,6 +286,14 @@ def test_int_function(hass):
     assert render(hass, "{{ int('bad') }}") == "bad"
     assert render(hass, "{{ int('bad', 1) }}") == 1
     assert render(hass, "{{ int('bad', default=1) }}") == 1
+
+    # Test with bytes based integer
+    variables = {"value": b"\xde\xad\xbe\xef"}
+    assert (render(hass, "{{ int(value) }}", variables=variables)) == 0xDEADBEEF
+    assert (
+        render(hass, "{{ int(value, little_endian=True) }}", variables=variables)
+        == 0xEFBEADDE
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -278,7 +278,7 @@ def test_int_filter(hass, caplog):
         render(hass, "{{ value | int(base=16) }}", variables=variables)
     ) == 0xDEADBEEF
     assert (
-        "Template warning: 'int' got 'bytes' type input, ignoring base=16 parameter."
+        "Template warning: 'int' got 'bytes' type input, ignoring base=16 parameter"
         in caplog.text
     )
 
@@ -308,7 +308,7 @@ def test_int_function(hass, caplog):
         render(hass, "{{ int(value, base=16) }}", variables=variables)
     ) == 0xDEADBEEF
     assert (
-        "Template warning: 'int' got 'bytes' type input, ignoring base=16 parameter."
+        "Template warning: 'int' got 'bytes' type input, ignoring base=16 parameter"
         in caplog.text
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow the `int` template filter and function to render integers from a raw `bytes` object like `bitewise_or`and `bitwise_and`.
The `int` function/filter takes an additonal extra parameter `little_endian` that defaults to `False`,

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20471

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
