### PR TITLE
Fix Flo returning stale data

### DIFF
--- a/homeassistant/components/flo/device.py
+++ b/homeassistant/components/flo/device.py
@@ -42,7 +42,11 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             async with timeout(10):
                 await asyncio.gather(
-                    *[self._update_device(), self._update_consumption_data()]
+                    *[
+                        self.send_presence_ping(),
+                        self._update_device(),
+                        self._update_consumption_data(),
+                    ]
                 )
         except (RequestError) as error:
             raise UpdateFailed(error) from error
@@ -187,6 +191,10 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
     def battery_level(self) -> float:
         """Return the battery level for battery-powered device, e.g. leak detectors."""
         return self._device_information["battery"]["level"]
+
+    async def send_presence_ping(self):
+        """Send Flo a presence ping."""
+        await self.api_client.presence.ping()
 
     async def async_set_mode_home(self):
         """Set the Flo location to home mode."""

--- a/homeassistant/components/flo/manifest.json
+++ b/homeassistant/components/flo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Flo",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flo",
-  "requirements": ["aioflo==0.4.1"],
+  "requirements": ["aioflo==2021.11.0"],
   "codeowners": ["@dmulcahey"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -164,7 +164,7 @@ aioemonitor==1.0.5
 aioesphomeapi==10.2.0
 
 # homeassistant.components.flo
-aioflo==0.4.1
+aioflo==2021.11.0
 
 # homeassistant.components.yi
 aioftp==0.12.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -115,7 +115,7 @@ aioemonitor==1.0.5
 aioesphomeapi==10.2.0
 
 # homeassistant.components.flo
-aioflo==0.4.1
+aioflo==2021.11.0
 
 # homeassistant.components.guardian
 aioguardian==2021.11.0

--- a/tests/components/flo/conftest.py
+++ b/tests/components/flo/conftest.py
@@ -44,6 +44,13 @@ def aioclient_mock_fixture(aioclient_mock):
         headers={"Content-Type": CONTENT_TYPE_JSON},
         status=HTTPStatus.OK,
     )
+    # Mocks the presence ping response for flo.
+    aioclient_mock.post(
+        "https://api-gw.meetflo.com/api/v2/presence/me",
+        text=load_fixture("flo/ping_response.json"),
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+        status=HTTPStatus.OK,
+    )
     # Mocks the devices for flo.
     aioclient_mock.get(
         "https://api-gw.meetflo.com/api/v2/devices/98765",

--- a/tests/components/flo/fixtures/ping_response.json
+++ b/tests/components/flo/fixtures/ping_response.json
@@ -1,0 +1,8 @@
+{
+  "ipAddress": "11.111.111.111",
+  "userId": "12345abcde",
+  "action": "report",
+  "type": "user",
+  "appName": "legacy",
+  "userData": { "account": { "type": "personal" } }
+}

--- a/tests/components/flo/test_device.py
+++ b/tests/components/flo/test_device.py
@@ -73,4 +73,4 @@ async def test_device(hass, config_entry, aioclient_mock_fixture, aioclient_mock
     async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=90))
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == call_count + 4
+    assert aioclient_mock.call_count == call_count + 6

--- a/tests/components/flo/test_device.py
+++ b/tests/components/flo/test_device.py
@@ -1,9 +1,14 @@
 """Define tests for device-related endpoints."""
 from datetime import timedelta
+from unittest.mock import patch
+
+from aioflo.errors import RequestError
+import pytest
 
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.components.flo.device import FloDeviceDataUpdateCoordinator
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
@@ -67,6 +72,7 @@ async def test_device(hass, config_entry, aioclient_mock_fixture, aioclient_mock
     assert detector.model == "puck_v1"
     assert detector.manufacturer == "Flo by Moen"
     assert detector.device_name == "Kitchen Sink"
+    assert detector.serial_number == "111111111112"
 
     call_count = aioclient_mock.call_count
 
@@ -74,3 +80,11 @@ async def test_device(hass, config_entry, aioclient_mock_fixture, aioclient_mock
     await hass.async_block_till_done()
 
     assert aioclient_mock.call_count == call_count + 6
+
+    # test error sending device ping
+    with patch(
+        "homeassistant.components.flo.device.FloDeviceDataUpdateCoordinator.send_presence_ping",
+        side_effect=RequestError,
+    ):
+        with pytest.raises(UpdateFailed):
+            await valve._async_update_data()

--- a/tests/components/flo/test_sensor.py
+++ b/tests/components/flo/test_sensor.py
@@ -50,4 +50,4 @@ async def test_manual_update_entity(
         {ATTR_ENTITY_ID: ["sensor.current_system_mode"]},
         blocking=True,
     )
-    assert aioclient_mock.call_count == call_count + 2
+    assert aioclient_mock.call_count == call_count + 3

--- a/tests/components/flo/test_services.py
+++ b/tests/components/flo/test_services.py
@@ -26,7 +26,7 @@ async def test_services(hass, config_entry, aioclient_mock_fixture, aioclient_mo
     await hass.async_block_till_done()
 
     assert len(hass.data[FLO_DOMAIN][config_entry.entry_id]["devices"]) == 2
-    assert aioclient_mock.call_count == 6
+    assert aioclient_mock.call_count == 8
 
     await hass.services.async_call(
         FLO_DOMAIN,
@@ -35,7 +35,7 @@ async def test_services(hass, config_entry, aioclient_mock_fixture, aioclient_mo
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 7
+    assert aioclient_mock.call_count == 9
 
     await hass.services.async_call(
         FLO_DOMAIN,
@@ -44,7 +44,7 @@ async def test_services(hass, config_entry, aioclient_mock_fixture, aioclient_mo
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 8
+    assert aioclient_mock.call_count == 10
 
     await hass.services.async_call(
         FLO_DOMAIN,
@@ -53,7 +53,7 @@ async def test_services(hass, config_entry, aioclient_mock_fixture, aioclient_mo
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 9
+    assert aioclient_mock.call_count == 11
 
     await hass.services.async_call(
         FLO_DOMAIN,
@@ -66,4 +66,4 @@ async def test_services(hass, config_entry, aioclient_mock_fixture, aioclient_mo
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 12


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes an issue where the Flo integration returns stale data from the API. The PR bumps aioflo to 2021.11.0: https://github.com/bachya/aioflo/compare/2021.10.0...2021.11.0 and implements the presence ping in the dataupdatecoordinator so that we get current data from subsequent API calls. 



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #54712
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
