### PR TITLE
Move Sonos bass & treble controls to number entities

### DIFF
--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -19,6 +19,7 @@ from homeassistant.components.media_player.const import (
     MEDIA_TYPE_PLAYLIST,
     MEDIA_TYPE_TRACK,
 )
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 
@@ -27,7 +28,13 @@ UPNP_ST = "urn:schemas-upnp-org:device:ZonePlayer:1"
 DOMAIN = "sonos"
 DATA_SONOS = "sonos_media_player"
 DATA_SONOS_DISCOVERY_MANAGER = "sonos_discovery_manager"
-PLATFORMS = {BINARY_SENSOR_DOMAIN, MP_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN}
+PLATFORMS = {
+    BINARY_SENSOR_DOMAIN,
+    MP_DOMAIN,
+    NUMBER_DOMAIN,
+    SENSOR_DOMAIN,
+    SWITCH_DOMAIN,
+}
 
 SONOS_ARTIST = "artists"
 SONOS_ALBUM = "albums"
@@ -139,6 +146,7 @@ SONOS_CHECK_ACTIVITY = "sonos_check_activity"
 SONOS_CREATE_ALARM = "sonos_create_alarm"
 SONOS_CREATE_BATTERY = "sonos_create_battery"
 SONOS_CREATE_SWITCHES = "sonos_create_switches"
+SONOS_CREATE_LEVELS = "sonos_create_levels"
 SONOS_CREATE_MEDIA_PLAYER = "sonos_create_media_player"
 SONOS_ENTITY_CREATED = "sonos_entity_created"
 SONOS_POLL_UPDATE = "sonos_poll_update"

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -108,7 +108,6 @@ SERVICE_RESTORE = "restore"
 SERVICE_SET_TIMER = "set_sleep_timer"
 SERVICE_CLEAR_TIMER = "clear_sleep_timer"
 SERVICE_UPDATE_ALARM = "update_alarm"
-SERVICE_SET_OPTION = "set_option"
 SERVICE_PLAY_QUEUE = "play_queue"
 SERVICE_REMOVE_FROM_QUEUE = "remove_from_queue"
 
@@ -120,8 +119,6 @@ ATTR_INCLUDE_LINKED_ZONES = "include_linked_zones"
 ATTR_MASTER = "master"
 ATTR_WITH_GROUP = "with_group"
 ATTR_QUEUE_POSITION = "queue_position"
-ATTR_EQ_BASS = "bass_level"
-ATTR_EQ_TREBLE = "treble_level"
 
 
 async def async_setup_entry(
@@ -223,19 +220,6 @@ async def async_setup_entry(
             vol.Optional(ATTR_INCLUDE_LINKED_ZONES): cv.boolean,
         },
         "set_alarm",
-    )
-
-    platform.async_register_entity_service(  # type: ignore
-        SERVICE_SET_OPTION,
-        {
-            vol.Optional(ATTR_EQ_BASS): vol.All(
-                vol.Coerce(int), vol.Range(min=-10, max=10)
-            ),
-            vol.Optional(ATTR_EQ_TREBLE): vol.All(
-                vol.Coerce(int), vol.Range(min=-10, max=10)
-            ),
-        },
-        "set_option",
     )
 
     platform.async_register_entity_service(  # type: ignore
@@ -606,19 +590,6 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         alarm.save()
 
     @soco_error()
-    def set_option(
-        self,
-        bass_level: int | None = None,
-        treble_level: int | None = None,
-    ) -> None:
-        """Modify playback options."""
-        if bass_level is not None:
-            self.soco.bass = bass_level
-
-        if treble_level is not None:
-            self.soco.treble = treble_level
-
-    @soco_error()
     def play_queue(self, queue_position: int = 0) -> None:
         """Start playing the queue."""
         self.soco.play_from_queue(queue_position)
@@ -634,12 +605,6 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         attributes: dict[str, Any] = {
             ATTR_SONOS_GROUP: self.speaker.sonos_group_entities
         }
-
-        if self.speaker.bass_level is not None:
-            attributes[ATTR_EQ_BASS] = self.speaker.bass_level
-
-        if self.speaker.treble_level is not None:
-            attributes[ATTR_EQ_TREBLE] = self.speaker.treble_level
 
         if self.media.queue_position is not None:
             attributes[ATTR_QUEUE_POSITION] = self.media.queue_position

--- a/homeassistant/components/sonos/number.py
+++ b/homeassistant/components/sonos/number.py
@@ -1,0 +1,63 @@
+"""Entity representing a Sonos number control."""
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import SONOS_CREATE_LEVELS
+from .entity import SonosEntity
+from .speaker import SonosSpeaker
+
+LEVEL_TYPES = ("bass", "treble")
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Sonos number platform from a config entry."""
+
+    async def _async_create_entities(speaker: SonosSpeaker) -> None:
+        entities = []
+        for level_type in LEVEL_TYPES:
+            entities.append(SonosLevelEntity(speaker, level_type))
+        async_add_entities(entities)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(hass, SONOS_CREATE_LEVELS, _async_create_entities)
+    )
+
+
+class SonosLevelEntity(SonosEntity, NumberEntity):
+    """Representation of a Sonos level entity."""
+
+    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_registry_enabled_default = False
+    _attr_min_value = -10
+    _attr_max_value = 10
+
+    def __init__(self, speaker: SonosSpeaker, level_type: str) -> None:
+        """Initialize the level entity."""
+        super().__init__(speaker)
+        self.level_type = level_type
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID."""
+        return f"{self.soco.uid}-{self.level_type}"
+
+    @property
+    def name(self) -> str:
+        """Return the name."""
+        return f"{self.speaker.zone_name} {self.level_type.capitalize()}"
+
+    async def _async_poll(self) -> None:
+        """Poll the value if subscriptions are not working."""
+        # Handled by SonosSpeaker
+
+    def set_value(self, value: float) -> None:
+        """Set a new value."""
+        setattr(self.soco, self.level_type, value)
+
+    @property
+    def value(self) -> float:
+        """Return the current value."""
+        return getattr(self.speaker, self.level_type)

--- a/homeassistant/components/sonos/number.py
+++ b/homeassistant/components/sonos/number.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import SONOS_CREATE_LEVELS
 from .entity import SonosEntity
+from .helpers import soco_error
 from .speaker import SonosSpeaker
 
 LEVEL_TYPES = ("bass", "treble")
@@ -53,6 +54,7 @@ class SonosLevelEntity(SonosEntity, NumberEntity):
         """Poll the value if subscriptions are not working."""
         # Handled by SonosSpeaker
 
+    @soco_error()
     def set_value(self, value: float) -> None:
         """Set a new value."""
         setattr(self.soco, self.level_type, value)

--- a/homeassistant/components/sonos/number.py
+++ b/homeassistant/components/sonos/number.py
@@ -31,7 +31,6 @@ class SonosLevelEntity(SonosEntity, NumberEntity):
     """Representation of a Sonos level entity."""
 
     _attr_entity_category = ENTITY_CATEGORY_CONFIG
-    _attr_entity_registry_enabled_default = False
     _attr_min_value = -10
     _attr_max_value = 10
 

--- a/homeassistant/components/sonos/services.yaml
+++ b/homeassistant/components/sonos/services.yaml
@@ -87,30 +87,6 @@ clear_sleep_timer:
     device:
       integration: sonos
 
-set_option:
-  name: Set option
-  description: Set Sonos sound options.
-  target:
-    device:
-      integration: sonos
-  fields:
-    bass_level:
-      name: Bass Level
-      description: Bass level for EQ.
-      selector:
-        number:
-          min: -10
-          max: 10
-          mode: box
-    treble_level:
-      name: Treble Level
-      description: Treble level for EQ.
-      selector:
-        number:
-          min: -10
-          max: 10
-          mode: box
-
 play_queue:
   name: Play queue
   description: Start playing the queue from the first item.

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -46,6 +46,7 @@ from .const import (
     SONOS_CHECK_ACTIVITY,
     SONOS_CREATE_ALARM,
     SONOS_CREATE_BATTERY,
+    SONOS_CREATE_LEVELS,
     SONOS_CREATE_MEDIA_PLAYER,
     SONOS_CREATE_SWITCHES,
     SONOS_ENTITY_CREATED,
@@ -192,8 +193,8 @@ class SonosSpeaker:
         self.night_mode: bool | None = None
         self.dialog_mode: bool | None = None
         self.cross_fade: bool | None = None
-        self.bass_level: int | None = None
-        self.treble_level: int | None = None
+        self.bass: int | None = None
+        self.treble: int | None = None
 
         # Misc features
         self.buttons_enabled: bool | None = None
@@ -233,6 +234,8 @@ class SonosSpeaker:
             self.async_setup_dispatchers(entry), self.hass.loop
         )
         future.result(timeout=10)
+
+        dispatcher_send(self.hass, SONOS_CREATE_LEVELS, self)
 
         if battery_info := fetch_battery_info_or_none(self.soco):
             self.battery_info = battery_info
@@ -490,11 +493,11 @@ class SonosSpeaker:
         if "dialog_level" in variables:
             self.dialog_mode = variables["dialog_level"] == "1"
 
-        if "bass_level" in variables:
-            self.bass_level = variables["bass_level"]
+        if "bass" in variables:
+            self.bass = variables["bass"]
 
-        if "treble_level" in variables:
-            self.treble_level = variables["treble_level"]
+        if "treble" in variables:
+            self.treble = variables["treble"]
 
         self.async_write_entity_states()
 
@@ -968,8 +971,8 @@ class SonosSpeaker:
         self.muted = self.soco.mute
         self.night_mode = self.soco.night_mode
         self.dialog_mode = self.soco.dialog_mode
-        self.bass_level = self.soco.bass
-        self.treble_level = self.soco.treble
+        self.bass = self.soco.bass
+        self.treble = self.soco.treble
 
         try:
             self.cross_fade = self.soco.cross_fade

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -22,7 +22,6 @@ from soco.snapshot import Snapshot
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
-from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -237,7 +236,6 @@ class SonosSpeaker:
         future.result(timeout=10)
 
         dispatcher_send(self.hass, SONOS_CREATE_LEVELS, self)
-        self._platforms_ready.add(NUMBER_DOMAIN)
 
         if battery_info := fetch_battery_info_or_none(self.soco):
             self.battery_info = battery_info

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -22,6 +22,7 @@ from soco.snapshot import Snapshot
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -236,6 +237,7 @@ class SonosSpeaker:
         future.result(timeout=10)
 
         dispatcher_send(self.hass, SONOS_CREATE_LEVELS, self)
+        self._platforms_ready.add(NUMBER_DOMAIN)
 
         if battery_info := fetch_battery_info_or_none(self.soco):
             self.battery_info = battery_info

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -70,6 +70,8 @@ def soco_fixture(music_library, speaker_info, battery_info, alarm_clock):
         mock_soco.night_mode = True
         mock_soco.dialog_mode = True
         mock_soco.volume = 19
+        mock_soco.bass = 1
+        mock_soco.treble = -1
         mock_soco.get_battery_info.return_value = battery_info
         mock_soco.all_zones = [mock_soco]
         yield mock_soco


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `sonos.set_option` service has been removed along with the `bass_level` and `treble_level` attributes on `media_player` entities. Controls for bass and treble adjustments have been moved to dedicated `number` entities.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move the bass and treble adjustment controls from an integration-specific service and attributes on the `media_player` entity to dedicated `number` entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #60394
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20555

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
