### PR TITLE
Add tolo fan platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1100,6 +1100,7 @@ omit =
     homeassistant/components/tolo/light.py
     homeassistant/components/tolo/select.py
     homeassistant/components/tolo/sensor.py
+    homeassistant/components/tolo/switch.py
     homeassistant/components/tomato/device_tracker.py
     homeassistant/components/toon/__init__.py
     homeassistant/components/toon/binary_sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1097,10 +1097,10 @@ omit =
     homeassistant/components/tolo/binary_sensor.py
     homeassistant/components/tolo/button.py
     homeassistant/components/tolo/climate.py
+    homeassistant/components/tolo/fan.py
     homeassistant/components/tolo/light.py
     homeassistant/components/tolo/select.py
     homeassistant/components/tolo/sensor.py
-    homeassistant/components/tolo/switch.py
     homeassistant/components/tomato/device_tracker.py
     homeassistant/components/toon/__init__.py
     homeassistant/components/toon/binary_sensor.py

--- a/homeassistant/components/tolo/__init__.py
+++ b/homeassistant/components/tolo/__init__.py
@@ -26,10 +26,10 @@ PLATFORMS = [
     "binary_sensor",
     "button",
     "climate",
+    "fan",
     "light",
     "select",
     "sensor",
-    "switch",
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/tolo/__init__.py
+++ b/homeassistant/components/tolo/__init__.py
@@ -22,7 +22,15 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DEFAULT_RETRY_COUNT, DEFAULT_RETRY_TIMEOUT, DOMAIN
 
-PLATFORMS = ["binary_sensor", "button", "climate", "light", "select", "sensor"]
+PLATFORMS = [
+    "binary_sensor",
+    "button",
+    "climate",
+    "light",
+    "select",
+    "sensor",
+    "switch",
+]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tolo/fan.py
+++ b/homeassistant/components/tolo/fan.py
@@ -1,15 +1,15 @@
-"""TOLO Sauna switch controls."""
+"""TOLO Sauna fan controls."""
 
 from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.components.fan import FanEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ToloSaunaCoordinatorEntity, ToloSaunaUpdateCoordinator
-from ..switch import SwitchEntity
 from .const import DOMAIN
 
 
@@ -18,31 +18,36 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up switch controls for TOLO Sauna."""
+    """Set up fan controls for TOLO Sauna."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([ToloFanPowerSwitch(coordinator, entry)])
+    async_add_entities([ToloFan(coordinator, entry)])
 
 
-class ToloFanPowerSwitch(ToloSaunaCoordinatorEntity, SwitchEntity):
-    """Sauna fan switch control."""
+class ToloFan(ToloSaunaCoordinatorEntity, FanEntity):
+    """Sauna fan control."""
 
-    _attr_icon = "mdi:fan"
     _attr_name = "Fan"
 
     def __init__(
         self, coordinator: ToloSaunaUpdateCoordinator, entry: ConfigEntry
     ) -> None:
-        """Initialize TOLO fan switch entity."""
+        """Initialize TOLO fan entity."""
         super().__init__(coordinator, entry)
 
-        self._attr_unique_id = f"{entry.entry_id}_fan_power_switch"
+        self._attr_unique_id = f"{entry.entry_id}_fan"
 
     @property
     def is_on(self) -> bool:
         """Return if sauna fan is running."""
         return self.coordinator.data.status.fan_on
 
-    def turn_on(self, **kwargs: Any) -> None:
+    def turn_on(
+        self,
+        speed: str | None = None,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Turn on sauna fan."""
         self.coordinator.client.set_fan_on(True)
 

--- a/homeassistant/components/tolo/switch.py
+++ b/homeassistant/components/tolo/switch.py
@@ -1,0 +1,51 @@
+"""TOLO Sauna switch controls."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import ToloSaunaCoordinatorEntity, ToloSaunaUpdateCoordinator
+from ..switch import SwitchEntity
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switch controls for TOLO Sauna."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([ToloFanPowerSwitch(coordinator, entry)])
+
+
+class ToloFanPowerSwitch(ToloSaunaCoordinatorEntity, SwitchEntity):
+    """Sauna fan switch control."""
+
+    _attr_icon = "mdi:fan"
+    _attr_name = "Fan"
+
+    def __init__(
+        self, coordinator: ToloSaunaUpdateCoordinator, entry: ConfigEntry
+    ) -> None:
+        """Initialize TOLO fan switch entity."""
+        super().__init__(coordinator, entry)
+
+        self._attr_unique_id = f"{entry.entry_id}_fan_power_switch"
+
+    @property
+    def is_on(self) -> bool:
+        """Return if sauna fan is running."""
+        return self.coordinator.data.status.fan_on
+
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn on sauna fan."""
+        self.coordinator.client.set_fan_on(True)
+
+    def turn_off(self, **kwargs: Any) -> None:
+        """Turn off sauna fan."""
+        self.coordinator.client.set_fan_on(False)


### PR DESCRIPTION
## Proposed change

This pull request adds the `fan` platform to the `tolo` integration to allow directly to control the fan.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: *already covered in documentation in `next` branch*

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
