### PR TITLE
Use correct value for current temperature for AVM Fritz!Smarthome thermostat devices

### DIFF
--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -88,6 +88,8 @@ class FritzboxThermostat(FritzBoxEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float:
         """Return the current temperature."""
+        if self.device.has_temperature_sensor and self.device.temperature is not None:
+            return self.device.temperature  # type: ignore [no-any-return]
         return self.device.actual_temperature  # type: ignore [no-any-return]
 
     @property

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -68,6 +68,7 @@ class FritzDeviceClimateMock(FritzDeviceBaseMock):
     """Mock of a AVM Fritz!Box climate device."""
 
     actual_temperature = 18.0
+    temperature = 18.0
     alert_state = "fake_state"
     battery_level = 23
     battery_low = True
@@ -79,7 +80,7 @@ class FritzDeviceClimateMock(FritzDeviceBaseMock):
     has_powermeter = False
     has_lightbulb = False
     has_switch = False
-    has_temperature_sensor = False
+    has_temperature_sensor = True
     has_thermostat = True
     holiday_active = "fake_holiday"
     lock = "fake_locked"

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -186,7 +186,7 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_MIN_TEMP] == 8
     assert state.attributes[ATTR_TEMPERATURE] == 19.5
 
-    device.actual_temperature = 19
+    device.temperature = 19
     device.target_temperature = 20
 
     next_update = dt_util.utcnow() + timedelta(seconds=200)
@@ -197,6 +197,24 @@ async def test_update(hass: HomeAssistant, fritz: Mock):
     assert fritz().update_devices.call_count == 2
     assert state
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 19
+    assert state.attributes[ATTR_TEMPERATURE] == 20
+
+
+async def test_automatic_offset(hass: HomeAssistant, fritz: Mock):
+    """Test when automtaic offset is configured on fritz!box device."""
+    device = FritzDeviceClimateMock()
+    device.temperature = 18
+    device.actual_temperature = 19
+    device.target_temperature = 20
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 18
+    assert state.attributes[ATTR_MAX_TEMP] == 28
+    assert state.attributes[ATTR_MIN_TEMP] == 8
     assert state.attributes[ATTR_TEMPERATURE] == 20
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This covers no following situations:
1. no offset
real temp. measured on device = 23°C
`device.temperature` = 23°C
`device.actual_temperature` = 23°C

2. manual offset (_+1°_)
real temp. measured on device = 23°C
`device.temperature` = 24°C
`device.actual_temperature` = 24°C

3. automatic offset (_21°C on external temp. sensor device_)
real temp. measured on device = 23°C
`device.temperature` = 21°C
`device.actual_temperature` = 23°C


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #60449
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
