### PR TITLE
Add zwave_js speed configurations for GE/Jasco 12730 and 14287 fans

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -47,6 +47,7 @@ from .discovery_data_template import (
     ConfigurableFanSpeedDataTemplate,
     CoverTiltDataTemplate,
     DynamicCurrentTempClimateDataTemplate,
+    FixedFanSpeedDataTemplate,
     NumericSensorDataTemplate,
     ZwaveValueID,
 )
@@ -230,11 +231,35 @@ DISCOVERY_SCHEMAS = [
         product_type={0x4944},
         primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
     ),
-    # GE/Jasco fan controllers using switch multilevel CC
+    # GE/Jasco - In-Wall Smart Fan Control - 12730 / ZW4002
+    ZWaveDiscoverySchema(
+        platform="fan",
+        hint="configured_fan_speed",
+        manufacturer_id={0x0063},
+        product_id={0x3034},
+        product_type={0x4944},
+        primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
+        data_template=FixedFanSpeedDataTemplate(
+            speeds=[33, 67, 99],
+        ),
+    ),
+    # GE/Jasco - In-Wall Smart Fan Control - 14287 / ZW4002
+    ZWaveDiscoverySchema(
+        platform="fan",
+        hint="configured_fan_speed",
+        manufacturer_id={0x0063},
+        product_id={0x3131},
+        product_type={0x4944},
+        primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
+        data_template=FixedFanSpeedDataTemplate(
+            speeds=[32, 66, 99],
+        ),
+    ),
+    # GE/Jasco - In-Wall Smart Fan Control - 14314 / ZW4002
     ZWaveDiscoverySchema(
         platform="fan",
         manufacturer_id={0x0063},
-        product_id={0x3034, 0x3131, 0x3138},
+        product_id={0x3138},
         product_type={0x4944},
         primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
     ),

--- a/homeassistant/components/zwave_js/discovery_data_template.py
+++ b/homeassistant/components/zwave_js/discovery_data_template.py
@@ -523,3 +523,48 @@ class ConfigurableFanSpeedDataTemplate(
             return None
 
         return speed_config
+
+
+@dataclass
+class FixedFanSpeedValueMix:
+    """Mixin data class for defining supported fan speeds."""
+
+    speeds: list[int]
+
+    def __post_init__(self) -> None:
+        """
+        Validate inputs.
+
+        These inputs are hardcoded in `discovery.py`, so these checks should
+        only fail due to developer error.
+        """
+        assert len(self.speeds) > 0
+        assert sorted(self.speeds) == self.speeds
+
+
+@dataclass
+class FixedFanSpeedDataTemplate(
+    BaseDiscoverySchemaDataTemplate, FanSpeedDataTemplate, FixedFanSpeedValueMix
+):
+    """
+    Specifies a fixed set of fan speeds.
+
+    Example:
+      ZWaveDiscoverySchema(
+          platform="fan",
+          hint="configured_fan_speed",
+          ...
+          data_template=FixedFanSpeedDataTemplate(
+              speeds=[32,65,99]
+          ),
+      ),
+
+    `speeds` indicates the maximum setting on the underlying fan controller
+    for each actual speed.
+    """
+
+    def get_speed_config(
+        self, resolved_data: dict[str, ZwaveConfigurationValue]
+    ) -> list[int]:
+        """Get the fan speed configuration for this device."""
+        return self.speeds

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -326,10 +326,10 @@ def window_cover_state_fixture():
     return json.loads(load_fixture("zwave_js/chain_actuator_zws12_state.json"))
 
 
-@pytest.fixture(name="in_wall_smart_fan_control_state", scope="session")
-def in_wall_smart_fan_control_state_fixture():
+@pytest.fixture(name="fan_generic_state", scope="session")
+def fan_generic_state_fixture():
     """Load the fan node state fixture data."""
-    return json.loads(load_fixture("zwave_js/in_wall_smart_fan_control_state.json"))
+    return json.loads(load_fixture("zwave_js/fan_generic_state.json"))
 
 
 @pytest.fixture(name="hs_fc200_state", scope="session")
@@ -695,10 +695,10 @@ def window_cover_fixture(client, chain_actuator_zws12_state):
     return node
 
 
-@pytest.fixture(name="in_wall_smart_fan_control")
-def in_wall_smart_fan_control_fixture(client, in_wall_smart_fan_control_state):
+@pytest.fixture(name="fan_generic")
+def fan_generic_fixture(client, fan_generic_state):
     """Mock a fan node."""
-    node = Node(client, copy.deepcopy(in_wall_smart_fan_control_state))
+    node = Node(client, copy.deepcopy(fan_generic_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/fixtures/fan_generic_state.json
+++ b/tests/components/zwave_js/fixtures/fan_generic_state.json
@@ -19,22 +19,22 @@
     "isSecure": false,
     "version": 4,
     "isBeaming": true,
-    "manufacturerId": 99,
-    "productId": 12593,
-    "productType": 18756,
+    "manufacturerId": 4919,
+    "productId": 4919,
+    "productType": 4919,
     "firmwareVersion": "5.22",
     "zwavePlusVersion": 1,
     "nodeType": 0,
     "roleType": 5,
     "deviceConfig": {
-      "manufacturerId": 99,
-      "manufacturer": "GE/Jasco",
+      "manufacturerId": 4919,
+      "manufacturer": "Unknown",
       "label": "ZW4002",
-      "description": "In-Wall Smart Fan Control",
+      "description": "Generic Fan Controller",
       "devices": [
         {
-          "productType": "0x4944",
-          "productId": "0x3131"
+          "productType": "0x1337",
+          "productId": "0x1337"
         }
       ],
       "firmwareVersion": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This may change which fan speed is selected at certain percentages for the GE/Jasco 12730 and 14287 fan controllers.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Explicitly support the speed ranges used by the GE/Jasco 12730 and 14287 fan controllers, using (and extending) the mechanisms added in PR #59697.

I got the fan speed info from freshcoast on this thread:
https://community.home-assistant.io/t/requesting-info-on-speed-ranges-for-various-z-wave-fan-controllers-e-g-ge-jasco-leviton/360075/3


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I did something a little unusual with the fixtures:

To adequately test the zwave_js fan component, we need to keep at least one fixture for a device where we don't have explicit speed information defined, to ensure that the fallback to 0-100% selection is working.  The current suite of tests uses `in_wall_smart_fan_control_state.json`, which is actually a GE/Jasco 12730, which this PR adds speed support for.

Somewhat interestingly, we actually have two different fixtures for the 12730:  `fan_ge_12730_state.json`, and `in_wall_smart_fan_control_state.json`.  Only `in_wall_smart_fan_control_state.json` was actually being used, so here's what I did:

* Renamed `in_wall_smart_fan_control_state.json` to `fan_generic_state.json`, and mangled the manufacturer/product IDs so that it wouldn't be recognized as a GE/Jasco 12730.  So this'll permanently be a "generic fan" fixture, representing all fan controllers that we don't have speed info for.  This continues to be used for the main test in `test_fan.py`.
* Used `fan_ge_12730_state.json` for additional tests for fan speed configuration.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

[~] The code change is tested and works locally. 
- I verified that HA starts, and I've verified that the `FixedFanSpeedDataTemplate` works by temporarily applying it to my FC200+, but I haven't tested with the actual GE/Jasco controllers.

- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
