### PR TITLE
Add get method to ZeroconfServiceInfo

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -120,19 +120,37 @@ class ZeroconfServiceInfo(BaseServiceInfo):
 
     def __getitem__(self, name: str) -> Any:
         """
-        Allow property access by name for compatibility reason.
+        Enable method for compatibility reason.
 
         Deprecated, and will be removed in version 2022.6.
         """
         if not self._warning_logged:
             report(
                 f"accessed discovery_info['{name}'] instead of discovery_info.{name}; this will fail in version 2022.6",
-                exclude_integrations={"zeroconf"},
+                exclude_integrations={DOMAIN},
                 error_if_core=False,
                 level=logging.DEBUG,
             )
             self._warning_logged = True
         return getattr(self, name)
+
+    def get(self, name: str, default: Any = None) -> Any:
+        """
+        Enable method for compatibility reason.
+
+        Deprecated, and will be removed in version 2022.6.
+        """
+        if not self._warning_logged:
+            report(
+                f"accessed discovery_info.get('{name}') instead of discovery_info.{name}; this will fail in version 2022.6",
+                exclude_integrations={DOMAIN},
+                error_if_core=False,
+                level=logging.DEBUG,
+            )
+            self._warning_logged = True
+        if hasattr(self, name):
+            return getattr(self, name)
+        return default
 
 
 @bind_hass

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1032,7 +1032,7 @@ async def test_no_name(hass, mock_async_zeroconf):
     assert info.name == "Home._home-assistant._tcp.local."
 
 
-async def test_service_info_compatibility(hass):
+async def test_service_info_compatibility(hass, caplog):
     """Test compatibility with old-style dict.
 
     To be removed in 2022.6
@@ -1046,7 +1046,21 @@ async def test_service_info_compatibility(hass):
         properties={},
     )
 
+    # Ensure first call get logged
     assert discovery_info["host"] == "mock_host"
     assert discovery_info.get("host") == "mock_host"
     assert discovery_info.get("host", "fallback_host") == "mock_host"
     assert discovery_info.get("invalid_key", "fallback_host") == "fallback_host"
+    assert "Detected code that accessed discovery_info['host']" in caplog.text
+    assert "Detected code that accessed discovery_info.get('host')" not in caplog.text
+
+    # Ensure second call doesn't get logged
+    caplog.clear()
+    assert discovery_info["host"] == "mock_host"
+    assert discovery_info.get("host") == "mock_host"
+    assert "Detected code that accessed discovery_info['host']" not in caplog.text
+    assert "Detected code that accessed discovery_info.get('host')" not in caplog.text
+
+    discovery_info._warning_logged = False
+    assert discovery_info.get("host") == "mock_host"
+    assert "Detected code that accessed discovery_info.get('host')" in caplog.text

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1030,3 +1030,23 @@ async def test_no_name(hass, mock_async_zeroconf):
     register_call = mock_async_zeroconf.async_register_service.mock_calls[-1]
     info = register_call.args[0]
     assert info.name == "Home._home-assistant._tcp.local."
+
+
+async def test_service_info_compatibility(hass):
+    """Test compatibility with old-style dict.
+
+    To be removed in 2022.6
+    """
+    discovery_info = zeroconf.ZeroconfServiceInfo(
+        host="mock_host",
+        port=None,
+        hostname="mock_hostname",
+        type="mock_type",
+        name="mock_name",
+        properties={},
+    )
+
+    assert discovery_info["host"] == "mock_host"
+    assert discovery_info.get("host") == "mock_host"
+    assert discovery_info.get("host", "fallback_host") == "mock_host"
+    assert discovery_info.get("invalid_key", "fallback_host") == "fallback_host"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #60206, add `get` method to `ZeroconfServiceInfo`, to increase compatibility for custom components and reduce the risk of breaking changes.

Sample use in `bosch_shc` (in release 2021.11.5):
https://github.com/home-assistant/core/blob/dbae448fe56e83eab5601d60a4c77c71f9a37afa/homeassistant/components/bosch_shc/config_flow.py#L184-L186

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
