### PR TITLE
Add quality scale for Fronius

### DIFF
--- a/homeassistant/components/fronius/manifest.json
+++ b/homeassistant/components/fronius/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "local_polling",
   "name": "Fronius",
   "quality_scale": "platinum",
-  "requirements": ["pyfronius==0.7.0"]
+  "requirements": ["pyfronius==0.7.1"]
 }

--- a/homeassistant/components/fronius/manifest.json
+++ b/homeassistant/components/fronius/manifest.json
@@ -1,14 +1,15 @@
 {
-  "domain": "fronius",
+  "codeowners": ["@nielstron", "@farmio"],
+  "config_flow": true,
   "dhcp": [
     {
       "macaddress": "0003AC*"
     }
   ],
-  "name": "Fronius",
-  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/fronius",
-  "requirements": ["pyfronius==0.7.1"],
-  "codeowners": ["@nielstron", "@farmio"],
-  "iot_class": "local_polling"
+  "domain": "fronius",
+  "iot_class": "local_polling",
+  "name": "Fronius",
+  "quality_scale": "platinum",
+  "requirements": ["pyfronius==0.7.0"]
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a quality scale `platinum` for the Fronius integration and sort manifest keys alphabetically.

### Silver

- [x] Satisfying all No score level requirements.
- [x] Connection/configuration is handled via a component.
- [x] Set an appropriate SCAN_INTERVAL (if a polling integration)
#60192
- [x] Raise PlatformNotReady if unable to connect during platform setup (if appropriate)
- [x] Handles expiration of auth credentials. 
no auth required
- [x] Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Set available property to False if appropriate
- [x] Entities have unique ID (if available)

most of these are met by using DataUpdateCoordinator

### Gold

- [x] Satisfying all Silver level requirements.
- [x] Configurable via config entries.
#59677
  - [x] Don't allow configuring already configured device/service (example: no 2 entries for same hub)
  - [x] Tests for the config flow
  - [x] Discoverable
  #60806
  - [x] Set unique ID in config flow
  - [x] Raise ConfigEntryNotReady if unable to connect during entry setup
- [x] Entities have device info
#60104
- [x] Tests for fetching data from the integration and controlling it
#60515
- [x] Has a code owner
- [x] Entities only subscribe to updates inside async_added_to_hass and unsubscribe inside async_will_remove_from_hass (docs)
- [x] Entities have correct device classes where appropriate
- [x] Supports entities being disabled and leverages Entity.entity_registry_enabled_default to disable less popular entities
- [x] If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry.
#60264

### Platinum

- [x] Satisfying all Gold level requirements.
- [ ] Set appropriate PARALLEL_UPDATES constant
I think this is not needed with DataUpdateCoordinators?!
- [x] Support config entry unloading (called when config entry is removed)
- [x] Integration + dependency are async
- [x] Uses aiohttp or httpx and allows passing in websession
`aiohttp` is used in `pyfronius`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
