### PR TITLE
Remove cleanup_registry from onewire

### DIFF
--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -1,11 +1,9 @@
 """The 1-Wire component."""
-import asyncio
 import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN, PLATFORMS
 from .onewirehub import CannotConnect, OneWireHub
@@ -25,34 +23,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = onewirehub
 
-    async def cleanup_registry(onewirehub: OneWireHub) -> None:
-        # Get registries
-        device_registry = dr.async_get(hass)
-        # Generate list of all device entries
-        registry_devices = list(
-            dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-        )
-        # Remove devices that don't belong to any entity
-        for device in registry_devices:
-            if not onewirehub.has_device_in_cache(device):
-                _LOGGER.debug(
-                    "Removing device `%s` because it is no longer available",
-                    device.id,
-                )
-                device_registry.async_remove_device(device.id)
-
-    async def start_platforms(onewirehub: OneWireHub) -> None:
-        """Start platforms and cleanup devices."""
-        # wait until all required platforms are ready
-        await asyncio.gather(
-            *(
-                hass.config_entries.async_forward_entry_setup(entry, platform)
-                for platform in PLATFORMS
-            )
-        )
-        await cleanup_registry(onewirehub)
-
-    hass.async_create_task(start_platforms(onewirehub))
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
 

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -22,7 +22,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import (
@@ -221,16 +220,6 @@ class OneWireHub:
         if TYPE_CHECKING:
             assert isinstance(device_type, str)
         return device_type
-
-    def has_device_in_cache(self, device: DeviceEntry) -> bool:
-        """Check if device was present in the cache."""
-        if TYPE_CHECKING:
-            assert self.devices
-        for internal_device in self.devices:
-            for identifier in internal_device.device_info[ATTR_IDENTIFIERS]:
-                if identifier in device.identifiers:
-                    return True
-        return False
 
 
 class CannotConnect(HomeAssistantError):

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -1,18 +1,11 @@
 """Tests for 1-Wire config flow."""
 import logging
-from unittest.mock import MagicMock, patch
 
 import pytest
 
 from homeassistant.components.onewire.const import DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
-
-from . import setup_owproxy_mock_devices
-
-from tests.common import mock_device_registry, mock_registry
 
 
 @pytest.mark.usefixtures("owproxy_with_connerror")
@@ -71,40 +64,3 @@ async def test_unload_sysbus_entry(
 
     assert sysbus_config_entry.state is ConfigEntryState.NOT_LOADED
     assert not hass.data.get(DOMAIN)
-
-
-@patch("homeassistant.components.onewire.PLATFORMS", [SENSOR_DOMAIN])
-async def test_registry_cleanup(
-    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock
-):
-    """Test for 1-Wire device.
-
-    As they would be on a clean setup: all binary-sensors and switches disabled.
-    """
-    entity_registry = mock_registry(hass)
-    device_registry = mock_device_registry(hass)
-
-    # Initialise with two components
-    setup_owproxy_mock_devices(
-        owproxy, SENSOR_DOMAIN, ["10.111111111111", "28.111111111111"]
-    )
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert len(dr.async_entries_for_config_entry(device_registry, "2")) == 2
-    assert len(er.async_entries_for_config_entry(entity_registry, "2")) == 2
-
-    # Second item has disappeared from bus, and was removed manually from the front-end
-    setup_owproxy_mock_devices(owproxy, SENSOR_DOMAIN, ["10.111111111111"])
-    entity_registry.async_remove("sensor.28_111111111111_temperature")
-    await hass.async_block_till_done()
-
-    assert len(er.async_entries_for_config_entry(entity_registry, "2")) == 1
-    assert len(dr.async_entries_for_config_entry(device_registry, "2")) == 2
-
-    # Second item has disappeared from bus, and was removed manually from the front-end
-    await hass.config_entries.async_reload("2")
-    await hass.async_block_till_done()
-
-    assert len(er.async_entries_for_config_entry(entity_registry, "2")) == 1
-    assert len(dr.async_entries_for_config_entry(device_registry, "2")) == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the automatic registry cleanup from `onewire` integration as it is causing issues when the `onewire` bus is flaky.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #59168
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
