### PR TITLE
Add support for Kogan smart blinds to Tuya

### DIFF
--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -10,6 +10,7 @@ from tuya_iot import TuyaDevice, TuyaDeviceManager
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
+    DEVICE_CLASS_BLIND,
     DEVICE_CLASS_CURTAIN,
     DEVICE_CLASS_GARAGE,
     SUPPORT_CLOSE,
@@ -67,6 +68,15 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.PERCENT_STATE_3,
             set_position=DPCode.PERCENT_CONTROL_3,
             device_class=DEVICE_CLASS_CURTAIN,
+        ),
+        # switch_1 is an undocumented code that behaves identically to control
+        # It is used by the Kogan Smart Blinds Driver
+        TuyaCoverEntityDescription(
+            key=DPCode.SWITCH_1,
+            name="Blind",
+            current_position=DPCode.PERCENT_CONTROL,
+            set_position=DPCode.PERCENT_CONTROL,
+            device_class=DEVICE_CLASS_BLIND,
         ),
     ),
     # Garage Door Opener
@@ -183,9 +193,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         if device.function[description.key].type == "Boolean":
             self._attr_supported_features |= SUPPORT_OPEN | SUPPORT_CLOSE
         elif device.function[description.key].type == "Enum":
-            data_type = EnumTypeData.from_json(
-                device.status_range[description.key].values
-            )
+            data_type = EnumTypeData.from_json(device.function[description.key].values)
             if "open" in data_type.range:
                 self._attr_supported_features |= SUPPORT_OPEN
             if "close" in data_type.range:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for Kogan smart blinds to the Tuya integration.

The device I own has the following configuration in Tuya:

Device Information:
 - Product Name: Smart Blinds
 - Product Category: cl

Standard Instruction Set:
<html>
<body>
<!--StartFragment-->

Code | Type | Values
-- | -- | --
switch_1 | Enum | {   "range": [     "open",     "stop",     "close",     "continue"   ] }
percent_control | Integer | {   "unit": "%",   "min": 0,   "max": 100,   "scale": 0,   "step": 1 }

<!--EndFragment-->
</body>
</html>

Standard Status Set:
<html>
<body>
<!--StartFragment-->

Code | Type | Values
-- | -- | --
percent_control | Integer | {   "unit": "%",   "min": 0,   "max": 100,   "scale": 0,   "step": 1 }
switch_1 | Boolean | "{true,false}"

<!--EndFragment-->
</body>
</html>

In the code segment that configures supported features, I changed where the enum is fetched from `device.status_range` to `device.function`. This seems right given that we make sure that the entry in `device.function` is an enum beforehand but I don't have any other devices available to test with. My device's `function` and `status_range` are:
```python
function={'switch_1': TuyaDeviceFunction(code='switch_1', type='Enum', values='{"range":["open","stop","close","continue"]}'), 
'percent_control': TuyaDeviceFunction(code='percent_control', type='Integer', values='{"unit":"%","min":0,"max":100,"scale":0,"step":1}')},
status_range={'percent_control': TuyaDeviceStatusRange(code='percent_control', type='Integer', values='{"unit":"%","min":0,"max":100,"scale":0,"step":1}'),
'switch_1': TuyaDeviceStatusRange(code='switch_1', type='Boolean', values='{}')}
```
Leaving the line unchanged doesn't work as `switch_1` is a Boolean in `status_range`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #59158

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
