### PR TITLE
Use dataclass properties in bosch_shc discovery

### DIFF
--- a/homeassistant/components/bosch_shc/config_flow.py
+++ b/homeassistant/components/bosch_shc/config_flow.py
@@ -190,20 +190,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="not_bosch_shc")
 
         try:
-            hosts = (
-                discovery_info.host
-                if isinstance(discovery_info.host, list)
-                else [discovery_info.host]
-            )
-            for host in hosts:
-                if host.startswith("169."):  # skip link local address
-                    continue
-                self.info = await self._get_info(host)
-                self.host = host
-            if self.info is None or self.host is None:
-                return self.async_abort(reason="cannot_connect")
+            self.info = await self._get_info(discovery_info.host)
         except SHCConnectionError:
             return self.async_abort(reason="cannot_connect")
+        self.host = discovery_info.host
 
         local_name = discovery_info.hostname[:-1]
         node_name = local_name[: -len(".local")]

--- a/homeassistant/components/bosch_shc/config_flow.py
+++ b/homeassistant/components/bosch_shc/config_flow.py
@@ -191,9 +191,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             hosts = (
-                discovery_info[zeroconf.ATTR_HOST]
-                if isinstance(discovery_info[zeroconf.ATTR_HOST], list)
-                else [discovery_info[zeroconf.ATTR_HOST]]
+                discovery_info.host
+                if isinstance(discovery_info.host, list)
+                else [discovery_info.host]
             )
             for host in hosts:
                 if host.startswith("169."):  # skip link local address
@@ -205,7 +205,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except SHCConnectionError:
             return self.async_abort(reason="cannot_connect")
 
-        local_name = discovery_info[zeroconf.ATTR_HOSTNAME][:-1]
+        local_name = discovery_info.hostname[:-1]
         node_name = local_name[: -len(".local")]
 
         await self.async_set_unique_id(self.info["unique_id"])

--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -21,7 +21,7 @@ MOCK_SETTINGS = {
     "device": {"mac": "test-mac", "hostname": "test-host"},
 }
 DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
-    host=["169.1.1.1", "1.1.1.1"],
+    host="1.1.1.1",
     hostname="shc012345.local.",
     name="Bosch SHC [test-mac]._http._tcp.local.",
     port=0,
@@ -521,29 +521,6 @@ async def test_zeroconf_cannot_connect(hass, mock_zeroconf):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             data=DISCOVERY_INFO,
-            context={"source": config_entries.SOURCE_ZEROCONF},
-        )
-        assert result["type"] == "abort"
-        assert result["reason"] == "cannot_connect"
-
-
-async def test_zeroconf_link_local(hass, mock_zeroconf):
-    """Test we get the form."""
-    DISCOVERY_INFO_LINK_LOCAL = zeroconf.ZeroconfServiceInfo(
-        host=["169.1.1.1"],
-        hostname="shc012345.local.",
-        name="Bosch SHC [test-mac]._http._tcp.local.",
-        port=0,
-        properties={},
-        type="_http._tcp.local.",
-    )
-
-    with patch(
-        "boschshcpy.session.SHCSession.mdns_info", side_effect=SHCConnectionError
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            data=DISCOVERY_INFO_LINK_LOCAL,
             context={"source": config_entries.SOURCE_ZEROCONF},
         )
         assert result["type"] == "abort"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use dataclass properties in `bosch_shc` discovery.

Linked to #60540

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
