### PR TITLE
Drop base ATTR constants in zeroconf

### DIFF
--- a/homeassistant/components/lutron_caseta/config_flow.py
+++ b/homeassistant/components/lutron_caseta/config_flow.py
@@ -67,14 +67,14 @@ class LutronCasetaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle a flow initialized by zeroconf discovery."""
-        hostname = discovery_info[zeroconf.ATTR_HOSTNAME]
+        hostname = discovery_info.hostname
         if hostname is None or not hostname.startswith("lutron-"):
             return self.async_abort(reason="not_lutron_device")
 
         self.lutron_id = hostname.split("-")[1].replace(".local.", "")
 
         await self.async_set_unique_id(self.lutron_id)
-        host = discovery_info[zeroconf.ATTR_HOST]
+        host = discovery_info.host
         self._abort_if_unique_id_configured({CONF_HOST: host})
 
         self.data[CONF_HOST] = host

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -302,8 +302,8 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by zeroconf discovery."""
         LOGGER.debug("Samsung device found via ZEROCONF: %s", discovery_info)
-        self._mac = format_mac(discovery_info[zeroconf.ATTR_PROPERTIES]["deviceid"])
-        self._host = discovery_info[zeroconf.ATTR_HOST]
+        self._mac = format_mac(discovery_info.properties["deviceid"])
+        self._host = discovery_info.host
         await self._async_start_discovery_with_mac_address()
         await self._async_set_device_unique_id()
         self.context["title_placeholders"] = {"device": self._title}

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -160,11 +160,11 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle zeroconf discovery."""
-        name = discovery_info[zeroconf.ATTR_NAME]
-        self.host = discovery_info[zeroconf.ATTR_HOST]
-        self.mac = discovery_info[zeroconf.ATTR_PROPERTIES].get("mac")
+        name = discovery_info.name
+        self.host = discovery_info.host
+        self.mac = discovery_info.properties.get("mac")
         if self.mac is None:
-            poch = discovery_info[zeroconf.ATTR_PROPERTIES].get("poch", "")
+            poch = discovery_info.properties.get("poch", "")
             if (result := search(r"mac=\w+", poch)) is not None:
                 self.mac = result.group(0).split("=")[1]
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -75,14 +75,6 @@ MAX_PROPERTY_VALUE_LEN = 230
 # Dns label max length
 MAX_NAME_LEN = 63
 
-# Attributes for ZeroconfServiceInfo
-ATTR_HOST: Final = "host"
-ATTR_HOSTNAME: Final = "hostname"
-ATTR_NAME: Final = "name"
-ATTR_PORT: Final = "port"
-ATTR_PROPERTIES: Final = "properties"
-ATTR_TYPE: Final = "type"
-
 # Attributes for ZeroconfServiceInfo[ATTR_PROPERTIES]
 ATTR_PROPERTIES_ID: Final = "id"
 

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -273,7 +273,7 @@ async def test_id_missing(hass, controller):
     discovery_info = get_device_discovery_info(device)
 
     # Remove id from device
-    del discovery_info[zeroconf.ATTR_PROPERTIES][zeroconf.ATTR_PROPERTIES_ID]
+    del discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID]
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -289,10 +289,8 @@ async def test_discovery_ignored_model(hass, controller):
     """Already paired."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
-    discovery_info[zeroconf.ATTR_PROPERTIES][
-        zeroconf.ATTR_PROPERTIES_ID
-    ] = "AA:BB:CC:DD:EE:FF"
-    discovery_info[zeroconf.ATTR_PROPERTIES]["md"] = "HHKBridge1,1"
+    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
+    discovery_info.properties["md"] = "HHKBridge1,1"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -319,9 +317,7 @@ async def test_discovery_ignored_hk_bridge(hass, controller):
         connections={(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)},
     )
 
-    discovery_info[zeroconf.ATTR_PROPERTIES][
-        zeroconf.ATTR_PROPERTIES_ID
-    ] = "AA:BB:CC:DD:EE:FF"
+    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -348,9 +344,7 @@ async def test_discovery_does_not_ignore_non_homekit(hass, controller):
         connections={(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)},
     )
 
-    discovery_info[zeroconf.ATTR_PROPERTIES][
-        zeroconf.ATTR_PROPERTIES_ID
-    ] = "AA:BB:CC:DD:EE:FF"
+    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -382,7 +376,7 @@ async def test_discovery_broken_pairing_flag(hass, controller):
     discovery_info = get_device_discovery_info(device)
 
     # Make sure that we are pairable
-    assert discovery_info[zeroconf.ATTR_PROPERTIES]["sf"] != 0x0
+    assert discovery_info.properties["sf"] != 0x0
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -454,7 +448,7 @@ async def test_discovery_already_configured(hass, controller):
     discovery_info = get_device_discovery_info(device)
 
     # Set device as already paired
-    discovery_info[zeroconf.ATTR_PROPERTIES]["sf"] = 0x00
+    discovery_info.properties["sf"] = 0x00
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -490,11 +484,9 @@ async def test_discovery_already_configured_update_csharp(hass, controller):
     discovery_info = get_device_discovery_info(device)
 
     # Set device as already paired
-    discovery_info[zeroconf.ATTR_PROPERTIES]["sf"] = 0x00
-    discovery_info[zeroconf.ATTR_PROPERTIES]["c#"] = 99999
-    discovery_info[zeroconf.ATTR_PROPERTIES][
-        zeroconf.ATTR_PROPERTIES_ID
-    ] = "AA:BB:CC:DD:EE:FF"
+    discovery_info.properties["sf"] = 0x00
+    discovery_info.properties["c#"] = 99999
+    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/ipp/test_config_flow.py
+++ b/tests/components/ipp/test_config_flow.py
@@ -2,7 +2,6 @@
 import dataclasses
 from unittest.mock import patch
 
-from homeassistant.components import zeroconf
 from homeassistant.components.ipp.const import CONF_BASE_PATH, CONF_UUID, DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SSL
@@ -282,7 +281,7 @@ async def test_zeroconf_with_uuid_device_exists_abort(
 
     discovery_info = dataclasses.replace(MOCK_ZEROCONF_IPP_SERVICE_INFO)
     discovery_info.properties = {
-        **MOCK_ZEROCONF_IPP_SERVICE_INFO[zeroconf.ATTR_PROPERTIES],
+        **MOCK_ZEROCONF_IPP_SERVICE_INFO.properties,
         "UUID": "cfe92100-67c4-11d4-a45f-f8d027761251",
     }
 
@@ -304,7 +303,7 @@ async def test_zeroconf_empty_unique_id(
 
     discovery_info = dataclasses.replace(MOCK_ZEROCONF_IPP_SERVICE_INFO)
     discovery_info.properties = {
-        **MOCK_ZEROCONF_IPP_SERVICE_INFO[zeroconf.ATTR_PROPERTIES],
+        **MOCK_ZEROCONF_IPP_SERVICE_INFO.properties,
         "UUID": "",
     }
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -5,7 +5,6 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
-from homeassistant.components import zeroconf
 from homeassistant.components.media_player import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV
 from homeassistant.components.vizio.config_flow import _get_config_schema
 from homeassistant.components.vizio.const import (
@@ -743,10 +742,8 @@ async def test_zeroconf_flow(
     # defaults which were set from discovery parameters
     user_input = result["data_schema"](
         {
-            CONF_HOST: f"{discovery_info[zeroconf.ATTR_HOST]}:{discovery_info[zeroconf.ATTR_PORT]}",
-            CONF_NAME: discovery_info[zeroconf.ATTR_NAME][
-                : -(len(discovery_info[zeroconf.ATTR_TYPE]) + 1)
-            ],
+            CONF_HOST: f"{discovery_info.host}:{discovery_info.port}",
+            CONF_NAME: discovery_info.name[: -(len(discovery_info.type) + 1)],
             CONF_DEVICE_CLASS: "speaker",
         }
     )

--- a/tests/components/volumio/test_config_flow.py
+++ b/tests/components/volumio/test_config_flow.py
@@ -27,10 +27,10 @@ TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
 )
 
 TEST_DISCOVERY_RESULT = {
-    "host": TEST_DISCOVERY[zeroconf.ATTR_HOST],
-    "port": TEST_DISCOVERY[zeroconf.ATTR_PORT],
-    "id": TEST_DISCOVERY[zeroconf.ATTR_PROPERTIES]["UUID"],
-    "name": TEST_DISCOVERY[zeroconf.ATTR_PROPERTIES]["volumioName"],
+    "host": TEST_DISCOVERY.host,
+    "port": TEST_DISCOVERY.port,
+    "id": TEST_DISCOVERY.properties["UUID"],
+    "name": TEST_DISCOVERY.properties["volumioName"],
 }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not a breaking change if this is merged before 2021.12

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop zeroconf constants created in #58671 and #58835.
Since ZeroconfServiceInfo was migrated to a dataclass, these should no longer be required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
