### PR TITLE
Use dataclass properties in hue discovery

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -214,7 +214,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="not_hue_bridge")
 
         bridge = await self._get_bridge(
-            str(host), discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
+            host, discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
         )
 
         await self.async_set_unique_id(bridge.id)

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -206,15 +206,18 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         ):
             return self.async_abort(reason="not_hue_bridge")
 
-        if ssdp.ATTR_UPNP_SERIAL not in discovery_info.upnp:
+        if (
+            not discovery_info.ssdp_location
+            or ssdp.ATTR_UPNP_SERIAL not in discovery_info.upnp
+        ):
             return self.async_abort(reason="not_hue_bridge")
 
-        host = urlparse(discovery_info.ssdp_location).hostname
-        if host is None:
+        url = urlparse(discovery_info.ssdp_location)
+        if not url.hostname:
             return self.async_abort(reason="not_hue_bridge")
 
         bridge = await self._get_bridge(
-            host, discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
+            url.hostname, discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
         )
 
         await self.async_set_unique_id(bridge.id)

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -209,12 +209,12 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if ssdp.ATTR_UPNP_SERIAL not in discovery_info.upnp:
             return self.async_abort(reason="not_hue_bridge")
 
-        host = str(urlparse(discovery_info.ssdp_location).hostname)
+        host = urlparse(discovery_info.ssdp_location).hostname
         if not host:
             return self.async_abort(reason="not_hue_bridge")
 
         bridge = await self._get_bridge(
-            host, discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
+            str(host), discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
         )
 
         await self.async_set_unique_id(bridge.id)

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from aiohue import LinkButtonNotPressed, create_app_key
@@ -207,15 +206,13 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         ):
             return self.async_abort(reason="not_hue_bridge")
 
-        if (
-            not discovery_info.ssdp_location
-            or ssdp.ATTR_UPNP_SERIAL not in discovery_info.upnp
-        ):
+        if ssdp.ATTR_UPNP_SERIAL not in discovery_info.upnp:
             return self.async_abort(reason="not_hue_bridge")
 
-        host = urlparse(discovery_info.ssdp_location).hostname
-        if TYPE_CHECKING:
-            assert host is not None
+        host = str(urlparse(discovery_info.ssdp_location).hostname)
+        if not host:
+            return self.async_abort(reason="not_hue_bridge")
+
         bridge = await self._get_bridge(
             host, discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
         )

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -210,7 +210,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="not_hue_bridge")
 
         host = urlparse(discovery_info.ssdp_location).hostname
-        if not host:
+        if host is None:
             return self.async_abort(reason="not_hue_bridge")
 
         bridge = await self._get_bridge(

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -423,6 +423,26 @@ async def test_bridge_ssdp_missing_serial(hass):
     assert result["reason"] == "not_hue_bridge"
 
 
+async def test_bridge_ssdp_invalid_location(hass):
+    """Test if discovery info is a serial attribute."""
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN,
+        context={"source": config_entries.SOURCE_SSDP},
+        data=ssdp.SsdpServiceInfo(
+            ssdp_usn="mock_usn",
+            ssdp_st="mock_st",
+            ssdp_location="http:///",
+            upnp={
+                ssdp.ATTR_UPNP_MANUFACTURER_URL: config_flow.HUE_MANUFACTURERURL[0],
+                ssdp.ATTR_UPNP_SERIAL: "1234",
+            },
+        ),
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "not_hue_bridge"
+
+
 async def test_bridge_ssdp_espalexa(hass):
     """Test if discovery info is from an Espalexa based device."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use dataclass properties in `hue` discovery.

Linked to #60540

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
