### PR TITLE
Add button device classes to WLED

### DIFF
--- a/homeassistant/components/wled/button.py
+++ b/homeassistant/components/wled/button.py
@@ -1,7 +1,7 @@
 """Support for WLED button."""
 from __future__ import annotations
 
-from homeassistant.components.button import ButtonEntity
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
@@ -23,7 +23,7 @@ async def async_setup_entry(
     async_add_entities(
         [
             WLEDRestartButton(coordinator),
-            WLEDUpgradeButton(coordinator),
+            WLEDUpdateButton(coordinator),
         ]
     )
 
@@ -31,7 +31,7 @@ async def async_setup_entry(
 class WLEDRestartButton(WLEDEntity, ButtonEntity):
     """Defines a WLED restart button."""
 
-    _attr_icon = "mdi:restart"
+    _attr_device_class = ButtonDeviceClass.RESTART
     _attr_entity_category = ENTITY_CATEGORY_CONFIG
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator) -> None:
@@ -46,21 +46,21 @@ class WLEDRestartButton(WLEDEntity, ButtonEntity):
         await self.coordinator.wled.reset()
 
 
-class WLEDUpgradeButton(WLEDEntity, ButtonEntity):
-    """Defines a WLED upgrade button."""
+class WLEDUpdateButton(WLEDEntity, ButtonEntity):
+    """Defines a WLED update button."""
 
-    _attr_icon = "mdi:cellphone-arrow-down"
+    _attr_device_class = ButtonDeviceClass.UPDATE
     _attr_entity_category = ENTITY_CATEGORY_CONFIG
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator) -> None:
         """Initialize the button entity."""
         super().__init__(coordinator=coordinator)
-        self._attr_name = f"{coordinator.data.info.name} Upgrade"
-        self._attr_unique_id = f"{coordinator.data.info.mac_address}_upgrade"
+        self._attr_name = f"{coordinator.data.info.name} Update"
+        self._attr_unique_id = f"{coordinator.data.info.mac_address}_update"
 
     @property
     def available(self) -> bool:
-        """Return if the entity and an upgrade is available."""
+        """Return if the entity and an update is available."""
         current = self.coordinator.data.info.version
         beta = self.coordinator.data.info.version_latest_beta
         stable = self.coordinator.data.info.version_latest_stable
@@ -82,13 +82,13 @@ class WLEDUpgradeButton(WLEDEntity, ButtonEntity):
 
     @wled_exception_handler
     async def async_press(self) -> None:
-        """Send out a restart command."""
+        """Send out a update command."""
         current = self.coordinator.data.info.version
         beta = self.coordinator.data.info.version_latest_beta
         stable = self.coordinator.data.info.version_latest_stable
 
-        # If we already run a pre-release, allow upgrading to a newer
-        # pre-release or newer stable, otherwise, offer a normal stable upgrades.
+        # If we already run a pre-release, allow update to a newer
+        # pre-release or newer stable, otherwise, offer a normal stable updates.
         version = stable
         if (
             current is not None

--- a/tests/components/wled/test_button.py
+++ b/tests/components/wled/test_button.py
@@ -5,8 +5,13 @@ from freezegun import freeze_time
 import pytest
 from wled import WLEDConnectionError, WLEDError
 
-from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.button import (
+    DOMAIN as BUTTON_DOMAIN,
+    SERVICE_PRESS,
+    ButtonDeviceClass,
+)
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
     ENTITY_CATEGORY_CONFIG,
     STATE_UNAVAILABLE,
@@ -27,6 +32,7 @@ async def test_button_restart(
     state = hass.states.get("button.wled_rgb_light_restart")
     assert state
     assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_DEVICE_CLASS] == ButtonDeviceClass.RESTART
 
     entry = entity_registry.async_get("button.wled_rgb_light_restart")
     assert entry
@@ -110,6 +116,7 @@ async def test_button_update_stay_stable(
     state = hass.states.get("button.wled_rgb_light_update")
     assert state
     assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_DEVICE_CLASS] == ButtonDeviceClass.UPDATE
 
     await hass.services.async_call(
         BUTTON_DOMAIN,

--- a/tests/components/wled/test_button.py
+++ b/tests/components/wled/test_button.py
@@ -8,7 +8,6 @@ from wled import WLEDConnectionError, WLEDError
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_ICON,
     ENTITY_CATEGORY_CONFIG,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -27,7 +26,6 @@ async def test_button_restart(
 
     state = hass.states.get("button.wled_rgb_light_restart")
     assert state
-    assert state.attributes.get(ATTR_ICON) == "mdi:restart"
     assert state.state == STATE_UNKNOWN
 
     entry = entity_registry.async_get("button.wled_rgb_light_restart")
@@ -93,31 +91,30 @@ async def test_button_connection_error(
     assert "Error communicating with API" in caplog.text
 
 
-async def test_button_upgrade_stay_stable(
+async def test_button_update_stay_stable(
     hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
 ) -> None:
-    """Test the upgrade button.
+    """Test the update button.
 
-    There is both an upgrade for beta and stable available, however, the device
-    is currently running a stable version. Therefore, the upgrade button should
-    upgrade the the next stable (even though beta is newer).
+    There is both an update for beta and stable available, however, the device
+    is currently running a stable version. Therefore, the update button should
+    update the the next stable (even though beta is newer).
     """
     entity_registry = er.async_get(hass)
 
-    entry = entity_registry.async_get("button.wled_rgb_light_upgrade")
+    entry = entity_registry.async_get("button.wled_rgb_light_update")
     assert entry
-    assert entry.unique_id == "aabbccddeeff_upgrade"
+    assert entry.unique_id == "aabbccddeeff_update"
     assert entry.entity_category == ENTITY_CATEGORY_CONFIG
 
-    state = hass.states.get("button.wled_rgb_light_upgrade")
+    state = hass.states.get("button.wled_rgb_light_update")
     assert state
-    assert state.attributes.get(ATTR_ICON) == "mdi:cellphone-arrow-down"
     assert state.state == STATE_UNKNOWN
 
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.wled_rgb_light_upgrade"},
+        {ATTR_ENTITY_ID: "button.wled_rgb_light_update"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -126,19 +123,19 @@ async def test_button_upgrade_stay_stable(
 
 
 @pytest.mark.parametrize("mock_wled", ["wled/rgbw.json"], indirect=True)
-async def test_button_upgrade_beta_to_stable(
+async def test_button_update_beta_to_stable(
     hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
 ) -> None:
-    """Test the upgrade button.
+    """Test the update button.
 
-    There is both an upgrade for beta and stable available the device
+    There is both an update for beta and stable available the device
     is currently a beta, however, a newer stable is available. Therefore, the
-    upgrade button should upgrade to the next stable.
+    update button should update to the next stable.
     """
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.wled_rgbw_light_upgrade"},
+        {ATTR_ENTITY_ID: "button.wled_rgbw_light_update"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -147,18 +144,18 @@ async def test_button_upgrade_beta_to_stable(
 
 
 @pytest.mark.parametrize("mock_wled", ["wled/rgb_single_segment.json"], indirect=True)
-async def test_button_upgrade_stay_beta(
+async def test_button_update_stay_beta(
     hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
 ) -> None:
-    """Test the upgrade button.
+    """Test the update button.
 
-    There is an upgrade for beta and the device is currently a beta. Therefore,
-    the upgrade button should upgrade to the next beta.
+    There is an update for beta and the device is currently a beta. Therefore,
+    the update button should update to the next beta.
     """
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.wled_rgb_light_upgrade"},
+        {ATTR_ENTITY_ID: "button.wled_rgb_light_update"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -167,10 +164,10 @@ async def test_button_upgrade_stay_beta(
 
 
 @pytest.mark.parametrize("mock_wled", ["wled/rgb_websocket.json"], indirect=True)
-async def test_button_no_upgrade_available(
+async def test_button_no_update_available(
     hass: HomeAssistant, init_integration: MockConfigEntry, mock_wled: MagicMock
 ) -> None:
-    """Test the upgrade button. There is no update available."""
-    state = hass.states.get("button.wled_websocket_upgrade")
+    """Test the update button. There is no update available."""
+    state = hass.states.get("button.wled_websocket_update")
     assert state
     assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add device classes to the button the WLED integration provides.
Also renamed the `upgrade` button to `update` to be consistent (these buttons have not been released to stable yet, so this has no impact yet).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
