### PR TITLE
Migrate number mode to StrEnum

### DIFF
--- a/homeassistant/components/demo/number.py
+++ b/homeassistant/components/demo/number.py
@@ -1,10 +1,7 @@
 """Demo platform that offers a fake Number entity."""
 from __future__ import annotations
 
-from typing import Literal
-
-from homeassistant.components.number import NumberEntity
-from homeassistant.components.number.const import MODE_AUTO, MODE_BOX, MODE_SLIDER
+from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.const import DEVICE_DEFAULT_NAME
 from homeassistant.helpers.entity import DeviceInfo
 
@@ -21,7 +18,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 42.0,
                 "mdi:volume-high",
                 False,
-                mode=MODE_SLIDER,
+                mode=NumberMode.SLIDER,
             ),
             DemoNumber(
                 "pwm1",
@@ -32,7 +29,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 0.0,
                 1.0,
                 0.01,
-                MODE_BOX,
+                NumberMode.BOX,
             ),
             DemoNumber(
                 "large_range",
@@ -78,7 +75,7 @@ class DemoNumber(NumberEntity):
         min_value: float | None = None,
         max_value: float | None = None,
         step: float | None = None,
-        mode: Literal["auto", "box", "slider"] = MODE_AUTO,
+        mode: NumberMode = NumberMode.AUTO,
     ) -> None:
         """Initialize the Demo Number entity."""
         self._attr_assumed_state = assumed

--- a/homeassistant/components/flux_led/number.py
+++ b/homeassistant/components/flux_led/number.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 from typing import cast
 
 from homeassistant import config_entries
-from homeassistant.components.number import NumberEntity
-from homeassistant.components.number.const import MODE_SLIDER
+from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -47,7 +46,7 @@ class FluxNumber(FluxEntity, CoordinatorEntity, NumberEntity):
     _attr_min_value = 1
     _attr_max_value = 100
     _attr_step = 1
-    _attr_mode = MODE_SLIDER
+    _attr_mode = NumberMode.SLIDER
     _attr_icon = "mdi:speedometer"
 
     def __init__(

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -18,7 +18,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.components.climate.const import HVAC_MODE_HEAT, HVAC_MODES
 from homeassistant.components.cover import DEVICE_CLASSES as COVER_DEVICE_CLASSES
-from homeassistant.components.number.const import MODE_AUTO, MODE_BOX, MODE_SLIDER
+from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import CONF_STATE_CLASS, STATE_CLASSES_SCHEMA
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
@@ -786,14 +786,14 @@ class NumberSchema(KNXPlatformSchema):
     CONF_STEP = "step"
     DEFAULT_NAME = "KNX Number"
 
-    NUMBER_MODES: Final = [MODE_AUTO, MODE_BOX, MODE_SLIDER]
-
     ENTITY_SCHEMA = vol.All(
         vol.Schema(
             {
                 vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
                 vol.Optional(CONF_RESPOND_TO_READ, default=False): cv.boolean,
-                vol.Optional(CONF_MODE, default=MODE_AUTO): vol.In(NUMBER_MODES),
+                vol.Optional(CONF_MODE, default=NumberMode.AUTO): vol.Coerce(
+                    NumberMode
+                ),
                 vol.Required(CONF_TYPE): numeric_type_validator,
                 vol.Required(KNX_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_STATE_ADDRESS): ga_list_validator,

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any, Literal, final
+from typing import Any, final
 
 import voluptuous as vol
 
@@ -18,6 +18,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.enum import StrEnum
 
 from .const import (
     ATTR_MAX,
@@ -28,7 +29,6 @@ from .const import (
     DEFAULT_MIN_VALUE,
     DEFAULT_STEP,
     DOMAIN,
-    MODE_AUTO,
     SERVICE_SET_VALUE,
 )
 
@@ -39,6 +39,14 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class NumberMode(StrEnum):
+    """Modes for number entities."""
+
+    AUTO = "auto"
+    BOX = "box"
+    SLIDER = "slider"
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -92,7 +100,7 @@ class NumberEntity(Entity):
     _attr_min_value: float = DEFAULT_MIN_VALUE
     _attr_state: None = None
     _attr_step: float
-    _attr_mode: Literal["auto", "slider", "box"] = MODE_AUTO
+    _attr_mode: NumberMode = NumberMode.AUTO
     _attr_value: float
 
     @property
@@ -128,7 +136,7 @@ class NumberEntity(Entity):
         return step
 
     @property
-    def mode(self) -> Literal["auto", "slider", "box"]:
+    def mode(self) -> NumberMode:
         """Return the mode of the entity."""
         return self._attr_mode
 

--- a/homeassistant/components/number/const.py
+++ b/homeassistant/components/number/const.py
@@ -7,10 +7,6 @@ ATTR_MIN = "min"
 ATTR_MAX = "max"
 ATTR_STEP = "step"
 
-MODE_AUTO: Final = "auto"
-MODE_BOX: Final = "box"
-MODE_SLIDER: Final = "slider"
-
 DEFAULT_MIN_VALUE = 0.0
 DEFAULT_MAX_VALUE = 100.0
 DEFAULT_STEP = 1.0
@@ -18,3 +14,8 @@ DEFAULT_STEP = 1.0
 DOMAIN = "number"
 
 SERVICE_SET_VALUE = "set_value"
+
+# MODE_* are deprecated as of 2021.12, use the NumberMode enum instead.
+MODE_AUTO: Final = "auto"
+MODE_BOX: Final = "box"
+MODE_SLIDER: Final = "slider"

--- a/tests/components/demo/test_number.py
+++ b/tests/components/demo/test_number.py
@@ -3,15 +3,13 @@
 import pytest
 import voluptuous as vol
 
+from homeassistant.components.number import NumberMode
 from homeassistant.components.number.const import (
     ATTR_MAX,
     ATTR_MIN,
     ATTR_STEP,
     ATTR_VALUE,
     DOMAIN,
-    MODE_AUTO,
-    MODE_BOX,
-    MODE_SLIDER,
     SERVICE_SET_VALUE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
@@ -42,25 +40,25 @@ def test_default_setup_params(hass):
     assert state.attributes.get(ATTR_MIN) == 0.0
     assert state.attributes.get(ATTR_MAX) == 100.0
     assert state.attributes.get(ATTR_STEP) == 1.0
-    assert state.attributes.get(ATTR_MODE) == MODE_SLIDER
+    assert state.attributes.get(ATTR_MODE) == NumberMode.SLIDER
 
     state = hass.states.get(ENTITY_PWM)
     assert state.attributes.get(ATTR_MIN) == 0.0
     assert state.attributes.get(ATTR_MAX) == 1.0
     assert state.attributes.get(ATTR_STEP) == 0.01
-    assert state.attributes.get(ATTR_MODE) == MODE_BOX
+    assert state.attributes.get(ATTR_MODE) == NumberMode.BOX
 
     state = hass.states.get(ENTITY_LARGE_RANGE)
     assert state.attributes.get(ATTR_MIN) == 1.0
     assert state.attributes.get(ATTR_MAX) == 1000.0
     assert state.attributes.get(ATTR_STEP) == 1.0
-    assert state.attributes.get(ATTR_MODE) == MODE_AUTO
+    assert state.attributes.get(ATTR_MODE) == NumberMode.AUTO
 
     state = hass.states.get(ENTITY_SMALL_RANGE)
     assert state.attributes.get(ATTR_MIN) == 1.0
     assert state.attributes.get(ATTR_MAX) == 255.0
     assert state.attributes.get(ATTR_STEP) == 1.0
-    assert state.attributes.get(ATTR_MODE) == MODE_AUTO
+    assert state.attributes.get(ATTR_MODE) == NumberMode.AUTO
 
 
 async def test_set_value_bad_attr(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The use of the `MODE_*` constants in the `number` entity platform is deprecated. Please use the `NumberMode` enum instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This migrates the `NumberMode` to a StrEnum; this will help with a typing/implementation issue for the upcoming ESPHome support for this feature.

The three integration that uses this feature, have been adjusted.

The change is backward compatible right now, but marked breaking due to the deprecation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
