### PR TITLE
Handle errors response to be None

### DIFF
--- a/homeassistant/auth/providers/insecure_example.py
+++ b/homeassistant/auth/providers/insecure_example.py
@@ -102,7 +102,7 @@ class ExampleLoginFlow(LoginFlow):
         self, user_input: dict[str, str] | None = None
     ) -> FlowResult:
         """Handle the step of the form."""
-        errors = {}
+        errors = None
 
         if user_input is not None:
             try:
@@ -110,7 +110,7 @@ class ExampleLoginFlow(LoginFlow):
                     user_input["username"], user_input["password"]
                 )
             except InvalidAuthError:
-                errors["base"] = "invalid_auth"
+                errors = {"base": "invalid_auth"}
 
             if not errors:
                 user_input.pop("password")

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -154,8 +154,8 @@ class LoginFlowBaseView(HomeAssistantView):
     async def _async_flow_result_to_response(self, request, client_id, result):
         """Convert the flow result to a response."""
         if result["type"] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
-            # @log_invalid_auth does not work here since it returns HTTP 200
-            # need manually log failed login attempts
+            # @log_invalid_auth does not work here since it returns HTTP 200.
+            # We need to manually log failed login attempts.
             if (
                 result["type"] == data_entry_flow.RESULT_TYPE_FORM
                 and (errors := result.get("errors"))

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -154,14 +154,18 @@ class LoginFlowBaseView(HomeAssistantView):
     async def _async_flow_result_to_response(self, request, client_id, result):
         """Convert the flow result to a response."""
         if result["type"] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
-            if result["type"] == data_entry_flow.RESULT_TYPE_FORM:
-                # @log_invalid_auth does not work here since it returns HTTP 200
-                # need manually log failed login attempts
-                if result.get("errors", {}).get("base") in (
+            # @log_invalid_auth does not work here since it returns HTTP 200
+            # need manually log failed login attempts
+            if (
+                result["type"] == data_entry_flow.RESULT_TYPE_FORM
+                and (errors := result.get("errors"))
+                and errors.get("base")
+                in (
                     "invalid_auth",
                     "invalid_code",
-                ):
-                    await process_wrong_login(request)
+                )
+            ):
+                await process_wrong_login(request)
             return self.json(_prepare_result_json(result))
 
         result.pop("data")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With #57598 I reused some code between different response handlers. It looks like the old code didn't handle all cases and this caused a stack trace as reported by @zacwest 

```
2021-11-30 19:08:28 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_protocol.py", line 430, in _handle_request
    resp = await request_handler(request)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/security_filter.py", line 60, in security_filter_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/forwarded.py", line 98, in forwarded_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/request_context.py", line 28, in request_context_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/ban.py", line 78, in ban_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/auth.py", line 181, in auth_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/view.py", line 137, in handle
    result = await result
  File "/usr/src/homeassistant/homeassistant/components/http/data_validator.py", line 62, in wrapper
    result = await method(view, request, *args, **kwargs)
  File "/usr/src/homeassistant/homeassistant/components/http/ban.py", line 93, in handle_req
    resp = await func(view, request, *args, **kwargs)
  File "/usr/src/homeassistant/homeassistant/components/auth/login_flow.py", line 239, in post
    return await self._async_flow_result_to_response(
  File "/usr/src/homeassistant/homeassistant/components/auth/login_flow.py", line 160, in _async_flow_result_to_response
    if result.get("errors", {}).get("base") in (
AttributeError: 'NoneType' object has no attribute 'get'
```

The change to insecure auth provider is able to reproduce this stack trace. I've added some more tests around it to make sure it all works as expected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
