### PR TITLE
Fix tests for Hue integration

### DIFF
--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -22,13 +22,18 @@ from tests.common import (
     mock_device_registry,
 )
 
-# from tests.components.light.conftest import mock_light_profiles  # noqa: F401
-
 
 @pytest.fixture(autouse=True)
 def no_request_delay():
     """Make the request refresh delay 0 for instant tests."""
     with patch("homeassistant.components.hue.const.REQUEST_REFRESH_DELAY", 0):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def no_check_migration():
+    """Make sure the check_migration code is not called in regular tests."""
+    with patch("homeassistant.components.hue.check_migration"):
         yield
 
 

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -703,7 +703,7 @@ async def test_bridge_zeroconf(hass, aioclient_mock):
         data=zeroconf.ZeroconfServiceInfo(
             host="192.168.1.217",
             port=443,
-            hostname="Philips-hue.local.",
+            hostname="Philips-hue.local",
             type="_hue._tcp.local.",
             name="Philips Hue - ABCABC._hue._tcp.local.",
             properties={
@@ -720,7 +720,9 @@ async def test_bridge_zeroconf(hass, aioclient_mock):
 
 async def test_bridge_zeroconf_already_exists(hass, aioclient_mock):
     """Test a bridge being discovered by zeroconf already exists."""
-    create_mock_api_discovery(aioclient_mock, [("192.168.1.217", "ecb5faabcabc")])
+    create_mock_api_discovery(
+        aioclient_mock, [("0.0.0.0", "ecb5faabcabc"), ("192.168.1.217", "ecb5faabcabc")]
+    )
     entry = MockConfigEntry(
         domain="hue",
         source=config_entries.SOURCE_SSDP,
@@ -734,7 +736,7 @@ async def test_bridge_zeroconf_already_exists(hass, aioclient_mock):
         data=zeroconf.ZeroconfServiceInfo(
             host="192.168.1.217",
             port=443,
-            hostname="Philips-hue.local.",
+            hostname="Philips-hue.local",
             type="_hue._tcp.local.",
             name="Philips Hue - ABCABC._hue._tcp.local.",
             properties={


### PR DESCRIPTION
## Proposed change
This fixes a small bug in the tests that was undetectable on CI (and my dev machine) but spotted by others while hunting for slow tests.

The init code for the v1 tests was calling the migration logic containing a web call to check if the bridge has v2 capabilities.
So a aiohttp call was made that was not mocked. Apparently on MacOS and Linux aiohttp will fail instantly while on Windows it doesn't. At least, that's my theory.

As the migration logic has its own tests I've made sure the migration logic is not called from all other tests by a global mock. Issue fixed.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #60604 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
