### PR TITLE
Add support for Ohmpilots to Fronius integration

### DIFF
--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -206,12 +206,9 @@ class FroniusSolarNet:
         coordinator: FroniusCoordinatorType,
     ) -> FroniusCoordinatorType | None:
         """Initialize an update coordinator and return it if devices are found."""
-        print(f"coordinator {coordinator}")
         try:
             await coordinator.async_config_entry_first_refresh()
-            print(f"co data {coordinator.data}")
-        except ConfigEntryNotReady as err:
-            print(f"co error {err}")
+        except ConfigEntryNotReady:
             # ConfigEntryNotReady raised form FroniusError / KeyError in
             # DataUpdateCoordinator if request not supported by the Fronius device
             return None

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -22,6 +22,7 @@ from .coordinator import (
     FroniusInverterUpdateCoordinator,
     FroniusLoggerUpdateCoordinator,
     FroniusMeterUpdateCoordinator,
+    FroniusOhmpilotUpdateCoordinator,
     FroniusPowerFlowUpdateCoordinator,
     FroniusStorageUpdateCoordinator,
 )
@@ -83,6 +84,7 @@ class FroniusSolarNet:
         self.inverter_coordinators: list[FroniusInverterUpdateCoordinator] = []
         self.logger_coordinator: FroniusLoggerUpdateCoordinator | None = None
         self.meter_coordinator: FroniusMeterUpdateCoordinator | None = None
+        self.ohmpilot_coordinator: FroniusOhmpilotUpdateCoordinator | None = None
         self.power_flow_coordinator: FroniusPowerFlowUpdateCoordinator | None = None
         self.storage_coordinator: FroniusStorageUpdateCoordinator | None = None
 
@@ -118,6 +120,15 @@ class FroniusSolarNet:
                 solar_net=self,
                 logger=_LOGGER,
                 name=f"{DOMAIN}_meters_{self.host}",
+            )
+        )
+
+        self.ohmpilot_coordinator = await self._init_optional_coordinator(
+            FroniusOhmpilotUpdateCoordinator(
+                hass=self.hass,
+                solar_net=self,
+                logger=_LOGGER,
+                name=f"{DOMAIN}_ohmpilot_{self.host}",
             )
         )
 
@@ -195,9 +206,12 @@ class FroniusSolarNet:
         coordinator: FroniusCoordinatorType,
     ) -> FroniusCoordinatorType | None:
         """Initialize an update coordinator and return it if devices are found."""
+        print(f"coordinator {coordinator}")
         try:
             await coordinator.async_config_entry_first_refresh()
-        except ConfigEntryNotReady:
+            print(f"co data {coordinator.data}")
+        except ConfigEntryNotReady as err:
+            print(f"co error {err}")
             # ConfigEntryNotReady raised form FroniusError / KeyError in
             # DataUpdateCoordinator if request not supported by the Fronius device
             return None

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -22,6 +22,7 @@ from .sensor import (
     INVERTER_ENTITY_DESCRIPTIONS,
     LOGGER_ENTITY_DESCRIPTIONS,
     METER_ENTITY_DESCRIPTIONS,
+    OHMPILOT_ENTITY_DESCRIPTIONS,
     POWER_FLOW_ENTITY_DESCRIPTIONS,
     STORAGE_ENTITY_DESCRIPTIONS,
 )
@@ -156,6 +157,19 @@ class FroniusMeterUpdateCoordinator(FroniusCoordinatorBase):
         """Return data per solar net id from pyfronius."""
         data = await self.solar_net.fronius.current_system_meter_data()
         return data["meters"]  # type: ignore[no-any-return]
+
+
+class FroniusOhmpilotUpdateCoordinator(FroniusCoordinatorBase):
+    """Query Fronius Ohmpilots and keep track of seen conditions."""
+
+    default_interval = timedelta(minutes=1)
+    error_interval = timedelta(minutes=10)
+    valid_descriptions = OHMPILOT_ENTITY_DESCRIPTIONS
+
+    async def _update_method(self) -> dict[SolarNetId, Any]:
+        """Return data per solar net id from pyfronius."""
+        data = await self.solar_net.fronius.current_system_ohmpilot_data()
+        return data["ohmpilots"]  # type: ignore[no-any-return]
 
 
 class FroniusPowerFlowUpdateCoordinator(FroniusCoordinatorBase):

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -373,11 +373,11 @@ async def test_gen24_storage(hass, aioclient_mock):
     mock_responses(aioclient_mock, fixture_set="gen24_storage")
     config_entry = await setup_fronius_integration(hass, is_logger=False)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 31
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 36
     await enable_all_entities(
         hass, config_entry.entry_id, FroniusMeterUpdateCoordinator.default_interval
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 63
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 68
     # inverter 1
     assert_state("sensor.current_dc_fronius_inverter_1_http_fronius", 0.3952)
     assert_state("sensor.voltage_dc_2_fronius_inverter_1_http_fronius", 318.8103)
@@ -437,6 +437,16 @@ async def test_gen24_storage(hass, aioclient_mock):
     assert_state("sensor.voltage_ac_phase_3_fronius_meter_0_http_fronius", 228.3)
     assert_state("sensor.power_apparent_fronius_meter_0_http_fronius", 821.9)
     assert_state("sensor.power_apparent_phase_3_fronius_meter_0_http_fronius", 118.4)
+    # ohmpilot
+    assert_state(
+        "sensor.energy_real_ac_consumed_fronius_ohmpilot_0_http_fronius", 1233295.0
+    )
+    assert_state("sensor.power_real_ac_fronius_ohmpilot_0_http_fronius", 0.0)
+    assert_state("sensor.temperature_channel_1_fronius_ohmpilot_0_http_fronius", 38.9)
+    assert_state("sensor.state_code_fronius_ohmpilot_0_http_fronius", 0.0)
+    assert_state(
+        "sensor.state_message_fronius_ohmpilot_0_http_fronius", "Up and running"
+    )
     # power_flow
     assert_state("sensor.power_grid_fronius_power_flow_0_http_fronius", 2274.9)
     assert_state("sensor.power_battery_fronius_power_flow_0_http_fronius", 0.1591)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for Ohmpilots (solar production controlled water heater) to Fronius integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
