### PR TITLE
Use dataclass properties in yamaha_musiccast

### DIFF
--- a/homeassistant/components/yamaha_musiccast/__init__.py
+++ b/homeassistant/components/yamaha_musiccast/__init__.py
@@ -39,11 +39,10 @@ SCAN_INTERVAL = timedelta(seconds=60)
 async def get_upnp_desc(hass: HomeAssistant, host: str):
     """Get the upnp description URL for a given host, using the SSPD scanner."""
     ssdp_entries = await ssdp.async_get_discovery_info_by_st(hass, "upnp:rootdevice")
-    matches = [w for w in ssdp_entries if w.get("_host", "") == host]
+    matches = [w for w in ssdp_entries if w.ssdp_headers.get("_host", "") == host]
     upnp_desc = None
     for match in matches:
-        if match.get(ssdp.ATTR_SSDP_LOCATION):
-            upnp_desc = match[ssdp.ATTR_SSDP_LOCATION]
+        if upnp_desc := match.ssdp_location:
             break
 
     if not upnp_desc:

--- a/homeassistant/components/yamaha_musiccast/config_flow.py
+++ b/homeassistant/components/yamaha_musiccast/config_flow.py
@@ -92,7 +92,9 @@ class MusicCastFlowHandler(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="yxc_control_url_missing")
 
         self.serial_number = discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
-        self.host = urlparse(discovery_info.ssdp_location or "").hostname or ""
+        self.host = urlparse(
+            discovery_info.ssdp_location
+        ).hostname  # type: ignore[assignment]
         self.upnp_description = discovery_info.ssdp_location
         await self.async_set_unique_id(self.serial_number)
         self._abort_if_unique_id_configured(

--- a/homeassistant/components/yamaha_musiccast/config_flow.py
+++ b/homeassistant/components/yamaha_musiccast/config_flow.py
@@ -92,10 +92,13 @@ class MusicCastFlowHandler(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="yxc_control_url_missing")
 
         self.serial_number = discovery_info.upnp[ssdp.ATTR_UPNP_SERIAL]
+        self.upnp_description = discovery_info.ssdp_location
+
+        # ssdp_location and hostname have been checked in check_yamaha_ssdp so it is safe to ignore type assignment
         self.host = urlparse(
             discovery_info.ssdp_location
         ).hostname  # type: ignore[assignment]
-        self.upnp_description = discovery_info.ssdp_location
+
         await self.async_set_unique_id(self.serial_number)
         self._abort_if_unique_id_configured(
             {

--- a/tests/components/yamaha_musiccast/test_config_flow.py
+++ b/tests/components/yamaha_musiccast/test_config_flow.py
@@ -94,10 +94,15 @@ def mock_valid_discovery_information():
     with patch(
         "homeassistant.components.ssdp.async_get_discovery_info_by_st",
         return_value=[
-            {
-                "ssdp_location": "http://127.0.0.1:9000/MediaRenderer/desc.xml",
-                "_host": "127.0.0.1",
-            }
+            ssdp.SsdpServiceInfo(
+                ssdp_usn="mock_usn",
+                ssdp_st="mock_st",
+                ssdp_location="http://127.0.0.1:9000/MediaRenderer/desc.xml",
+                ssdp_headers={
+                    "_host": "127.0.0.1",
+                },
+                upnp={},
+            )
         ],
     ):
         yield


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use dataclass properties in yamaha_musiccast.

Linked to #60540

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
