### PR TITLE
Bump aiopvpc version to fix server banning for pvpc_hourly_pricing

### DIFF
--- a/homeassistant/components/pvpc_hourly_pricing/manifest.json
+++ b/homeassistant/components/pvpc_hourly_pricing/manifest.json
@@ -3,7 +3,7 @@
   "name": "Spain electricity hourly pricing (PVPC)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/pvpc_hourly_pricing",
-  "requirements": ["aiopvpc==2.2.4"],
+  "requirements": ["aiopvpc==2.3.0"],
   "codeowners": ["@azogue"],
   "quality_scale": "platinum",
   "iot_class": "cloud_polling"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -234,7 +234,7 @@ aiopulse==0.4.3
 aiopvapi==1.6.14
 
 # homeassistant.components.pvpc_hourly_pricing
-aiopvpc==2.2.4
+aiopvpc==2.3.0
 
 # homeassistant.components.webostv
 aiopylgtv==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -164,7 +164,7 @@ aiopulse==0.4.3
 aiopvapi==1.6.14
 
 # homeassistant.components.pvpc_hourly_pricing
-aiopvpc==2.2.4
+aiopvpc==2.3.0
 
 # homeassistant.components.webostv
 aiopylgtv==0.4.0

--- a/tests/components/pvpc_hourly_pricing/test_sensor.py
+++ b/tests/components/pvpc_hourly_pricing/test_sensor.py
@@ -64,9 +64,9 @@ async def test_sensor_availability(
 
         await _process_time_step(hass, mock_data, "price_21h", 0.13896)
         await _process_time_step(hass, mock_data, "price_22h", 0.06893)
-        assert pvpc_aioclient_mock.call_count == 4
+        assert pvpc_aioclient_mock.call_count == 3
         await _process_time_step(hass, mock_data, "price_23h", 0.06935)
-        assert pvpc_aioclient_mock.call_count == 5
+        assert pvpc_aioclient_mock.call_count == 4
 
         # sensor has no more prices, state is "unavailable" from now on
         await _process_time_step(hass, mock_data, value="unavailable")
@@ -79,7 +79,7 @@ async def test_sensor_availability(
         num_warnings = sum(1 for x in caplog.records if x.levelno == logging.WARNING)
         assert num_warnings == 1
         assert num_errors == 0
-        assert pvpc_aioclient_mock.call_count == 9
+        assert pvpc_aioclient_mock.call_count == 8
 
         # check that it is silent until it becomes available again
         caplog.clear()
@@ -87,20 +87,20 @@ async def test_sensor_availability(
             # silent mode
             for _ in range(21):
                 await _process_time_step(hass, mock_data, value="unavailable")
-            assert pvpc_aioclient_mock.call_count == 30
+            assert pvpc_aioclient_mock.call_count == 29
             assert len(caplog.messages) == 0
 
             # warning about data access recovered
             await _process_time_step(hass, mock_data, value="unavailable")
-            assert pvpc_aioclient_mock.call_count == 31
+            assert pvpc_aioclient_mock.call_count == 30
             assert len(caplog.messages) == 1
             assert caplog.records[0].levelno == logging.WARNING
 
             # working ok again
             await _process_time_step(hass, mock_data, "price_00h", value=0.06821)
-            assert pvpc_aioclient_mock.call_count == 32
+            assert pvpc_aioclient_mock.call_count == 30
             await _process_time_step(hass, mock_data, "price_01h", value=0.06627)
-            assert pvpc_aioclient_mock.call_count == 33
+            assert pvpc_aioclient_mock.call_count == 30
             assert len(caplog.messages) == 1
             assert caplog.records[0].levelno == logging.WARNING
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Quick-Fix Release motivated by the last change in the ESIOS server (on 2021-11-30 😱), which is now apparently banning HomeAssistant requests (#60556), filtering us out because of the 'User-Agent' request header 😤 (the server is returning a 403 status code error for a PUBLIC URL 🤷)

This is a follow up for #58986, which was the first attempt to filter us out from the server (just exactly 4 weeks before this new _incident_ 🕵️‍♂️). 
At that time, the solution was to add a User-Agent header to the aiohttp request, but now they are filtering that same `User-Agent` 😅 (and as observed by some users, by doing regex with 'aiopvpc' 😖)

In this second attempt we are doing a little more:
* An **optimal** download rate of **just 1 or 2 API requests by day**, instead of the _crazy_ previous rate of ~56 requests/day (YES, not a typo, those numbers are daily rates, not by hour or minute 🤣)
* We now set a _standard_ `User-Agent`, randomly selected for a small set of combinations, and we loop it if receiving a 403 status error 😝
Version bump of `aiopvpc` containing the fix. Details:

- Release notes: https://github.com/azogue/aiopvpc/releases/tag/v2.3.0
- Changelog: https://github.com/azogue/aiopvpc/blob/master/CHANGELOG.md
- Diff/compare against current version: https://github.com/azogue/aiopvpc/compare/v2.2.4...v2.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #60556
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
