### PR TITLE
Update flux_led for upstream strict typing

### DIFF
--- a/homeassistant/components/flux_led/__init__.py
+++ b/homeassistant/components/flux_led/__init__.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Any, Final, cast
+from typing import Any, Final
 
 from flux_led import DeviceType
 from flux_led.aio import AIOWifiLedBulb
 from flux_led.aioscanner import AIOBulbScanner
 from flux_led.const import ATTR_ID, ATTR_IPADDR, ATTR_MODEL, ATTR_MODEL_DESCRIPTION
+from flux_led.scanner import FluxLEDDiscovery
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
@@ -50,33 +51,36 @@ def async_wifi_bulb_for_host(host: str) -> AIOWifiLedBulb:
 
 
 @callback
-def async_name_from_discovery(device: dict[str, Any]) -> str:
+def async_name_from_discovery(device: FluxLEDDiscovery) -> str:
     """Convert a flux_led discovery to a human readable name."""
-    if (mac := device.get(ATTR_ID)) is None:
-        return cast(str, device[ATTR_IPADDR])
-    short_mac = mac[-6:]
-    if device.get(ATTR_MODEL_DESCRIPTION):
+    mac_address = device[ATTR_ID]
+    if mac_address is None:
+        return device[ATTR_IPADDR]
+    short_mac = mac_address[-6:]
+    if device[ATTR_MODEL_DESCRIPTION]:
         return f"{device[ATTR_MODEL_DESCRIPTION]} {short_mac}"
     return f"{device[ATTR_MODEL]} {short_mac}"
 
 
 @callback
 def async_update_entry_from_discovery(
-    hass: HomeAssistant, entry: config_entries.ConfigEntry, device: dict[str, Any]
+    hass: HomeAssistant, entry: config_entries.ConfigEntry, device: FluxLEDDiscovery
 ) -> None:
     """Update a config entry from a flux_led discovery."""
     name = async_name_from_discovery(device)
+    mac_address = device[ATTR_ID]
+    assert mac_address is not None
     hass.config_entries.async_update_entry(
         entry,
         data={**entry.data, CONF_NAME: name},
         title=name,
-        unique_id=dr.format_mac(device[ATTR_ID]),
+        unique_id=dr.format_mac(mac_address),
     )
 
 
 async def async_discover_devices(
     hass: HomeAssistant, timeout: int, address: str | None = None
-) -> list[dict[str, str]]:
+) -> list[FluxLEDDiscovery]:
     """Discover flux led devices."""
     domain_data = hass.data.setdefault(DOMAIN, {})
     if FLUX_LED_DISCOVERY_LOCK not in domain_data:
@@ -84,9 +88,7 @@ async def async_discover_devices(
     async with domain_data[FLUX_LED_DISCOVERY_LOCK]:
         scanner = AIOBulbScanner()
         try:
-            discovered: list[dict[str, str]] = await scanner.async_scan(
-                timeout=timeout, address=address
-            )
+            discovered = await scanner.async_scan(timeout=timeout, address=address)
         except OSError as ex:
             _LOGGER.debug("Scanning failed with error: %s", ex)
             return []
@@ -96,7 +98,7 @@ async def async_discover_devices(
 
 async def async_discover_device(
     hass: HomeAssistant, host: str
-) -> dict[str, str] | None:
+) -> FluxLEDDiscovery | None:
     """Direct discovery at a single ip instead of broadcast."""
     # If we are missing the unique_id we should be able to fetch it
     # from the device by doing a directed discovery at the host only
@@ -109,7 +111,7 @@ async def async_discover_device(
 @callback
 def async_trigger_discovery(
     hass: HomeAssistant,
-    discovered_devices: list[dict[str, Any]],
+    discovered_devices: list[FluxLEDDiscovery],
 ) -> None:
     """Trigger config flows for discovered devices."""
     for device in discovered_devices:
@@ -117,7 +119,7 @@ def async_trigger_discovery(
             hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": config_entries.SOURCE_DISCOVERY},
-                data=device,
+                data={**device},
             )
         )
 

--- a/homeassistant/components/flux_led/entity.py
+++ b/homeassistant/components/flux_led/entity.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, cast
+from typing import Any
 
 from flux_led.aiodevice import AIOWifiLedBulb
 
@@ -72,7 +72,7 @@ class FluxOnOffEntity(FluxEntity):
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
-        return cast(bool, self._device.is_on)
+        return self._device.is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified device on."""

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import ast
 import logging
-from typing import Any, Final, cast
+from typing import Any, Final
 
 from flux_led.const import ATTR_ID, ATTR_IPADDR
 from flux_led.utils import (
@@ -244,7 +244,7 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
     @property
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
-        return cast(int, self._device.brightness)
+        return self._device.brightness
 
     @property
     def color_temp(self) -> int:
@@ -254,20 +254,17 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
     @property
     def rgb_color(self) -> tuple[int, int, int]:
         """Return the rgb color value."""
-        rgb: tuple[int, int, int] = self._device.rgb_unscaled
-        return rgb
+        return self._device.rgb_unscaled
 
     @property
     def rgbw_color(self) -> tuple[int, int, int, int]:
         """Return the rgbw color value."""
-        rgbw: tuple[int, int, int, int] = self._device.rgbw
-        return rgbw
+        return self._device.rgbw
 
     @property
     def rgbww_color(self) -> tuple[int, int, int, int, int]:
         """Return the rgbww aka rgbcw color value."""
-        rgbcw: tuple[int, int, int, int, int] = self._device.rgbcw
-        return rgbcw
+        return self._device.rgbcw
 
     @property
     def color_mode(self) -> str:
@@ -279,10 +276,7 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
     @property
     def effect(self) -> str | None:
         """Return the current effect."""
-        effect = self._device.effect
-        if effect is None:
-            return None
-        return cast(str, effect)
+        return self._device.effect
 
     async def _async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified or all lights on."""
@@ -353,7 +347,8 @@ class FluxLight(FluxOnOffEntity, CoordinatorEntity, LightEntity):
             return
         # Handle switch to RGB Color Mode
         if rgb := kwargs.get(ATTR_RGB_COLOR):
-            await self._device.async_set_levels(*rgb, brightness=brightness)
+            red, green, blue = rgb
+            await self._device.async_set_levels(red, green, blue, brightness=brightness)
             return
         # Handle switch to RGBW Color Mode
         if rgbw := kwargs.get(ATTR_RGBW_COLOR):

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -3,7 +3,7 @@
   "name": "Flux LED/MagicHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "requirements": ["flux_led==0.25.2"],
+  "requirements": ["flux_led==0.25.10"],
   "quality_scale": "platinum",
   "codeowners": ["@icemanch"],
   "iot_class": "local_push",

--- a/homeassistant/components/flux_led/util.py
+++ b/homeassistant/components/flux_led/util.py
@@ -18,8 +18,12 @@ def _hass_color_modes(device: AIOWifiLedBulb) -> set[str]:
     return {_flux_color_mode_to_hass(mode, color_modes) for mode in color_modes}
 
 
-def _flux_color_mode_to_hass(flux_color_mode: str, flux_color_modes: set[str]) -> str:
+def _flux_color_mode_to_hass(
+    flux_color_mode: str | None, flux_color_modes: set[str]
+) -> str:
     """Map the flux color mode to Home Assistant color mode."""
+    if flux_color_mode is None:
+        return COLOR_MODE_ONOFF
     if flux_color_mode == FLUX_COLOR_MODE_DIM:
         if len(flux_color_modes) > 1:
             return COLOR_MODE_WHITE

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -658,7 +658,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.25.2
+flux_led==0.25.10
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -399,7 +399,7 @@ fjaraskupan==1.0.2
 flipr-api==1.4.1
 
 # homeassistant.components.flux_led
-flux_led==0.25.2
+flux_led==0.25.10
 
 # homeassistant.components.homekit
 fnvhash==0.1.0

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -2,20 +2,19 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 from typing import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from flux_led import DeviceType
 from flux_led.aio import AIOWifiLedBulb
 from flux_led.const import (
-    ATTR_ID,
-    ATTR_IPADDR,
-    ATTR_MODEL,
-    ATTR_MODEL_DESCRIPTION,
     COLOR_MODE_CCT as FLUX_COLOR_MODE_CCT,
     COLOR_MODE_RGB as FLUX_COLOR_MODE_RGB,
 )
+from flux_led.models_db import MODEL_MAP
 from flux_led.protocol import LEDENETRawState
+from flux_led.scanner import FluxLEDDiscovery
 
 from homeassistant.components import dhcp
 from homeassistant.core import HomeAssistant
@@ -23,14 +22,14 @@ from homeassistant.core import HomeAssistant
 MODULE = "homeassistant.components.flux_led"
 MODULE_CONFIG_FLOW = "homeassistant.components.flux_led.config_flow"
 IP_ADDRESS = "127.0.0.1"
+MODEL_NUM_HEX = "0x35"
 MODEL = "AZ120444"
-MODEL_DESCRIPTION = "RGBW Controller"
+MODEL_DESCRIPTION = "Bulb RGBCW"
 MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
 FLUX_MAC_ADDRESS = "aabbccddeeff"
 SHORT_MAC_ADDRESS = "ddeeff"
 
 DEFAULT_ENTRY_TITLE = f"{MODEL_DESCRIPTION} {SHORT_MAC_ADDRESS}"
-DEFAULT_ENTRY_TITLE_PARTIAL = f"{MODEL} {SHORT_MAC_ADDRESS}"
 
 
 DHCP_DISCOVERY = dhcp.DhcpServiceInfo(
@@ -38,17 +37,26 @@ DHCP_DISCOVERY = dhcp.DhcpServiceInfo(
     ip=IP_ADDRESS,
     macaddress=MAC_ADDRESS,
 )
-FLUX_DISCOVERY_PARTIAL = {
-    ATTR_IPADDR: IP_ADDRESS,
-    ATTR_MODEL: MODEL,
-    ATTR_ID: FLUX_MAC_ADDRESS,
-}
-FLUX_DISCOVERY = {
-    ATTR_IPADDR: IP_ADDRESS,
-    ATTR_MODEL: MODEL,
-    ATTR_ID: FLUX_MAC_ADDRESS,
-    ATTR_MODEL_DESCRIPTION: MODEL_DESCRIPTION,
-}
+FLUX_DISCOVERY_PARTIAL = FluxLEDDiscovery(
+    ipaddr=IP_ADDRESS,
+    model=MODEL,
+    id=FLUX_MAC_ADDRESS,
+    model_num=None,
+    version_num=None,
+    firmware_date=None,
+    model_info=None,
+    model_description=None,
+)
+FLUX_DISCOVERY = FluxLEDDiscovery(
+    ipaddr=IP_ADDRESS,
+    model=MODEL,
+    id=FLUX_MAC_ADDRESS,
+    model_num=0x25,
+    version_num=0x04,
+    firmware_date=datetime.date(2021, 5, 5),
+    model_info=MODEL,
+    model_description=MODEL_DESCRIPTION,
+)
 
 
 def _mocked_bulb() -> AIOWifiLedBulb:
@@ -85,9 +93,10 @@ def _mocked_bulb() -> AIOWifiLedBulb:
     bulb.getWhiteTemperature = MagicMock(return_value=(2700, 128))
     bulb.brightness = 128
     bulb.model_num = 0x35
+    bulb.model_data = MODEL_MAP[0x35]
     bulb.effect = None
     bulb.speed = 50
-    bulb.model = "Smart Bulb (0x35)"
+    bulb.model = "Bulb RGBCW (0x35)"
     bulb.version_num = 8
     bulb.speed_adjust_off = True
     bulb.rgbwcapable = True
@@ -112,7 +121,8 @@ def _mocked_switch() -> AIOWifiLedBulb:
     switch.async_turn_off = AsyncMock()
     switch.async_turn_on = AsyncMock()
     switch.model_num = 0x97
-    switch.model = "Smart Switch (0x97)"
+    switch.model_data = MODEL_MAP[0x97]
+    switch.model = "Switch (0x97)"
     switch.version_num = 0x97
     switch.raw_state = LEDENETRawState(
         0, 0x97, 0, 0x61, 0x97, 50, 255, 0, 0, 50, 8, 0, 0, 0

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -29,7 +29,6 @@ from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
 
 from . import (
     DEFAULT_ENTRY_TITLE,
-    DEFAULT_ENTRY_TITLE_PARTIAL,
     DHCP_DISCOVERY,
     FLUX_DISCOVERY,
     IP_ADDRESS,
@@ -428,7 +427,7 @@ async def test_discovered_by_dhcp_no_udp_response(hass):
     assert result2["type"] == "create_entry"
     assert result2["data"] == {
         CONF_HOST: IP_ADDRESS,
-        CONF_NAME: DEFAULT_ENTRY_TITLE_PARTIAL,
+        CONF_NAME: DEFAULT_ENTRY_TITLE,
     }
     assert mock_async_setup.called
     assert mock_async_setup_entry.called
@@ -509,4 +508,4 @@ async def test_options(hass: HomeAssistant):
     assert result2["type"] == "create_entry"
     assert result2["data"] == user_input
     assert result2["data"] == config_entry.options
-    assert hass.states.get("light.rgbw_controller_ddeeff") is not None
+    assert hass.states.get("light.bulb_rgbcw_ddeeff") is not None

--- a/tests/components/flux_led/test_init.py
+++ b/tests/components/flux_led/test_init.py
@@ -15,7 +15,6 @@ from homeassistant.util.dt import utcnow
 
 from . import (
     DEFAULT_ENTRY_TITLE,
-    DEFAULT_ENTRY_TITLE_PARTIAL,
     FLUX_DISCOVERY,
     FLUX_DISCOVERY_PARTIAL,
     IP_ADDRESS,
@@ -75,7 +74,7 @@ async def test_config_entry_retry(hass: HomeAssistant) -> None:
     "discovery,title",
     [
         (FLUX_DISCOVERY, DEFAULT_ENTRY_TITLE),
-        (FLUX_DISCOVERY_PARTIAL, DEFAULT_ENTRY_TITLE_PARTIAL),
+        (FLUX_DISCOVERY_PARTIAL, "AZ120444 ddeeff"),
     ],
 )
 async def test_config_entry_fills_unique_id_with_directed_discovery(

--- a/tests/components/flux_led/test_number.py
+++ b/tests/components/flux_led/test_number.py
@@ -45,7 +45,7 @@ async def test_number_unique_id(hass: HomeAssistant) -> None:
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    entity_id = "number.rgbw_controller_ddeeff_effect_speed"
+    entity_id = "number.bulb_rgbcw_ddeeff_effect_speed"
     entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == MAC_ADDRESS
 
@@ -70,8 +70,8 @@ async def test_rgb_light_effect_speed(hass: HomeAssistant) -> None:
 
     await async_mock_device_turn_on(hass, bulb)
 
-    light_entity_id = "light.rgbw_controller_ddeeff"
-    number_entity_id = "number.rgbw_controller_ddeeff_effect_speed"
+    light_entity_id = "light.bulb_rgbcw_ddeeff"
+    number_entity_id = "number.bulb_rgbcw_ddeeff_effect_speed"
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -135,8 +135,8 @@ async def test_original_addressable_light_effect_speed(hass: HomeAssistant) -> N
 
     await async_mock_device_turn_on(hass, bulb)
 
-    light_entity_id = "light.rgbw_controller_ddeeff"
-    number_entity_id = "number.rgbw_controller_ddeeff_effect_speed"
+    light_entity_id = "light.bulb_rgbcw_ddeeff"
+    number_entity_id = "number.bulb_rgbcw_ddeeff_effect_speed"
 
     state = hass.states.get(light_entity_id)
     assert state.state == STATE_ON
@@ -192,8 +192,8 @@ async def test_addressable_light_effect_speed(hass: HomeAssistant) -> None:
 
     await async_mock_device_turn_on(hass, bulb)
 
-    light_entity_id = "light.rgbw_controller_ddeeff"
-    number_entity_id = "number.rgbw_controller_ddeeff_effect_speed"
+    light_entity_id = "light.bulb_rgbcw_ddeeff"
+    number_entity_id = "number.bulb_rgbcw_ddeeff_effect_speed"
 
     state = hass.states.get(light_entity_id)
     assert state.state == STATE_ON

--- a/tests/components/flux_led/test_switch.py
+++ b/tests/components/flux_led/test_switch.py
@@ -39,7 +39,7 @@ async def test_switch_on_off(hass: HomeAssistant) -> None:
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    entity_id = "switch.rgbw_controller_ddeeff"
+    entity_id = "switch.bulb_rgbcw_ddeeff"
 
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Bump library to 0.25.10 (Fixes effects brightness reporting, Fixes missing rgb_cycle effect on some devices, Fixes discovery reliablity, strict typing)

- Changelog: https://github.com/Danielhiversen/flux_led/compare/0.25.2...0.25.10

- This is a squashed version of #60554 since that one keeps failing to restore the python env on 3.9


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
