### PR TITLE
Use entity category enum in Rituals

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/binary_sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/binary_sensor.py
@@ -8,8 +8,8 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import RitualsDataUpdateCoordinator
@@ -39,7 +39,7 @@ class DiffuserBatteryChargingBinarySensor(DiffuserEntity, BinarySensorEntity):
     """Representation of a diffuser battery charging binary sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self, diffuser: Diffuser, coordinator: RitualsDataUpdateCoordinator

--- a/homeassistant/components/rituals_perfume_genie/select.py
+++ b/homeassistant/components/rituals_perfume_genie/select.py
@@ -5,8 +5,9 @@ from pyrituals import Diffuser
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import AREA_SQUARE_METERS, ENTITY_CATEGORY_CONFIG
+from homeassistant.const import AREA_SQUARE_METERS
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import RitualsDataUpdateCoordinator
@@ -36,7 +37,7 @@ class DiffuserRoomSize(DiffuserEntity, SelectEntity):
     _attr_icon = "mdi:ruler-square"
     _attr_unit_of_measurement = AREA_SQUARE_METERS
     _attr_options = ["15", "30", "60", "100"]
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self, diffuser: Diffuser, coordinator: RitualsDataUpdateCoordinator

--- a/homeassistant/components/rituals_perfume_genie/sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/sensor.py
@@ -5,8 +5,9 @@ from pyrituals import Diffuser
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC, PERCENTAGE
+from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import RitualsDataUpdateCoordinator
@@ -88,7 +89,7 @@ class DiffuserBatterySensor(DiffuserEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self, diffuser: Diffuser, coordinator: RitualsDataUpdateCoordinator
@@ -107,7 +108,7 @@ class DiffuserWifiSensor(DiffuserEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
     _attr_native_unit_of_measurement = PERCENTAGE
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self, diffuser: Diffuser, coordinator: RitualsDataUpdateCoordinator

--- a/tests/components/rituals_perfume_genie/test_binary_sensor.py
+++ b/tests/components/rituals_perfume_genie/test_binary_sensor.py
@@ -1,9 +1,10 @@
 """Tests for the Rituals Perfume Genie binary sensor platform."""
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.rituals_perfume_genie.binary_sensor import CHARGING_SUFFIX
-from homeassistant.const import ATTR_DEVICE_CLASS, ENTITY_CATEGORY_DIAGNOSTIC, STATE_ON
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
+from homeassistant.helpers.entity import EntityCategory
 
 from .common import (
     init_integration,
@@ -30,4 +31,4 @@ async def test_binary_sensors(hass: HomeAssistant) -> None:
     entry = registry.async_get("binary_sensor.genie_battery_charging")
     assert entry
     assert entry.unique_id == f"{hublot}{CHARGING_SUFFIX}"
-    assert entry.entity_category == ENTITY_CATEGORY_DIAGNOSTIC
+    assert entry.entity_category == EntityCategory.DIAGNOSTIC

--- a/tests/components/rituals_perfume_genie/test_select.py
+++ b/tests/components/rituals_perfume_genie/test_select.py
@@ -9,11 +9,11 @@ from homeassistant.const import (
     AREA_SQUARE_METERS,
     ATTR_ENTITY_ID,
     ATTR_ICON,
-    ENTITY_CATEGORY_CONFIG,
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.setup import async_setup_component
 
 from .common import init_integration, mock_config_entry, mock_diffuser
@@ -37,7 +37,7 @@ async def test_select_entity(hass: HomeAssistant) -> None:
     assert entry
     assert entry.unique_id == f"{diffuser.hublot}{ROOM_SIZE_SUFFIX}"
     assert entry.unit_of_measurement == AREA_SQUARE_METERS
-    assert entry.entity_category == ENTITY_CATEGORY_CONFIG
+    assert entry.entity_category == EntityCategory.CONFIG
 
 
 async def test_select_option(hass: HomeAssistant) -> None:

--- a/tests/components/rituals_perfume_genie/test_sensor.py
+++ b/tests/components/rituals_perfume_genie/test_sensor.py
@@ -10,11 +10,11 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
-    ENTITY_CATEGORY_DIAGNOSTIC,
     PERCENTAGE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
+from homeassistant.helpers.entity import EntityCategory
 
 from .common import (
     init_integration,
@@ -59,7 +59,7 @@ async def test_sensors_diffuser_v1_battery_cartridge(hass: HomeAssistant) -> Non
     entry = registry.async_get("sensor.genie_battery")
     assert entry
     assert entry.unique_id == f"{hublot}{BATTERY_SUFFIX}"
-    assert entry.entity_category == ENTITY_CATEGORY_DIAGNOSTIC
+    assert entry.entity_category == EntityCategory.DIAGNOSTIC
 
     state = hass.states.get("sensor.genie_wifi")
     assert state
@@ -70,7 +70,7 @@ async def test_sensors_diffuser_v1_battery_cartridge(hass: HomeAssistant) -> Non
     entry = registry.async_get("sensor.genie_wifi")
     assert entry
     assert entry.unique_id == f"{hublot}{WIFI_SUFFIX}"
-    assert entry.entity_category == ENTITY_CATEGORY_DIAGNOSTIC
+    assert entry.entity_category == EntityCategory.DIAGNOSTIC
 
 
 async def test_sensors_diffuser_v2_no_battery_no_cartridge(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
Makes use of the new entity category enum in Rituals Perfume Genie, instead of the deprecated constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
