### PR TITLE
Use dataclass for HassioServiceInfo

### DIFF
--- a/homeassistant/components/adguard/config_flow.py
+++ b/homeassistant/components/adguard/config_flow.py
@@ -112,7 +112,7 @@ class AdGuardHomeFlowHandler(ConfigFlow, domain=DOMAIN):
         """
         await self._async_handle_discovery_without_unique_id()
 
-        self._hassio_discovery = discovery_info
+        self._hassio_discovery = discovery_info.config
         return await self.async_step_hassio_confirm()
 
     async def async_step_hassio_confirm(

--- a/homeassistant/components/adguard/config_flow.py
+++ b/homeassistant/components/adguard/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 from adguardhome import AdGuardHome, AdGuardHomeConnectionError
 import voluptuous as vol
 
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import (
     CONF_HOST,

--- a/homeassistant/components/adguard/config_flow.py
+++ b/homeassistant/components/adguard/config_flow.py
@@ -6,6 +6,7 @@ from typing import Any
 from adguardhome import AdGuardHome, AdGuardHomeConnectionError
 import voluptuous as vol
 
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import (
     CONF_HOST,
@@ -104,7 +105,7 @@ class AdGuardHomeFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResult:
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
         """Prepare configuration for a Hass.io AdGuard Home add-on.
 
         This flow is triggered by the discovery component.

--- a/homeassistant/components/almond/config_flow.py
+++ b/homeassistant/components/almond/config_flow.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 from yarl import URL
 
 from homeassistant import config_entries, core, data_entry_flow
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
 
@@ -94,7 +95,7 @@ class AlmondFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
             data={"type": TYPE_LOCAL, "host": user_input["host"]},
         )
 
-    async def async_step_hassio(self, discovery_info):
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
         """Receive a Hass.io discovery."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")

--- a/homeassistant/components/almond/config_flow.py
+++ b/homeassistant/components/almond/config_flow.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from yarl import URL
 
 from homeassistant import config_entries, core, data_entry_flow
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
 

--- a/homeassistant/components/almond/config_flow.py
+++ b/homeassistant/components/almond/config_flow.py
@@ -100,7 +100,7 @@ class AlmondFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
 
-        self.hassio_discovery = discovery_info
+        self.hassio_discovery = discovery_info.config
 
         return await self.async_step_hassio_confirm()
 

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -20,7 +20,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import ssdp
 from homeassistant.components.deconz.gateway import DeconzGateway
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant, callback

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -20,6 +20,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import ssdp
 from homeassistant.components.deconz.gateway import DeconzGateway
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
@@ -233,7 +234,7 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_link()
 
-    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResult:
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
         """Prepare configuration for a Hass.io deCONZ bridge.
 
         This flow is triggered by the discovery component.

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -239,20 +239,20 @@ class DeconzFlowHandler(ConfigFlow, domain=DOMAIN):
 
         This flow is triggered by the discovery component.
         """
-        LOGGER.debug("deCONZ HASSIO discovery %s", pformat(discovery_info))
+        LOGGER.debug("deCONZ HASSIO discovery %s", pformat(discovery_info.config))
 
-        self.bridge_id = normalize_bridge_id(discovery_info[CONF_SERIAL])
+        self.bridge_id = normalize_bridge_id(discovery_info.config[CONF_SERIAL])
         await self.async_set_unique_id(self.bridge_id)
 
         self._abort_if_unique_id_configured(
             updates={
-                CONF_HOST: discovery_info[CONF_HOST],
-                CONF_PORT: discovery_info[CONF_PORT],
-                CONF_API_KEY: discovery_info[CONF_API_KEY],
+                CONF_HOST: discovery_info.config[CONF_HOST],
+                CONF_PORT: discovery_info.config[CONF_PORT],
+                CONF_API_KEY: discovery_info.config[CONF_API_KEY],
             }
         )
 
-        self._hassio_discovery = discovery_info
+        self._hassio_discovery = discovery_info.config
 
         return await self.async_step_hassio_confirm()
 

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 import os
@@ -24,6 +25,7 @@ from homeassistant.const import (
     SERVICE_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import DOMAIN as HASS_DOMAIN, HomeAssistant, callback
+from homeassistant.data_entry_flow import BaseServiceInfo
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, recorder
 from homeassistant.helpers.device_registry import (
@@ -181,6 +183,13 @@ MAP_SERVICE_API = {
         True,
     ),
 }
+
+
+@dataclass
+class HassioServiceInfo(BaseServiceInfo):
+    """Prepared info from hassio entries."""
+
+    config: dict[str, Any]
 
 
 @bind_hass

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
 from datetime import timedelta
 import logging
 import os
@@ -25,7 +24,6 @@ from homeassistant.const import (
     SERVICE_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import DOMAIN as HASS_DOMAIN, HomeAssistant, callback
-from homeassistant.data_entry_flow import BaseServiceInfo
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, recorder
 from homeassistant.helpers.device_registry import (
@@ -59,7 +57,7 @@ from .const import (
     DOMAIN,
     SupervisorEntityModel,
 )
-from .discovery import async_setup_discovery_view
+from .discovery import HassioServiceInfo, async_setup_discovery_view  # noqa: F401
 from .handler import HassIO, HassioAPIError, api_data
 from .http import HassIOView
 from .ingress import async_setup_ingress_view
@@ -183,13 +181,6 @@ MAP_SERVICE_API = {
         True,
     ),
 }
-
-
-@dataclass
-class HassioServiceInfo(BaseServiceInfo):
-    """Prepared info from hassio entries."""
-
-    config: dict[str, Any]
 
 
 @bind_hass

--- a/homeassistant/components/hassio/discovery.py
+++ b/homeassistant/components/hassio/discovery.py
@@ -14,7 +14,6 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import ATTR_NAME, ATTR_SERVICE, EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import BaseServiceInfo
-from homeassistant.helpers.frame import report
 
 from .const import ATTR_ADDON, ATTR_CONFIG, ATTR_DISCOVERY, ATTR_UUID
 from .handler import HassioAPIError
@@ -27,25 +26,6 @@ class HassioServiceInfo(BaseServiceInfo):
     """Prepared info from hassio entries."""
 
     config: dict[str, Any]
-
-    # Used to prevent log flooding. To be removed in 2022.6
-    _warning_logged: bool = False
-
-    def __getitem__(self, name: str) -> Any:
-        """
-        Allow property access by name for compatibility reason.
-
-        Deprecated, and will be removed in version 2022.6.
-        """
-        if not self._warning_logged:
-            report(
-                f"accessed discovery_info['{name}'] instead of discovery_info.config['{name}']; this will fail in version 2022.6",
-                exclude_integrations={"hassio"},
-                error_if_core=False,
-                level=logging.DEBUG,
-            )
-            self._warning_logged = True
-        return self.config[name]
 
 
 @callback

--- a/homeassistant/components/hassio/discovery.py
+++ b/homeassistant/components/hassio/discovery.py
@@ -2,30 +2,21 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
 import logging
-from typing import Any
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPServiceUnavailable
 
 from homeassistant import config_entries
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import ATTR_NAME, ATTR_SERVICE, EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import BaseServiceInfo
 
 from .const import ATTR_ADDON, ATTR_CONFIG, ATTR_DISCOVERY, ATTR_UUID
 from .handler import HassioAPIError
 
 _LOGGER = logging.getLogger(__name__)
-
-
-@dataclass
-class HassioServiceInfo(BaseServiceInfo):
-    """Prepared info from hassio entries."""
-
-    config: dict[str, Any]
 
 
 @callback

--- a/homeassistant/components/hassio/discovery.py
+++ b/homeassistant/components/hassio/discovery.py
@@ -8,7 +8,7 @@ from aiohttp import web
 from aiohttp.web_exceptions import HTTPServiceUnavailable
 
 from homeassistant import config_entries
-from homeassistant.components.hassio import HassioServiceInfo
+from homeassistant.components import hassio
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import ATTR_NAME, ATTR_SERVICE, EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant, callback
@@ -93,7 +93,7 @@ class HassIODiscovery(HomeAssistantView):
         await self.hass.config_entries.flow.async_init(
             service,
             context={"source": config_entries.SOURCE_HASSIO},
-            data=HassioServiceInfo(config=config_data),
+            data=hassio.HassioServiceInfo(config=config_data),
         )
 
     async def async_process_del(self, data):

--- a/homeassistant/components/hassio/discovery.py
+++ b/homeassistant/components/hassio/discovery.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
 from dataclasses import dataclass
 import logging
 from typing import Any
@@ -27,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 class HassioServiceInfo(BaseServiceInfo):
     """Prepared info from hassio entries."""
 
-    config: Mapping[str, Any]
+    config: dict[str, Any]
 
     # Used to prevent log flooding. To be removed in 2022.6
     _warning_logged: bool = False

--- a/homeassistant/components/hassio/discovery.py
+++ b/homeassistant/components/hassio/discovery.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import logging
+from typing import Any
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPServiceUnavailable
@@ -11,12 +13,19 @@ from homeassistant import config_entries
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import ATTR_NAME, ATTR_SERVICE, EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import BaseServiceInfo
 
-from .. import hassio
 from .const import ATTR_ADDON, ATTR_CONFIG, ATTR_DISCOVERY, ATTR_UUID
 from .handler import HassioAPIError
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class HassioServiceInfo(BaseServiceInfo):
+    """Prepared info from hassio entries."""
+
+    config: dict[str, Any]
 
 
 @callback
@@ -93,7 +102,7 @@ class HassIODiscovery(HomeAssistantView):
         await self.hass.config_entries.flow.async_init(
             service,
             context={"source": config_entries.SOURCE_HASSIO},
-            data=hassio.HassioServiceInfo(config=config_data),
+            data=HassioServiceInfo(config=config_data),
         )
 
     async def async_process_del(self, data):

--- a/homeassistant/components/hassio/discovery.py
+++ b/homeassistant/components/hassio/discovery.py
@@ -8,11 +8,11 @@ from aiohttp import web
 from aiohttp.web_exceptions import HTTPServiceUnavailable
 
 from homeassistant import config_entries
-from homeassistant.components import hassio
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import ATTR_NAME, ATTR_SERVICE, EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant, callback
 
+from .. import hassio
 from .const import ATTR_ADDON, ATTR_CONFIG, ATTR_DISCOVERY, ATTR_UUID
 from .handler import HassioAPIError
 

--- a/homeassistant/components/hassio/discovery.py
+++ b/homeassistant/components/hassio/discovery.py
@@ -121,7 +121,9 @@ class HassIODiscovery(HomeAssistantView):
 
         # Use config flow
         await self.hass.config_entries.flow.async_init(
-            service, context={"source": config_entries.SOURCE_HASSIO}, data=config_data
+            service,
+            context={"source": config_entries.SOURCE_HASSIO},
+            data=HassioServiceInfo(config=config_data),
         )
 
     async def async_process_del(self, data):

--- a/homeassistant/components/motioneye/config_flow.py
+++ b/homeassistant/components/motioneye/config_flow.py
@@ -10,7 +10,7 @@ from motioneye_client.client import (
 )
 import voluptuous as vol
 
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
     ConfigEntry,

--- a/homeassistant/components/motioneye/config_flow.py
+++ b/homeassistant/components/motioneye/config_flow.py
@@ -10,6 +10,7 @@ from motioneye_client.client import (
 )
 import voluptuous as vol
 
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
     ConfigEntry,
@@ -162,9 +163,9 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle a reauthentication flow."""
         return await self.async_step_user(config_data)
 
-    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResult:
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
         """Handle Supervisor discovery."""
-        self._hassio_discovery = discovery_info
+        self._hassio_discovery = discovery_info.config
         await self._async_handle_discovery_without_unique_id()
 
         return await self.async_step_hassio_confirm()

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -5,6 +5,7 @@ import queue
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.const import (
     CONF_DISCOVERY,
     CONF_HOST,
@@ -14,6 +15,7 @@ from homeassistant.const import (
     CONF_PROTOCOL,
     CONF_USERNAME,
 )
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
     ATTR_PAYLOAD,
@@ -93,7 +95,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title="configuration.yaml", data={})
 
-    async def async_step_hassio(self, discovery_info):
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
         """Receive a Hass.io discovery."""
         await self._async_handle_discovery_without_unique_id()
 

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -5,7 +5,7 @@ import queue
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.const import (
     CONF_DISCOVERY,
     CONF_HOST,

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -97,7 +97,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Receive a Hass.io discovery."""
         await self._async_handle_discovery_without_unique_id()
 
-        self._hassio_discovery = discovery_info
+        self._hassio_discovery = discovery_info.config
 
         return await self.async_step_hassio_confirm()
 

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -4,7 +4,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 

--- a/homeassistant/components/ozw/config_flow.py
+++ b/homeassistant/components/ozw/config_flow.py
@@ -4,8 +4,9 @@ import logging
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import AbortFlow
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 
 from .const import CONF_INTEGRATION_CREATED_ADDON, CONF_USE_ADDON, DOMAIN
 
@@ -48,7 +49,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_on_supervisor()
 
-    async def async_step_hassio(self, discovery_info):
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
         """Receive configuration from add-on discovery info.
 
         This flow is triggered by the OpenZWave add-on.

--- a/homeassistant/components/vlc_telnet/config_flow.py
+++ b/homeassistant/components/vlc_telnet/config_flow.py
@@ -9,7 +9,7 @@ from aiovlc.exceptions import AuthError, ConnectError
 import voluptuous as vol
 
 from homeassistant import core, exceptions
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult

--- a/homeassistant/components/vlc_telnet/config_flow.py
+++ b/homeassistant/components/vlc_telnet/config_flow.py
@@ -9,6 +9,7 @@ from aiovlc.exceptions import AuthError, ConnectError
 import voluptuous as vol
 
 from homeassistant import core, exceptions
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
@@ -151,13 +152,13 @@ class VLCTelnetConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResult:
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
         """Handle the discovery step via hassio."""
         await self.async_set_unique_id("hassio")
-        self._abort_if_unique_id_configured(discovery_info)
+        self._abort_if_unique_id_configured(discovery_info.config)
 
-        self.hassio_discovery = discovery_info
-        self.context["title_placeholders"] = {"host": discovery_info[CONF_HOST]}
+        self.hassio_discovery = discovery_info.config
+        self.context["title_placeholders"] = {"host": discovery_info.config[CONF_HOST]}
         return await self.async_step_hassio_confirm()
 
     async def async_step_hassio_confirm(

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -14,6 +14,7 @@ from zwave_js_server.version import VersionInfo, get_server_version
 from homeassistant import config_entries, exceptions
 from homeassistant.components import usb
 from homeassistant.components.hassio import is_hassio
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.const import CONF_NAME, CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import (
@@ -430,7 +431,7 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
             step_id="manual", data_schema=get_manual_schema(user_input), errors=errors
         )
 
-    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResult:
+    async def async_step_hassio(self, discovery_info: HassioServiceInfo) -> FlowResult:
         """Receive configuration from add-on discovery info.
 
         This flow is triggered by the Z-Wave JS add-on.

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -439,7 +439,9 @@ class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_in_progress():
             return self.async_abort(reason="already_in_progress")
 
-        self.ws_address = f"ws://{discovery_info['host']}:{discovery_info['port']}"
+        self.ws_address = (
+            f"ws://{discovery_info.config['host']}:{discovery_info.config['port']}"
+        )
         try:
             version_info = await async_get_version_info(self.hass, self.ws_address)
         except CannotConnect:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -13,8 +13,7 @@ from zwave_js_server.version import VersionInfo, get_server_version
 
 from homeassistant import config_entries, exceptions
 from homeassistant.components import usb
-from homeassistant.components.hassio import is_hassio
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo, is_hassio
 from homeassistant.const import CONF_NAME, CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import (

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -34,6 +34,7 @@ import homeassistant.util.uuid as uuid_util
 
 if TYPE_CHECKING:
     from homeassistant.components.dhcp import DhcpServiceInfo
+    from homeassistant.components.hassio.discovery import HassioServiceInfo
     from homeassistant.components.mqtt.discovery import MqttServiceInfo
     from homeassistant.components.ssdp import SsdpServiceInfo
     from homeassistant.components.usb import UsbServiceInfo
@@ -1353,10 +1354,10 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         )
 
     async def async_step_hassio(
-        self, discovery_info: DiscoveryInfoType
+        self, discovery_info: HassioServiceInfo
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by HASS IO discovery."""
-        return await self.async_step_discovery(discovery_info)
+        return await self.async_step_discovery(dict(discovery_info.config))
 
     async def async_step_homekit(
         self, discovery_info: ZeroconfServiceInfo

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1357,7 +1357,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         self, discovery_info: HassioServiceInfo
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by HASS IO discovery."""
-        return await self.async_step_discovery(dict(discovery_info.config))
+        return await self.async_step_discovery(discovery_info.config)
 
     async def async_step_homekit(
         self, discovery_info: ZeroconfServiceInfo

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -34,7 +34,7 @@ import homeassistant.util.uuid as uuid_util
 
 if TYPE_CHECKING:
     from homeassistant.components.dhcp import DhcpServiceInfo
-    from homeassistant.components.hassio.discovery import HassioServiceInfo
+    from homeassistant.components.hassio import HassioServiceInfo
     from homeassistant.components.mqtt.discovery import MqttServiceInfo
     from homeassistant.components.ssdp import SsdpServiceInfo
     from homeassistant.components.usb import UsbServiceInfo

--- a/tests/components/adguard/test_config_flow.py
+++ b/tests/components/adguard/test_config_flow.py
@@ -3,7 +3,7 @@ import aiohttp
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.adguard.const import DOMAIN
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_HOST,

--- a/tests/components/almond/test_config_flow.py
+++ b/tests/components/almond/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.almond import config_flow
 from homeassistant.components.almond.const import DOMAIN
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.helpers import config_entry_oauth2_flow
 

--- a/tests/components/almond/test_config_flow.py
+++ b/tests/components/almond/test_config_flow.py
@@ -90,7 +90,7 @@ async def test_abort_if_existing_entry(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "single_instance_allowed"
 
-    result = await flow.async_step_hassio({})
+    result = await flow.async_step_hassio(HassioServiceInfo(config={}))
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "single_instance_allowed"
 

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.components.deconz.const import (
     CONF_MASTER_GATEWAY,
     DOMAIN as DECONZ_DOMAIN,
 )
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.components.ssdp import ATTR_UPNP_MANUFACTURER_URL, ATTR_UPNP_SERIAL
 from homeassistant.config_entries import (
     SOURCE_HASSIO,

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -2,7 +2,7 @@
 from http import HTTPStatus
 from unittest.mock import Mock, patch
 
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -175,29 +175,3 @@ async def test_hassio_discovery_webhook(hass, aioclient_mock, hassio_client):
                 }
             )
         )
-
-
-async def test_service_info_compatibility(hass, caplog):
-    """Test compatibility with old-style dict.
-
-    To be removed in 2022.6
-    """
-    discovery_info = HassioServiceInfo(
-        config={
-            "broker": "mock-broker",
-            "port": 1883,
-            "username": "mock-user",
-            "password": "mock-pass",
-            "protocol": "3.1.1",
-            "addon": "Mosquitto Test",
-        }
-    )
-
-    # Ensure first call get logged
-    assert discovery_info["broker"] == "mock-broker"
-    assert "Detected code that accessed discovery_info['broker']" in caplog.text
-
-    # Ensure second call doesn't get logged
-    caplog.clear()
-    assert discovery_info["broker"] == "mock-broker"
-    assert "Detected code that accessed discovery_info['broker']" not in caplog.text

--- a/tests/components/hassio/test_discovery.py
+++ b/tests/components/hassio/test_discovery.py
@@ -49,14 +49,16 @@ async def test_hassio_discovery_startup(hass, aioclient_mock, hassio_client):
         assert aioclient_mock.call_count == 2
         assert mock_mqtt.called
         mock_mqtt.assert_called_with(
-            {
-                "broker": "mock-broker",
-                "port": 1883,
-                "username": "mock-user",
-                "password": "mock-pass",
-                "protocol": "3.1.1",
-                "addon": "Mosquitto Test",
-            }
+            HassioServiceInfo(
+                config={
+                    "broker": "mock-broker",
+                    "port": 1883,
+                    "username": "mock-user",
+                    "password": "mock-pass",
+                    "protocol": "3.1.1",
+                    "addon": "Mosquitto Test",
+                }
+            )
         )
 
 
@@ -110,14 +112,16 @@ async def test_hassio_discovery_startup_done(hass, aioclient_mock, hassio_client
         assert aioclient_mock.call_count == 2
         assert mock_mqtt.called
         mock_mqtt.assert_called_with(
-            {
-                "broker": "mock-broker",
-                "port": 1883,
-                "username": "mock-user",
-                "password": "mock-pass",
-                "protocol": "3.1.1",
-                "addon": "Mosquitto Test",
-            }
+            HassioServiceInfo(
+                config={
+                    "broker": "mock-broker",
+                    "port": 1883,
+                    "username": "mock-user",
+                    "password": "mock-pass",
+                    "protocol": "3.1.1",
+                    "addon": "Mosquitto Test",
+                }
+            )
         )
 
 
@@ -160,14 +164,16 @@ async def test_hassio_discovery_webhook(hass, aioclient_mock, hassio_client):
         assert aioclient_mock.call_count == 2
         assert mock_mqtt.called
         mock_mqtt.assert_called_with(
-            {
-                "broker": "mock-broker",
-                "port": 1883,
-                "username": "mock-user",
-                "password": "mock-pass",
-                "protocol": "3.1.1",
-                "addon": "Mosquitto Test",
-            }
+            HassioServiceInfo(
+                config={
+                    "broker": "mock-broker",
+                    "port": 1883,
+                    "username": "mock-user",
+                    "password": "mock-pass",
+                    "protocol": "3.1.1",
+                    "addon": "Mosquitto Test",
+                }
+            )
         )
 
 

--- a/tests/components/motioneye/test_config_flow.py
+++ b/tests/components/motioneye/test_config_flow.py
@@ -8,7 +8,7 @@ from motioneye_client.client import (
 )
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.components.motioneye.const import (
     CONF_ADMIN_PASSWORD,
     CONF_ADMIN_USERNAME,

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import mqtt
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import mqtt
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -124,7 +125,9 @@ async def test_hassio_ignored(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.flow.async_init(
         mqtt.DOMAIN,
-        data={"addon": "Mosquitto", "host": "mock-mosquitto", "port": "1883"},
+        data=HassioServiceInfo(
+            config={"addon": "Mosquitto", "host": "mock-mosquitto", "port": "1883"}
+        ),
         context={"source": config_entries.SOURCE_HASSIO},
     )
     assert result
@@ -140,14 +143,16 @@ async def test_hassio_confirm(
 
     result = await hass.config_entries.flow.async_init(
         "mqtt",
-        data={
-            "addon": "Mock Addon",
-            "host": "mock-broker",
-            "port": 1883,
-            "username": "mock-user",
-            "password": "mock-pass",
-            "protocol": "3.1.1",
-        },
+        data=HassioServiceInfo(
+            config={
+                "addon": "Mock Addon",
+                "host": "mock-broker",
+                "port": 1883,
+                "username": "mock-user",
+                "password": "mock-pass",
+                "protocol": "3.1.1",
+            }
+        ),
         context={"source": config_entries.SOURCE_HASSIO},
     )
     assert result["type"] == "form"

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -36,16 +36,19 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers.entity import EntityCategory
 
 ATTR_DEFAULT_DISABLED = "default_disabled"
 ATTR_DEVICE_FILE = "device_file"
 ATTR_DEVICE_INFO = "device_info"
+ATTR_ENTITY_CATEGORY = "entity_category"
 ATTR_INJECT_READS = "inject_reads"
 ATTR_UNIQUE_ID = "unique_id"
 ATTR_UNKNOWN_DEVICE = "unknown_device"
 
 FIXED_ATTRIBUTES = (
     ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_CATEGORY,
     ATTR_STATE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
 )
@@ -404,6 +407,7 @@ MOCK_OWPROXY_DEVICES = {
         SWITCH_DOMAIN: [
             {
                 ATTR_DEFAULT_DISABLED: True,
+                ATTR_ENTITY_CATEGORY: EntityCategory.CONFIG,
                 ATTR_ENTITY_ID: "switch.26_111111111111_iad",
                 ATTR_INJECT_READS: b"    1",
                 ATTR_STATE: STATE_ON,

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -36,19 +36,16 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     TEMP_CELSIUS,
 )
-from homeassistant.helpers.entity import EntityCategory
 
 ATTR_DEFAULT_DISABLED = "default_disabled"
 ATTR_DEVICE_FILE = "device_file"
 ATTR_DEVICE_INFO = "device_info"
-ATTR_ENTITY_CATEGORY = "entity_category"
 ATTR_INJECT_READS = "inject_reads"
 ATTR_UNIQUE_ID = "unique_id"
 ATTR_UNKNOWN_DEVICE = "unknown_device"
 
 FIXED_ATTRIBUTES = (
     ATTR_DEVICE_CLASS,
-    ATTR_ENTITY_CATEGORY,
     ATTR_STATE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
 )
@@ -407,7 +404,6 @@ MOCK_OWPROXY_DEVICES = {
         SWITCH_DOMAIN: [
             {
                 ATTR_DEFAULT_DISABLED: True,
-                ATTR_ENTITY_CATEGORY: EntityCategory.CONFIG,
                 ATTR_ENTITY_ID: "switch.26_111111111111_iad",
                 ATTR_INJECT_READS: b"    1",
                 ATTR_STATE: STATE_ON,

--- a/tests/components/ozw/test_config_flow.py
+++ b/tests/components/ozw/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.ozw.config_flow import TITLE
 from homeassistant.components.ozw.const import DOMAIN

--- a/tests/components/vlc_telnet/test_config_flow.py
+++ b/tests/components/vlc_telnet/test_config_flow.py
@@ -8,7 +8,7 @@ from aiovlc.exceptions import AuthError, ConnectError
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.components.vlc_telnet.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (

--- a/tests/components/vlc_telnet/test_config_flow.py
+++ b/tests/components/vlc_telnet/test_config_flow.py
@@ -309,23 +309,21 @@ async def test_hassio_flow(hass: HomeAssistant) -> None:
 async def test_hassio_already_configured(hass: HomeAssistant) -> None:
     """Test successful hassio flow."""
 
-    entry_data = HassioServiceInfo(
-        config={
-            "password": "test-password",
-            "host": "1.1.1.1",
-            "port": 8888,
-            "name": "custom name",
-            "addon": "vlc",
-        }
-    )
+    entry_data = {
+        "password": "test-password",
+        "host": "1.1.1.1",
+        "port": 8888,
+        "name": "custom name",
+        "addon": "vlc",
+    }
 
-    entry = MockConfigEntry(domain=DOMAIN, data=entry_data.config, unique_id="hassio")
+    entry = MockConfigEntry(domain=DOMAIN, data=entry_data, unique_id="hassio")
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
-        data=entry_data,
+        data=HassioServiceInfo(config=entry_data),
     )
     await hass.async_block_till_done()
 

--- a/tests/components/vlc_telnet/test_config_flow.py
+++ b/tests/components/vlc_telnet/test_config_flow.py
@@ -301,7 +301,7 @@ async def test_hassio_flow(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
         assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
-        assert result2["title"] == test_data["name"]
+        assert result2["title"] == test_data.config["name"]
         assert result2["data"] == test_data.config
         assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/vlc_telnet/test_config_flow.py
+++ b/tests/components/vlc_telnet/test_config_flow.py
@@ -8,6 +8,7 @@ from aiovlc.exceptions import AuthError, ConnectError
 import pytest
 
 from homeassistant import config_entries
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.components.vlc_telnet.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
@@ -278,13 +279,15 @@ async def test_hassio_flow(hass: HomeAssistant) -> None:
         "homeassistant.components.vlc_telnet.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        test_data = {
-            "password": "test-password",
-            "host": "1.1.1.1",
-            "port": 8888,
-            "name": "custom name",
-            "addon": "vlc",
-        }
+        test_data = HassioServiceInfo(
+            config={
+                "password": "test-password",
+                "host": "1.1.1.1",
+                "port": 8888,
+                "name": "custom name",
+                "addon": "vlc",
+            }
+        )
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -299,22 +302,24 @@ async def test_hassio_flow(hass: HomeAssistant) -> None:
 
         assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
         assert result2["title"] == test_data["name"]
-        assert result2["data"] == test_data
+        assert result2["data"] == test_data.config
         assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_hassio_already_configured(hass: HomeAssistant) -> None:
     """Test successful hassio flow."""
 
-    entry_data = {
-        "password": "test-password",
-        "host": "1.1.1.1",
-        "port": 8888,
-        "name": "custom name",
-        "addon": "vlc",
-    }
+    entry_data = HassioServiceInfo(
+        config={
+            "password": "test-password",
+            "host": "1.1.1.1",
+            "port": 8888,
+            "name": "custom name",
+            "addon": "vlc",
+        }
+    )
 
-    entry = MockConfigEntry(domain=DOMAIN, data=entry_data, unique_id="hassio")
+    entry = MockConfigEntry(domain=DOMAIN, data=entry_data.config, unique_id="hassio")
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -354,13 +359,15 @@ async def test_hassio_errors(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_HASSIO},
-            data={
-                "password": "test-password",
-                "host": "1.1.1.1",
-                "port": 8888,
-                "name": "custom name",
-                "addon": "vlc",
-            },
+            data=HassioServiceInfo(
+                config={
+                    "password": "test-password",
+                    "host": "1.1.1.1",
+                    "port": 8888,
+                    "name": "custom name",
+                    "addon": "vlc",
+                }
+            ),
         )
         await hass.async_block_till_done()
 

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -8,7 +8,7 @@ from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries
 from homeassistant.components import usb
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.components.hassio.handler import HassioAPIError
 from homeassistant.components.zwave_js.config_flow import SERVER_VERSION_TIMEOUT, TITLE
 from homeassistant.components.zwave_js.const import DOMAIN

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -15,13 +15,11 @@ from homeassistant.components.zwave_js.const import DOMAIN
 
 from tests.common import MockConfigEntry
 
-ADDON_DISCOVERY_INFO = HassioServiceInfo(
-    config={
-        "addon": "Z-Wave JS",
-        "host": "host1",
-        "port": 3001,
-    }
-)
+ADDON_DISCOVERY_INFO = {
+    "addon": "Z-Wave JS",
+    "host": "host1",
+    "port": 3001,
+}
 
 
 USB_DISCOVERY_INFO = usb.UsbServiceInfo(
@@ -285,7 +283,7 @@ async def test_supervisor_discovery(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
-        data=ADDON_DISCOVERY_INFO,
+        data=HassioServiceInfo(config=ADDON_DISCOVERY_INFO),
     )
 
     with patch(
@@ -325,7 +323,7 @@ async def test_supervisor_discovery_cannot_connect(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
-        data=ADDON_DISCOVERY_INFO,
+        data=HassioServiceInfo(config=ADDON_DISCOVERY_INFO),
     )
 
     assert result["type"] == "abort"
@@ -347,7 +345,7 @@ async def test_clean_discovery_on_user_create(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
-        data=ADDON_DISCOVERY_INFO,
+        data=HassioServiceInfo(config=ADDON_DISCOVERY_INFO),
     )
 
     assert result["type"] == "form"
@@ -410,7 +408,7 @@ async def test_abort_discovery_with_existing_entry(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
-        data=ADDON_DISCOVERY_INFO,
+        data=HassioServiceInfo(config=ADDON_DISCOVERY_INFO),
     )
 
     assert result["type"] == "abort"
@@ -434,7 +432,7 @@ async def test_abort_hassio_discovery_with_existing_flow(
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
-        data=ADDON_DISCOVERY_INFO,
+        data=HassioServiceInfo(config=ADDON_DISCOVERY_INFO),
     )
 
     assert result2["type"] == "abort"
@@ -629,7 +627,7 @@ async def test_discovery_addon_not_running(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
-        data=ADDON_DISCOVERY_INFO,
+        data=HassioServiceInfo(config=ADDON_DISCOVERY_INFO),
     )
 
     assert result["step_id"] == "hassio_confirm"
@@ -711,7 +709,7 @@ async def test_discovery_addon_not_installed(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
-        data=ADDON_DISCOVERY_INFO,
+        data=HassioServiceInfo(config=ADDON_DISCOVERY_INFO),
     )
 
     assert result["step_id"] == "hassio_confirm"
@@ -792,7 +790,7 @@ async def test_abort_usb_discovery_with_existing_flow(hass, supervisor, addon_op
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HASSIO},
-        data=ADDON_DISCOVERY_INFO,
+        data=HassioServiceInfo(config=ADDON_DISCOVERY_INFO),
     )
 
     assert result["type"] == "form"

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, loader
-from homeassistant.components.hassio.discovery import HassioServiceInfo
+from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CoreState, callback
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, BaseServiceInfo

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, loader
+from homeassistant.components.hassio.discovery import HassioServiceInfo
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CoreState, callback
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, BaseServiceInfo
@@ -2356,7 +2357,7 @@ async def test_async_setup_update_entry(hass):
         (config_entries.SOURCE_HOMEKIT, BaseServiceInfo()),
         (config_entries.SOURCE_DHCP, BaseServiceInfo()),
         (config_entries.SOURCE_ZEROCONF, BaseServiceInfo()),
-        (config_entries.SOURCE_HASSIO, BaseServiceInfo()),
+        (config_entries.SOURCE_HASSIO, HassioServiceInfo(config={})),
     ),
 )
 async def test_flow_with_default_discovery(hass, manager, discovery_source):

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2356,7 +2356,7 @@ async def test_async_setup_update_entry(hass):
         (config_entries.SOURCE_HOMEKIT, BaseServiceInfo()),
         (config_entries.SOURCE_DHCP, BaseServiceInfo()),
         (config_entries.SOURCE_ZEROCONF, BaseServiceInfo()),
-        (config_entries.SOURCE_HASSIO, {}),
+        (config_entries.SOURCE_HASSIO, BaseServiceInfo()),
     ),
 )
 async def test_flow_with_default_discovery(hass, manager, discovery_source):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
## Breaking change

Hassio discovery now uses a dataclass instead of a dictionary object.
Access using `__getitem__` will fail in version 2022.6.
Please use `discovery_info.config[<name>]` instead.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Hassio discovery now uses a dataclass instead of a dictionary object.
<!-- Access using `__getitem__` will fail in version 2022.6. -->
Please use `discovery_info.config[<name>]` instead.

Linked to this comment in the architecture discussion https://github.com/home-assistant/architecture/discussions/662#discussioncomment-1674270

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
