### PR TITLE
CI: Upload coverage results in a single step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -733,5 +733,11 @@ jobs:
     steps:
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v2
-      - name: Upload coverage to Codecov
+      - name: Upload coverage to Codecov (full coverage)
+        if: needs.changes.outputs.test_full_suite == 'true'
+        uses: codecov/codecov-action@v2.1.0
+        with:
+          flags: full-suite
+      - name: Upload coverage to Codecov (partial coverage)
+        if: needs.changes.outputs.test_full_suite == 'false'
         uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -717,12 +717,21 @@ jobs:
         with:
           files: coverage.xml
           flags: full-suite
-      - name: Upload coverage to Codecov (partial coverage)
-        if: needs.changes.outputs.test_full_suite == 'false'
-        uses: codecov/codecov-action@v2.1.0
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v2.2.4
         with:
-          files: coverage.xml
-          flags: ${{ matrix.group }}
+          name: coverage-${{ matrix.python-version }}-${{ matrix.group }}.xml
+          path: coverage.xml
       - name: Check dirty
         run: |
           ./script/check_dirty
+
+  coverage:
+    name: Upload test coverage to Codecov
+    runs-on: ubuntu-latest
+    needs: ["pytest"]
+    steps:
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v2
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -727,6 +727,8 @@ jobs:
       - changes
       - pytest
     steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.4.0
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v2
       - name: Upload coverage to Codecov (full coverage)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -723,7 +723,9 @@ jobs:
   coverage:
     name: Upload test coverage to Codecov
     runs-on: ubuntu-latest
-    needs: ["pytest"]
+    needs:
+      - changes
+      - pytest
     steps:
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -711,12 +711,6 @@ jobs:
             --durations-min=1 \
             -p no:sugar \
             tests/components/${{ matrix.group }}
-      - name: Upload coverage to Codecov (full coverage)
-        if: needs.changes.outputs.test_full_suite == 'true'
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          files: coverage.xml
-          flags: full-suite
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v2.2.4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -714,7 +714,7 @@ jobs:
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v2.2.4
         with:
-          name: coverage-${{ matrix.python-version }}-${{ matrix.group }}.xml
+          name: coverage-${{ matrix.python-version }}-${{ matrix.group }}
           path: coverage.xml
       - name: Check dirty
         run: |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR moves the upload of coverage results into a single step. Storing artifacts in the job in between.

This prevents us uploading e.g., 1 or 2 test reports of all the groups running, causing us to carry forward partial coverage data (and thus show dropped coverage on subsequently done PRs).

This issue was introduced when we added concurrency limits to our GitHub actions.

Downsides:
 - Extra job
 - We lose tagging on individual components, however, that has not been put to practical use yet.

Result of the new job:

![image](https://user-images.githubusercontent.com/195327/144451190-68d47c80-0fd0-4977-a9f2-d822c30f5fa2.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
