### PR TITLE
Add template filters pack and unpack

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -17,7 +17,7 @@ from operator import attrgetter
 import random
 import re
 import statistics
-from struct import error as StructError, pack, unpack, unpack_from
+from struct import error as StructError, pack, unpack_from
 import sys
 from typing import Any, cast
 from urllib.parse import urlencode as urllib_urlencode
@@ -1680,11 +1680,7 @@ def struct_pack(value: Any | None, format_string: str) -> bytes | None:
 def struct_unpack(value: bytes, format_string: str, offset: int = 0) -> Any | None:
     """Unpack an object from bytes an return the first native object."""
     try:
-        unpacked_value = (
-            unpack_from(format_string, value, offset)
-            if offset
-            else unpack(format_string, value)
-        )
+        unpacked_value = unpack_from(format_string, value, offset)
         return unpacked_value[0]
     except StructError:
         _LOGGER.warning(

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1680,13 +1680,13 @@ def struct_pack(value: Any | None, format_string: str) -> bytes | None:
 def struct_unpack(value: bytes, format_string: str, offset: int = 0) -> Any | None:
     """Unpack an object from bytes an return the first native object."""
     try:
-        unpacked_value = unpack_from(format_string, value, offset)
-        return unpacked_value[0]
+        return unpack_from(format_string, value, offset)[0]
     except StructError:
         _LOGGER.warning(
-            "Template warning: 'unpack' unable to unpack object '%s' with format_string '%s' see https://docs.python.org/3/library/struct.html for more information",
+            "Template warning: 'unpack' unable to unpack object '%s' with format_string '%s' and offset %s see https://docs.python.org/3/library/struct.html for more information",
             value,
             format_string,
+            offset,
         )
         return None
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1693,6 +1693,18 @@ def test_unpack(hass, caplog):
     }
     assert tpl.async_render(variables=variables) == 0xDEADBEEF
 
+    # unpack with offset
+    tpl = template.Template(
+        """
+{{ unpack(value, '>H', offset=2) }}
+            """,
+        hass,
+    )
+    variables = {
+        "value": b"\xde\xad\xbe\xef",
+    }
+    assert tpl.async_render(variables=variables) == 0xBEEF
+
     # test with an empty bytes object
     tpl = template.Template(
         """

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1717,7 +1717,7 @@ def test_unpack(hass, caplog):
     }
     assert tpl.async_render(variables=variables) is None
     assert (
-        "Template warning: 'unpack' unable to unpack object 'b''' with format_string '>I' see https://docs.python.org/3/library/struct.html for more information"
+        "Template warning: 'unpack' unable to unpack object 'b''' with format_string '>I' and offset 0 see https://docs.python.org/3/library/struct.html for more information"
         in caplog.text
     )
 
@@ -1733,7 +1733,7 @@ def test_unpack(hass, caplog):
     }
     assert tpl.async_render(variables=variables) is None
     assert (
-        "Template warning: 'unpack' unable to unpack object 'b''' with format_string 'invalid filter' see https://docs.python.org/3/library/struct.html for more information"
+        "Template warning: 'unpack' unable to unpack object 'b''' with format_string 'invalid filter' and offset 0 see https://docs.python.org/3/library/struct.html for more information"
         in caplog.text
     )
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1604,6 +1604,128 @@ def test_bitwise_or(hass):
     assert tpl.async_render(variables=variables) == 0x9BC2
 
 
+def test_pack(hass, caplog):
+    """Test struct pack method."""
+
+    # render as filter
+    tpl = template.Template(
+        """
+{{ value | pack('>I') }}
+            """,
+        hass,
+    )
+    variables = {
+        "value": 0xDEADBEEF,
+    }
+    assert tpl.async_render(variables=variables) == b"\xde\xad\xbe\xef"
+
+    # render as function
+    tpl = template.Template(
+        """
+{{ pack(value, '>I') }}
+            """,
+        hass,
+    )
+    variables = {
+        "value": 0xDEADBEEF,
+    }
+    assert tpl.async_render(variables=variables) == b"\xde\xad\xbe\xef"
+
+    # test with None value
+    tpl = template.Template(
+        """
+{{ pack(value, '>I') }}
+            """,
+        hass,
+    )
+    variables = {
+        "value": None,
+    }
+    # "Template warning: 'pack' unable to pack object with type '%s' and format_string '%s' see https://docs.python.org/3/library/struct.html for more information"
+    assert tpl.async_render(variables=variables) is None
+    assert (
+        "Template warning: 'pack' unable to pack object 'None' with type 'NoneType' and format_string '>I' see https://docs.python.org/3/library/struct.html for more information"
+        in caplog.text
+    )
+
+    # test with invalid filter
+    tpl = template.Template(
+        """
+{{ pack(value, 'invalid filter') }}
+            """,
+        hass,
+    )
+    variables = {
+        "value": 0xDEADBEEF,
+    }
+    # "Template warning: 'pack' unable to pack object with type '%s' and format_string '%s' see https://docs.python.org/3/library/struct.html for more information"
+    assert tpl.async_render(variables=variables) is None
+    assert (
+        "Template warning: 'pack' unable to pack object '3735928559' with type 'int' and format_string 'invalid filter' see https://docs.python.org/3/library/struct.html for more information"
+        in caplog.text
+    )
+
+
+def test_unpack(hass, caplog):
+    """Test struct unpack method."""
+
+    # render as filter
+    tpl = template.Template(
+        """
+{{ value | unpack('>I') }}
+            """,
+        hass,
+    )
+    variables = {
+        "value": b"\xde\xad\xbe\xef",
+    }
+    assert tpl.async_render(variables=variables) == 0xDEADBEEF
+
+    # render as function
+    tpl = template.Template(
+        """
+{{ unpack(value, '>I') }}
+            """,
+        hass,
+    )
+    variables = {
+        "value": b"\xde\xad\xbe\xef",
+    }
+    assert tpl.async_render(variables=variables) == 0xDEADBEEF
+
+    # test with an empty bytes object
+    tpl = template.Template(
+        """
+{{ unpack(value, '>I') }}
+            """,
+        hass,
+    )
+    variables = {
+        "value": b"",
+    }
+    assert tpl.async_render(variables=variables) is None
+    assert (
+        "Template warning: 'unpack' unable to unpack object 'b''' with format_string '>I' see https://docs.python.org/3/library/struct.html for more information"
+        in caplog.text
+    )
+
+    # test with invalid filter
+    tpl = template.Template(
+        """
+{{ unpack(value, 'invalid filter') }}
+            """,
+        hass,
+    )
+    variables = {
+        "value": b"",
+    }
+    assert tpl.async_render(variables=variables) is None
+    assert (
+        "Template warning: 'unpack' unable to unpack object 'b''' with format_string 'invalid filter' see https://docs.python.org/3/library/struct.html for more information"
+        in caplog.text
+    )
+
+
 def test_distance_function_with_1_state(hass):
     """Test distance function with 1 state."""
     _set_up_units(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement 2 new filters, `pack`and `unpack`, that make use of the Python 3 `struct` library.
https://docs.python.org/3/library/struct.html

The Python 3 library `struct` supplies `pack` and `unpack_from` functions that enable to pack native python types to `bytes`. They will help to setup support to process `binary` payloads for MQTT platforms.

### `pack` filter and function
The `pack` filter accepts `Any` type as input and will output a `bytes` type object, or `None` if the conversion fails.
Syntax: `value | pack(format_string)` or `pack(value, format_string)`

Example:
To convert an integer to bytes (unsigned big-endian) template `{{ 16 | pack('>I') }}` will call `struct.pack('>I', 16)` and results in value `b'\x00\x00\x00\x10'` as output.
To use `pack` as a function: `{{ pack(16, '>I') }}`.

> Note that the order or the parameters is different from the `struct.pack()` function. If a filter or value is invalid a warning message will be logged.

### `unpack` filter and function
The `pack` filter accepts a `bytes` type as input and will output a native object, or `None` if the conversion fails.

If multiple values are returned by the `struct.unpack()` function only the first value will be return. Use the `offset` parameter to index the value form the bytes buffer to `unpack`.

Syntax: `value | unpack(format_string, offset=0)` or `unpack(value, format_string, offset=0)`

Example:
To convert bytes to an integer (unsigned big-endian), with a given `value = b'\x00\x00\x00\x10'` the filter `{{ value| unpack('>I') }}` will call `struct.unpack_from('>I', b'\x00\x00\x00\x10', offset=0)` and results in value 16 as output.

> Note that the order or the parameters is different from the `struct.unpack_from()` function. To use `unpack` as a function: `{{ unpack(value, '>I') }}`.

The first value of tuple as a result of the call to `struct.unpack_from()` will be returned. To address another index, use the `offset` parameter.
The `offset` parameter defines the offset position in bytes from the start of the input `bytes` based buffer.

Example with offset:
To convert the second unsigned word (2 bytes) from an integer (4 bytes):
With a given `value` of `b"\xde\xad\xbe\xef"` the template `{{ unpack(value, '>H', offset=2) }}` will output the second word `0xBEEF`.

>If a filter or value is invalid a warning message will be logged.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20547

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
