### PR TITLE
Add parse_hostname method to ssdp

### DIFF
--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -1,6 +1,4 @@
 """Config flow to configure Heos."""
-from urllib.parse import urlparse
-
 from pyheos import Heos, HeosError
 import voluptuous as vol
 
@@ -25,7 +23,7 @@ class HeosFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle a discovered Heos device."""
         # Store discovered host
-        hostname = urlparse(discovery_info.ssdp_location or "").hostname
+        hostname = ssdp.parse_hostname(discovery_info.ssdp_location)
         friendly_name = (
             f"{discovery_info.upnp[ssdp.ATTR_UPNP_FRIENDLY_NAME]} ({hostname})"
         )

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from urllib.parse import urlparse
 
 from huawei_lte_api.AuthorizedConnection import AuthorizedConnection
 from huawei_lte_api.Client import Client
@@ -217,7 +216,7 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         url = url_normalize(
             discovery_info.upnp.get(
                 ssdp.ATTR_UPNP_PRESENTATION_URL,
-                f"http://{urlparse(discovery_info.ssdp_location or '').hostname}/",
+                f"http://{ssdp.parse_hostname(discovery_info.ssdp_location)}/",
             )
         )
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -9,6 +9,7 @@ from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
 import logging
 from typing import Any, Callable
+from urllib.parse import urlparse
 
 from async_upnp_client.aiohttp import AiohttpSessionRequester
 from async_upnp_client.const import DeviceOrServiceType, SsdpHeaders, SsdpSource
@@ -172,6 +173,20 @@ SSDP_SOURCE_SSDP_CHANGE_MAPPING: Mapping[SsdpSource, SsdpChange] = {
     SsdpSource.ADVERTISEMENT_BYEBYE: SsdpChange.BYEBYE,
     SsdpSource.ADVERTISEMENT_UPDATE: SsdpChange.UPDATE,
 }
+
+
+def parse_hostname(url: str | None, default: str | None = None) -> str:
+    """Extract hostname from a url."""
+    if url is None:
+        if default is None:
+            raise ValueError("url is None")
+        return default
+    parsed_url = urlparse(url)
+    if parsed_url.hostname is None:
+        if default is None:
+            raise ValueError("hostname is None")
+        return default
+    return parsed_url.hostname
 
 
 @bind_hass

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -793,3 +793,22 @@ async def test_ipv4_does_additional_search_for_sonos(
         ),
     )
     assert ssdp_listener.async_search.call_args[1] == {}
+
+
+def test_parse_hostname(hass):
+    """Test parse_hostname returns."""
+    # Test valid values
+    assert ssdp.parse_hostname("http://this.is.a.url:195/path?args") == "this.is.a.url"
+    assert ssdp.parse_hostname("https://this.is.a.url/path?args") == "this.is.a.url"
+    assert ssdp.parse_hostname("scheme://1.2.3.4") == "1.2.3.4"
+
+    # Test invalid values
+    with pytest.raises(ValueError, match="url is None"):
+        assert ssdp.parse_hostname(None)
+
+    with pytest.raises(ValueError, match="hostname is None"):
+        assert ssdp.parse_hostname("")
+
+    # Test default values
+    assert ssdp.parse_hostname(None, "my.hostname") == "my.hostname"
+    assert ssdp.parse_hostname("", "my.hostname") == "my.hostname"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `parse_hostname` method to `ssdp`, to ensure `mypy` compatibility.

Background:

> previously `discovery_info[ATTR_SSDP_LOCATION]` return type was `Any`
> now `discovery_info.ssdp_location` is defined as `str | None`
> 
> If the first argument of `urlparse` is `Any`, then `urlparse.hostname` returns `str | None`
> If the first argument of `urlparse` is `str | None`, then `urlparse.hostname` returns `str | bytes | None`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
