### PR TITLE
Allow to lock SQLite database during backup

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -817,9 +817,9 @@ class Recorder(threading.Thread):
                 if self.queue.qsize() > MAX_QUEUE_BACKLOG * 0.9:
                     _LOGGER.warning(
                         "Database queue backlog reached more than 90% of maximum queue "
-						"length while waiting for backup to finish; recorder will now "
-						"resume writing to database. The backup can not be trusted and "
-						"must be restarted"
+                        "length while waiting for backup to finish; recorder will now "
+                        "resume writing to database. The backup can not be trusted and "
+                        "must be restarted"
                     )
                     task.queue_overflow = True
                     break

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -125,6 +125,8 @@ KEEPALIVE_TIME = 30
 # States and Events objects
 EXPIRE_AFTER_COMMITS = 120
 
+DB_LOCK_QUEUE_CHECK_TIMEOUT = 1
+
 CONF_AUTO_PURGE = "auto_purge"
 CONF_DB_URL = "db_url"
 CONF_DB_MAX_RETRIES = "db_max_retries"
@@ -810,7 +812,7 @@ class Recorder(threading.Thread):
         with write_lock_db(self):
             # Notify that lock is being held, wait until database can be used again.
             self.hass.add_job(_async_set_database_locked, task)
-            while not task.database_unlock.wait(timeout=1):
+            while not task.database_unlock.wait(timeout=DB_LOCK_QUEUE_CHECK_TIMEOUT):
                 if self.queue.qsize() > MAX_QUEUE_BACKLOG * 0.9:
                     _LOGGER.warning(
                         "Database queue backlog reached more than 90% of maximum queue length. Continue writing to database. Your Backup might be corrupted"

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -809,12 +809,12 @@ class Recorder(threading.Thread):
             while not task.database_unlock.wait(timeout=1):
                 if self.queue.qsize() > MAX_QUEUE_BACKLOG * 0.9:
                     _LOGGER.warning(
-                        "Database queue backlog reached more than 90% of maximum queue length. Continue writing. Your Backup might be corrupted."
+                        "Database queue backlog reached more than 90% of maximum queue length. Continue writing to database. Your Backup might be corrupted"
                     )
                     task.queue_overflow = True
                     break
         _LOGGER.info(
-            "Database queue backlog reached %d entries during backup.",
+            "Database queue backlog reached %d entries during backup",
             self.queue.qsize(),
         )
 
@@ -1021,7 +1021,7 @@ class Recorder(threading.Thread):
     async def lock_database(self) -> bool:
         """Lock database so it can be backed up safely."""
         if self._database_lock_task:
-            _LOGGER.warning("Database already locked.")
+            _LOGGER.warning("Database already locked")
             return False
 
         task = DatabaseLockTask(threading.Event(), threading.Event(), False)
@@ -1043,7 +1043,7 @@ class Recorder(threading.Thread):
         Returns true if database lock has been held throughout the process.
         """
         if not self._database_lock_task:
-            _LOGGER.warning("Database currently not locked.")
+            _LOGGER.warning("Database currently not locked")
             return False
 
         self._database_lock_task.database_unlock.set()

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -816,7 +816,10 @@ class Recorder(threading.Thread):
             while not task.database_unlock.wait(timeout=DB_LOCK_QUEUE_CHECK_TIMEOUT):
                 if self.queue.qsize() > MAX_QUEUE_BACKLOG * 0.9:
                     _LOGGER.warning(
-                        "Database queue backlog reached more than 90% of maximum queue length. Continue writing to database. Your Backup might be corrupted"
+                        "Database queue backlog reached more than 90% of maximum queue "
+						"length while waiting for backup to finish; recorder will now "
+						"resume writing to database. The backup can not be trusted and "
+						"must be restarted"
                     )
                     task.queue_overflow = True
                     break

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -457,6 +457,25 @@ def perodic_db_cleanups(instance: Recorder):
             connection.execute(text("PRAGMA wal_checkpoint(TRUNCATE);"))
 
 
+@contextmanager
+def write_lock_db(instance: Recorder):
+    """Lock database for writes."""
+
+    if instance.engine.dialect.name == "sqlite":
+        with instance.engine.connect() as connection:
+            # Execute sqlite to create a wal checkpoint
+            # This is optional but makes sure the backup is going to be minimal
+            connection.execute(text("PRAGMA wal_checkpoint(TRUNCATE)"))
+            # Create write lock
+            _LOGGER.debug("Lock database")
+            connection.execute(text("BEGIN IMMEDIATE;"))
+            try:
+                yield
+            finally:
+                _LOGGER.debug("Unlock database")
+                connection.execute(text("END;"))
+
+
 def async_migration_in_progress(hass: HomeAssistant) -> bool:
     """Determine is a migration is in progress.
 

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -121,7 +121,7 @@ async def ws_backup_start(
 ) -> None:
     """Backup start notification."""
 
-    _LOGGER.info("Received backup start notification. Locking database for writes.")
+    _LOGGER.info("Backup start notification, locking database for writes")
     instance: Recorder = hass.data[DATA_INSTANCE]
     try:
         await instance.lock_database()
@@ -140,7 +140,7 @@ async def ws_backup_end(
     """Backup end notification."""
 
     instance: Recorder = hass.data[DATA_INSTANCE]
-    _LOGGER.info("Received end of backup, releasing write lock.")
+    _LOGGER.info("Backup end notification, releasing write lock")
     if not instance.unlock_database():
         connection.send_error(
             msg["id"], "database_unlock_failed", "Failed to unlock database."

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -1,6 +1,7 @@
 """The Energy websocket API."""
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
@@ -15,6 +16,8 @@ from .util import async_migration_in_progress
 if TYPE_CHECKING:
     from . import Recorder
 
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
 
 @callback
 def async_setup(hass: HomeAssistant) -> None:
@@ -23,6 +26,8 @@ def async_setup(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_clear_statistics)
     websocket_api.async_register_command(hass, ws_update_statistics_metadata)
     websocket_api.async_register_command(hass, ws_info)
+    websocket_api.async_register_command(hass, ws_backup_start)
+    websocket_api.async_register_command(hass, ws_backup_end)
 
 
 @websocket_api.websocket_command(
@@ -106,3 +111,38 @@ def ws_info(
         "thread_running": thread_alive,
     }
     connection.send_result(msg["id"], recorder_info)
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required("type"): "backup/start"})
+@websocket_api.async_response
+async def ws_backup_start(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Backup start notification."""
+
+    _LOGGER.info("Received backup start notification. Locking database for writes.")
+    instance: Recorder = hass.data[DATA_INSTANCE]
+    try:
+        await instance.lock_database()
+    except TimeoutError as err:
+        connection.send_error(msg["id"], "timeout_error", str(err))
+        return
+    connection.send_result(msg["id"])
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required("type"): "backup/end"})
+@websocket_api.async_response
+async def ws_backup_end(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
+) -> None:
+    """Backup end notification."""
+
+    instance: Recorder = hass.data[DATA_INSTANCE]
+    _LOGGER.info("Received end of backup, releasing write lock.")
+    if not instance.unlock_database():
+        connection.send_error(
+            msg["id"], "database_unlock_failed", "Failed to unlock database."
+        )
+    connection.send_result(msg["id"])

--- a/tests/common.py
+++ b/tests/common.py
@@ -897,10 +897,10 @@ def init_recorder_component(hass, add_config=None):
     _LOGGER.info("In-memory recorder successfully started")
 
 
-async def async_init_recorder_component(hass, add_config=None):
+async def async_init_recorder_component(hass, config={}):
     """Initialize the recorder asynchronously."""
-    config = dict(add_config) if add_config else {}
-    config[recorder.CONF_DB_URL] = "sqlite://"
+    if recorder.CONF_DB_URL not in config:
+        config[recorder.CONF_DB_URL] = "sqlite://"
 
     with patch("homeassistant.components.recorder.migration.migrate_schema"):
         assert await async_setup_component(

--- a/tests/common.py
+++ b/tests/common.py
@@ -897,8 +897,9 @@ def init_recorder_component(hass, add_config=None):
     _LOGGER.info("In-memory recorder successfully started")
 
 
-async def async_init_recorder_component(hass, config={}):
+async def async_init_recorder_component(hass, add_config=None):
     """Initialize the recorder asynchronously."""
+    config = add_config or {}
     if recorder.CONF_DB_URL not in config:
         config[recorder.CONF_DB_URL] = "sqlite://"
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1205,5 +1205,8 @@ async def test_database_lock_timeout(hass):
     await hass.async_block_till_done()
 
     instance: Recorder = hass.data[DATA_INSTANCE]
-    with pytest.raises(TimeoutError):
-        await instance.lock_database(lock_timeout=0.1)
+    try:
+        with pytest.raises(TimeoutError):
+            await instance.lock_database(lock_timeout=0.1)
+    finally:
+        instance.unlock_database()

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the Recorder component."""
 # pylint: disable=protected-access
+import asyncio
 from datetime import datetime, timedelta
 import sqlite3
 from unittest.mock import patch
@@ -1134,3 +1135,46 @@ def test_entity_id_filter(hass_recorder):
             db_events = list(session.query(Events).filter_by(event_type="hello"))
             # Keep referring idx + 1, as no new events are being added
             assert len(db_events) == idx + 1, data
+
+
+async def test_database_lock_and_unlock(hass: HomeAssistant, tmp_path):
+    """Test writing events during lock getting written after unlocking."""
+    # Use file DB, in memory DB cannot do write locks.
+    config = {recorder.CONF_DB_URL: "sqlite:///" + str(tmp_path / "pytest.db")}
+    await async_init_recorder_component(hass, config)
+    await hass.async_block_till_done()
+
+    instance: Recorder = hass.data[DATA_INSTANCE]
+
+    await instance.lock_database()
+
+    event_type = "EVENT_TEST"
+    event_data = {"test_attr": 5, "test_attr_10": "nice"}
+    hass.bus.fire(event_type, event_data)
+    task = asyncio.create_task(async_wait_recording_done(hass, instance))
+
+    # Recording can't be finished while lock is held
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(task), timeout=5)
+
+    with session_scope(hass=hass) as session:
+        db_events = list(session.query(Events).filter_by(event_type=event_type))
+        assert len(db_events) == 0
+
+    assert instance.unlock_database()
+
+    await task
+    with session_scope(hass=hass) as session:
+        db_events = list(session.query(Events).filter_by(event_type=event_type))
+        assert len(db_events) == 1
+
+
+async def test_database_lock_timeout(hass):
+    """Test locking database timeout when recorder stopped."""
+    await async_init_recorder_component(hass)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+    instance: Recorder = hass.data[DATA_INSTANCE]
+    with pytest.raises(TimeoutError):
+        await instance.lock_database(lock_timeout=1)

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1155,7 +1155,7 @@ async def test_database_lock_and_unlock(hass: HomeAssistant, tmp_path):
 
     # Recording can't be finished while lock is held
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(asyncio.shield(task), timeout=5)
+        await asyncio.wait_for(asyncio.shield(task), timeout=1)
 
     with session_scope(hass=hass) as session:
         db_events = list(session.query(Events).filter_by(event_type=event_type))
@@ -1177,4 +1177,4 @@ async def test_database_lock_timeout(hass):
 
     instance: Recorder = hass.data[DATA_INSTANCE]
     with pytest.raises(TimeoutError):
-        await instance.lock_database(lock_timeout=1)
+        await instance.lock_database(lock_timeout=0.1)

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1146,7 +1146,9 @@ async def test_database_lock_and_unlock(hass: HomeAssistant, tmp_path):
 
     instance: Recorder = hass.data[DATA_INSTANCE]
 
-    await instance.lock_database()
+    assert await instance.lock_database()
+
+    assert not await instance.lock_database()
 
     event_type = "EVENT_TEST"
     event_data = {"test_attr": 5, "test_attr_10": "nice"}

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1205,8 +1205,9 @@ async def test_database_lock_timeout(hass):
     await hass.async_block_till_done()
 
     instance: Recorder = hass.data[DATA_INSTANCE]
-    try:
-        with pytest.raises(TimeoutError):
-            await instance.lock_database(lock_timeout=0.1)
-    finally:
-        instance.unlock_database()
+    with patch.object(recorder, "DB_LOCK_TIMEOUT", 0.1):
+        try:
+            with pytest.raises(TimeoutError):
+                await instance.lock_database()
+        finally:
+            instance.unlock_database()

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sqlalchemy import text
 from sqlalchemy.sql.elements import TextClause
+from homeassistant.components import recorder
 
 from homeassistant.components.recorder import run_information_with_session, util
 from homeassistant.components.recorder.const import DATA_INSTANCE, SQLITE_URL_PREFIX
@@ -556,3 +557,21 @@ def test_perodic_db_cleanups(hass_recorder):
     ][0]
     assert isinstance(text_obj, TextClause)
     assert str(text_obj) == "PRAGMA wal_checkpoint(TRUNCATE);"
+
+
+async def test_write_lock_db(hass, tmp_path):
+    """Test database write lock."""
+    from sqlalchemy.exc import OperationalError
+
+    # Use file DB, in memory DB cannot do write locks.
+    config = {recorder.CONF_DB_URL: "sqlite:///" + str(tmp_path / "pytest.db")}
+    await async_init_recorder_component(hass, config)
+    await hass.async_block_till_done()
+
+    instance = hass.data[DATA_INSTANCE]
+
+    with util.write_lock_db(instance):
+        # Database should be locked now, try writing SQL command
+        with instance.engine.connect() as connection:
+            with pytest.raises(OperationalError):
+                connection.execute(text("DROP TABLE events;"))

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sqlalchemy import text
 from sqlalchemy.sql.elements import TextClause
-from homeassistant.components import recorder
 
+from homeassistant.components import recorder
 from homeassistant.components.recorder import run_information_with_session, util
 from homeassistant.components.recorder.const import DATA_INSTANCE, SQLITE_URL_PREFIX
 from homeassistant.components.recorder.models import RecorderRuns

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -358,3 +358,44 @@ async def test_recorder_info_migration_queue_exhausted(hass, hass_ws_client):
     assert response["result"]["migration_in_progress"] is False
     assert response["result"]["recording"] is True
     assert response["result"]["thread_running"] is True
+
+
+async def test_backup_start_no_recorder(hass, hass_ws_client):
+    """Test getting backup start when recorder is not present."""
+    client = await hass_ws_client()
+
+    await client.send_json({"id": 1, "type": "backup/start"})
+    response = await client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "unknown_command"
+
+
+async def test_backup_end(hass, hass_ws_client):
+    """Test backup start."""
+    client = await hass_ws_client()
+    await async_init_recorder_component(hass)
+
+    # Ensure there are no queued events
+    await async_wait_recording_done_without_instance(hass)
+
+    await client.send_json({"id": 1, "type": "backup/start"})
+    response = await client.receive_json()
+    assert response["success"]
+
+    await client.send_json({"id": 2, "type": "backup/end"})
+    response = await client.receive_json()
+    assert response["success"]
+
+
+async def test_backup_end_without_start(hass, hass_ws_client):
+    """Test backup start."""
+    client = await hass_ws_client()
+    await async_init_recorder_component(hass)
+
+    # Ensure there are no queued events
+    await async_wait_recording_done_without_instance(hass)
+
+    await client.send_json({"id": 1, "type": "backup/end"})
+    response = await client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "database_unlock_failed"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This implements two new Websocket API endpoints `backup/start` and `backup/end`. Those are meant to notify the Core when the Supervisor is creating a backup of the Core. Since backups are done while the Core is running, this allows the Core to make sure all files in the `config` directory are in a safe state to read. Until now, the recorder continued to write to the database file while the backup is being made. This can lead to corrupted database files in the backup. With this implementation, the recorder locks the database using `BEGIN IMMEDIATE`, which essentially prevents writes from any Database connection while keeping the database available for reads. The implementation also halts the recorders queue so that no database inserts are even attempted.

This method is described as "historical" method in the SQLite documentation. Developers also confirmed that this method is still save to use and also works with WAL enabled.
https://www.sqlite.org/backup.html
https://sqlite.org/forum/forumpost/1307e369863b7b24?t=h

Note: Currently the `backup/start` and `backup/end` endpoints are implemented in the recorder directly. In case other components need to know when a backup is created, the Websocket API endpoint should be implemented as part of the `hassio` component or similar.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
