### PR TITLE
Revert "Move Platform StrEnum to const"

### DIFF
--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import Platform
 
 from .const import DOMAIN
 from .coordinator import WLEDDataUpdateCoordinator

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from typing import Final
 
-from homeassistant.util.enum import StrEnum
-
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 12
 PATCH_VERSION: Final = "0.dev0"
@@ -17,42 +15,6 @@ REQUIRED_NEXT_PYTHON_HA_RELEASE: Final = "2022.1"
 
 # Format for platform files
 PLATFORM_FORMAT: Final = "{platform}.{domain}"
-
-
-class Platform(StrEnum):
-    """Available entity platforms."""
-
-    AIR_QUALITY = "air_quality"
-    ALARM_CONTROL_PANEL = "alarm_control_panel"
-    BINARY_SENSOR = "binary_sensor"
-    BUTTON = "button"
-    CALENDAR = "calendar"
-    CAMERA = "camera"
-    CLIMATE = "climate"
-    COVER = "cover"
-    DEVICE_TRACKER = "device_tracker"
-    FAN = "fan"
-    GEO_LOCATION = "geo_location"
-    HUMIDIFIER = "humidifier"
-    IMAGE_PROCESSING = "image_processing"
-    LIGHT = "light"
-    LOCK = "lock"
-    MAILBOX = "mailbox"
-    MEDIA_PLAYER = "media_player"
-    NOTIFY = "notify"
-    NUMBER = "number"
-    REMOTE = "remote"
-    SCENE = "scene"
-    SELECT = "select"
-    SENSOR = "sensor"
-    SIREN = "siren"
-    SST = "sst"
-    SWITCH = "switch"
-    TTS = "tts"
-    VACUUM = "vacuum"
-    WATER_HEATER = "water_heater"
-    WEATHER = "weather"
-
 
 # Can be used to specify a catch all when registering state or event listeners.
 MATCH_ALL: Final = "*"

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -34,6 +34,7 @@ from homeassistant.exceptions import (
 )
 from homeassistant.setup import async_start_setup
 from homeassistant.util.async_ import run_callback_threadsafe
+from homeassistant.util.enum import StrEnum
 
 from . import (
     config_validation as cv,
@@ -60,6 +61,41 @@ DATA_ENTITY_PLATFORM = "entity_platform"
 PLATFORM_NOT_READY_BASE_WAIT_TIME = 30  # seconds
 
 _LOGGER = getLogger(__name__)
+
+
+class Platform(StrEnum):
+    """Available platforms."""
+
+    AIR_QUALITY = "air_quality"
+    ALARM_CONTROL_PANEL = "alarm_control_panel"
+    BINARY_SENSOR = "binary_sensor"
+    BUTTON = "button"
+    CALENDAR = "calendar"
+    CAMERA = "camera"
+    CLIMATE = "climate"
+    COVER = "cover"
+    DEVICE_TRACKER = "device_tracker"
+    FAN = "fan"
+    GEO_LOCATION = "geo_location"
+    HUMIDIFIER = "humidifier"
+    IMAGE_PROCESSING = "image_processing"
+    LIGHT = "light"
+    LOCK = "lock"
+    MAILBOX = "mailbox"
+    MEDIA_PLAYER = "media_player"
+    NOTIFY = "notify"
+    NUMBER = "number"
+    REMOTE = "remote"
+    SCENE = "scene"
+    SELECT = "select"
+    SENSOR = "sensor"
+    SIREN = "siren"
+    SST = "sst"
+    SWITCH = "switch"
+    TTS = "tts"
+    VACUUM = "vacuum"
+    WATER_HEATER = "water_heater"
+    WEATHER = "weather"
 
 
 class AddEntitiesCallback(Protocol):

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
     EVENT_HOMEASSISTANT_START,
     PLATFORM_FORMAT,
-    Platform,
 )
 from homeassistant.core import CALLBACK_TYPE
 from homeassistant.exceptions import HomeAssistantError
@@ -27,7 +26,34 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_COMPONENT = "component"
 
-BASE_PLATFORMS = {platform.value for platform in Platform}
+BASE_PLATFORMS = {
+    "air_quality",
+    "alarm_control_panel",
+    "binary_sensor",
+    "camera",
+    "calendar",
+    "climate",
+    "cover",
+    "device_tracker",
+    "fan",
+    "humidifier",
+    "image_processing",
+    "light",
+    "lock",
+    "media_player",
+    "notify",
+    "number",
+    "remote",
+    "scene",
+    "select",
+    "sensor",
+    "siren",
+    "switch",
+    "tts",
+    "vacuum",
+    "water_heater",
+    "weather",
+}
 
 DATA_SETUP_DONE = "setup_done"
 DATA_SETUP_STARTED = "setup_started"

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -10,6 +10,8 @@ from typing import Any, cast
 
 import ciso8601
 
+from homeassistant.const import MATCH_ALL
+
 if sys.version_info[:2] >= (3, 9):
     import zoneinfo
 else:
@@ -213,7 +215,7 @@ def get_age(date: dt.datetime) -> str:
 
 def parse_time_expression(parameter: Any, min_value: int, max_value: int) -> list[int]:
     """Parse the time expression part and return a list of times to match."""
-    if parameter is None or parameter == "*":
+    if parameter is None or parameter == MATCH_ALL:
         res = list(range(min_value, max_value + 1))
     elif isinstance(parameter, str):
         if parameter.startswith("/"):

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-from homeassistant.const import Platform
 from homeassistant.requirements import DISCOVERY_INTEGRATIONS
+from homeassistant.setup import BASE_PLATFORMS
 
 from .model import Integration
 
@@ -91,11 +91,12 @@ class ImportCollector(ast.NodeVisitor):
 
 
 ALLOWED_USED_COMPONENTS = {
-    *{platform.value for platform in Platform},
     # Internal integrations
     "alert",
     "automation",
+    "button",
     "conversation",
+    "button",
     "device_automation",
     "frontend",
     "group",
@@ -118,6 +119,8 @@ ALLOWED_USED_COMPONENTS = {
     "webhook",
     "websocket_api",
     "zone",
+    # Entity integrations with platforms
+    *BASE_PLATFORMS,
     # Other
     "mjpeg",  # base class, has no reqs or component to load.
     "stream",  # Stream cannot install on all systems, can be imported without reqs.


### PR DESCRIPTION
Reverts home-assistant/core#60857

```
Obtaining file:///__w/core/core
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /__w/core/core/venv/bin/python /__w/core/core/venv/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpaey7owsl
       cwd: /__w/core/core
  Complete output (22 lines):
  Traceback (most recent call last):
    File "/__w/core/core/venv/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 280, in <module>
      main()
    File "/__w/core/core/venv/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 263, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/__w/core/core/venv/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 114, in get_requires_for_build_wheel
      return hook(config_settings)
    File "/tmp/pip-build-env-mwzgrknq/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 162, in get_requires_for_build_wheel
      return self._get_build_requires(
    File "/tmp/pip-build-env-mwzgrknq/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 143, in _get_build_requires
      self.run_setup()
    File "/tmp/pip-build-env-mwzgrknq/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 267, in run_setup
      super(_BuildMetaLegacyBackend,
    File "/tmp/pip-build-env-mwzgrknq/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 158, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 7, in <module>
      import homeassistant.const as hass_const
    File "/__w/core/core/homeassistant/const.py", line 6, in <module>
      from homeassistant.util.enum import StrEnum
    File "/__w/core/core/homeassistant/util/__init__.py", line 16, in <module>
      import slugify as unicode_slug
  ModuleNotFoundError: No module named 'slugify'
```

Const is used by setup, so we can use util here...